### PR TITLE
feat: resend failed certificate

### DIFF
--- a/agglayer/types.go
+++ b/agglayer/types.go
@@ -137,9 +137,9 @@ type Certificate struct {
 // ID returns a string with the ident of this cert (height/certID)
 func (c *Certificate) ID() string {
 	if c == nil {
-		return nilStr
+		return "cert{" + nilStr + "}"
 	}
-	return fmt.Sprintf("height:%d / networkID:%d", c.Height, c.NetworkID)
+	return fmt.Sprintf("cert{height:%d, networkID:%d}", c.Height, c.NetworkID)
 }
 
 // Brief returns a string with a brief cert

--- a/agglayer/types.go
+++ b/agglayer/types.go
@@ -134,6 +134,14 @@ type Certificate struct {
 	Metadata            common.Hash           `json:"metadata"`
 }
 
+// ID returns a string with the ident of this cert (height/certID)
+func (c *Certificate) ID() string {
+	if c == nil {
+		return nilStr
+	}
+	return fmt.Sprintf("height:%d / networkID:%d", c.Height, c.NetworkID)
+}
+
 // Brief returns a string with a brief cert
 func (c *Certificate) Brief() string {
 	if c == nil {

--- a/agglayer/types_test.go
+++ b/agglayer/types_test.go
@@ -1201,3 +1201,13 @@ func Test_UnmarshalClaimFromRollup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, claim, unmarshalled)
 }
+
+func TestCertificate_ID(t *testing.T) {
+	var cert *Certificate
+	require.Equal(t, "cert{"+nilStr+"}", cert.ID())
+	cert = &Certificate{
+		NetworkID: 1,
+		Height:    2,
+	}
+	require.Equal(t, "cert{height:2, networkID:1}", cert.ID())
+}

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -345,7 +345,8 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 	return signedCertificate, nil
 }
 func (a *AggSender) isAllowedSendCertificateEpochPercent() bool {
-	if a.cfg.ForbiddenSendCertificateAfterEpochPercentage == 0 || a.cfg.ForbiddenSendCertificateAfterEpochPercentage >= maxPercent {
+	if a.cfg.ForbiddenSendCertificateAfterEpochPercentage == 0 ||
+		a.cfg.ForbiddenSendCertificateAfterEpochPercentage >= maxPercent {
 		return true
 	}
 	status := a.epochNotifier.GetEpochStatus()

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -297,7 +297,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 			rateLimitSleepTime.String(), a.rateLimiter.String())
 		time.Sleep(*rateLimitSleepTime)
 	}
