### PR TITLE
chore(deps): increase PR limit and add reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: weekly
     target-branch: develop
     open-pull-requests-limit: 10
+    reviewers:
+      - "agglayer/aggkit"


### PR DESCRIPTION
## Description

Increase the deps PR limit to 10 and add reviewers to Dependabot PRs.

Fixes # (issue)
