### PR TITLE
feat: small improvements on the `aggsender`

### DIFF
--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -45,7 +45,6 @@ func TestConfigString(t *testing.T) {
 		URLRPCL2:                    "http://l2.rpc.url",
 		BlockFinality:               "latestBlock",
 		EpochNotificationPercentage: 50,
-		SaveCertificatesToFilesPath: "/path/to/certificates",
 		Mode:                        "PP",
 	}
 
@@ -55,7 +54,6 @@ func TestConfigString(t *testing.T) {
 		"URLRPCL2: http://l2.rpc.url\n" +
 		"BlockFinality: latestBlock\n" +
 		"EpochNotificationPercentage: 50\n" +
-		"SaveCertificatesToFilesPath: /path/to/certificates\n" +
 		"DryRun: false\n" +
 		"EnableRPC: false\n" +
 		"AggchainProofURL: \n" +
@@ -459,7 +457,6 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 		rateLimiter:      aggkitcommon.NewRateLimit(aggkitcommon.RateLimitConfig{}),
 	}
 
-	mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 	mockStorage.On("GetLastSentCertificate").Return(&aggsendertypes.CertificateInfo{
 		NewLocalExitRoot: common.HexToHash("0x123"),
 		Height:           1,
@@ -742,37 +739,11 @@ func TestSendCertificate(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name: "error getting pending certificates",
-			mockFn: func(mockStorage *mocks.AggSenderStorage,
-				mockFlow *mocks.AggsenderFlow,
-				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
-				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return(nil, errors.New("some error")).Once()
-			},
-			expectedError: "error getting pending certificates",
-		},
-		{
-			name: "has pending certificates",
-			mockFn: func(mockStorage *mocks.AggSenderStorage,
-				mockFlow *mocks.AggsenderFlow,
-				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
-				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return(
-					[]*aggsendertypes.CertificateInfo{
-						{
-							Height: 0,
-							Status: agglayer.Pending,
-						},
-					}, nil).Once()
-			},
-		},
-		{
 			name: "error getting certificate build params",
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(nil, errors.New("some error")).Once()
 			},
 			expectedError: "error getting certificate build params",
@@ -783,7 +754,6 @@ func TestSendCertificate(t *testing.T) {
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{},
 				}, nil).Once()
@@ -795,7 +765,6 @@ func TestSendCertificate(t *testing.T) {
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
@@ -809,7 +778,6 @@ func TestSendCertificate(t *testing.T) {
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
@@ -829,7 +797,6 @@ func TestSendCertificate(t *testing.T) {
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
@@ -850,7 +817,6 @@ func TestSendCertificate(t *testing.T) {
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
@@ -912,7 +878,6 @@ func TestLimitEpochPercent_Greater(t *testing.T) {
 	testData.sut.cfg.MaxEpochPercentageAllowedToSendCertificate = 80
 
 	ctx := context.TODO()
-	testData.storageMock.EXPECT().GetCertificatesByStatus(mock.Anything).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()
 	testData.l2syncerMock.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(100), nil).Once()
 	testData.storageMock.EXPECT().GetLastSentCertificate().Return(&aggsendertypes.CertificateInfo{
 		FromBlock: 1,

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -24,8 +24,6 @@ type Config struct {
 	// 0 -> Begin
 	// 50 -> Middle
 	EpochNotificationPercentage uint `mapstructure:"EpochNotificationPercentage"`
-	// SaveCertificatesToFilesPath if != "" tells  the AggSender to save the certificates to a file in this path
-	SaveCertificatesToFilesPath string `mapstructure:"SaveCertificatesToFilesPath"`
 	// MaxRetriesStoreCertificate is the maximum number of retries to store a certificate
 	// 0 is infinite
 	MaxRetriesStoreCertificate int `mapstructure:"MaxRetriesStoreCertificate"`
@@ -46,8 +44,8 @@ type Config struct {
 	EnableRPC bool `mapstructure:"EnableRPC"`
 	// AggchainProofURL is the URL of the AggkitProver
 	AggchainProofURL string `mapstructure:"AggchainProofURL"`
-	// Mode is the mode of the AggSender (regular pessimistic proof mode or the aggchain prover mode)
-	Mode string `jsonschema:"enum=PessimisticProof, enum=AggchainProver" mapstructure:"Mode"`
+	// Mode is the mode of the AggSender (regular pessimistic proof mode or the aggchain proof mode)
+	Mode string `jsonschema:"enum=PessimisticProof, enum=AggchainProof" mapstructure:"Mode"`
 	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
 	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
 	// RetryCertAfterInError when a cert pass to 'InError'
@@ -76,7 +74,6 @@ func (c Config) String() string {
 		"URLRPCL2: " + c.URLRPCL2 + "\n" +
 		"BlockFinality: " + c.BlockFinality + "\n" +
 		"EpochNotificationPercentage: " + fmt.Sprintf("%d", c.EpochNotificationPercentage) + "\n" +
-		"SaveCertificatesToFilesPath: " + c.SaveCertificatesToFilesPath + "\n" +
 		"DryRun: " + fmt.Sprintf("%t", c.DryRun) + "\n" +
 		"EnableRPC: " + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
 		"AggchainProofURL: " + c.AggchainProofURL + "\n" +

--- a/aggsender/flow_aggchain_prover_test.go
+++ b/aggsender/flow_aggchain_prover_test.go
@@ -63,7 +63,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			expectedError: "no bridges to resend the same certificate",
 		},
 		{
-			name: "resend InError certificate with no auth proof",
+			name: "resend InError certificate",
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2Syncer *mocks.L2BridgeSyncer,
 				mockProverClient *mocks.AggchainProofClientInterface,
@@ -104,7 +104,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			},
 		},
 		{
-			name: "resend InError certificate with no auth proof - aggchain prover returned smaller range",
+			name: "resend InError certificate - aggchain prover returned smaller range",
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2Syncer *mocks.L2BridgeSyncer,
 				mockProverClient *mocks.AggchainProofClientInterface,
@@ -143,37 +143,6 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					FromBlock: 1,
 					ToBlock:   10,
 					Status:    agglayer.InError,
-				},
-			},
-		},
-		{
-			name: "resend InError certificate with auth proof",
-			mockFn: func(mockStorage *mocks.AggSenderStorage,
-				mockL2Syncer *mocks.L2BridgeSyncer,
-				mockProverClient *mocks.AggchainProofClientInterface,
-				mockL1Client *mocks.EthClient,
-				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer) {
-				mockStorage.On("GetLastSentCertificate").Return(&types.CertificateInfo{
-					FromBlock:     1,
-					ToBlock:       10,
-					Status:        agglayer.InError,
-					AggchainProof: []byte("existing-proof"),
-				}, nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
-				mockL2Syncer.On("GetClaims", ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{{}}, nil)
-			},
-			expectedParams: &types.CertificateBuildParams{
-				FromBlock:     1,
-				ToBlock:       10,
-				RetryCount:    1,
-				Bridges:       []bridgesync.Bridge{{}},
-				Claims:        []bridgesync.Claim{{}},
-				AggchainProof: []byte("existing-proof"),
-				LastSentCertificate: &types.CertificateInfo{
-					FromBlock:     1,
-					ToBlock:       10,
-					Status:        agglayer.InError,
-					AggchainProof: []byte("existing-proof"),
 				},
 			},
 		},

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -20,7 +20,7 @@ type AggsenderMode string
 
 const (
 	PessimisticProofMode AggsenderMode = "PessimisticProof"
-	AggchainProverMode   AggsenderMode = "AggchainProver"
+	AggchainProofMode    AggsenderMode = "AggchainProof"
 )
 
 // AggsenderFlow is an interface that defines the methods to manage the flow of the AggSender

--- a/config/default.go
+++ b/config/default.go
@@ -210,7 +210,6 @@ AggsenderPrivateKey = {Path = "{{SequencerPrivateKeyPath}}", Password = "{{Seque
 URLRPCL2="{{L2URL}}"
 BlockFinality = "LatestBlock"
 EpochNotificationPercentage = 50
-SaveCertificatesToFilesPath = ""
 MaxRetriesStoreCertificate = 3
 DelayBeetweenRetries = "60s"
 KeepCertificatesHistory = true

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -12,7 +12,7 @@ The image below, depicts the `Aggsender` components (the editable link of the di
 
 ### Starting the AggSender
 
-`Aggsender` gets the epoch configuration from the `Agglayer`. 
+`Aggsender` gets the epoch configuration from the `Agglayer`.
 It checks the last certificate in DB (if exists) against the `Agglayer`, to be sure that both are on the same page:
     - If the DB is empty then get, as starting point, the last certificate `Agglayer` has.
     - If it is a fresh start, and there are no certificates before this, it will set its starting block to 1 and start polling bridges and claims from the syncer from that block.
@@ -38,7 +38,7 @@ If we have bridges, certificate will be built, signed, and sent to the `Agglayer
 
 Currently, `Agglayer` only supports one certificate per L1 epoch, per network, so we can not send more than one certificate. After the certificate is sent, we wait until the next epoch, either to resend it if its status is `InError`, or to build a new one if its status `Settled`. Also, we have no limit yet in how many bridges and claims can be sent in a single certificate. This might be something to test and check, because certificates carry a lot of data through RPC, so we might hit a limit at some point.
 
-`InError` status can mean a number of things. It can be an error that happened on the `Agglayer`. It can be an error in the data `Aggsender` sent, or the certificate was sent in between two epochs, which `Agglayer` considers invalid. Either way, the given certificate needs to be re-sent in the next epoch, with all the previously sent bridges and claims, plus the new ones that happened after them, that the syncer saw and saved. 
+`InError` status can mean a number of things. It can be an error that happened on the `Agglayer`. It can be an error in the data `Aggsender` sent, or the certificate was sent in between two epochs, which `Agglayer` considers invalid. Either way, the given certificate needs to be re-sent in the next epoch, with all the previously sent bridges and claims, plus the new ones that happened after them, that the syncer saw and saved.
 
 It is important to mention that, in the case of resending the certificate, the certificate height must be reused. If we are sending a new certificate, its height must be incremented based on the previously sent certificate.
 
@@ -113,7 +113,7 @@ The certificate is the data submitted to `Agglayer`. Must be signed to be accept
 | CheckStatusCertificateInterval| Duration           | Interval at which the AggSender will check the certificate status in Agglayer                                  |
 | RetryCertAfterInError         | bool               | Indicates if Aggsender should re-send InError certificates immediatelly after it notices their status change   |
 | MaxEpochPercentageAllowedToSendCertificate | uint  | Percentage of the epoch after which Aggsender is forbidden to send certificates to the Agglayer               |
-| MaxSubmitCertificateRate      | RateLimitConfig    | Maximum allowed rate of submission of certificates in a given time                                            | 
+| MaxSubmitCertificateRate      | RateLimitConfig    | Maximum allowed rate of submission of certificates in a given time                                            |
 
 ## Use Cases
 
@@ -154,11 +154,13 @@ This paragraph explains different use cases with outcomes.
    ]
 }
 ```
+
 4. Copy this to your `launch.json` and start debugging.
 5. This will start the `aggkit` with the `aggsender` running.
 6. Navigate to the `test/bats/pp` folder (`cd test/bats/pp`).
 7. Run a test in `bridge-e2e.bats` file: `bats -f "Native gas token deposit to WETH" bridge-e2e.bats`. This will build a new certificate after it is done, and you can debug the whole process.
 
 ## Additional Documentation
+
 [1] https://potential-couscous-4gw6qyo.pages.github.io/protocol/workflow_centralized.html 
 [2] https://agglayer.github.io/agglayer/pessimistic_proof/index.html	

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -101,7 +101,6 @@ The certificate is the data submitted to `Agglayer`. Must be signed to be accept
 | URLRPCL2                      | string             | L2 RPC                                                                                                         |
 | BlockFinality                 | string             | Block type to calculate epochs on L1.                                                                          |
 | EpochNotificationPercentage   | uint               | `0` -> at beginning of epoch <br> `100` -> at end of the epoch <br> *(default: 50)*                             |
-| SaveCertificatesToFilesPath   | string             | Default option to store the certificate as a file. <br> Files: `certificate_<height>-<tstamp>.json`            |
 | MaxRetriesStoreCertificate    | int                | Number of retries if Aggsender fails to store certificates on DB                                               |
 | DelayBeetweenRetries          | Duration           | Initial status check delay <br> Store certificate on DB delay                                                  |
 | KeepCertificatesHistory       | bool               | Instead of deleting them, discarded certificates are moved to the `certificate_info_history` table             |
@@ -109,7 +108,12 @@ The certificate is the data submitted to `Agglayer`. Must be signed to be accept
 | BridgeMetadataAsHash          | bool               | Flag indicating to import the bridge metadata as a hash                                                        |
 | DryRun                        | bool               | Flag to enable the dry-run mode. <br> In this mode, the AggSender will not send certificates to the Agglayer.   |
 | EnableRPC                     | bool               | Flag to enable the Aggsender's RPC layer                                                                       |
-
+| AggchainProofURL              | string             | URL to the Aggchain Prover                                                                                     |
+| Mode                          | string             | Defines the mode of the AggSender (regular pessimistic proof mode or the aggchain proof mode)                  |
+| CheckStatusCertificateInterval| Duration           | Interval at which the AggSender will check the certificate status in Agglayer                                  |
+| RetryCertAfterInError         | bool               | Indicates if Aggsender should re-send InError certificates immediatelly after it notices their status change   |
+| MaxEpochPercentageAllowedToSendCertificate | uint  | Percentage of the epoch after which Aggsender is forbidden to send certificates to the Agglayer               |
+| MaxSubmitCertificateRate      | RateLimitConfig    | Maximum allowed rate of submission of certificates in a given time                                            | 
 
 ## Use Cases
 

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -46,7 +46,6 @@ Level = "{{.global_log_level}}"
 Outputs = ["stderr"]
        
 [AggSender]
-SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}/"
 CheckStatusCertificateInterval = "1s"
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20


### PR DESCRIPTION
## Description

This PR introduces couple of improvements to the `aggsender`:

1. Remove unnecessary `SaveCertificatesToFilesPath` config parameter, which was used to save certificates we send to the `agglayer` to some temporary file. Since we are already saving the entire `json` format to the `aggsender` `db`, this became redundant.
2. Expanded the `aggsender.md` with new configuration parameters that were added in couple of previous PRs.
3. Removed the check for pending certificates in the `sendCertificate` function, since we are already checking this before we make a call to that function.
4. In the `aggchain prover flow`, when we are resending the certificate that is `InError`, we will always make a call to the `aggchain prover` to get the proof, even though we might have it, because, the previously sent `InError` certificate might be subject to a reorg, and the previous sent proof might not be valid anymore.
5. Renamed the `AggchainProverMode` to the `AggchainProofMode` to be more consistent.

Fixes # (issue)
