### PR TITLE
feat: allows reorg detectors configure the what kind of block is a finalized block

### DIFF
--- a/aggsender/block_notifier_polling_test.go
+++ b/aggsender/block_notifier_polling_test.go
@@ -149,7 +149,7 @@ func TestNewBlockNotifierPolling(t *testing.T) {
 	testData := newBlockNotifierPollingTestData(t, nil)
 	require.NotNil(t, testData.sut)
 	_, err := NewBlockNotifierPolling(testData.ethClientMock, ConfigBlockNotifierPolling{
-		BlockFinalityType: etherman.BlockNumberFinality("invalid"),
+		BlockFinalityType: etherman.NewBlockNumberFinality("invalid"),
 	}, log.WithFields("test", "test"), nil)
 	require.Error(t, err)
 }

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -207,22 +207,6 @@ func (s *BridgeSync) GetLastProcessedBlock(ctx context.Context) (uint64, error) 
 	return s.processor.GetLastProcessedBlock(ctx)
 }
 
-func (s *BridgeSync) GetLastRequestedBlock(ctx context.Context) (uint64, error) {
-	if s.processor.isHalted() {
-		return 0, sync.ErrInconsistentState
-	}
-	storageLastBlock, err := s.processor.GetLastProcessedBlock(ctx)
-	if err != nil {
-		return 0, err
-	}
-	downloaderLastBlock := s.downloader.LastBlockNumberRequested()
-	log.Infof("storage: %d downloader: %d", storageLastBlock, downloaderLastBlock)
-	if downloaderLastBlock > storageLastBlock {
-		return downloaderLastBlock, nil
-	}
-	return storageLastBlock, nil
-}
-
 func (s *BridgeSync) GetBridgeRootByHash(ctx context.Context, root common.Hash) (*tree.Root, error) {
 	if s.processor.isHalted() {
 		return nil, sync.ErrInconsistentState

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -29,6 +29,7 @@ type BridgeSync struct {
 
 	originNetwork uint32
 	reorgDetector ReorgDetector
+	blockFinality etherman.BlockNumberFinality
 }
 
 // NewL1 creates a bridge syncer that synchronizes the mainnet exit tree
@@ -152,7 +153,7 @@ func newBridgeSync(
 		appender,
 		[]common.Address{bridge},
 		rh,
-		rd.GetFinalizedBlock(),
+		rd.GetFinalizedBlockType(),
 	)
 	if err != nil {
 		return nil, err
@@ -192,6 +193,7 @@ func newBridgeSync(
 		downloader:    downloader,
 		originNetwork: originNetwork,
 		reorgDetector: rd,
+		blockFinality: blockFinalityType,
 	}, nil
 }
 
@@ -279,5 +281,5 @@ func (s *BridgeSync) OriginNetwork() uint32 {
 
 // BlockFinality returns the block finality type
 func (s *BridgeSync) BlockFinality() etherman.BlockNumberFinality {
-	return s.reorgDetector.GetFinalizedBlock()
+	return s.blockFinality
 }

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -43,7 +43,7 @@ func TestNewLx(t *testing.T) {
 	mockReorgDetector := mocksbridgesync.NewReorgDetector(t)
 
 	mockReorgDetector.EXPECT().Subscribe(mock.Anything).Return(nil, nil)
-	mockReorgDetector.EXPECT().GetFinalizedBlock().Return(blockFinalityType)
+	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 	l1BridgeSync, err := NewL1(
 		ctx,

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -31,19 +31,20 @@ func TestNewLx(t *testing.T) {
 	bridge := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 	const (
 		syncBlockChunkSize         = uint64(100)
-		blockFinalityType          = etherman.SafeBlock
 		initialBlock               = uint64(0)
 		waitForNewBlocksPeriod     = time.Second * 10
 		retryAfterErrorPeriod      = time.Second * 5
 		maxRetryAttemptsAfterError = 3
 		originNetwork              = uint32(1)
 	)
+	var blockFinalityType = etherman.SafeBlock
 
 	mockEthClient := mocksbridgesync.NewEthClienter(t)
 	mockReorgDetector := mocksbridgesync.NewReorgDetector(t)
 
 	mockReorgDetector.EXPECT().Subscribe(mock.Anything).Return(nil, nil)
-
+	mockReorgDetector.EXPECT().GetFinalizedBlock().Return(blockFinalityType)
+	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 	l1BridgeSync, err := NewL1(
 		ctx,
 		dbPath,
@@ -58,7 +59,6 @@ func TestNewLx(t *testing.T) {
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		blockFinalityType,
 	)
 
 	assert.NoError(t, err)
@@ -80,7 +80,6 @@ func TestNewLx(t *testing.T) {
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		blockFinalityType,
 	)
 
 	assert.NoError(t, err)

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -60,12 +60,12 @@ func TestBridgeEventE2E(t *testing.T) {
 		expectedBridges = append(expectedBridges, bridge)
 		expectedRoot, err := setup.L1Environment.BridgeContract.GetRoot(nil)
 		require.NoError(t, err)
-		finalizedBlock := GetFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
+		finalizedBlock := getFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
 		log.Infof("*** iteration: %d, Bridge Root: %s latestBlock:%d finalizedBlock:%d", i, common.Hash(expectedRoot).Hex(), bn, finalizedBlock)
 		bridgesSent++
 		bn, err = setup.L1Environment.SimBackend.Client().BlockNumber(ctx)
 		require.NoError(t, err)
-		finalizedBlockNumber := GetFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
+		finalizedBlockNumber := getFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
 		blocksToReorg := 1 + i%maxReorgDepth
 		// Trigger reorg but prevent to reorg a finalized block
 		if i%reorgEveryXIterations == 0 && bn-uint64(blocksToReorg) > finalizedBlockNumber {
@@ -101,7 +101,7 @@ func TestBridgeEventE2E(t *testing.T) {
 	// Wait for syncer to catch up
 	time.Sleep(time.Second * 2) // sleeping since the processor could be up to date, but have pending reorgs
 
-	lb := GetFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
+	lb := getFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
 	helpers.RequireProcessorUpdated(t, setup.L1Environment.BridgeSync, lb)
 
 	// Get bridges
@@ -127,7 +127,7 @@ func TestBridgeEventE2E(t *testing.T) {
 	require.Equal(t, expectedBridges, actualBridges)
 }
 
-func GetFinalizedBlockNumber(t *testing.T, ctx context.Context, client simulated.Client) uint64 {
+func getFinalizedBlockNumber(t *testing.T, ctx context.Context, client simulated.Client) uint64 {
 	t.Helper()
 	lastBlockFinalityType, err := etherman.FinalizedBlock.ToBlockNum()
 	require.NoError(t, err)

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/agglayer/aggkit/bridgesync"
+	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/test/helpers"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,13 +58,19 @@ func TestBridgeEventE2E(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 		expectedBridges = append(expectedBridges, bridge)
+		expectedRoot, err := setup.L1Environment.BridgeContract.GetRoot(nil)
+		require.NoError(t, err)
+		finalizedBlock := GetFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
+		log.Infof("*** iteration: %d, Bridge Root: %s latestBlock:%d finalizedBlock:%d", i, common.Hash(expectedRoot).Hex(), bn, finalizedBlock)
 		bridgesSent++
-
-		// Trigger reorg
-		if i%reorgEveryXIterations == 0 {
-			blocksToReorg := 1 + i%maxReorgDepth
-			bn, err := setup.L1Environment.SimBackend.Client().BlockNumber(ctx)
-			require.NoError(t, err)
+		bn, err = setup.L1Environment.SimBackend.Client().BlockNumber(ctx)
+		require.NoError(t, err)
+		finalizedBlockNumber := GetFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
+		blocksToReorg := 1 + i%maxReorgDepth
+		// Trigger reorg but prevent to reorg a finalized block
+		if i%reorgEveryXIterations == 0 && bn-uint64(blocksToReorg) > finalizedBlockNumber {
+			log.Infof("*** Reorg iteration: %d, Reorging %d blocks. From block: %d to %d. finalizedBlockNumber: %d",
+				i, blocksToReorg, bn, bn-uint64(blocksToReorg), finalizedBlockNumber)
 			helpers.Reorg(t, setup.L1Environment.SimBackend, uint64(blocksToReorg))
 			// Clean expected bridges
 			lastValidBlock := bn - uint64(blocksToReorg)
@@ -92,21 +100,38 @@ func TestBridgeEventE2E(t *testing.T) {
 
 	// Wait for syncer to catch up
 	time.Sleep(time.Second * 2) // sleeping since the processor could be up to date, but have pending reorgs
-	lb, err := setup.L1Environment.SimBackend.Client().BlockNumber(ctx)
-	require.NoError(t, err)
+
+	lb := GetFinalizedBlockNumber(t, ctx, setup.L1Environment.SimBackend.Client())
 	helpers.RequireProcessorUpdated(t, setup.L1Environment.BridgeSync, lb)
 
 	// Get bridges
 	lastBlock, err := setup.L1Environment.SimBackend.Client().BlockNumber(ctx)
 	require.NoError(t, err)
-	actualBridges, err := setup.L1Environment.BridgeSync.GetBridges(ctx, 0, lastBlock)
+	lastProcessedBlock, err := setup.L1Environment.BridgeSync.GetLastProcessedBlock(ctx)
 	require.NoError(t, err)
-
+	actualBridges, err := setup.L1Environment.BridgeSync.GetBridges(ctx, 0, lastProcessedBlock)
+	require.NoError(t, err)
+	log.Infof("lastBlockOnChain:%d lastProcessedBlock: %d, len(actualBridges): %d", lb, lastProcessedBlock, len(actualBridges))
 	// Assert bridges
 	expectedRoot, err := setup.L1Environment.BridgeContract.GetRoot(nil)
 	require.NoError(t, err)
 	root, err := setup.L1Environment.BridgeSync.GetExitRootByIndex(ctx, expectedBridges[len(expectedBridges)-1].DepositCount)
 	require.NoError(t, err)
+	log.Infof("expectedRoot: %s lastBlock: %d lastFinalized:%d DepositCount:%d ", common.Hash(expectedRoot).Hex(), lastBlock, lb, expectedBridges[len(expectedBridges)-1].DepositCount)
+	for i := 119; i >= 00; i-- {
+		root, err := setup.L1Environment.BridgeSync.GetExitRootByIndex(ctx, uint32(i))
+		require.NoError(t, err)
+		log.Infof("DepositCount:%d root: %s", i, root.Hash.Hex())
+	}
 	require.Equal(t, common.Hash(expectedRoot).Hex(), root.Hash.Hex())
 	require.Equal(t, expectedBridges, actualBridges)
+}
+
+func GetFinalizedBlockNumber(t *testing.T, ctx context.Context, client simulated.Client) uint64 {
+	t.Helper()
+	lastBlockFinalityType, err := etherman.FinalizedBlock.ToBlockNum()
+	require.NoError(t, err)
+	lastBlockHeader, err := client.HeaderByNumber(ctx, lastBlockFinalityType)
+	require.NoError(t, err)
+	return lastBlockHeader.Number.Uint64()
 }

--- a/bridgesync/mocks/mock_reorg_detector.go
+++ b/bridgesync/mocks/mock_reorg_detector.go
@@ -7,6 +7,8 @@ import (
 
 	common "github.com/ethereum/go-ethereum/common"
 
+	etherman "github.com/agglayer/aggkit/etherman"
+
 	mock "github.com/stretchr/testify/mock"
 
 	reorgdetector "github.com/agglayer/aggkit/reorgdetector"
@@ -70,6 +72,96 @@ func (_c *ReorgDetector_AddBlockToTrack_Call) Return(_a0 error) *ReorgDetector_A
 }
 
 func (_c *ReorgDetector_AddBlockToTrack_Call) RunAndReturn(run func(context.Context, string, uint64, common.Hash) error) *ReorgDetector_AddBlockToTrack_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFinalizedBlock provides a mock function with no fields
+func (_m *ReorgDetector) GetFinalizedBlock() etherman.BlockNumberFinality {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFinalizedBlock")
+	}
+
+	var r0 etherman.BlockNumberFinality
+	if rf, ok := ret.Get(0).(func() etherman.BlockNumberFinality); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(etherman.BlockNumberFinality)
+	}
+
+	return r0
+}
+
+// ReorgDetector_GetFinalizedBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlock'
+type ReorgDetector_GetFinalizedBlock_Call struct {
+	*mock.Call
+}
+
+// GetFinalizedBlock is a helper method to define mock.On call
+func (_e *ReorgDetector_Expecter) GetFinalizedBlock() *ReorgDetector_GetFinalizedBlock_Call {
+	return &ReorgDetector_GetFinalizedBlock_Call{Call: _e.mock.On("GetFinalizedBlock")}
+}
+
+func (_c *ReorgDetector_GetFinalizedBlock_Call) Run(run func()) *ReorgDetector_GetFinalizedBlock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ReorgDetector_GetFinalizedBlock_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetector_GetFinalizedBlock_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorgDetector_GetFinalizedBlock_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetector_GetFinalizedBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// String provides a mock function with no fields
+func (_m *ReorgDetector) String() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for String")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// ReorgDetector_String_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'String'
+type ReorgDetector_String_Call struct {
+	*mock.Call
+}
+
+// String is a helper method to define mock.On call
+func (_e *ReorgDetector_Expecter) String() *ReorgDetector_String_Call {
+	return &ReorgDetector_String_Call{Call: _e.mock.On("String")}
+}
+
+func (_c *ReorgDetector_String_Call) Run(run func()) *ReorgDetector_String_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ReorgDetector_String_Call) Return(_a0 string) *ReorgDetector_String_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorgDetector_String_Call) RunAndReturn(run func() string) *ReorgDetector_String_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/bridgesync/mocks/mock_reorg_detector.go
+++ b/bridgesync/mocks/mock_reorg_detector.go
@@ -76,12 +76,12 @@ func (_c *ReorgDetector_AddBlockToTrack_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// GetFinalizedBlock provides a mock function with no fields
-func (_m *ReorgDetector) GetFinalizedBlock() etherman.BlockNumberFinality {
+// GetFinalizedBlockType provides a mock function with no fields
+func (_m *ReorgDetector) GetFinalizedBlockType() etherman.BlockNumberFinality {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFinalizedBlock")
+		panic("no return value specified for GetFinalizedBlockType")
 	}
 
 	var r0 etherman.BlockNumberFinality
@@ -94,29 +94,29 @@ func (_m *ReorgDetector) GetFinalizedBlock() etherman.BlockNumberFinality {
 	return r0
 }
 
-// ReorgDetector_GetFinalizedBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlock'
-type ReorgDetector_GetFinalizedBlock_Call struct {
+// ReorgDetector_GetFinalizedBlockType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlockType'
+type ReorgDetector_GetFinalizedBlockType_Call struct {
 	*mock.Call
 }
 
-// GetFinalizedBlock is a helper method to define mock.On call
-func (_e *ReorgDetector_Expecter) GetFinalizedBlock() *ReorgDetector_GetFinalizedBlock_Call {
-	return &ReorgDetector_GetFinalizedBlock_Call{Call: _e.mock.On("GetFinalizedBlock")}
+// GetFinalizedBlockType is a helper method to define mock.On call
+func (_e *ReorgDetector_Expecter) GetFinalizedBlockType() *ReorgDetector_GetFinalizedBlockType_Call {
+	return &ReorgDetector_GetFinalizedBlockType_Call{Call: _e.mock.On("GetFinalizedBlockType")}
 }
 
-func (_c *ReorgDetector_GetFinalizedBlock_Call) Run(run func()) *ReorgDetector_GetFinalizedBlock_Call {
+func (_c *ReorgDetector_GetFinalizedBlockType_Call) Run(run func()) *ReorgDetector_GetFinalizedBlockType_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *ReorgDetector_GetFinalizedBlock_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetector_GetFinalizedBlock_Call {
+func (_c *ReorgDetector_GetFinalizedBlockType_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetector_GetFinalizedBlockType_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ReorgDetector_GetFinalizedBlock_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetector_GetFinalizedBlock_Call {
+func (_c *ReorgDetector_GetFinalizedBlockType_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetector_GetFinalizedBlockType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -128,7 +128,7 @@ func createAggSender(
 	logger := log.WithFields("module", aggkitcommon.AGGSENDER)
 	agglayerClient := agglayer.NewAggLayerClient(cfg.AggLayerURL)
 	blockNotifier, err := aggsender.NewBlockNotifierPolling(l1EthClient, aggsender.ConfigBlockNotifierPolling{
-		BlockFinalityType:     etherman.BlockNumberFinality(cfg.BlockFinality),
+		BlockFinalityType:     etherman.NewBlockNumberFinality(cfg.BlockFinality),
 		CheckNewBlockInterval: aggsender.AutomaticBlockInterval,
 	}, logger, nil)
 	if err != nil {
@@ -212,7 +212,7 @@ func createAggoracle(
 		sender,
 		l1Client,
 		syncer,
-		etherman.BlockNumberFinality(cfg.AggOracle.BlockFinality),
+		etherman.NewBlockNumberFinality(cfg.AggOracle.BlockFinality),
 		cfg.AggOracle.WaitPeriodNextGER.Duration,
 	)
 	if err != nil {
@@ -294,7 +294,7 @@ func runL1InfoTreeSyncerIfNeeded(
 		cfg.L1InfoTreeSync.GlobalExitRootAddr,
 		cfg.L1InfoTreeSync.RollupManagerAddr,
 		cfg.L1InfoTreeSync.SyncBlockChunkSize,
-		etherman.BlockNumberFinality(cfg.L1InfoTreeSync.BlockFinality),
+		etherman.NewBlockNumberFinality(cfg.L1InfoTreeSync.BlockFinality),
 		reorgDetector,
 		l1Client,
 		cfg.L1InfoTreeSync.WaitForNewBlocksPeriod.Duration,
@@ -465,7 +465,7 @@ func runLastGERSyncIfNeeded(
 		l1InfoTreeSync,
 		cfg.RetryAfterErrorPeriod.Duration,
 		cfg.MaxRetryAttemptsAfterError,
-		etherman.BlockNumberFinality(cfg.BlockFinality),
+		etherman.NewBlockNumberFinality(cfg.BlockFinality),
 		cfg.WaitForNewBlocksPeriod.Duration,
 		cfg.DownloadBufferSize,
 	)
@@ -494,7 +494,7 @@ func runBridgeSyncL1IfNeeded(
 		cfg.DBPath,
 		cfg.BridgeAddr,
 		cfg.SyncBlockChunkSize,
-		etherman.BlockNumberFinality(cfg.BlockFinality),
+		etherman.NewBlockNumberFinality(cfg.BlockFinality),
 		reorgDetectorL1,
 		l1Client,
 		cfg.InitialBlockNum,
@@ -503,7 +503,6 @@ func runBridgeSyncL1IfNeeded(
 		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
 		false,
-		etherman.FinalizedBlock,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -530,7 +529,7 @@ func runBridgeSyncL2IfNeeded(
 		cfg.DBPath,
 		cfg.BridgeAddr,
 		cfg.SyncBlockChunkSize,
-		etherman.BlockNumberFinality(cfg.BlockFinality),
+		etherman.NewBlockNumberFinality(cfg.BlockFinality),
 		reorgDetectorL2,
 		l2Client,
 		cfg.InitialBlockNum,
@@ -539,7 +538,6 @@ func runBridgeSyncL2IfNeeded(
 		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
 		true,
-		etherman.LatestBlock,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agglayer/aggkit/etherman"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
@@ -28,6 +29,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 	cfg, err := Load(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
+	require.Equal(t, etherman.FinalizedBlock, cfg.ReorgDetectorL1.FinalizedBlock)
 	require.Equal(t, cfg.AggSender.MaxSubmitCertificateRate.NumRequests, 20)
 	require.Equal(t, cfg.AggSender.MaxSubmitCertificateRate.Interval.Duration, time.Hour)
 }

--- a/config/default.go
+++ b/config/default.go
@@ -77,9 +77,11 @@ ContractVersions = "{{ContractVersions}}"
 
 [ReorgDetectorL1]
 DBPath = "{{PathRWData}}/reorgdetectorl1.sqlite"
+FinalizedBlock="FinalizedBlock"
 
 [ReorgDetectorL2]
 DBPath = "{{PathRWData}}/reorgdetectorl2.sqlite"
+FinalizedBlock="LatestBlock"
 
 [L1InfoTreeSync]
 DBPath = "{{PathRWData}}/L1InfoTreeSync.sqlite"

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -154,7 +154,7 @@ func (BlockNumberFinality) JSONSchema() *jsonschema.Schema {
 	}
 }
 
-func (b BlockNumberFinality) IsFinalized() bool {
+func (b BlockNumberFinality) IsFinalized() bool { //nolint:stylecheck
 	return b == FinalizedBlock
 }
 

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -154,6 +154,10 @@ func (BlockNumberFinality) JSONSchema() *jsonschema.Schema {
 	}
 }
 
+func (b BlockNumberFinality) IsEmpty() bool { //nolint:stylecheck
+	return b.string == ""
+}
+
 func (b BlockNumberFinality) IsFinalized() bool { //nolint:stylecheck
 	return b == FinalizedBlock
 }

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonvalidiumetrog"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/invopop/jsonschema"
 )
 
 // Block struct
@@ -93,30 +95,62 @@ type ForkID struct {
 	Version     string
 }
 
-type BlockNumberFinality string
+type BlockNumberFinality struct {
+	string `validate:"required"`
+}
 
-const (
-	SafeBlock      = BlockNumberFinality("SafeBlock")
-	FinalizedBlock = BlockNumberFinality("FinalizedBlock")
-	LatestBlock    = BlockNumberFinality("LatestBlock")
-	PendingBlock   = BlockNumberFinality("PendingBlock")
-	EarliestBlock  = BlockNumberFinality("EarliestBlock")
+func NewBlockNumberFinality(s string) BlockNumberFinality {
+	return BlockNumberFinality{s}
+}
+
+var (
+	SafeBlock      = BlockNumberFinality{"SafeBlock"}
+	FinalizedBlock = BlockNumberFinality{"FinalizedBlock"}
+	LatestBlock    = BlockNumberFinality{"LatestBlock"}
+	PendingBlock   = BlockNumberFinality{"PendingBlock"}
+	EarliestBlock  = BlockNumberFinality{"EarliestBlock"}
 )
 
 func (b *BlockNumberFinality) ToBlockNum() (*big.Int, error) {
-	switch *b {
-	case FinalizedBlock:
+	switch strings.ToUpper(b.String()) {
+	case strings.ToUpper(FinalizedBlock.String()):
 		return big.NewInt(int64(Finalized)), nil
-	case SafeBlock:
+	case strings.ToUpper(SafeBlock.String()):
 		return big.NewInt(int64(Safe)), nil
-	case PendingBlock:
+	case strings.ToUpper(PendingBlock.String()):
 		return big.NewInt(int64(Pending)), nil
-	case LatestBlock:
+	case strings.ToUpper(LatestBlock.String()):
 		return big.NewInt(int64(Latest)), nil
-	case EarliestBlock:
+	case strings.ToUpper(EarliestBlock.String()):
 		return big.NewInt(int64(Earliest)), nil
 	default:
-		return nil, fmt.Errorf("invalid finality keyword: %s", string(*b))
+		return nil, fmt.Errorf("invalid finality keyword: %s", b.String())
+	}
+}
+func (b BlockNumberFinality) String() string {
+	return b.string
+}
+
+// UnmarshalText unmarshalls BlockNumberFinality from text.
+func (d *BlockNumberFinality) UnmarshalText(data []byte) error {
+	res := BlockNumberFinality{string(data)}
+	_, err := res.ToBlockNum()
+	if err != nil {
+		return fmt.Errorf("failed to parse BlockNumberFinality %s: %w", string(data), err)
+	}
+	d.string = res.string
+	return nil
+}
+
+func (BlockNumberFinality) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:        "string",
+		Title:       "BlockNumberFinality",
+		Description: "BlockNumberFinality is a block finality name",
+		Examples: []interface{}{
+			"SafeBlock",
+			"LatestBlock",
+		},
 	}
 }
 

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -158,7 +158,7 @@ func (b BlockNumberFinality) IsEmpty() bool { //nolint:stylecheck
 	return b.string == ""
 }
 
-func (b BlockNumberFinality) IsFinalized() bool { //nolint:stylecheck
+func (b BlockNumberFinality) IsFinalized() bool {
 	return b == FinalizedBlock
 }
 

--- a/etherman/types_test.go
+++ b/etherman/types_test.go
@@ -1,0 +1,61 @@
+package etherman
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockNumberFinality(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		expectedResult BlockNumberFinality
+		expectedErr    error
+	}{
+		{
+			name:           "valid finalized block",
+			input:          "FinalizedBlock",
+			expectedResult: FinalizedBlock,
+		},
+		{
+			name:           "valid safe block",
+			input:          "SafeBlock",
+			expectedResult: SafeBlock,
+		},
+		{
+			name:           "valid pending block",
+			input:          "PendingBlock",
+			expectedResult: PendingBlock,
+		},
+		{
+			name:           "valid latest block",
+			input:          "LatestBlock",
+			expectedResult: LatestBlock,
+		},
+		{
+			name:           "valid earliest block",
+			input:          "EarliestBlock",
+			expectedResult: EarliestBlock,
+		},
+		{
+			name:        "invalid block",
+			input:       "InvalidBlock",
+			expectedErr: fmt.Errorf("invalid finality keyword: InvalidBlock"),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var b BlockNumberFinality
+			err := b.UnmarshalText([]byte(testCase.input))
+
+			if testCase.expectedErr == nil {
+				require.Equal(t, testCase.expectedResult, b)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), testCase.expectedErr.Error())
+			}
+		})
+	}
+}

--- a/etherman/types_test.go
+++ b/etherman/types_test.go
@@ -59,3 +59,9 @@ func TestBlockNumberFinality(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockNumberFinalityJSONSchema(t *testing.T) {
+	schema := BlockNumberFinality{}.JSONSchema()
+	require.Equal(t, "string", schema.Type)
+	require.Equal(t, "BlockNumberFinality", schema.Title)
+}

--- a/l1infotreesync/mocks/mock_reorg_detector.go
+++ b/l1infotreesync/mocks/mock_reorg_detector.go
@@ -76,12 +76,12 @@ func (_c *ReorgDetectorMock_AddBlockToTrack_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// GetFinalizedBlock provides a mock function with no fields
-func (_m *ReorgDetectorMock) GetFinalizedBlock() etherman.BlockNumberFinality {
+// GetFinalizedBlockType provides a mock function with no fields
+func (_m *ReorgDetectorMock) GetFinalizedBlockType() etherman.BlockNumberFinality {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFinalizedBlock")
+		panic("no return value specified for GetFinalizedBlockType")
 	}
 
 	var r0 etherman.BlockNumberFinality
@@ -94,29 +94,29 @@ func (_m *ReorgDetectorMock) GetFinalizedBlock() etherman.BlockNumberFinality {
 	return r0
 }
 
-// ReorgDetectorMock_GetFinalizedBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlock'
-type ReorgDetectorMock_GetFinalizedBlock_Call struct {
+// ReorgDetectorMock_GetFinalizedBlockType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlockType'
+type ReorgDetectorMock_GetFinalizedBlockType_Call struct {
 	*mock.Call
 }
 
-// GetFinalizedBlock is a helper method to define mock.On call
-func (_e *ReorgDetectorMock_Expecter) GetFinalizedBlock() *ReorgDetectorMock_GetFinalizedBlock_Call {
-	return &ReorgDetectorMock_GetFinalizedBlock_Call{Call: _e.mock.On("GetFinalizedBlock")}
+// GetFinalizedBlockType is a helper method to define mock.On call
+func (_e *ReorgDetectorMock_Expecter) GetFinalizedBlockType() *ReorgDetectorMock_GetFinalizedBlockType_Call {
+	return &ReorgDetectorMock_GetFinalizedBlockType_Call{Call: _e.mock.On("GetFinalizedBlockType")}
 }
 
-func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Run(run func()) *ReorgDetectorMock_GetFinalizedBlock_Call {
+func (_c *ReorgDetectorMock_GetFinalizedBlockType_Call) Run(run func()) *ReorgDetectorMock_GetFinalizedBlockType_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+func (_c *ReorgDetectorMock_GetFinalizedBlockType_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlockType_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+func (_c *ReorgDetectorMock_GetFinalizedBlockType_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlockType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/l1infotreesync/mocks/mock_reorg_detector.go
+++ b/l1infotreesync/mocks/mock_reorg_detector.go
@@ -7,6 +7,8 @@ import (
 
 	common "github.com/ethereum/go-ethereum/common"
 
+	etherman "github.com/agglayer/aggkit/etherman"
+
 	mock "github.com/stretchr/testify/mock"
 
 	reorgdetector "github.com/agglayer/aggkit/reorgdetector"
@@ -70,6 +72,96 @@ func (_c *ReorgDetectorMock_AddBlockToTrack_Call) Return(_a0 error) *ReorgDetect
 }
 
 func (_c *ReorgDetectorMock_AddBlockToTrack_Call) RunAndReturn(run func(context.Context, string, uint64, common.Hash) error) *ReorgDetectorMock_AddBlockToTrack_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFinalizedBlock provides a mock function with no fields
+func (_m *ReorgDetectorMock) GetFinalizedBlock() etherman.BlockNumberFinality {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFinalizedBlock")
+	}
+
+	var r0 etherman.BlockNumberFinality
+	if rf, ok := ret.Get(0).(func() etherman.BlockNumberFinality); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(etherman.BlockNumberFinality)
+	}
+
+	return r0
+}
+
+// ReorgDetectorMock_GetFinalizedBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlock'
+type ReorgDetectorMock_GetFinalizedBlock_Call struct {
+	*mock.Call
+}
+
+// GetFinalizedBlock is a helper method to define mock.On call
+func (_e *ReorgDetectorMock_Expecter) GetFinalizedBlock() *ReorgDetectorMock_GetFinalizedBlock_Call {
+	return &ReorgDetectorMock_GetFinalizedBlock_Call{Call: _e.mock.On("GetFinalizedBlock")}
+}
+
+func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Run(run func()) *ReorgDetectorMock_GetFinalizedBlock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// String provides a mock function with no fields
+func (_m *ReorgDetectorMock) String() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for String")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// ReorgDetectorMock_String_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'String'
+type ReorgDetectorMock_String_Call struct {
+	*mock.Call
+}
+
+// String is a helper method to define mock.On call
+func (_e *ReorgDetectorMock_Expecter) String() *ReorgDetectorMock_String_Call {
+	return &ReorgDetectorMock_String_Call{Call: _e.mock.On("String")}
+}
+
+func (_c *ReorgDetectorMock_String_Call) Run(run func()) *ReorgDetectorMock_String_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ReorgDetectorMock_String_Call) Return(_a0 string) *ReorgDetectorMock_String_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorgDetectorMock_String_Call) RunAndReturn(run func() string) *ReorgDetectorMock_String_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/reorgdetector/config.go
+++ b/reorgdetector/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/etherman"
 )
 
 const (
@@ -17,6 +18,11 @@ type Config struct {
 
 	// CheckReorgsInterval is the interval to check for reorgs in tracked blocks
 	CheckReorgsInterval types.Duration `mapstructure:"CheckReorgsInterval"`
+	// FinalizedBlockType indicates the status of the blocks that will be queried in order to sync
+	// if finalizedBlock == "LatestBlock" then is like to disable reorg detector beacuse
+	// there are no chances to reorg
+	FinalizedBlock etherman.BlockNumberFinality `jsonschema:"enum=LatestBlock, enum=SafeBlock, enum=PendingBlock, enum=FinalizedBlock, enum=EarliestBlock" mapstructure:"FinalizedBlock"` //nolint:lll
+
 }
 
 // GetCheckReorgsInterval returns the interval to check for reorgs in tracked blocks

--- a/reorgdetector/config.go
+++ b/reorgdetector/config.go
@@ -19,8 +19,7 @@ type Config struct {
 	// CheckReorgsInterval is the interval to check for reorgs in tracked blocks
 	CheckReorgsInterval types.Duration `mapstructure:"CheckReorgsInterval"`
 	// FinalizedBlockType indicates the status of the blocks that will be queried in order to sync
-	// if finalizedBlock == "LatestBlock" then is like to disable reorg detector
-	// there are no chances to reorg
+	// if finalizedBlock == "LatestBlock" then it's disabled and we assume the network has no chances of reorgs
 	FinalizedBlock etherman.BlockNumberFinality `jsonschema:"enum=LatestBlock, enum=SafeBlock, enum=PendingBlock, enum=FinalizedBlock, enum=EarliestBlock" mapstructure:"FinalizedBlock"` //nolint:lll
 
 }

--- a/reorgdetector/config.go
+++ b/reorgdetector/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// CheckReorgsInterval is the interval to check for reorgs in tracked blocks
 	CheckReorgsInterval types.Duration `mapstructure:"CheckReorgsInterval"`
 	// FinalizedBlockType indicates the status of the blocks that will be queried in order to sync
-	// if finalizedBlock == "LatestBlock" then is like to disable reorg detector beacuse
+	// if finalizedBlock == "LatestBlock" then is like to disable reorg detector
 	// there are no chances to reorg
 	FinalizedBlock etherman.BlockNumberFinality `jsonschema:"enum=LatestBlock, enum=SafeBlock, enum=PendingBlock, enum=FinalizedBlock, enum=EarliestBlock" mapstructure:"FinalizedBlock"` //nolint:lll
 

--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -39,7 +39,7 @@ type ReorgDetector struct {
 	client               EthClient
 	db                   *sql.DB
 	checkReorgInterval   time.Duration
-	finalizedBlockName   etherman.BlockNumberFinality
+	finalizedBlockType   etherman.BlockNumberFinality
 	finalizedBlockNumber *big.Int
 	network              Network
 
@@ -76,7 +76,7 @@ func New(client EthClient, cfg Config, network Network) (*ReorgDetector, error) 
 		client:               client,
 		db:                   db,
 		checkReorgInterval:   cfg.GetCheckReorgsInterval(),
-		finalizedBlockName:   cfg.FinalizedBlock,
+		finalizedBlockType:   cfg.FinalizedBlock,
 		finalizedBlockNumber: finalizedBlockNumber,
 		network:              network,
 		trackedBlocks:        make(map[string]*headersList),
@@ -86,7 +86,7 @@ func New(client EthClient, cfg Config, network Network) (*ReorgDetector, error) 
 }
 
 func (rd *ReorgDetector) IsDisabled() bool {
-	return rd.finalizedBlockName == etherman.LatestBlock
+	return rd.finalizedBlockType == etherman.LatestBlock
 }
 
 // Start starts the reorg detector
@@ -120,12 +120,12 @@ func (rd *ReorgDetector) String() string {
 		return "ReorgDetector{nil}"
 	}
 	return fmt.Sprintf("ReorgDetector{network: %s, finalized: %v, check_interval: %s}",
-		rd.network, rd.finalizedBlockName, rd.checkReorgInterval)
+		rd.network, rd.finalizedBlockType, rd.checkReorgInterval)
 }
 
-// GetFinalizedBlock returns the finalized block name
-func (rd *ReorgDetector) GetFinalizedBlock() etherman.BlockNumberFinality {
-	return rd.finalizedBlockName
+// GetFinalizedBlockType returns the finalized block name
+func (rd *ReorgDetector) GetFinalizedBlockType() etherman.BlockNumberFinality {
+	return rd.finalizedBlockType
 }
 
 // AddBlockToTrack adds a block to the tracked list for a subscriber

--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -119,7 +119,7 @@ func (rd *ReorgDetector) String() string {
 	if rd == nil {
 		return "ReorgDetector{nil}"
 	}
-	return fmt.Sprintf("ReorgDetector{%s, %v, %s}",
+	return fmt.Sprintf("ReorgDetector{network: %s, finalized: %v, check_interval: %s}",
 		rd.network, rd.finalizedBlockName, rd.checkReorgInterval)
 }
 

--- a/reorgdetector/reorgdetector_test.go
+++ b/reorgdetector/reorgdetector_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	aggkittypes "github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/etherman"
 	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
@@ -28,7 +29,12 @@ func Test_ReorgDetector(t *testing.T) {
 	// Create test DB dir
 	testDir := path.Join(t.TempDir(), "reorgdetectorTest_ReorgDetector.sqlite")
 
-	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: aggkittypes.NewDuration(time.Millisecond * 100)}, L1)
+	reorgDetector, err := New(clientL1.Client(),
+		Config{
+			DBPath:              testDir,
+			CheckReorgsInterval: aggkittypes.NewDuration(time.Millisecond * 100),
+			FinalizedBlock:      etherman.FinalizedBlock,
+		}, L1)
 	require.NoError(t, err)
 
 	err = reorgDetector.Start(ctx)

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -42,7 +42,6 @@ type EVMDownloader struct {
 	log                        *log.Logger
 	finalizedBlockType         etherman.BlockNumberFinality
 	stopDownloaderOnIterationN int
-	lastBlockNumberRequested   uint64
 }
 
 func NewEVMDownloader(
@@ -154,7 +153,6 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 		blocks := d.GetEventsByBlockRange(ctx, fromBlock, requestToBlock)
 		d.log.Debugf("result events from blocks [%d to  %d] -> len(blocks)=%d",
 			fromBlock, requestToBlock, len(blocks))
-		d.lastBlockNumberRequested = requestToBlock
 		if toBlock <= lastFinalizedBlockNumber {
 			d.reportBlocks(downloadedCh, blocks, lastFinalizedBlockNumber)
 			if blocks.Len() == 0 || blocks[blocks.Len()-1].Num < toBlock {

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -47,7 +47,7 @@ type processorInterface interface {
 type ReorgDetector interface {
 	Subscribe(id string) (*reorgdetector.Subscription, error)
 	AddBlockToTrack(ctx context.Context, id string, blockNum uint64, blockHash common.Hash) error
-	GetFinalizedBlock() etherman.BlockNumberFinality
+	GetFinalizedBlockType() etherman.BlockNumberFinality
 	String() string
 }
 

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/ethereum/go-ethereum/common"
@@ -46,6 +47,8 @@ type processorInterface interface {
 type ReorgDetector interface {
 	Subscribe(id string) (*reorgdetector.Subscription, error)
 	AddBlockToTrack(ctx context.Context, id string, blockNum uint64, blockHash common.Hash) error
+	GetFinalizedBlock() etherman.BlockNumberFinality
+	String() string
 }
 
 func NewEVMDriver(

--- a/sync/mock_reorg_detector.go
+++ b/sync/mock_reorg_detector.go
@@ -76,12 +76,12 @@ func (_c *ReorgDetectorMock_AddBlockToTrack_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// GetFinalizedBlock provides a mock function with no fields
-func (_m *ReorgDetectorMock) GetFinalizedBlock() etherman.BlockNumberFinality {
+// GetFinalizedBlockType provides a mock function with no fields
+func (_m *ReorgDetectorMock) GetFinalizedBlockType() etherman.BlockNumberFinality {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFinalizedBlock")
+		panic("no return value specified for GetFinalizedBlockType")
 	}
 
 	var r0 etherman.BlockNumberFinality
@@ -94,29 +94,29 @@ func (_m *ReorgDetectorMock) GetFinalizedBlock() etherman.BlockNumberFinality {
 	return r0
 }
 
-// ReorgDetectorMock_GetFinalizedBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlock'
-type ReorgDetectorMock_GetFinalizedBlock_Call struct {
+// ReorgDetectorMock_GetFinalizedBlockType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlockType'
+type ReorgDetectorMock_GetFinalizedBlockType_Call struct {
 	*mock.Call
 }
 
-// GetFinalizedBlock is a helper method to define mock.On call
-func (_e *ReorgDetectorMock_Expecter) GetFinalizedBlock() *ReorgDetectorMock_GetFinalizedBlock_Call {
-	return &ReorgDetectorMock_GetFinalizedBlock_Call{Call: _e.mock.On("GetFinalizedBlock")}
+// GetFinalizedBlockType is a helper method to define mock.On call
+func (_e *ReorgDetectorMock_Expecter) GetFinalizedBlockType() *ReorgDetectorMock_GetFinalizedBlockType_Call {
+	return &ReorgDetectorMock_GetFinalizedBlockType_Call{Call: _e.mock.On("GetFinalizedBlockType")}
 }
 
-func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Run(run func()) *ReorgDetectorMock_GetFinalizedBlock_Call {
+func (_c *ReorgDetectorMock_GetFinalizedBlockType_Call) Run(run func()) *ReorgDetectorMock_GetFinalizedBlockType_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+func (_c *ReorgDetectorMock_GetFinalizedBlockType_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlockType_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+func (_c *ReorgDetectorMock_GetFinalizedBlockType_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlockType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sync/mock_reorg_detector.go
+++ b/sync/mock_reorg_detector.go
@@ -7,6 +7,8 @@ import (
 
 	common "github.com/ethereum/go-ethereum/common"
 
+	etherman "github.com/agglayer/aggkit/etherman"
+
 	mock "github.com/stretchr/testify/mock"
 
 	reorgdetector "github.com/agglayer/aggkit/reorgdetector"
@@ -70,6 +72,96 @@ func (_c *ReorgDetectorMock_AddBlockToTrack_Call) Return(_a0 error) *ReorgDetect
 }
 
 func (_c *ReorgDetectorMock_AddBlockToTrack_Call) RunAndReturn(run func(context.Context, string, uint64, common.Hash) error) *ReorgDetectorMock_AddBlockToTrack_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFinalizedBlock provides a mock function with no fields
+func (_m *ReorgDetectorMock) GetFinalizedBlock() etherman.BlockNumberFinality {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFinalizedBlock")
+	}
+
+	var r0 etherman.BlockNumberFinality
+	if rf, ok := ret.Get(0).(func() etherman.BlockNumberFinality); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(etherman.BlockNumberFinality)
+	}
+
+	return r0
+}
+
+// ReorgDetectorMock_GetFinalizedBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFinalizedBlock'
+type ReorgDetectorMock_GetFinalizedBlock_Call struct {
+	*mock.Call
+}
+
+// GetFinalizedBlock is a helper method to define mock.On call
+func (_e *ReorgDetectorMock_Expecter) GetFinalizedBlock() *ReorgDetectorMock_GetFinalizedBlock_Call {
+	return &ReorgDetectorMock_GetFinalizedBlock_Call{Call: _e.mock.On("GetFinalizedBlock")}
+}
+
+func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Run(run func()) *ReorgDetectorMock_GetFinalizedBlock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) Return(_a0 etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorgDetectorMock_GetFinalizedBlock_Call) RunAndReturn(run func() etherman.BlockNumberFinality) *ReorgDetectorMock_GetFinalizedBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// String provides a mock function with no fields
+func (_m *ReorgDetectorMock) String() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for String")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// ReorgDetectorMock_String_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'String'
+type ReorgDetectorMock_String_Call struct {
+	*mock.Call
+}
+
+// String is a helper method to define mock.On call
+func (_e *ReorgDetectorMock_Expecter) String() *ReorgDetectorMock_String_Call {
+	return &ReorgDetectorMock_String_Call{Call: _e.mock.On("String")}
+}
+
+func (_c *ReorgDetectorMock_String_Call) Run(run func()) *ReorgDetectorMock_String_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ReorgDetectorMock_String_Call) Return(_a0 string) *ReorgDetectorMock_String_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorgDetectorMock_String_Call) RunAndReturn(run func() string) *ReorgDetectorMock_String_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -187,9 +187,9 @@ func L2Setup(t *testing.T) *L2Environment {
 	dbPathReorgL2 := path.Join(t.TempDir(), "ReorgDetectorL2.sqlite")
 	rdL2, err := reorgdetector.New(l2Client.Client(), reorgdetector.Config{
 		DBPath:              dbPathReorgL2,
-		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100},
+		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}, //nolint:mnd
 		FinalizedBlock:      etherman.FinalizedBlock,
-	}, //nolint:mnd
+	},
 		reorgdetector.L2,
 	)
 	require.NoError(t, err)

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -106,6 +106,7 @@ func L1Setup(t *testing.T) *L1Environment {
 	rdL1, err := reorgdetector.New(l1Client.Client(), reorgdetector.Config{
 		DBPath:              dbPathReorgDetectorL1,
 		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}, //nolint:mnd
+		FinalizedBlock:      etherman.FinalizedBlock,
 	}, reorgdetector.L1)
 	require.NoError(t, err)
 	go rdL1.Start(ctx) //nolint:errcheck
@@ -145,7 +146,7 @@ func L1Setup(t *testing.T) *L1Environment {
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
 		syncBlockChunkSize, etherman.LatestBlock, rdL1, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, etherman.SafeBlock)
+		retriesCount, originNetwork, false)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -186,7 +187,9 @@ func L2Setup(t *testing.T) *L2Environment {
 	dbPathReorgL2 := path.Join(t.TempDir(), "ReorgDetectorL2.sqlite")
 	rdL2, err := reorgdetector.New(l2Client.Client(), reorgdetector.Config{
 		DBPath:              dbPathReorgL2,
-		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}}, //nolint:mnd
+		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100},
+		FinalizedBlock:      etherman.FinalizedBlock,
+	}, //nolint:mnd
 		reorgdetector.L2,
 	)
 	require.NoError(t, err)
@@ -208,7 +211,7 @@ func L2Setup(t *testing.T) *L2Environment {
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,
 		etherman.LatestBlock, rdL2, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, etherman.LatestBlock)
+		retriesCount, originNetwork, false)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)


### PR DESCRIPTION
Fixes #176
## Description
- Reorg detector allow to configure the what kind of block is a finalized block (`ReorgDetectorLX.FinalizedBlock`)
- Syncers use finalizedBlock configuration from reorgDetector
- Fix e2e test for bridgesyncer that sometimes fails because a forced reorg affect to a finalized block

## Configuration
```
[ReorgDetectorL1]
DBPath = "{{PathRWData}}/reorgdetectorl1.sqlite"
FinalizedBlock="FinalizedBlock"

[ReorgDetectorL2]
DBPath = "{{PathRWData}}/reorgdetectorl2.sqlite"
FinalizedBlock="LatestBlock"
``` 