### PR TITLE
chore: add Dependabot configuration for Go module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: develop


### PR DESCRIPTION
## Description

Add Dependabot configuration, in order to track the `develop` branch, since it is up to date at all occasions.

Fixes #130 
