### PR TITLE
feat: Prevent missconfiguration of bridgeAddress in bridgesyncer

### DIFF
--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -135,7 +135,8 @@ func newBridgeSync(
 		if flags&FlagAllowWrongContractsAddr == 0 {
 			return nil, err
 		} else {
-			logger.Warnf("sanityCheckContract(bridge:%s) fails sanity check but FlagAllowWrongContractsAddrs is set", bridge.String())
+			logger.Warnf("sanityCheckContract(bridge:%s) fails sanity check but FlagAllowWrongContractsAddrs is set",
+				bridge.String())
 		}
 	}
 	processor, err := newProcessor(dbPath, logger)
@@ -312,8 +313,10 @@ func sanityCheckContract(logger *log.Logger, bridgeAddr common.Address, ethClien
 	}
 	lastUpdatedDespositCount, err := contract.LastUpdatedDepositCount(nil)
 	if err != nil {
-		return fmt.Errorf("sanityCheckContract(bridge:%s) fails getting lastUpdatedDespositCount. Err: %w", bridgeAddr.String(), err)
+		return fmt.Errorf("sanityCheckContract(bridge:%s) fails getting lastUpdatedDespositCount. Err: %w",
+			bridgeAddr.String(), err)
 	}
-	logger.Infof("sanityCheckContract(bridge:%s) OK. lastUpdatedDespositCount: %d", bridgeAddr.String(), lastUpdatedDespositCount)
+	logger.Infof("sanityCheckContract(bridge:%s) OK. lastUpdatedDespositCount: %d",
+		bridgeAddr.String(), lastUpdatedDespositCount)
 	return nil
 }

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -128,7 +128,6 @@ func newBridgeSync(
 		logger.Errorf("sanityCheckContract(bridge:%s) fails sanity check. Err: %w",
 			bridge.String(), err)
 		return nil, err
-
 	}
 	processor, err := newProcessor(dbPath, logger)
 	if err != nil {

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -65,7 +65,6 @@ func NewL1(
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		syncFullClaims,
-		finalizedBlockType,
 	)
 }
 
@@ -100,7 +99,6 @@ func NewL2(
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		syncFullClaims,
-		finalizedBlockType,
 	)
 }
 
@@ -119,7 +117,6 @@ func newBridgeSync(
 	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
-	finalizedBlockType etherman.BlockNumberFinality,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID)
 

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -107,7 +107,6 @@ func TestNewLx(t *testing.T) {
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		blockFinalityType,
 	)
 	t.Log(err)
 	assert.Error(t, err)

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,8 @@ const (
 	SaveConfigFileName = "aggkit_config.toml"
 
 	DefaultCreationFilePermissions = os.FileMode(0600)
+
+	bridgeAddrSetOnWrongSection = "Bridge contract address must be set in the root of config file as polygonBridgeAddr."
 )
 
 type DeprecatedFieldsError struct {
@@ -74,7 +76,16 @@ type DeprecatedField struct {
 }
 
 var (
-	deprecatedFieldsOnConfig = []DeprecatedField{}
+	deprecatedFieldsOnConfig = []DeprecatedField{
+		{
+			FieldNamePattern: "L1Config.polygonBridgeAddr",
+			Reason:           bridgeAddrSetOnWrongSection,
+		},
+		{
+			FieldNamePattern: "L2Config.polygonBridgeAddr",
+			Reason:           bridgeAddrSetOnWrongSection,
+		},
+	}
 )
 
 /*

--- a/config/config.go
+++ b/config/config.go
@@ -297,7 +297,7 @@ func checkDeprecatedFields(keysOnConfig []string) error {
 
 func getDeprecatedField(fieldName string) *DeprecatedField {
 	for _, deprecatedField := range deprecatedFieldsOnConfig {
-		if deprecatedField.FieldNamePattern == fieldName {
+		if strings.ToLower(deprecatedField.FieldNamePattern) == strings.ToLower(fieldName) {
 			return &deprecatedField
 		}
 		// If the field name ends with a dot, it means FieldNamePattern*

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,3 +75,17 @@ func newCliContextConfigFlag(t *testing.T, values ...string) *cli.Context {
 	}
 	return cli.NewContext(nil, flagSet, nil)
 }
+
+func TestLoadConfigWithDeprecatedFields(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "ut_config")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.Write([]byte(`
+	[L1Config]
+	polygonBridgeAddr = "0x0000000000000000000000000000000000000000"
+`))
+	require.NoError(t, err)
+	ctx := newCliContextConfigFlag(t, tmpFile.Name())
+	_, err = Load(ctx)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Description

- A common mistake is to set the variable `polygonBridgeAddr` inside the section `[L1Config]` in config file. This is prevented with the list of deprecated variables on config file
- Another possible error is to set the wrong address. To fix that the code checks that the contract is the bridge one testing a method.

Fixes #167
