### PR TITLE
chore: bump docker image versions & pass the e2e tests

### DIFF
--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,8 +1,8 @@
 args:
+  agglayer_image: ghcr.io/agglayer/agglayer:main
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
   cdk_node_image: aggkit:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,11 +1,11 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
+  agglayer_image: ghcr.io/agglayer/agglayer:main
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
   cdk_node_image: aggkit:latest
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon


### PR DESCRIPTION
## Description

Fix the e2e tests by bumping the Docker images used for e2e testing (see https://github.com/0xPolygon/kurtosis-cdk/blob/vcastellm/adapt-aggkit/input_parser.star#L37-L53).

Fixes #212 
