### PR TITLE
feat: `bridge_getClaims` endpoint

### DIFF
--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -218,7 +218,7 @@ func newBridgeSync(
 func (s *BridgeSync) GetClaimsPaged(
 	ctx context.Context,
 	page, pageSize uint32,
-) ([]*Claim, int, error) {
+) ([]*ClaimResponse, int, error) {
 	if s.processor.isHalted() {
 		return nil, 0, sync.ErrInconsistentState
 	}

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -215,6 +215,16 @@ func newBridgeSync(
 	}, nil
 }
 
+func (s *BridgeSync) GetClaimsPaged(
+	ctx context.Context,
+	page, pageSize uint32,
+) ([]*Claim, int, error) {
+	if s.processor.isHalted() {
+		return nil, 0, sync.ErrInconsistentState
+	}
+	return s.processor.GetClaimsPaged(ctx, page, pageSize)
+}
+
 // Start starts the synchronization process
 func (s *BridgeSync) Start(ctx context.Context) {
 	s.driver.Sync(ctx)

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -289,3 +289,9 @@ func TestGetBridgePaged(t *testing.T) {
 	_, _, err := s.GetBridgesPaged(context.Background(), 0, 0, nil)
 	require.ErrorIs(t, err, sync.ErrInconsistentState)
 }
+
+func TestGetClaimPaged(t *testing.T) {
+	s := BridgeSync{processor: &processor{halted: true}}
+	_, _, err := s.GetClaimsPaged(context.Background(), 0, 0)
+	require.ErrorIs(t, err, sync.ErrInconsistentState)
+}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -98,6 +98,9 @@ func buildAppender(client EthClienter, bridge common.Address, syncFullClaims boo
 			OriginAddress:      claimEvent.OriginAddress,
 			DestinationAddress: claimEvent.DestinationAddress,
 			Amount:             claimEvent.Amount,
+			BlockTimestamp:     b.Timestamp,
+			TxHash:             l.TxHash,
+			FromAddress:        l.Address,
 		}
 		if syncFullClaims {
 			if err := setClaimCalldata(client, bridge, l.TxHash, claim); err != nil {

--- a/bridgesync/migrations/bridgesync0002.sql
+++ b/bridgesync/migrations/bridgesync0002.sql
@@ -5,6 +5,7 @@ ALTER TABLE claim DROP COLUMN tx_hash;
 ALTER TABLE bridge DROP COLUMN block_timestamp;
 ALTER TABLE claim DROP COLUMN block_timestamp;
 ALTER TABLE bridge DROP COLUMN from_address;
+ALTER TABLE claim DROP COLUMN from_address;
 
 -- +migrate Up
 CREATE TABLE
@@ -24,3 +25,4 @@ ALTER TABLE claim ADD COLUMN tx_hash VARCHAR;
 ALTER TABLE bridge ADD COLUMN block_timestamp INTEGER;
 ALTER TABLE claim ADD COLUMN block_timestamp INTEGER;
 ALTER TABLE bridge ADD COLUMN from_address VARCHAR;
+ALTER TABLE claim ADD COLUMN from_address VARCHAR;

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -103,8 +103,9 @@ func TestMigration0002(t *testing.T) {
 			metadata,
 			deposit_count,
 			block_timestamp,
-			tx_hash
-		) VALUES (1, 0, 0, 0, '0x3', 0, '0x0000', 0, NULL, 0, 1739270804, '0xabcd');
+			tx_hash,
+			from_address
+		) VALUES (1, 0, 0, 0, '0x3', 0, '0x0000', 0, NULL, 0, 1739270804, '0xabcd', '0x123');
 
 		INSERT INTO claim (
 			block_num,
@@ -118,8 +119,9 @@ func TestMigration0002(t *testing.T) {
 			metadata,
 			is_message,
 			block_timestamp,
-			tx_hash
-		) VALUES (1, 0, 0, 0, '0x3', '0x0000', 0, 0, NULL, FALSE, 1739270804, '0xabcd');
+			tx_hash,
+			from_address
+		) VALUES (1, 0, 0, 0, '0x3', '0x0000', 0, 0, NULL, FALSE, 1739270804, '0xabcd', '0x123');
 	`)
 	require.NoError(t, err)
 	err = tx.Commit()
@@ -160,6 +162,7 @@ func TestMigration0002(t *testing.T) {
 		DepositCount       uint32   `meddler:"deposit_count"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
+		FromAddress        string   `meddler:"from_address"`
 	}
 
 	err = meddler.QueryRow(db, &bridge,
@@ -181,6 +184,7 @@ func TestMigration0002(t *testing.T) {
 		IsMessage          bool     `meddler:"is_message"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
+		FromAddress        string   `meddler:"from_address"`
 	}
 
 	err = meddler.QueryRow(db, &claim,
@@ -188,4 +192,5 @@ func TestMigration0002(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, claim)
 	require.Equal(t, uint64(1739270804), claim.BlockTimestamp)
+	require.Equal(t, "0x123", claim.FromAddress)
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -42,25 +42,25 @@ var (
 
 // Bridge is the representation of a bridge event
 type Bridge struct {
-	BlockNum           uint64         `meddler:"block_num"`
-	BlockPos           uint64         `meddler:"block_pos"`
-	LeafType           uint8          `meddler:"leaf_type"`
-	OriginNetwork      uint32         `meddler:"origin_network"`
-	OriginAddress      common.Address `meddler:"origin_address"`
-	DestinationNetwork uint32         `meddler:"destination_network"`
-	DestinationAddress common.Address `meddler:"destination_address"`
-	Amount             *big.Int       `meddler:"amount,bigint"`
-	Metadata           []byte         `meddler:"metadata"`
-	DepositCount       uint32         `meddler:"deposit_count"`
+	BlockNum           uint64         `meddler:"block_num" json:"block_num"`
+	BlockPos           uint64         `meddler:"block_pos" json:"block_pos"`
 	BlockTimestamp     uint64         `meddler:"block_timestamp"`
-	TxHash             common.Hash    `meddler:"tx_hash,hash"`
-	FromAddress        common.Address `meddler:"from_address,address"`
+	LeafType           uint8          `meddler:"leaf_type" json:"leaf_type"`
+	OriginNetwork      uint32         `meddler:"origin_network" json:"origin_network"`
+	OriginAddress      common.Address `meddler:"origin_address" json:"origin_address"`
+	DestinationNetwork uint32         `meddler:"destination_network" json:"destination_network"`
+	DestinationAddress common.Address `meddler:"destination_address" json:"destination_address"`
+	Amount             *big.Int       `meddler:"amount,bigint" json:"amount"`
+	Metadata           []byte         `meddler:"metadata" json:"metadata"`
+	DepositCount       uint32         `meddler:"deposit_count" json:"deposit_count"`
+	TxHash             common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
+	FromAddress        common.Address `meddler:"from_address,address" json:"from_address"`
 }
 
 // BridgeResponse is the representation of a bridge event with additional fields
 type BridgeResponse struct {
 	Bridge
-	BridgeHash common.Hash
+	BridgeHash common.Hash `json:"bridge_hash"`
 }
 
 // Cant change the Hash() here after adding BlockTimestamp, TxHash. Might affect previous versions
@@ -116,28 +116,28 @@ type Claim struct {
 
 // ClaimResponse is the representation of a claim event with trimmed fields
 type ClaimResponse struct {
-	GlobalIndex        *big.Int
-	DestinationNetwork uint32
-	TxHash             common.Hash
-	Amount             *big.Int
-	BlockNum           uint64
-	FromAddress        common.Address
-	DestinationAddress common.Address
-	OriginAddress      common.Address
-	OriginNetwork      uint32
-	BlockTimestamp     uint64
+	BlockNum           uint64         `json:"block_num"`
+	BlockTimestamp     uint64         `json:"block_timestamp"`
+	TxHash             common.Hash    `json:"tx_hash"`
+	GlobalIndex        *big.Int       `json:"global_index"`
+	OriginAddress      common.Address `json:"origin_address"`
+	OriginNetwork      uint32         `json:"origin_network"`
+	DestinationAddress common.Address `json:"destination_address"`
+	DestinationNetwork uint32         `json:"destination_network"`
+	Amount             *big.Int       `json:"amount"`
+	FromAddress        common.Address `json:"from_address"`
 }
 
 // TokenMapping representation of a NewWrappedToken event, that is emitted by the bridge contract
 type TokenMapping struct {
-	BlockNum            uint64         `meddler:"block_num"`
-	BlockPos            uint64         `meddler:"block_pos"`
-	BlockTimestamp      uint64         `meddler:"block_timestamp"`
-	TxHash              common.Hash    `meddler:"tx_hash,hash"`
-	OriginNetwork       uint32         `meddler:"origin_network"`
-	OriginTokenAddress  common.Address `meddler:"origin_token_address,address"`
-	WrappedTokenAddress common.Address `meddler:"wrapped_token_address,address"`
-	Metadata            []byte         `meddler:"metadata"`
+	BlockNum            uint64         `meddler:"block_num" json:"block_num"`
+	BlockPos            uint64         `meddler:"block_pos" json:"block_pos"`
+	BlockTimestamp      uint64         `meddler:"block_timestamp" json:"block_timestamp"`
+	TxHash              common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
+	OriginNetwork       uint32         `meddler:"origin_network" json:"origin_network"`
+	OriginTokenAddress  common.Address `meddler:"origin_token_address,address" json:"origin_token_address"`
+	WrappedTokenAddress common.Address `meddler:"wrapped_token_address,address" json:"wrapped_token_address"`
+	Metadata            []byte         `meddler:"metadata" json:"metadata"`
 }
 
 // Event combination of bridge, claim and token mapping events

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -264,7 +264,7 @@ func (p *processor) GetBridgesPaged(
 		pageSize = 1
 	}
 	offset := (pageNumber - 1) * pageSize
-	if int(offset) >= count {
+	if offset >= uint32(count) {
 		p.log.Debugf("offset is larger than total bridges (page number=%d, page size=%d, total bridges=%d)",
 			pageNumber, pageSize, count)
 		return nil, 0, db.ErrNotFound
@@ -316,7 +316,7 @@ func (p *processor) GetClaimsPaged(
 	}
 
 	offset := (pageNumber - 1) * pageSize
-	if int(offset) >= count {
+	if offset >= uint32(count) {
 		p.log.Debugf("offset is larger than total claims (page number=%d, page size=%d, total claims=%d)",
 			pageNumber, pageSize, count)
 		return nil, 0, db.ErrNotFound
@@ -550,7 +550,7 @@ func (p *processor) GetTokenMappings(ctx context.Context, pageNumber, pageSize u
 	}
 
 	offset := (pageNumber - 1) * pageSize
-	if int(offset) >= totalTokenMappings {
+	if offset >= uint32(totalTokenMappings) {
 		p.log.Debugf("offset is larger than total token mappings (page number=%d, page size=%d, total token mappings=%d)",
 			pageNumber, pageSize, totalTokenMappings)
 		return nil, 0, db.ErrNotFound

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -296,7 +296,7 @@ func (p *processor) GetClaimsPaged(
 	orderBy := "global_index + 0"
 	order := "DESC"
 	whereClause := ""
-	count, err := p.GetTotalNumberOfRecords("claim")
+	count, err := p.GetTotalNumberOfRecords(claimTableName)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -308,7 +308,7 @@ func (p *processor) GetClaimsPaged(
 		return nil, count, db.ErrNotFound
 	}
 
-	rows, err := p.queryPaged(tx, offset, pageSize, "claim", orderBy, order, whereClause)
+	rows, err := p.queryPaged(tx, offset, pageSize, claimTableName, orderBy, order, whereClause)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -44,7 +44,7 @@ var (
 type Bridge struct {
 	BlockNum           uint64         `meddler:"block_num" json:"block_num"`
 	BlockPos           uint64         `meddler:"block_pos" json:"block_pos"`
-	BlockTimestamp     uint64         `meddler:"block_timestamp"`
+	BlockTimestamp     uint64         `meddler:"block_timestamp" json:"block_timestamp"`
 	LeafType           uint8          `meddler:"leaf_type" json:"leaf_type"`
 	OriginNetwork      uint32         `meddler:"origin_network" json:"origin_network"`
 	OriginAddress      common.Address `meddler:"origin_address" json:"origin_address"`

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -307,9 +307,6 @@ func (p *processor) GetClaimsPaged(
 			log.Warnf("error rolling back tx: %v", err)
 		}
 	}()
-	orderBy := "global_index + 0"
-	order := "DESC"
-	whereClause := ""
 	count, err := p.GetTotalNumberOfRecords(claimTableName)
 	if err != nil {
 		return nil, 0, err
@@ -322,6 +319,9 @@ func (p *processor) GetClaimsPaged(
 		return nil, 0, db.ErrNotFound
 	}
 
+	orderBy := "global_index + 0"
+	order := "DESC"
+	whereClause := ""
 	rows, err := p.queryPaged(tx, offset, pageSize, claimTableName, orderBy, order, whereClause)
 	if err != nil {
 		return nil, 0, err

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1077,12 +1077,12 @@ func TestGetClaimsPaged(t *testing.T) {
 
 	claims :=
 		[]Claim{
-			{BlockNum: 1, BlockPos: 1, GlobalIndex: big.NewInt(1), Amount: big.NewInt(1)},
-			{BlockNum: 2, BlockPos: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
-			{BlockNum: 3, BlockPos: 3, GlobalIndex: big.NewInt(3), Amount: big.NewInt(1)},
-			{BlockNum: 4, BlockPos: 4, GlobalIndex: big.NewInt(4), Amount: big.NewInt(1)},
-			{BlockNum: 5, BlockPos: 5, GlobalIndex: uint64Max, Amount: big.NewInt(1)},
-			{BlockNum: 6, BlockPos: 6, GlobalIndex: uint256Max, Amount: big.NewInt(1)},
+			{BlockNum: 1, GlobalIndex: big.NewInt(1), Amount: big.NewInt(1)},
+			{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
+			{BlockNum: 3, GlobalIndex: big.NewInt(3), Amount: big.NewInt(1)},
+			{BlockNum: 4, GlobalIndex: big.NewInt(4), Amount: big.NewInt(1)},
+			{BlockNum: 5, GlobalIndex: uint64Max, Amount: big.NewInt(1)},
+			{BlockNum: 6, GlobalIndex: uint256Max, Amount: big.NewInt(1)},
 		}
 
 	path := path.Join(t.TempDir(), "bridgesyncGetClaimsPaged.sqlite")
@@ -1109,7 +1109,7 @@ func TestGetClaimsPaged(t *testing.T) {
 		pageSize       uint32
 		page           uint32
 		expectedCount  int
-		expectedClaims []*Claim
+		expectedClaims []*ClaimResponse
 		expectedError  error
 	}{
 		{
@@ -1117,8 +1117,8 @@ func TestGetClaimsPaged(t *testing.T) {
 			pageSize:      1,
 			page:          2,
 			expectedCount: 6,
-			expectedClaims: []*Claim{
-				{BlockNum: 5, BlockPos: 5, GlobalIndex: uint64Max, Amount: big.NewInt(1)},
+			expectedClaims: []*ClaimResponse{
+				{BlockNum: 5, GlobalIndex: uint64Max, Amount: big.NewInt(1)},
 			},
 			expectedError: nil,
 		},
@@ -1127,13 +1127,13 @@ func TestGetClaimsPaged(t *testing.T) {
 			pageSize:      20,
 			page:          1,
 			expectedCount: 6,
-			expectedClaims: []*Claim{
-				{BlockNum: 6, BlockPos: 6, GlobalIndex: uint256Max, Amount: big.NewInt(1)},
-				{BlockNum: 5, BlockPos: 5, GlobalIndex: uint64Max, Amount: big.NewInt(1)},
-				{BlockNum: 4, BlockPos: 4, GlobalIndex: big.NewInt(4), Amount: big.NewInt(1)},
-				{BlockNum: 3, BlockPos: 3, GlobalIndex: big.NewInt(3), Amount: big.NewInt(1)},
-				{BlockNum: 2, BlockPos: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
-				{BlockNum: 1, BlockPos: 1, GlobalIndex: big.NewInt(1), Amount: big.NewInt(1)},
+			expectedClaims: []*ClaimResponse{
+				{BlockNum: 6, GlobalIndex: uint256Max, Amount: big.NewInt(1)},
+				{BlockNum: 5, GlobalIndex: uint64Max, Amount: big.NewInt(1)},
+				{BlockNum: 4, GlobalIndex: big.NewInt(4), Amount: big.NewInt(1)},
+				{BlockNum: 3, GlobalIndex: big.NewInt(3), Amount: big.NewInt(1)},
+				{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
+				{BlockNum: 1, GlobalIndex: big.NewInt(1), Amount: big.NewInt(1)},
 			},
 			expectedError: nil,
 		},
@@ -1142,10 +1142,10 @@ func TestGetClaimsPaged(t *testing.T) {
 			pageSize:      3,
 			page:          2,
 			expectedCount: 6,
-			expectedClaims: []*Claim{
-				{BlockNum: 3, BlockPos: 3, GlobalIndex: big.NewInt(3), Amount: big.NewInt(1)},
-				{BlockNum: 2, BlockPos: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
-				{BlockNum: 1, BlockPos: 1, GlobalIndex: big.NewInt(1), Amount: big.NewInt(1)},
+			expectedClaims: []*ClaimResponse{
+				{BlockNum: 3, GlobalIndex: big.NewInt(3), Amount: big.NewInt(1)},
+				{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
+				{BlockNum: 1, GlobalIndex: big.NewInt(1), Amount: big.NewInt(1)},
 			},
 			expectedError: nil,
 		},
@@ -1154,7 +1154,7 @@ func TestGetClaimsPaged(t *testing.T) {
 			pageSize:       3,
 			page:           4,
 			expectedCount:  6,
-			expectedClaims: []*Claim{},
+			expectedClaims: []*ClaimResponse{},
 			expectedError:  db.ErrNotFound,
 		},
 	}

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1153,7 +1153,7 @@ func TestGetClaimsPaged(t *testing.T) {
 			name:           "t4: offset is larger than total claims",
 			pageSize:       3,
 			page:           4,
-			expectedCount:  6,
+			expectedCount:  0,
 			expectedClaims: []*ClaimResponse{},
 			expectedError:  db.ErrNotFound,
 		},

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1157,3 +1157,7 @@ func TestGetTokenMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestGetClaimsPaged(t *testing.T) {
+	fmt.Println("TestGetClaimsPaged")
+}

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -264,8 +264,8 @@ func (b *BridgeEndpoints) GetBridges(
 
 // ClaimsResult contains the claims and the total count of claims
 type ClaimsResult struct {
-	Claims []*bridgesync.Claim `json:"claims"`
-	Count  int                 `json:"count"`
+	Claims []*bridgesync.ClaimResponse `json:"claims"`
+	Count  int                         `json:"count"`
 }
 
 func (b *BridgeEndpoints) GetClaims(networkID uint32,
@@ -286,7 +286,7 @@ func (b *BridgeEndpoints) GetClaims(networkID uint32,
 	c.Add(ctx, 1)
 
 	var (
-		claims []*bridgesync.Claim
+		claims []*bridgesync.ClaimResponse
 		count  int
 	)
 

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -262,7 +262,7 @@ func (b *BridgeEndpoints) GetBridges(
 	}, nil
 }
 
-// BridgesResult contains the bridges and the total count of bridges
+// ClaimsResult contains the claims and the total count of claims
 type ClaimsResult struct {
 	Claims []*bridgesync.Claim `json:"claims"`
 	Count  int                 `json:"count"`

--- a/rpc/bridge_interfaces.go
+++ b/rpc/bridge_interfaces.go
@@ -21,6 +21,7 @@ type Bridger interface {
 		depositCount *uint64,
 	) ([]*bridgesync.BridgeResponse, int, error)
 	GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.TokenMapping, int, error)
+	GetClaimsPaged(ctx context.Context, page, pageSize uint32) ([]*bridgesync.Claim, int, error)
 }
 
 type LastGERer interface {

--- a/rpc/bridge_interfaces.go
+++ b/rpc/bridge_interfaces.go
@@ -21,7 +21,7 @@ type Bridger interface {
 		depositCount *uint64,
 	) ([]*bridgesync.BridgeResponse, int, error)
 	GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.TokenMapping, int, error)
-	GetClaimsPaged(ctx context.Context, page, pageSize uint32) ([]*bridgesync.Claim, int, error)
+	GetClaimsPaged(ctx context.Context, page, pageSize uint32) ([]*bridgesync.ClaimResponse, int, error)
 }
 
 type LastGERer interface {

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetClaims(t *testing.T) {
+}
+
 func TestGetFirstL1InfoTreeIndexForL1Bridge(t *testing.T) {
 	type testCase struct {
 		description   string

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/agglayer/aggkit/bridgesync"
@@ -16,9 +17,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func TestGetClaims(t *testing.T) {
-}
 
 func TestGetFirstL1InfoTreeIndexForL1Bridge(t *testing.T) {
 	type testCase struct {
@@ -604,6 +602,85 @@ func TestGetBridges(t *testing.T) {
 		unsupportedNetworkID := uint32(999)
 
 		result, err := bridgeMocks.bridge.GetBridges(unsupportedNetworkID, nil, nil, nil)
+		require.ErrorContains(t, err, fmt.Sprintf("this client does not support network %d", unsupportedNetworkID))
+		require.Nil(t, result)
+	})
+}
+
+func TestGetClaims(t *testing.T) {
+	networkID := uint32(10)
+	bridgeMocks := newBridgeWithMocks(t, networkID)
+
+	t.Run("GetClaims for L1 network", func(t *testing.T) {
+		page := uint32(1)
+		pageSize := uint32(10)
+		claims := []*bridgesync.Claim{
+			{
+				BlockNum:           1,
+				BlockPos:           1,
+				GlobalIndex:        big.NewInt(1),
+				OriginNetwork:      0,
+				OriginAddress:      common.HexToAddress("0x1"),
+				DestinationNetwork: 10,
+				DestinationAddress: common.HexToAddress("0x2"),
+				Amount:             common.Big0,
+				Metadata:           []byte("metadata"),
+			},
+		}
+
+		bridgeMocks.bridgeL1.On("GetClaimsPaged", mock.Anything, mock.Anything, mock.Anything).
+			Return(claims, len(claims), nil)
+
+		result, err := bridgeMocks.bridge.GetClaims(0, &page, &pageSize)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		claimsResult, ok := result.(ClaimsResult)
+		require.True(t, ok)
+		require.Equal(t, claims, claimsResult.Claims)
+		require.Equal(t, len(claimsResult.Claims), claimsResult.Count)
+
+		bridgeMocks.bridgeL1.AssertExpectations(t)
+	})
+
+	t.Run("GetClaims for L2 network", func(t *testing.T) {
+		page := uint32(1)
+		pageSize := uint32(10)
+		Claims := []*bridgesync.Claim{
+			{
+				BlockNum:           1,
+				BlockPos:           1,
+				GlobalIndex:        big.NewInt(1),
+				OriginNetwork:      0,
+				OriginAddress:      common.HexToAddress("0x1"),
+				DestinationNetwork: 10,
+				DestinationAddress: common.HexToAddress("0x2"),
+				Amount:             common.Big0,
+				Metadata:           []byte("metadata"),
+			},
+		}
+
+		bridgeMocks.bridge.networkID = 10
+
+		bridgeMocks.bridgeL2.On("GetClaimsPaged", mock.Anything, mock.Anything, mock.Anything).
+			Return(Claims, len(Claims), nil)
+
+		result, err := bridgeMocks.bridge.GetClaims(10, &page, &pageSize)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		claimsResult, ok := result.(ClaimsResult)
+		require.True(t, ok)
+		require.Equal(t, Claims, claimsResult.Claims)
+		require.Equal(t, len(claimsResult.Claims), claimsResult.Count)
+
+		bridgeMocks.bridgeL2.AssertExpectations(t)
+	})
+
+	t.Run("GetClaims with unsupported network", func(t *testing.T) {
+		unsupportedNetworkID := uint32(999)
+
+		result, err := bridgeMocks.bridge.GetClaims(unsupportedNetworkID, nil, nil)
 		require.ErrorContains(t, err, fmt.Sprintf("this client does not support network %d", unsupportedNetworkID))
 		require.Nil(t, result)
 	})

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -614,17 +614,15 @@ func TestGetClaims(t *testing.T) {
 	t.Run("GetClaims for L1 network", func(t *testing.T) {
 		page := uint32(1)
 		pageSize := uint32(10)
-		claims := []*bridgesync.Claim{
+		claims := []*bridgesync.ClaimResponse{
 			{
 				BlockNum:           1,
-				BlockPos:           1,
 				GlobalIndex:        big.NewInt(1),
 				OriginNetwork:      0,
 				OriginAddress:      common.HexToAddress("0x1"),
 				DestinationNetwork: 10,
 				DestinationAddress: common.HexToAddress("0x2"),
 				Amount:             common.Big0,
-				Metadata:           []byte("metadata"),
 			},
 		}
 
@@ -646,17 +644,15 @@ func TestGetClaims(t *testing.T) {
 	t.Run("GetClaims for L2 network", func(t *testing.T) {
 		page := uint32(1)
 		pageSize := uint32(10)
-		Claims := []*bridgesync.Claim{
+		Claims := []*bridgesync.ClaimResponse{
 			{
 				BlockNum:           1,
-				BlockPos:           1,
 				GlobalIndex:        big.NewInt(1),
 				OriginNetwork:      0,
 				OriginAddress:      common.HexToAddress("0x1"),
 				DestinationNetwork: 10,
 				DestinationAddress: common.HexToAddress("0x2"),
 				Amount:             common.Big0,
-				Metadata:           []byte("metadata"),
 			},
 		}
 

--- a/rpc/mocks/mock_bridger.go
+++ b/rpc/mocks/mock_bridger.go
@@ -95,24 +95,24 @@ func (_c *Bridger_GetBridgesPaged_Call) RunAndReturn(run func(context.Context, u
 }
 
 // GetClaimsPaged provides a mock function with given fields: ctx, page, pageSize
-func (_m *Bridger) GetClaimsPaged(ctx context.Context, page uint32, pageSize uint32) ([]*bridgesync.Claim, int, error) {
+func (_m *Bridger) GetClaimsPaged(ctx context.Context, page uint32, pageSize uint32) ([]*bridgesync.ClaimResponse, int, error) {
 	ret := _m.Called(ctx, page, pageSize)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetClaimsPaged")
 	}
 
-	var r0 []*bridgesync.Claim
+	var r0 []*bridgesync.ClaimResponse
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) ([]*bridgesync.Claim, int, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) ([]*bridgesync.ClaimResponse, int, error)); ok {
 		return rf(ctx, page, pageSize)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) []*bridgesync.Claim); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) []*bridgesync.ClaimResponse); ok {
 		r0 = rf(ctx, page, pageSize)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*bridgesync.Claim)
+			r0 = ret.Get(0).([]*bridgesync.ClaimResponse)
 		}
 	}
 
@@ -151,12 +151,12 @@ func (_c *Bridger_GetClaimsPaged_Call) Run(run func(ctx context.Context, page ui
 	return _c
 }
 
-func (_c *Bridger_GetClaimsPaged_Call) Return(_a0 []*bridgesync.Claim, _a1 int, _a2 error) *Bridger_GetClaimsPaged_Call {
+func (_c *Bridger_GetClaimsPaged_Call) Return(_a0 []*bridgesync.ClaimResponse, _a1 int, _a2 error) *Bridger_GetClaimsPaged_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *Bridger_GetClaimsPaged_Call) RunAndReturn(run func(context.Context, uint32, uint32) ([]*bridgesync.Claim, int, error)) *Bridger_GetClaimsPaged_Call {
+func (_c *Bridger_GetClaimsPaged_Call) RunAndReturn(run func(context.Context, uint32, uint32) ([]*bridgesync.ClaimResponse, int, error)) *Bridger_GetClaimsPaged_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/rpc/mocks/mock_bridger.go
+++ b/rpc/mocks/mock_bridger.go
@@ -94,6 +94,73 @@ func (_c *Bridger_GetBridgesPaged_Call) RunAndReturn(run func(context.Context, u
 	return _c
 }
 
+// GetClaimsPaged provides a mock function with given fields: ctx, page, pageSize
+func (_m *Bridger) GetClaimsPaged(ctx context.Context, page uint32, pageSize uint32) ([]*bridgesync.Claim, int, error) {
+	ret := _m.Called(ctx, page, pageSize)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetClaimsPaged")
+	}
+
+	var r0 []*bridgesync.Claim
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) ([]*bridgesync.Claim, int, error)); ok {
+		return rf(ctx, page, pageSize)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) []*bridgesync.Claim); ok {
+		r0 = rf(ctx, page, pageSize)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*bridgesync.Claim)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32) int); ok {
+		r1 = rf(ctx, page, pageSize)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, uint32, uint32) error); ok {
+		r2 = rf(ctx, page, pageSize)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// Bridger_GetClaimsPaged_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetClaimsPaged'
+type Bridger_GetClaimsPaged_Call struct {
+	*mock.Call
+}
+
+// GetClaimsPaged is a helper method to define mock.On call
+//   - ctx context.Context
+//   - page uint32
+//   - pageSize uint32
+func (_e *Bridger_Expecter) GetClaimsPaged(ctx interface{}, page interface{}, pageSize interface{}) *Bridger_GetClaimsPaged_Call {
+	return &Bridger_GetClaimsPaged_Call{Call: _e.mock.On("GetClaimsPaged", ctx, page, pageSize)}
+}
+
+func (_c *Bridger_GetClaimsPaged_Call) Run(run func(ctx context.Context, page uint32, pageSize uint32)) *Bridger_GetClaimsPaged_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint32), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *Bridger_GetClaimsPaged_Call) Return(_a0 []*bridgesync.Claim, _a1 int, _a2 error) *Bridger_GetClaimsPaged_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *Bridger_GetClaimsPaged_Call) RunAndReturn(run func(context.Context, uint32, uint32) ([]*bridgesync.Claim, int, error)) *Bridger_GetClaimsPaged_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetProof provides a mock function with given fields: ctx, depositCount, localExitRoot
 func (_m *Bridger) GetProof(ctx context.Context, depositCount uint32, localExitRoot common.Hash) (types.Proof, error) {
 	ret := _m.Called(ctx, depositCount, localExitRoot)

--- a/rpc/openrpc.json
+++ b/rpc/openrpc.json
@@ -254,7 +254,7 @@
             },
             "count": {
               "type": "integer",
-              "description": "The total number of bridges."
+              "description": "The total number of claims."
             }
           }
         }

--- a/rpc/openrpc.json
+++ b/rpc/openrpc.json
@@ -181,6 +181,86 @@
       }
     },
     {
+      "name": "bridge_getClaims",
+      "summary": "Get Claims",
+      "description": "Returns the claims for the given network.",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/NetworkID"
+        },
+        {
+          "name": "page",
+          "description": "The page number for pagination.",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        },
+        {
+          "name": "pageSize",
+          "description": "The number of items per page for pagination.",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The claims result.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "bridges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "globalIndex": {
+                    "$ref": "#/components/schemas/GlobalIndex"
+                  },
+                  "destinationNetwork": {
+                    "$ref": "#/components/schemas/DestinationNetwork"
+                  },
+                  "txHash": {
+                    "$ref": "#/components/schemas/Keccak"
+                  },
+                  "amount": {
+                    "$ref": "#/components/schemas/Amount"
+                  },
+                  "blockNum": {
+                    "$ref": "#/components/schemas/BlockNumber"
+                  },
+                  "fromAddress": {
+                    "$ref": "#/components/schemas/Address"
+                  },
+                  "destinationAddress": {
+                    "$ref": "#/components/schemas/DestinationAddress"
+                  },
+                  "originAddress": {
+                    "$ref": "#/components/schemas/OriginTokenAddress"
+                  },
+                  "originNetwork": {
+                    "$ref": "#/components/schemas/OriginNetwork"
+                  },
+                  "blockTimestamp": {
+                    "type": "integer",
+                    "description": "The unix timestamp for when the block was collated"
+                  }
+                }
+              }
+            },
+            "count": {
+              "type": "integer",
+              "description": "The total number of bridges."
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "bridge_l1InfoTreeIndexForBridge",
       "summary": "Returns the first L1 Info Tree index in which the bridge was included. NetworkID represents the origin network. This call needs to be done to a client of the same network were the bridge tx was sent",
       "params": [

--- a/test/bats/helpers/lxly-bridge.bash
+++ b/test/bats/helpers/lxly-bridge.bash
@@ -353,21 +353,21 @@ function wait_for_expected_token() {
         # Fetch token mappings from the RPC
         token_mappings_result=$(cast rpc --rpc-url "$aggkit_node_url" "bridge_getTokenMappings" "$l2_rpc_network_id")
 
-        # Extract the first OriginTokenAddress (if available)
-        origin_token_address=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].OriginTokenAddress')
+        # Extract the first origin_token_address (if available)
+        origin_token_address=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].origin_token_address')
 
-        echo "Attempt $attempt: found OriginTokenAddress = $origin_token_address (Expected: $expected_origin_token)" >&3
+        echo "Attempt $attempt: found origin_token_address = $origin_token_address (Expected: $expected_origin_token)" >&3
 
         # Break loop if the expected token is found
         if [[ "$origin_token_address" == "$expected_origin_token" ]]; then
-            echo "Success: Expected OriginTokenAddress '$expected_origin_token' found. Exiting loop." >&3
+            echo "Success: Expected origin_token_address '$expected_origin_token' found. Exiting loop." >&3
             echo "$token_mappings_result"
             return 0
         fi
 
         # Fail test if max attempts are reached
         if [[ "$attempt" -ge "$max_attempts" ]]; then
-            echo "Error: Reached max attempts ($max_attempts) without finding expected OriginTokenAddress." >&2
+            echo "Error: Reached max attempts ($max_attempts) without finding expected origin_token_address." >&2
             return 1
         fi
 

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -225,10 +225,10 @@ setup() {
     assert_success
     local token_mappings_result=$output
 
-    local origin_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].OriginTokenAddress')
+    local origin_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].origin_token_address')
     assert_equal "$l1_erc20_addr" "$origin_token_addr"
 
-    local l2_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].WrappedTokenAddress')
+    local l2_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].wrapped_token_address')
     echo "L2 token addr $l2_token_addr" >&3
 
     run verify_balance "$l2_rpc_url" "$l2_token_addr" "$receiver" 0 "$tokens_amount"

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -65,7 +65,7 @@ setup() {
     assert_success
 
     echo "=== Running LxLy claim on L2" >&3
-    timeout="120"
+    timeout="180"
     claim_frequency="10"
     run wait_for_claim "$timeout" "$claim_frequency" "$l2_rpc_url" "bridgeAsset"
     assert_success
@@ -130,7 +130,7 @@ setup() {
     assert_success
 
     # Claim deposits (settle them on the L2)
-    timeout="60"
+    timeout="180"
     claim_frequency="10"
     run wait_for_claim "$timeout" "$claim_frequency" "$l2_rpc_url" "bridgeAsset"
     assert_success
@@ -152,7 +152,7 @@ setup() {
     assert_success
 
     # Claim withdrawals (settle them on the L1)
-    timeout="360"
+    timeout="180"
     claim_frequency="10"
     destination_net=$l1_rpc_network_id
     run wait_for_claim "$timeout" "$claim_frequency" "$l1_rpc_url" "bridgeAsset"
@@ -214,7 +214,7 @@ setup() {
     assert_success
 
     # Claim deposits (settle them on the L2)
-    timeout="120"
+    timeout="180"
     claim_frequency="10"
     run wait_for_claim "$timeout" "$claim_frequency" "$l2_rpc_url" "bridgeAsset"
     assert_success


### PR DESCRIPTION
## Description

This PR exposes a JSON-RPC endpoint to fetch bridge claims. It returns all claimed transactions on the network, sorted in descending order by globalIndex, with support for pagination.

