### PR TITLE
fix: reorg detector removes non-finalized block

### DIFF
--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -159,10 +159,11 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 					// and hashes matches. If higher than finalized block, we assume a reorg still might happen.
 					if hdr.Num <= lastFinalisedBlock.Number.Uint64() {
 						hdrs.removeRange(hdr.Num, hdr.Num)
-					}
-					if err := rd.removeTrackedBlockRange(id, hdr.Num, hdr.Num); err != nil {
-						return fmt.Errorf("error removing blocks from DB for subscriber %s between blocks %d and %d: %w",
-							id, hdr.Num, hdr.Num, err)
+
+						if err := rd.removeTrackedBlockRange(id, hdr.Num, hdr.Num); err != nil {
+							return fmt.Errorf("error removing blocks from DB for subscriber %s between blocks %d and %d: %w",
+								id, hdr.Num, hdr.Num, err)
+						}
 					}
 
 					continue

--- a/reorgdetector/reorgdetector_db.go
+++ b/reorgdetector/reorgdetector_db.go
@@ -70,7 +70,7 @@ func (rd *ReorgDetector) saveTrackedBlock(id string, b header) error {
 // updateTrackedBlocksDB updates the tracked blocks for a subscriber in db
 func (rd *ReorgDetector) removeTrackedBlockRange(id string, fromBlock, toBlock uint64) error {
 	_, err := rd.db.Exec(
-		"DELETE FROM tracked_block WHERE num >= $1 AND NUM <= 2 AND subscriber_id = $3;",
+		"DELETE FROM tracked_block WHERE num >= $1 AND num <= $2 AND subscriber_id = $3;",
 		fromBlock, toBlock, id,
 	)
 	return err


### PR DESCRIPTION
## Description

This bug fix is a cherry pick of a fix from cdk: https://github.com/0xPolygon/cdk/pull/266/

Fixes #113 (issue)