-	if a.isAllowedSendCertificateEpochPercent() {
+	if !a.isAllowedSendCertificateEpochPercent() {
 		return nil, fmt.Errorf("forbidden to send certificate due epoch percentage")
 	}
 

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -298,7 +298,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 		time.Sleep(*rateLimitSleepTime)
 	}
 	if a.isAllowedSendCertificateEpochPercent() {
-
+		return nil, fmt.Errorf("forbidden to send certificate due epoch percentage")
 	}
 
 	a.saveCertificateToFile(signedCertificate)

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -177,14 +177,14 @@ func (a *AggSender) sendCertificates(ctx context.Context, returnAfterNIterations
 			checkResult := a.checkPendingCertificatesStatus(ctx)
 			if !checkResult.existPendingCerts && checkResult.existNewInErrorCert {
 				if a.cfg.RetryCertAfterInError {
-					a.log.Infof("Appears an InError cert sending a new one (%s)", a.cfg.CheckCertConfigBriefString())
+					a.log.Infof("An InError cert exists. Sending a new one (%s)", a.cfg.CheckCertConfigBriefString())
 					_, err := a.sendCertificate(ctx)
 					a.status.SetLastError(err)
 					if err != nil {
 						a.log.Error(err)
 					}
 				} else {
-					a.log.Infof("Appears an InError cert but skipping send cert because RetryCertInmediatlyAfterInError is false")
+					a.log.Infof("An InError cert exists but skipping send cert because RetryCertInmediatlyAfterInError is false")
 				}
 			}
 			if returnAfterNIterations > 0 && iteration >= returnAfterNIterations {

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -345,12 +345,12 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 	return signedCertificate, nil
 }
 func (a *AggSender) isAllowedSendCertificateEpochPercent() bool {
-	if a.cfg.ForbiddenSendCertificateAfterEpochPercentage == 0 ||
-		a.cfg.ForbiddenSendCertificateAfterEpochPercentage >= maxPercent {
+	if a.cfg.MaxEpochPercentageAllowedToSendCertificate == 0 ||
+		a.cfg.MaxEpochPercentageAllowedToSendCertificate >= maxPercent {
 		return true
 	}
 	status := a.epochNotifier.GetEpochStatus()
-	if status.PercentEpoch >= float64(a.cfg.ForbiddenSendCertificateAfterEpochPercentage)/100.0 {
+	if status.PercentEpoch >= float64(a.cfg.MaxEpochPercentageAllowedToSendCertificate)/100.0 {
 		a.log.Warnf("forbidden to send certificate after epoch percentage: %f", status.PercentEpoch)
 		return false
 	}

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -79,7 +79,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	rateLimit := createRateLimit(cfg)
+	rateLimit := aggkitcommon.NewRateLimit(cfg.MaxSubmitCertificateRate)
 
 	logger.Infof("Aggsender Config: %s.", cfg.String())
 
@@ -95,11 +95,6 @@ func New(
 		status:           types.AggsenderStatus{Status: types.StatusNone},
 		rateLimiter:      rateLimit,
 	}, nil
-}
-
-func createRateLimit(cfg Config) *aggkitcommon.RateLimit {
-	rateLimit := aggkitcommon.NewRateLimit(cfg.MaxSubmitCertificateRate)
-	return rateLimit
 }
 
 func (a *AggSender) Info() types.AggsenderInfo {

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -57,7 +57,7 @@ type AggSender struct {
 	rateLimiter RateLimiter
 }
 
-// New returns a new AggSender
+// New returns a new AggSender instance
 func New(
 	ctx context.Context,
 	logger *log.Logger,

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -98,11 +98,8 @@ func New(
 }
 
 func createRateLimit(cfg Config) *aggkitcommon.RateLimit {
-	if cfg.MaxSubmitCertificateRate.Enabled() {
-		rateLimit := aggkitcommon.NewRateLimit(cfg.MaxSubmitCertificateRate)
-		return &rateLimit
-	}
-	return nil
+	rateLimit := aggkitcommon.NewRateLimit(cfg.MaxSubmitCertificateRate)
+	return rateLimit
 }
 
 func (a *AggSender) Info() types.AggsenderInfo {

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -53,7 +53,12 @@ func TestConfigString(t *testing.T) {
 		"URLRPCL2: http://l2.rpc.url\n" +
 		"BlockFinality: latestBlock\n" +
 		"EpochNotificationPercentage: 50\n" +
-		"SaveCertificatesToFilesPath: /path/to/certificates\n"
+		"SaveCertificatesToFilesPath: /path/to/certificates\n" +
+		"DryRun: false\n" +
+		"EnableRPC: false\n" +
+		"CheckStatusCertificateInterval: 0s\n" +
+		"RetryCertInmediatlyAfterInError: false\n" +
+		"MaxSubmitRate: RateLimitConfig{Unlimited}\n"
 
 	require.Equal(t, expected, config.String())
 }

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -61,7 +61,7 @@ func TestConfigString(t *testing.T) {
 		"CheckStatusCertificateInterval: 0s\n" +
 		"RetryCertInmediatlyAfterInError: false\n" +
 		"MaxSubmitRate: RateLimitConfig{Unlimited}\n" +
-		"ForbiddenSendCertificateAfterEpochPercentage: 0\n"
+		"MaxEpochPercentageAllowedToSendCertificate: 0\n"
 
 	require.Equal(t, expected, config.String())
 }
@@ -2095,7 +2095,7 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 func TestLimitEpochPercent_Greater(t *testing.T) {
 	testData := newAggsenderTestData(t, testDataFlagMockStorage)
 	testData.sut.cfg.MaxCertSize = (aggsendertypes.EstimatedSizeBridgeExit * 3) + 1
-	testData.sut.cfg.ForbiddenSendCertificateAfterEpochPercentage = 80
+	testData.sut.cfg.MaxEpochPercentageAllowedToSendCertificate = 80
 
 	ctx := context.TODO()
 	testData.storageMock.EXPECT().GetCertificatesByStatus(mock.Anything).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
@@ -929,8 +930,8 @@ func TestCheckIfCertificatesAreSettled(t *testing.T) {
 			}
 
 			ctx := context.TODO()
-			thereArePendingCerts := aggSender.checkPendingCertificatesStatus(ctx)
-			require.Equal(t, tt.expectedError, thereArePendingCerts)
+			checkResult := aggSender.checkPendingCertificatesStatus(ctx)
+			require.Equal(t, tt.expectedError, checkResult.thereArePendingCerts)
 			mockAggLayerClient.AssertExpectations(t)
 			mockStorage.AssertExpectations(t)
 		})
@@ -968,6 +969,7 @@ func TestSendCertificate(t *testing.T) {
 				log:          log.WithFields("aggsender", 1),
 				cfg:          Config{MaxRetriesStoreCertificate: 1},
 				sequencerKey: cfg.sequencerKey,
+				rateLimiter:  aggkitcommon.NewRateLimit(aggkitcommon.RateLimitConfig{}),
 			}
 			mockStorage          *mocks.AggSenderStorage
 			mockL2Syncer         *mocks.L2BridgeSyncer
@@ -1666,6 +1668,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 		l1infoTreeSyncer: mockL1InfoTreeSyncer,
 		sequencerKey:     privateKey,
 		cfg:              Config{},
+		rateLimiter:      aggkitcommon.NewRateLimit(aggkitcommon.RateLimitConfig{}),
 	}
 
 	mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -59,7 +59,8 @@ func TestConfigString(t *testing.T) {
 		"EnableRPC: false\n" +
 		"CheckStatusCertificateInterval: 0s\n" +
 		"RetryCertInmediatlyAfterInError: false\n" +
-		"MaxSubmitRate: RateLimitConfig{Unlimited}\n"
+		"MaxSubmitRate: RateLimitConfig{Unlimited}\n" +
+		"ForbiddenSendCertificateAfterEpochPercentage: 0\n"
 
 	require.Equal(t, expected, config.String())
 }

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -331,7 +331,6 @@ func TestAggSenderSendCertificates(t *testing.T) {
 	require.NotNil(t, aggSender)
 
 	t.Run("regular case (1 cert send)", func(t *testing.T) {
-
 		aggSender.cfg.CheckStatusCertificateInterval = types.Duration{Duration: 0}
 		ch := make(chan aggsendertypes.EpochEvent, 2)
 		epochNotifierMock.EXPECT().Subscribe("aggsender").Return(ch).Once()

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -2054,6 +2054,13 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 	}
 }
 
+func TestNewAggSender(t *testing.T) {
+	sut, err := New(context.TODO(), log.WithFields("module", "ut"), Config{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sut)
+	require.Contains(t, sut.rateLimiter.String(), "Unlimited")
+}
+
 type testDataFlags = int
 
 const (

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -967,7 +967,7 @@ func TestCheckIfCertificatesAreSettled(t *testing.T) {
 
 			ctx := context.TODO()
 			checkResult := aggSender.checkPendingCertificatesStatus(ctx)
-			require.Equal(t, tt.expectedError, checkResult.thereArePendingCerts)
+			require.Equal(t, tt.expectedError, checkResult.existPendingCerts)
 			mockAggLayerClient.AssertExpectations(t)
 			mockStorage.AssertExpectations(t)
 		})

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -331,7 +331,7 @@ func TestAggSenderSendCertificates(t *testing.T) {
 	require.NotNil(t, aggSender)
 
 	t.Run("regular case (1 cert send)", func(t *testing.T) {
-		aggSender.cfg.CheckStatusCertificateInterval = types.Duration{Duration: 0}
+		aggSender.cfg.CheckStatusCertificateInterval = types.Duration{Duration: time.Microsecond}
 		ch := make(chan aggsendertypes.EpochEvent, 2)
 		epochNotifierMock.EXPECT().Subscribe("aggsender").Return(ch).Once()
 		err = aggSender.storage.SaveLastSentCertificate(ctx, aggsendertypes.CertificateInfo{
@@ -343,9 +343,6 @@ func TestAggSenderSendCertificates(t *testing.T) {
 			Status: agglayer.Pending,
 		}, nil).Once()
 
-		ch <- aggsendertypes.EpochEvent{
-			Epoch: 1,
-		}
 		aggSender.sendCertificates(ctx, 1)
 		AggLayerMock.AssertExpectations(t)
 		epochNotifierMock.AssertExpectations(t)

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -103,6 +103,14 @@ func (b *BlockNotifierPolling) Start(ctx context.Context) {
 	}
 }
 
+func (b *BlockNotifierPolling) GetCurrentBlockNumber() uint64 {
+	status := b.getGlobalStatus()
+	if status == nil {
+		return 0
+	}
+	return status.lastBlockSeen
+}
+
 func (b *BlockNotifierPolling) setGlobalStatus(status *blockNotifierPollingInternalStatus) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -79,5 +79,6 @@ func (c Config) String() string {
 		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
 		"RetryCertInmediatlyAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
 		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n" +
-		"ForbiddenSendCertificateAfterEpochPercentage: " + fmt.Sprintf("%d", c.ForbiddenSendCertificateAfterEpochPercentage) + "\n"
+		"ForbiddenSendCertificateAfterEpochPercentage: " +
+		fmt.Sprintf("%d", c.ForbiddenSendCertificateAfterEpochPercentage) + "\n"
 }

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	EnableRPC bool `mapstructure:"EnableRPC"`
 	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
 	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
-	//RetryCertAfterInError when a cert pass to 'InError'
+	// RetryCertAfterInError when a cert pass to 'InError'
 	// state the AggSender will retry to send it inmediatly
 	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
 	// MaxSubmitCertificateRate is the maximum rate of certificate submission allowed

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -44,6 +44,15 @@ type Config struct {
 	DryRun bool `mapstructure:"DryRun"`
 	// EnableRPC is a flag to enable the RPC for aggsender
 	EnableRPC bool `mapstructure:"EnableRPC"`
+	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
+	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
+	//RetryCertAfterInError when a cert pass to 'InError'
+	// state the AggSender will retry to send it inmediatly
+	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
+}
+
+func (c Config) CheckCertConfigBriefString() string {
+	return fmt.Sprintf("check_interval: %s, retry: %t", c.CheckStatusCertificateInterval, c.RetryCertAfterInError)
 }
 
 // String returns a string representation of the Config
@@ -54,5 +63,9 @@ func (c Config) String() string {
 		"URLRPCL2: " + c.URLRPCL2 + "\n" +
 		"BlockFinality: " + c.BlockFinality + "\n" +
 		"EpochNotificationPercentage: " + fmt.Sprintf("%d", c.EpochNotificationPercentage) + "\n" +
-		"SaveCertificatesToFilesPath: " + c.SaveCertificatesToFilesPath + "\n"
+		"SaveCertificatesToFilesPath: " + c.SaveCertificatesToFilesPath + "\n" +
+		"DryRun" + fmt.Sprintf("%t", c.DryRun) + "\n" +
+		"EnableRPC" + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
+		"CheckStatusCertificateInterval" + c.CheckStatusCertificateInterval.String() + "\n" +
+		"RetryCertInmediatlyAfterInError" + fmt.Sprintf("%t", c.RetryCertAfterInError)
 }

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
 	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
 	// RetryCertAfterInError when a cert pass to 'InError'
-	// state the AggSender will retry to send it inmediatly
+	// state the AggSender will try to resend it inmediatly
 	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
 	// MaxSubmitCertificateRate is the maximum rate of certificate submission allowed
 	MaxSubmitCertificateRate common.RateLimitConfig `mapstructure:"MaxSubmitCertificateRate"`

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -3,6 +3,7 @@ package aggsender
 import (
 	"fmt"
 
+	"github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/config/types"
 )
 
@@ -49,6 +50,8 @@ type Config struct {
 	//RetryCertAfterInError when a cert pass to 'InError'
 	// state the AggSender will retry to send it inmediatly
 	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
+	// MaxSubmitCertificateRate is the maximum rate of certificate submission allowed
+	MaxSubmitCertificateRate common.RateLimitConfig `mapstructure:"MaxSubmitCertificateRate"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {
@@ -64,8 +67,9 @@ func (c Config) String() string {
 		"BlockFinality: " + c.BlockFinality + "\n" +
 		"EpochNotificationPercentage: " + fmt.Sprintf("%d", c.EpochNotificationPercentage) + "\n" +
 		"SaveCertificatesToFilesPath: " + c.SaveCertificatesToFilesPath + "\n" +
-		"DryRun" + fmt.Sprintf("%t", c.DryRun) + "\n" +
-		"EnableRPC" + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
-		"CheckStatusCertificateInterval" + c.CheckStatusCertificateInterval.String() + "\n" +
-		"RetryCertInmediatlyAfterInError" + fmt.Sprintf("%t", c.RetryCertAfterInError)
+		"DryRun: " + fmt.Sprintf("%t", c.DryRun) + "\n" +
+		"EnableRPC: " + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
+		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
+		"RetryCertInmediatlyAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
+		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n"
 }

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
 	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
 	// RetryCertAfterInError when a cert pass to 'InError'
-	// state the AggSender will try to resend it inmediatly
+	// state the AggSender will try to resend it immediately
 	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
 	// MaxEpochPercentageAllowedToSendCertificate is the percentage of the epoch
 	// after which the AggSender is forbidden to send the certificate.

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -50,13 +50,13 @@ type Config struct {
 	// RetryCertAfterInError when a cert pass to 'InError'
 	// state the AggSender will try to resend it inmediatly
 	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
-	// ForbiddenSendCertificateAfterEpochPercentage is the percentage of the epoch
+	// MaxEpochPercentageAllowedToSendCertificate is the percentage of the epoch
 	// after which the AggSender is forbidden to send the certificate.
 	// If value==0  || value >= 100 the check is disabled
 	// 0 -> Begin
 	// 50 -> Middle
 	// 100 -> End
-	ForbiddenSendCertificateAfterEpochPercentage uint `mapstructure:"ForbiddenSendCertificateAfterEpochPercentage"`
+	MaxEpochPercentageAllowedToSendCertificate uint `mapstructure:"MaxEpochPercentageAllowedToSendCertificate"`
 	// MaxSubmitCertificateRate is the maximum rate of certificate submission allowed
 	MaxSubmitCertificateRate common.RateLimitConfig `mapstructure:"MaxSubmitCertificateRate"`
 }
@@ -79,6 +79,6 @@ func (c Config) String() string {
 		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
 		"RetryCertInmediatlyAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
 		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n" +
-		"ForbiddenSendCertificateAfterEpochPercentage: " +
-		fmt.Sprintf("%d", c.ForbiddenSendCertificateAfterEpochPercentage) + "\n"
+		"MaxEpochPercentageAllowedToSendCertificate: " +
+		fmt.Sprintf("%d", c.MaxEpochPercentageAllowedToSendCertificate) + "\n"
 }

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -50,6 +50,13 @@ type Config struct {
 	// RetryCertAfterInError when a cert pass to 'InError'
 	// state the AggSender will try to resend it inmediatly
 	RetryCertAfterInError bool `mapstructure:"RetryCertAfterInError"`
+	// ForbiddenSendCertificateAfterEpochPercentage is the percentage of the epoch
+	// after which the AggSender is forbidden to send the certificate.
+	// If value==0  || value >= 100 the check is disabled
+	// 0 -> Begin
+	// 50 -> Middle
+	// 100 -> End
+	ForbiddenSendCertificateAfterEpochPercentage uint `mapstructure:"ForbiddenSendCertificateAfterEpochPercentage"`
 	// MaxSubmitCertificateRate is the maximum rate of certificate submission allowed
 	MaxSubmitCertificateRate common.RateLimitConfig `mapstructure:"MaxSubmitCertificateRate"`
 }
@@ -71,5 +78,6 @@ func (c Config) String() string {
 		"EnableRPC: " + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
 		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
 		"RetryCertInmediatlyAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
-		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n"
+		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n" +
+		"ForbiddenSendCertificateAfterEpochPercentage: " + fmt.Sprintf("%d", c.ForbiddenSendCertificateAfterEpochPercentage) + "\n"
 }

--- a/aggsender/epoch_notifier_per_block.go
+++ b/aggsender/epoch_notifier_per_block.go
@@ -112,6 +112,15 @@ func (e *EpochNotifierPerBlock) Start(ctx context.Context) {
 	e.startInternal(ctx, eventNewBlockChannel)
 }
 
+// GetCurrentStatus returns the current status of the epoch
+func (e *EpochNotifierPerBlock) GetEpochStatus() types.EpochStatus {
+	currentBlock := e.blockNotifier.GetCurrentBlockNumber()
+	return types.EpochStatus{
+		Epoch:        e.epochNumber(currentBlock),
+		PercentEpoch: e.percentEpoch(currentBlock),
+	}
+}
+
 func (e *EpochNotifierPerBlock) startInternal(ctx context.Context, eventNewBlockChannel <-chan types.EventNewBlock) {
 	status := internalStatus{
 		lastBlockSeen:   e.Config.StartingEpochBlock,

--- a/aggsender/epoch_notifier_per_block_test.go
+++ b/aggsender/epoch_notifier_per_block_test.go
@@ -203,6 +203,14 @@ func TestBlockBeforeEpoch(t *testing.T) {
 	require.Equal(t, uint64(114), newStatus.lastBlockSeen)
 }
 
+func TestGetEpochStatus(t *testing.T) {
+	testData := newNotifierPerBlockTestData(t, nil)
+	testData.blockNotifierMock.EXPECT().GetCurrentBlockNumber().Return(uint64(105))
+	status := testData.sut.GetEpochStatus()
+	require.Equal(t, uint64(11), status.Epoch)
+	require.Equal(t, float64(0.5), status.PercentEpoch)
+}
+
 type notifierPerBlockTestData struct {
 	sut               *EpochNotifierPerBlock
 	blockNotifierMock *mocks.BlockNotifier

--- a/aggsender/mocks/mock_block_notifier.go
+++ b/aggsender/mocks/mock_block_notifier.go
@@ -20,6 +20,51 @@ func (_m *BlockNotifier) EXPECT() *BlockNotifier_Expecter {
 	return &BlockNotifier_Expecter{mock: &_m.Mock}
 }
 
+// GetCurrentBlockNumber provides a mock function with no fields
+func (_m *BlockNotifier) GetCurrentBlockNumber() uint64 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCurrentBlockNumber")
+	}
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
+// BlockNotifier_GetCurrentBlockNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCurrentBlockNumber'
+type BlockNotifier_GetCurrentBlockNumber_Call struct {
+	*mock.Call
+}
+
+// GetCurrentBlockNumber is a helper method to define mock.On call
+func (_e *BlockNotifier_Expecter) GetCurrentBlockNumber() *BlockNotifier_GetCurrentBlockNumber_Call {
+	return &BlockNotifier_GetCurrentBlockNumber_Call{Call: _e.mock.On("GetCurrentBlockNumber")}
+}
+
+func (_c *BlockNotifier_GetCurrentBlockNumber_Call) Run(run func()) *BlockNotifier_GetCurrentBlockNumber_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *BlockNotifier_GetCurrentBlockNumber_Call) Return(_a0 uint64) *BlockNotifier_GetCurrentBlockNumber_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *BlockNotifier_GetCurrentBlockNumber_Call) RunAndReturn(run func() uint64) *BlockNotifier_GetCurrentBlockNumber_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // String provides a mock function with no fields
 func (_m *BlockNotifier) String() string {
 	ret := _m.Called()

--- a/aggsender/mocks/mock_epoch_notifier.go
+++ b/aggsender/mocks/mock_epoch_notifier.go
@@ -22,6 +22,51 @@ func (_m *EpochNotifier) EXPECT() *EpochNotifier_Expecter {
 	return &EpochNotifier_Expecter{mock: &_m.Mock}
 }
 
+// GetEpochStatus provides a mock function with no fields
+func (_m *EpochNotifier) GetEpochStatus() types.EpochStatus {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEpochStatus")
+	}
+
+	var r0 types.EpochStatus
+	if rf, ok := ret.Get(0).(func() types.EpochStatus); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(types.EpochStatus)
+	}
+
+	return r0
+}
+
+// EpochNotifier_GetEpochStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEpochStatus'
+type EpochNotifier_GetEpochStatus_Call struct {
+	*mock.Call
+}
+
+// GetEpochStatus is a helper method to define mock.On call
+func (_e *EpochNotifier_Expecter) GetEpochStatus() *EpochNotifier_GetEpochStatus_Call {
+	return &EpochNotifier_GetEpochStatus_Call{Call: _e.mock.On("GetEpochStatus")}
+}
+
+func (_c *EpochNotifier_GetEpochStatus_Call) Run(run func()) *EpochNotifier_GetEpochStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EpochNotifier_GetEpochStatus_Call) Return(_a0 types.EpochStatus) *EpochNotifier_GetEpochStatus_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EpochNotifier_GetEpochStatus_Call) RunAndReturn(run func() types.EpochStatus) *EpochNotifier_GetEpochStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Start provides a mock function with given fields: ctx
 func (_m *EpochNotifier) Start(ctx context.Context) {
 	_m.Called(ctx)

--- a/aggsender/types/block_notifier.go
+++ b/aggsender/types/block_notifier.go
@@ -16,5 +16,6 @@ type EventNewBlock struct {
 type BlockNotifier interface {
 	// NotifyEpochStarted notifies the epoch has started.
 	Subscribe(id string) <-chan EventNewBlock
+	GetCurrentBlockNumber() uint64
 	String() string
 }

--- a/aggsender/types/epoch_notifier.go
+++ b/aggsender/types/epoch_notifier.go
@@ -12,6 +12,11 @@ type EpochEvent struct {
 	ExtraInfo fmt.Stringer
 }
 
+type EpochStatus struct {
+	Epoch        uint64
+	PercentEpoch float64
+}
+
 func (e EpochEvent) String() string {
 	return fmt.Sprintf("EpochEvent: epoch=%d extra=%s", e.Epoch, e.ExtraInfo)
 }
@@ -21,5 +26,7 @@ type EpochNotifier interface {
 	Subscribe(id string) <-chan EpochEvent
 	// Start starts the notifier synchronously
 	Start(ctx context.Context)
+	// GetEpochStatus returns the current status of the epoch
+	GetEpochStatus() EpochStatus
 	String() string
 }

--- a/common/rate_limit.go
+++ b/common/rate_limit.go
@@ -1,0 +1,91 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-synchronizer-l1/config/types"
+	"github.com/0xPolygonHermez/zkevm-synchronizer-l1/log"
+)
+
+var (
+	TimeProvider = time.Now
+)
+
+type RateLimitConfig struct {
+	NumRequests int            `mapstructure:"NumRequests"`
+	Interval    types.Duration `mapstructure:"Interval"`
+}
+
+func NewRateLimitConfig(numRequests int, period time.Duration) RateLimitConfig {
+	return RateLimitConfig{
+		NumRequests: numRequests,
+		Interval:    types.Duration{Duration: period},
+	}
+}
+
+func (r RateLimitConfig) String() string {
+	if !r.Enabled() {
+		return "RateLimitConfig{Unlimited}"
+	}
+	return fmt.Sprintf("RateLimitConfig{NumRequests: %d, Period: %s}", r.NumRequests, r.Interval)
+}
+
+func (r RateLimitConfig) Enabled() bool {
+	return r.NumRequests > 0 && r.Interval.Duration > 0
+}
+
+type RateLimit struct {
+	cfg RateLimitConfig
+	// Calls realized in the current period
+	bucket []time.Time
+}
+
+func NewRateLimit(cfg RateLimitConfig) RateLimit {
+	return RateLimit{
+		cfg: cfg,
+	}
+}
+
+func (r *RateLimit) String() string {
+	if r == nil {
+		return "RateLimit{nil}"
+	}
+	return fmt.Sprintf("RateLimit{cfg: %s, bucket len: %v}", r.cfg, len(r.bucket))
+}
+
+// This is a call
+func (r *RateLimit) Call(msg string, allowToSleep bool) *time.Duration {
+	if r == nil || !r.cfg.Enabled() {
+		return nil
+	}
+	var returnSleepTime *time.Duration
+	now := TimeProvider()
+	r.cleanOutdatedCalls(now)
+	if len(r.bucket) >= r.cfg.NumRequests {
+		sleepTime := r.cfg.Interval.Duration - TimeProvider().Sub(r.bucket[0])
+		if allowToSleep {
+			if msg != "" {
+				log.Debugf("Rate limit reached, sleeping for %s for %s", sleepTime, msg)
+			}
+			time.Sleep(sleepTime)
+		} else {
+			// If no sleep, ignore the call
+			return &sleepTime
+		}
+		returnSleepTime = &sleepTime
+	}
+	r.bucket = append(r.bucket, now)
+	return returnSleepTime
+}
+
+func (r *RateLimit) cleanOutdatedCalls(now time.Time) {
+	for i, call := range r.bucket {
+		diff := now.Sub(call)
+		if diff < r.cfg.Interval.Duration {
+			r.bucket = r.bucket[i:]
+			return
+		}
+	}
+	r.bucket = []time.Time{}
+}

--- a/common/rate_limit.go
+++ b/common/rate_limit.go
@@ -41,8 +41,8 @@ type RateLimit struct {
 	bucket []time.Time
 }
 
-func NewRateLimit(cfg RateLimitConfig) RateLimit {
-	return RateLimit{
+func NewRateLimit(cfg RateLimitConfig) *RateLimit {
+	return &RateLimit{
 		cfg: cfg,
 	}
 }

--- a/common/rate_limit.go
+++ b/common/rate_limit.go
@@ -12,11 +12,13 @@ var (
 	TimeProvider = time.Now
 )
 
+// RateLimitConfig is the configuration for the rate limit, if NumRequests==0 or Interval==0, the rate limit is disabled
 type RateLimitConfig struct {
 	NumRequests int            `mapstructure:"NumRequests"`
 	Interval    types.Duration `mapstructure:"Interval"`
 }
 
+// NewRateLimitConfig creates a new RateLimitConfig
 func NewRateLimitConfig(numRequests int, period time.Duration) RateLimitConfig {
 	return RateLimitConfig{
 		NumRequests: numRequests,
@@ -24,6 +26,7 @@ func NewRateLimitConfig(numRequests int, period time.Duration) RateLimitConfig {
 	}
 }
 
+// String returns a string representation of the RateLimitConfig
 func (r RateLimitConfig) String() string {
 	if !r.Enabled() {
 		return "RateLimitConfig{Unlimited}"
@@ -31,30 +34,34 @@ func (r RateLimitConfig) String() string {
 	return fmt.Sprintf("RateLimitConfig{NumRequests: %d, Period: %s}", r.NumRequests, r.Interval)
 }
 
+// Enabled returns true if the rate limit is enabled
 func (r RateLimitConfig) Enabled() bool {
 	return r.NumRequests > 0 && r.Interval.Duration > 0
 }
 
+// RateLimit is a rate limiter
 type RateLimit struct {
 	cfg RateLimitConfig
 	// Calls realized in the current period
-	bucket []time.Time
+	calls []time.Time
 }
 
+// NewRateLimit creates a new RateLimit
 func NewRateLimit(cfg RateLimitConfig) *RateLimit {
 	return &RateLimit{
 		cfg: cfg,
 	}
 }
 
+// String returns a string representation of the RateLimit
 func (r *RateLimit) String() string {
 	if r == nil {
 		return "RateLimit{nil}"
 	}
-	return fmt.Sprintf("RateLimit{cfg: %s, bucket len: %v}", r.cfg, len(r.bucket))
+	return fmt.Sprintf("RateLimit{cfg: %s, bucket len: %v}", r.cfg, len(r.calls))
 }
 
-// This is a call
+// Call is used before making a call, it will sleep if the rate limit is reached if param allowToSleep is true
 func (r *RateLimit) Call(msg string, allowToSleep bool) *time.Duration {
 	if r == nil || !r.cfg.Enabled() {
 		return nil
@@ -62,8 +69,8 @@ func (r *RateLimit) Call(msg string, allowToSleep bool) *time.Duration {
 	var returnSleepTime *time.Duration
 	now := TimeProvider()
 	r.cleanOutdatedCalls(now)
-	if len(r.bucket) >= r.cfg.NumRequests {
-		sleepTime := r.cfg.Interval.Duration - TimeProvider().Sub(r.bucket[0])
+	if len(r.calls) >= r.cfg.NumRequests {
+		sleepTime := r.cfg.Interval.Duration - TimeProvider().Sub(r.calls[0])
 		if allowToSleep {
 			if msg != "" {
 				log.Debugf("Rate limit reached, sleeping for %s for %s", sleepTime, msg)
@@ -75,17 +82,17 @@ func (r *RateLimit) Call(msg string, allowToSleep bool) *time.Duration {
 		}
 		returnSleepTime = &sleepTime
 	}
-	r.bucket = append(r.bucket, now)
+	r.calls = append(r.calls, now)
 	return returnSleepTime
 }
 
 func (r *RateLimit) cleanOutdatedCalls(now time.Time) {
-	for i, call := range r.bucket {
+	for i, call := range r.calls {
 		diff := now.Sub(call)
 		if diff < r.cfg.Interval.Duration {
-			r.bucket = r.bucket[i:]
+			r.calls = r.calls[i:]
 			return
 		}
 	}
-	r.bucket = []time.Time{}
+	r.calls = []time.Time{}
 }

--- a/common/rate_limit.go
+++ b/common/rate_limit.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-synchronizer-l1/config/types"
-	"github.com/0xPolygonHermez/zkevm-synchronizer-l1/log"
+	"github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/log"
 )
 
 var (

--- a/common/rate_limit_test.go
+++ b/common/rate_limit_test.go
@@ -59,3 +59,16 @@ func TestRateLimitDisabled(t *testing.T) {
 		require.Nil(t, sut.Call("test", false))
 	}
 }
+
+func TestRateLimitString(t *testing.T) {
+	rateLimit := &common.RateLimit{}
+	require.Equal(t, "RateLimit{cfg: RateLimitConfig{Unlimited}, bucket len: 0}", rateLimit.String())
+
+	var empty *common.RateLimit
+	require.Equal(t, "RateLimit{nil}", empty.String())
+}
+
+func TestRateLimitConfigString(t *testing.T) {
+	cfg := common.NewRateLimitConfig(2, time.Minute)
+	require.Equal(t, "RateLimitConfig{NumRequests: 2, Period: 1m0s}", cfg.String())
+}

--- a/common/rate_limit_test.go
+++ b/common/rate_limit_test.go
@@ -1,0 +1,61 @@
+package common_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimit(t *testing.T) {
+	now := time.Now()
+	common.TimeProvider = func() time.Time {
+		return now
+	}
+	sut := common.NewRateLimit(common.NewRateLimitConfig(2, time.Second))
+	require.Nil(t, sut.Call("test", false))
+	require.Nil(t, sut.Call("test", false))
+	sleepTime := sut.Call("test", false)
+	require.NotNil(t, sleepTime)
+	require.Equal(t, time.Second, *sleepTime)
+
+	common.TimeProvider = func() time.Time {
+		return now.Add(time.Second * 2)
+	}
+	require.Nil(t, sut.Call("test", false))
+	require.Nil(t, sut.Call("test", false))
+}
+
+func TestRateLimitSleepTime(t *testing.T) {
+	now := time.Now()
+	common.TimeProvider = func() time.Time {
+		return now
+	}
+	sut := common.NewRateLimit(common.NewRateLimitConfig(2, time.Minute))
+	require.Nil(t, sut.Call("test", false))
+	common.TimeProvider = func() time.Time {
+		return now.Add(time.Second * 55)
+	}
+	require.Nil(t, sut.Call("test", false))
+	sleepTime := sut.Call("test", false)
+	require.NotNil(t, sleepTime)
+	require.Equal(t, time.Second*5, *sleepTime)
+	common.TimeProvider = func() time.Time {
+		return now.Add(time.Second * 55).Add(time.Second * 4)
+	}
+	// It sleeps 1 second
+	sut.Call("test", true)
+}
+
+func TestRateLimitDisabled(t *testing.T) {
+	now := time.Now()
+	common.TimeProvider = func() time.Time {
+		return now
+	}
+	sut := common.NewRateLimit(common.NewRateLimitConfig(0, time.Minute))
+	require.Nil(t, sut.Call("test", false))
+	for i := 1; i <= 1000; i++ {
+		require.Nil(t, sut.Call("test", false))
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
@@ -27,6 +28,8 @@ func TestLoadDefaultConfig(t *testing.T) {
 	cfg, err := Load(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
+	require.Equal(t, cfg.AggSender.MaxSubmitCertificateRate.NumRequests, 20)
+	require.Equal(t, cfg.AggSender.MaxSubmitCertificateRate.Interval.Duration, time.Hour)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -219,4 +219,6 @@ MaxCertSize = 8388608
 BridgeMetadataAsHash = true
 DryRun = false
 EnableRPC = true
+CheckStatusCertificateInterval = "5m"
+RetryCertInmediatlyAfterInError = true
 `

--- a/config/default.go
+++ b/config/default.go
@@ -221,6 +221,8 @@ DryRun = false
 EnableRPC = true
 CheckStatusCertificateInterval = "5m"
 RetryCertInmediatlyAfterInError = true
+# Don't send certificate over 80% of the epoch
+ForbiddenSendCertificateAfterEpochPercentage=80
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1h"

--- a/config/default.go
+++ b/config/default.go
@@ -221,4 +221,8 @@ DryRun = false
 EnableRPC = true
 CheckStatusCertificateInterval = "5m"
 RetryCertInmediatlyAfterInError = true
+	[AggSender.MaxSubmitCertificateRate]
+		NumRequests = 20
+		Interval = "1h"
+
 `

--- a/config/default.go
+++ b/config/default.go
@@ -222,7 +222,7 @@ EnableRPC = true
 CheckStatusCertificateInterval = "5m"
 RetryCertInmediatlyAfterInError = true
 # Don't send certificate over 80% of the epoch
-ForbiddenSendCertificateAfterEpochPercentage=80
+MaxEpochPercentageAllowedToSendCertificate=80
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1h"

--- a/sync/mock_evm_downloader_full.go
+++ b/sync/mock_evm_downloader_full.go
@@ -53,7 +53,7 @@ func (_c *EVMDownloaderMock_Download_Call) Return() *EVMDownloaderMock_Download_
 }
 
 func (_c *EVMDownloaderMock_Download_Call) RunAndReturn(run func(context.Context, uint64, chan EVMBlock)) *EVMDownloaderMock_Download_Call {
-	_c.Call.Return(run)
+	_c.Run(run)
 	return _c
 }
 

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -47,5 +47,7 @@ Outputs = ["stderr"]
        
 [AggSender]
 SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}/"
+CheckStatusCertificateInterval = "1s"
+
 
 

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -48,6 +48,8 @@ Outputs = ["stderr"]
 [AggSender]
 SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}/"
 CheckStatusCertificateInterval = "1s"
-
+	[AggSender.MaxSubmitCertificateRate]
+		NumRequests = 20
+		Interval = "1m"
 
 


### PR DESCRIPTION
Fixes #47

## Description
- The `aggsender`is going to check periodically the status of certificates (`AggSender.CheckStatusCertificateInterval`) and rebuild certificate as soon as `InError`is detected.
- To avoid spamming Agglayer implements a rate limiter
- To avoid submit a certificate too close to end of a epoch avoid to send certificates after reaching a percentage of epoch.

## Configuration
```
[AggSender]
CheckStatusCertificateInterval = "5m"
```
- Rate limit configuration:
```
[AggSender.MaxSubmitCertificateRate]
		NumRequests = 20
		Interval = "1h"
```
It can be disabled setting `NumRequests` to 0

- Configuration of percentatge that we can't submit a new certificate to agglayer:
```
[AggSender]
MaxEpochPercentageAllowedToSendCertificate=80
```
A value of 0 or > 100 disable this check
