### PR TITLE
chore: update CodeQL action to version 3 in workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
@@ -56,6 +56,6 @@ jobs:
 
       # Perform CodeQL Analysis
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/codeql/${{ matrix.language }}-analysis"


### PR DESCRIPTION
## Description

Bump version of CodeQL to v3, since the v2 is deprecated as of beginning of December 2024 https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

Fixes # (issue)
