### PR TITLE
chore(ci): update SonarCloud action to SonarQube Scan v4.2.1

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Test
         run: make test-unit
 
-      - name: Analyze with SonarCloud
-        uses: sonarsource/sonarcloud-github-action@master
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Description

Use SonarQube Scan action, instead of Sonarcloud one (which is about to be deprecated with the next version).

Closes #158
