### PR TITLE
test: bridge l2 erc20 token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.html
 .idea/*
 build/*
 data
+*.log

--- a/test/bats/helpers/common.bash
+++ b/test/bats/helpers/common.bash
@@ -129,7 +129,7 @@ function send_eoa_transaction() {
     local sender_initial_balance="$5"
     local receiver_initial_balance="$6"
 
-    log "✉️ Sending EOA transaction (from: $sender, rpc url: $rpc_url) to: $receiver_addr with value: $value"
+    log "📨 Sending EOA transaction (from: $sender, rpc url: $rpc_url) to: $receiver_addr with value: $value"
 
     # Send transaction via cast
     local cast_output tx_hash
@@ -170,7 +170,7 @@ function send_smart_contract_transaction() {
     shift 3
     local params=("$@")
 
-    log "✉️ Sending smart contract transaction to $receiver_addr with function signature: '$function_sig' and params: ${params[*]}"
+    log "📨 Sending smart contract transaction to $receiver_addr with function signature: '$function_sig' and params: ${params[*]}"
 
     # Send the smart contract interaction using cast
     local cast_output tx_hash

--- a/test/bats/helpers/lxly-bridge.bash
+++ b/test/bats/helpers/lxly-bridge.bash
@@ -267,6 +267,8 @@ function wait_for_expected_token() {
     local token_mappings_result
     local origin_token_address
 
+    echo "Waiting for expected origin_token_address $aggkit_node_url @ $enclave..." >&3
+
     while true; do
         ((attempt++))
 

--- a/test/bats/helpers/lxly-bridge.bash
+++ b/test/bats/helpers/lxly-bridge.bash
@@ -267,7 +267,7 @@ function wait_for_expected_token() {
     local token_mappings_result
     local origin_token_address
 
-    echo "Waiting for expected origin_token_address $aggkit_node_url @ $enclave..." >&3
+    log "⏳ Waiting for expected origin_token_address $aggkit_node_url @ $enclave..."
 
     while true; do
         ((attempt++))
@@ -278,11 +278,11 @@ function wait_for_expected_token() {
         # Extract the first origin_token_address (if available)
         origin_token_address=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].origin_token_address')
 
-        echo "Attempt $attempt: found origin_token_address = $origin_token_address (Expected: $expected_origin_token)" >&3
+        log "Attempt $attempt: found origin_token_address = $origin_token_address (Expected: $expected_origin_token)"
 
         # Break loop if the expected token is found
         if [[ "$origin_token_address" == "$expected_origin_token" ]]; then
-            echo "Success: Expected origin_token_address '$expected_origin_token' found. Exiting loop." >&3
+            log "✅ Expected origin_token_address '$expected_origin_token' found. Exiting loop."
             echo "$token_mappings_result"
             return 0
         fi

--- a/test/bats/helpers/lxly-bridge.bash
+++ b/test/bats/helpers/lxly-bridge.bash
@@ -258,24 +258,23 @@ function check_claim_revert_code() {
 }
 
 function wait_for_expected_token() {
-    local expected_origin_token="$1"
-    local max_attempts="$2"
-    local poll_frequency="$3"
-    local aggkit_url="$4"
+    local bridge_indexer_url="$1"
+    local expected_origin_token="$2"
+    local max_attempts="$3"
+    local poll_frequency="$4"
     local network_id="$5"
 
-    local aggkit_node_url=$(kurtosis port print $enclave cdk-node-001 rpc)
     local attempt=0
     local token_mappings_result
     local origin_token_address
 
-    log "⏳ Waiting for expected origin_token_address $aggkit_node_url @ $enclave..."
+    log "⏳ Waiting for expected origin_token_address $bridge_indexer_url @ $enclave..."
 
     while true; do
         ((attempt++))
 
         # Fetch token mappings from the RPC
-        token_mappings_result=$(cast rpc --rpc-url "$aggkit_url" "bridge_getTokenMappings" "$network_id")
+        token_mappings_result=$(cast rpc --rpc-url "$bridge_indexer_url" "bridge_getTokenMappings" "$network_id")
 
         # Extract the first origin_token_address (if available)
         origin_token_address=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].origin_token_address')

--- a/test/bats/helpers/lxly-bridge.bash
+++ b/test/bats/helpers/lxly-bridge.bash
@@ -260,7 +260,9 @@ function wait_for_expected_token() {
     local max_attempts="$2"
     local poll_frequency="$3"
     local aggkit_url="$4"
+    local network_id="$5"
 
+    local aggkit_node_url=$(kurtosis port print $enclave cdk-node-001 rpc)
     local attempt=0
     local token_mappings_result
     local origin_token_address
@@ -269,7 +271,7 @@ function wait_for_expected_token() {
         ((attempt++))
 
         # Fetch token mappings from the RPC
-        token_mappings_result=$(cast rpc --rpc-url "$aggkit_url" "bridge_getTokenMappings" "$l2_rpc_network_id")
+        token_mappings_result=$(cast rpc --rpc-url "$aggkit_url" "bridge_getTokenMappings" "$network_id")
 
         # Extract the first origin_token_address (if available)
         origin_token_address=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].origin_token_address')

--- a/test/bats/helpers/lxly-bridge.bash
+++ b/test/bats/helpers/lxly-bridge.bash
@@ -14,7 +14,7 @@ function bridge_message() {
     else
         local balance_wei=$(cast call --rpc-url "$rpc_url" "$token_addr" "$balance_of_fn_sig" "$sender_addr" | awk '{print $1}')
         local token_balance=$(cast --from-wei "$balance_wei")
-        log "💎 $sender_addr Token Balance: $token_balance units [$token_addr]"
+        log "💎 $sender_addr token ($token_addr) balance: $token_balance [eth]"
     fi
 
     log "🚀 Bridge message $amount wei → $destination_addr [network: $destination_net, token: $token_addr, rpc: $rpc_url]"
@@ -57,10 +57,10 @@ function bridge_asset() {
     else
         local balance_wei=$(cast call --rpc-url "$rpc_url" "$token_addr" "$balance_of_fn_sig" "$sender_addr" | awk '{print $1}')
         local token_balance=$(cast --from-wei "$balance_wei")
-        log "💎 $sender_addr Token Balance: $token_balance units [$token_addr]"
+        log "💎 $sender_addr token ($token_addr) balance: $token_balance [eth]"
     fi
 
-    log "🚀 Bridge asset $amount wei → $destination_addr [network: $destination_net]"
+    log "🚀 Bridge asset $amount wei → $destination_addr [network: $destination_net, rpc url: $rpc_url]"
 
     if [[ $dry_run == "true" ]]; then
         log "📝 Dry run bridge asset (showing calldata only)"
@@ -84,6 +84,8 @@ function bridge_asset() {
             echo $bridge_tx_hash
         else
             log "❌ Error: Transaction failed (no hash returned)"
+            log "Response:"
+            log "$response"
             return 1
         fi
     fi

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -7,14 +7,14 @@ setup() {
 
     if [ -z "$BRIDGE_ADDRESS" ]; then
         local combined_json_file="/opt/zkevm/combined.json"
-        echo "BRIDGE_ADDRESS env variable is not provided, resolving the bridge address from the Kurtosis CDK '$combined_json_file'" >&3
+        log "BRIDGE_ADDRESS env variable is not provided, resolving the bridge address from the Kurtosis CDK '$combined_json_file'"
 
         # Fetching the combined JSON output and filtering to get polygonZkEVMBridgeAddress
         combined_json_output=$($contracts_service_wrapper "cat $combined_json_file" | tail -n +2)
         bridge_default_address=$(echo "$combined_json_output" | jq -r .polygonZkEVMBridgeAddress)
         BRIDGE_ADDRESS=$bridge_default_address
     fi
-    echo "Bridge address=$BRIDGE_ADDRESS" >&3
+    log "Bridge address=$BRIDGE_ADDRESS"
 
     readonly sender_private_key=${SENDER_PRIVATE_KEY:-"12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
     readonly sender_addr="$(cast wallet address --private-key $sender_private_key)"
@@ -24,10 +24,10 @@ setup() {
     amount=$(cast to-wei $ether_value ether)
     readonly native_token_addr=${NATIVE_TOKEN_ADDRESS:-"0x0000000000000000000000000000000000000000"}
     if [[ -n "$GAS_TOKEN_ADDR" ]]; then
-        echo "Using provided GAS_TOKEN_ADDR: $GAS_TOKEN_ADDR" >&3
+        log "Using provided GAS_TOKEN_ADDR: $GAS_TOKEN_ADDR"
         gas_token_addr="$GAS_TOKEN_ADDR"
     else
-        echo "GAS_TOKEN_ADDR not provided, retrieving from rollup parameters file." >&3
+        log "GAS_TOKEN_ADDR not provided, retrieving from rollup parameters file."
         readonly rollup_params_file=/opt/zkevm/create_rollup_parameters.json
         run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | tail -n +2 | jq -r '.gasTokenAddress'"
         assert_success
@@ -56,7 +56,7 @@ setup() {
 
     destination_addr=$sender_addr
     local initial_receiver_balance=$(cast call --rpc-url "$l2_rpc_url" "$weth_token_addr" "$balance_of_fn_sig" "$destination_addr" | awk '{print $1}')
-    echo "Initial receiver balance of native token on L2 $initial_receiver_balance" >&3
+    log "Initial receiver balance of native token on L2 $initial_receiver_balance"
 
     echo "=== Running LxLy deposit on L1 to network: $l2_rpc_network_id native_token: $native_token_addr" >&3
     destination_net=$l2_rpc_network_id
@@ -88,22 +88,22 @@ setup() {
 }
 
 @test "Custom gas token deposit L1 -> L2" {
-    echo "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" >&3
+    log "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)"
 
     # SETUP
     # Set receiver address and query for its initial native token balance on the L2
     receiver=${RECEIVER:-"0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6"}
     local initial_receiver_balance=$(cast balance "$receiver" --rpc-url "$l2_rpc_url")
-    echo "Initial receiver ($receiver) balance of native token on L2 $initial_receiver_balance" >&3
+    log "Initial receiver ($receiver) balance of native token on L2 $initial_receiver_balance"
 
     local l1_minter_balance=$(cast balance "0x8943545177806ED17B9F23F0a21ee5948eCaa776" --rpc-url "$l1_rpc_url")
-    echo "Initial minter balance on L1 $l1_minter_balance" >&3
+    log "Initial minter balance on L1 $l1_minter_balance"
 
     # Query for initial sender balance
     run query_contract "$l1_rpc_url" "$gas_token_addr" "$balance_of_fn_sig" "$sender_addr"
     assert_success
     local gas_token_init_sender_balance=$(echo "$output" | tail -n 1 | awk '{print $1}')
-    echo "Initial sender balance $gas_token_init_sender_balance" of gas token on L1 >&3
+    log "Initial sender balance "$gas_token_init_sender_balance" of gas token on L1"
 
     # Mint gas token on L1
     local tokens_amount="0.1ether"
@@ -122,7 +122,7 @@ setup() {
         bc |
         awk '{print $1}')
 
-    echo "Sender balance ($sender_addr) (gas token L1): $gas_token_final_sender_balance" >&3
+    log "Sender balance ($sender_addr) (gas token L1): $gas_token_final_sender_balance"
     assert_equal "$gas_token_final_sender_balance" "$expected_balance"
 
     # Send approve transaction to the gas token on L1
@@ -174,11 +174,11 @@ setup() {
 }
 
 @test "Custom gas token deposit L2 -> L1" {
-    echo "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" >&3
+    log "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" 
 
     local initial_receiver_balance=$(cast call --rpc-url "$l1_rpc_url" "$gas_token_addr" "$balance_of_fn_sig" "$destination_addr" | awk '{print $1}')
     assert_success
-    echo "Receiver balance of gas token on L1 $initial_receiver_balance" >&3
+    log "Receiver balance of gas token on L1 $initial_receiver_balance"
 
     # Deposit token (on L2)
     destination_net=$l1_rpc_network_id
@@ -211,7 +211,7 @@ setup() {
 }
 
 @test "ERC20 token deposit L1 -> L2" {
-    echo "Retrieving ERC20 contract artifact from $erc20_artifact_path" >&3
+    log "Retrieving ERC20 contract artifact from $erc20_artifact_path"
 
     run jq -r '.bytecode' "$erc20_artifact_path"
     assert_success
@@ -226,7 +226,7 @@ setup() {
         grep 'contractAddress' |
         awk '{print $2}' |
         tr '[:upper:]' '[:lower:]')
-    echo "ERC20 contract address: $l1_erc20_addr" >&3
+    log "ERC20 contract address: $l1_erc20_addr"
 
     # Mint gas token on L1
     local tokens_amount="0.1ether"
@@ -240,7 +240,7 @@ setup() {
     local l1_erc20_token_sender_balance=$(echo "$output" |
         tail -n 1 |
         awk '{print $1}')
-    echo "Sender balance ($sender_addr) (ERC20 token L1): $l1_erc20_token_sender_balance [weis]" >&3
+    log "Sender balance ($sender_addr) (ERC20 token L1): $l1_erc20_token_sender_balance [weis]"
 
     # Send approve transaction to the gas token on L1
     run send_tx "$l1_rpc_url" "$sender_private_key" "$l1_erc20_addr" "$approve_fn_sig" "$bridge_addr" "$tokens_amount"
@@ -281,20 +281,20 @@ setup() {
     assert_equal "$l1_erc20_addr" "$origin_token_addr"
 
     local l2_wrapped_token=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].wrapped_token_address')
-    echo "L2 wrapped token address $l2_wrapped_token" >&3
+    log "L2 wrapped token address $l2_wrapped_token"
 
     run verify_balance "$l2_rpc_url" "$l2_wrapped_token" "$receiver" 0 "$tokens_amount"
     assert_success
 }
 
 @test "ERC20 token deposit L2 -> L1" {
-    echo "Retrieving ERC20 contract artifact from $erc20_artifact_path" >&3
+    log "Retrieving ERC20 contract artifact from $erc20_artifact_path"
 
     run jq -r '.bytecode' "$erc20_artifact_path"
     assert_success
     local erc20_bytecode="$output"
 
-    echo "Deploying ERC20 contract on L2 ($l2_rpc_url)" >&3
+    log "Deploying ERC20 contract on L2 ($l2_rpc_url)"
     run cast send --rpc-url "$l2_rpc_url" --private-key "$sender_private_key" --legacy --create "$erc20_bytecode"
     assert_success
     local erc20_deploy_output=$output
@@ -303,7 +303,7 @@ setup() {
         grep 'contractAddress' |
         awk '{print $2}' |
         tr '[:upper:]' '[:lower:]')
-    echo "ERC20 contract address: $l2_erc20_addr" >&3
+    log "ERC20 contract address: $l2_erc20_addr"
 
     # Mint ERC20 tokens on L2
     local tokens_amount="0.1ether"
@@ -317,7 +317,7 @@ setup() {
     local l2_erc20_token_sender_balance=$(echo "$output" |
         tail -n 1 |
         awk '{print $1}')
-    echo "Sender balance ($sender_addr) (ERC20 token L2): $l2_erc20_token_sender_balance [weis]" >&3
+    log "Sender balance ($sender_addr) (ERC20 token L2): $l2_erc20_token_sender_balance [weis]"
 
     # Send approve transaction to the ERC20 token on L2
     run send_tx "$l2_rpc_url" "$sender_private_key" "$l2_erc20_addr" "$approve_fn_sig" "$bridge_addr" "$tokens_amount"
@@ -347,7 +347,7 @@ setup() {
     assert_equal "$l2_erc20_addr" "$origin_token_addr"
 
     local l1_wrapped_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].wrapped_token_address')
-    echo "L1 wrapped token address $l1_wrapped_token_addr" >&3
+    log "L1 wrapped token address $l1_wrapped_token_addr"
 
     run verify_balance "$l1_rpc_url" "$l1_wrapped_token_addr" "$receiver" 0 "$tokens_amount"
     assert_success

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -49,12 +49,12 @@ setup() {
     readonly erc20_artifact_path=${ERC20_ARTIFACT_PATH:-"./contracts/erc20mock/ERC20Mock.json"}
 }
 
-@test "Native gas token deposit to WETH" {
-    destination_addr=$sender_addr
+@test "Native gas token bridge L1 -> L2" {
     run cast call --rpc-url $l2_rpc_url $bridge_addr 'WETHToken() (address)'
     assert_success
     readonly weth_token_addr=$output
 
+    destination_addr=$sender_addr
     local initial_receiver_balance=$(cast call --rpc-url "$l2_rpc_url" "$weth_token_addr" "$balance_of_fn_sig" "$destination_addr" | awk '{print $1}')
     echo "Initial receiver balance of native token on L2 $initial_receiver_balance" >&3
 
@@ -173,14 +173,14 @@ setup() {
     assert_success
 }
 
-@test "Custom gas token withdrawal L2 -> L1" {
-    echo "Custom gas token withdrawal (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" >&3
+@test "Custom gas token deposit L2 -> L1" {
+    echo "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" >&3
 
     local initial_receiver_balance=$(cast call --rpc-url "$l1_rpc_url" "$gas_token_addr" "$balance_of_fn_sig" "$destination_addr" | awk '{print $1}')
     assert_success
     echo "Receiver balance of gas token on L1 $initial_receiver_balance" >&3
 
-    # Deposit token on L2
+    # Deposit token (on L2)
     destination_net=$l1_rpc_network_id
     run bridge_asset "$native_token_addr" "$l2_rpc_url"
     assert_success

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -14,7 +14,7 @@ setup() {
         bridge_default_address=$(echo "$combined_json_output" | jq -r .polygonZkEVMBridgeAddress)
         BRIDGE_ADDRESS=$bridge_default_address
     fi
-    log "Bridge address=$BRIDGE_ADDRESS"
+    log "🌉 Bridge address=$BRIDGE_ADDRESS"
 
     readonly sender_private_key=${SENDER_PRIVATE_KEY:-"12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
     readonly sender_addr="$(cast wallet address --private-key $sender_private_key)"
@@ -24,10 +24,10 @@ setup() {
     amount=$(cast to-wei $ether_value ether)
     readonly native_token_addr=${NATIVE_TOKEN_ADDRESS:-"0x0000000000000000000000000000000000000000"}
     if [[ -n "$GAS_TOKEN_ADDR" ]]; then
-        log "Using provided GAS_TOKEN_ADDR: $GAS_TOKEN_ADDR"
+        log "🪙 Using provided GAS_TOKEN_ADDR: $GAS_TOKEN_ADDR"
         gas_token_addr="$GAS_TOKEN_ADDR"
     else
-        log "GAS_TOKEN_ADDR not provided, retrieving from rollup parameters file."
+        log "🪙 GAS_TOKEN_ADDR not provided, retrieving from rollup parameters file."
         readonly rollup_params_file=/opt/zkevm/create_rollup_parameters.json
         run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | tail -n +2 | jq -r '.gasTokenAddress'"
         assert_success
@@ -56,7 +56,7 @@ setup() {
 
     destination_addr=$sender_addr
     local initial_receiver_balance=$(cast call --rpc-url "$l2_rpc_url" "$weth_token_addr" "$balance_of_fn_sig" "$destination_addr" | awk '{print $1}')
-    log "Initial receiver balance of native token on L2 $initial_receiver_balance"
+    log "💰 Initial receiver balance of native token on L2 $initial_receiver_balance"
 
     echo "=== Running LxLy deposit on L1 to network: $l2_rpc_network_id native_token: $native_token_addr" >&3
     destination_net=$l2_rpc_network_id
@@ -88,22 +88,22 @@ setup() {
 }
 
 @test "Custom gas token deposit L1 -> L2" {
-    log "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)"
+    echo "🪙 Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)"
 
     # SETUP
     # Set receiver address and query for its initial native token balance on the L2
     receiver=${RECEIVER:-"0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6"}
     local initial_receiver_balance=$(cast balance "$receiver" --rpc-url "$l2_rpc_url")
-    log "Initial receiver ($receiver) balance of native token on L2 $initial_receiver_balance"
+    log "💰 Initial receiver ($receiver) balance of native token on L2 $initial_receiver_balance"
 
     local l1_minter_balance=$(cast balance "0x8943545177806ED17B9F23F0a21ee5948eCaa776" --rpc-url "$l1_rpc_url")
-    log "Initial minter balance on L1 $l1_minter_balance"
+    log "💰 Initial minter balance on L1 $l1_minter_balance"
 
     # Query for initial sender balance
     run query_contract "$l1_rpc_url" "$gas_token_addr" "$balance_of_fn_sig" "$sender_addr"
     assert_success
     local gas_token_init_sender_balance=$(echo "$output" | tail -n 1 | awk '{print $1}')
-    log "Initial sender balance "$gas_token_init_sender_balance" of gas token on L1"
+    log "💰 Initial sender balance "$gas_token_init_sender_balance" of gas token on L1"
 
     # Mint gas token on L1
     local tokens_amount="0.1ether"
@@ -122,7 +122,7 @@ setup() {
         bc |
         awk '{print $1}')
 
-    log "Sender balance ($sender_addr) (gas token L1): $gas_token_final_sender_balance"
+    log "💰 Sender balance ($sender_addr) (gas token L1): $gas_token_final_sender_balance"
     assert_equal "$gas_token_final_sender_balance" "$expected_balance"
 
     # Send approve transaction to the gas token on L1
@@ -174,11 +174,11 @@ setup() {
 }
 
 @test "Custom gas token deposit L2 -> L1" {
-    log "Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" 
+    log "🪙 Custom gas token deposit (gas token addr: $gas_token_addr, L1 RPC: $l1_rpc_url, L2 RPC: $l2_rpc_url)" 
 
     local initial_receiver_balance=$(cast call --rpc-url "$l1_rpc_url" "$gas_token_addr" "$balance_of_fn_sig" "$destination_addr" | awk '{print $1}')
     assert_success
-    log "Receiver balance of gas token on L1 $initial_receiver_balance"
+    log "💰 Receiver balance of gas token on L1 $initial_receiver_balance"
 
     # Deposit token (on L2)
     destination_net=$l1_rpc_network_id
@@ -211,7 +211,7 @@ setup() {
 }
 
 @test "ERC20 token deposit L1 -> L2" {
-    log "Retrieving ERC20 contract artifact from $erc20_artifact_path"
+    log "📜 Retrieving ERC20 contract artifact from $erc20_artifact_path"
 
     run jq -r '.bytecode' "$erc20_artifact_path"
     assert_success
@@ -226,7 +226,7 @@ setup() {
         grep 'contractAddress' |
         awk '{print $2}' |
         tr '[:upper:]' '[:lower:]')
-    log "ERC20 contract address: $l1_erc20_addr"
+    log "📜 ERC20 contract address: $l1_erc20_addr"
 
     # Mint gas token on L1
     local tokens_amount="0.1ether"
@@ -240,7 +240,7 @@ setup() {
     local l1_erc20_token_sender_balance=$(echo "$output" |
         tail -n 1 |
         awk '{print $1}')
-    log "Sender balance ($sender_addr) (ERC20 token L1): $l1_erc20_token_sender_balance [weis]"
+    log "💰 Sender balance ($sender_addr) (ERC20 token L1): $l1_erc20_token_sender_balance [weis]"
 
     # Send approve transaction to the gas token on L1
     run send_tx "$l1_rpc_url" "$sender_private_key" "$l1_erc20_addr" "$approve_fn_sig" "$bridge_addr" "$tokens_amount"
@@ -281,7 +281,7 @@ setup() {
     assert_equal "$l1_erc20_addr" "$origin_token_addr"
 
     local l2_wrapped_token=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].wrapped_token_address')
-    log "L2 wrapped token address $l2_wrapped_token"
+    log "🪙 L2 wrapped token address $l2_wrapped_token"
 
     run verify_balance "$l2_rpc_url" "$l2_wrapped_token" "$receiver" 0 "$tokens_amount"
     assert_success
@@ -294,7 +294,7 @@ setup() {
     assert_success
     local erc20_bytecode="$output"
 
-    log "Deploying ERC20 contract on L2 ($l2_rpc_url)"
+    echo "🚀 Deploying ERC20 contract on L2 ($l2_rpc_url)"
     run cast send --rpc-url "$l2_rpc_url" --private-key "$sender_private_key" --legacy --create "$erc20_bytecode"
     assert_success
     local erc20_deploy_output=$output
@@ -303,7 +303,7 @@ setup() {
         grep 'contractAddress' |
         awk '{print $2}' |
         tr '[:upper:]' '[:lower:]')
-    log "ERC20 contract address: $l2_erc20_addr"
+    log "📜 ERC20 contract address: $l2_erc20_addr"
 
     # Mint ERC20 tokens on L2
     local tokens_amount="0.1ether"
@@ -317,7 +317,7 @@ setup() {
     local l2_erc20_token_sender_balance=$(echo "$output" |
         tail -n 1 |
         awk '{print $1}')
-    log "Sender balance ($sender_addr) (ERC20 token L2): $l2_erc20_token_sender_balance [weis]"
+    log "💰 Sender balance ($sender_addr) (ERC20 token L2): $l2_erc20_token_sender_balance [weis]"
 
     # Send approve transaction to the ERC20 token on L2
     run send_tx "$l2_rpc_url" "$sender_private_key" "$l2_erc20_addr" "$approve_fn_sig" "$bridge_addr" "$tokens_amount"
@@ -347,7 +347,7 @@ setup() {
     assert_equal "$l2_erc20_addr" "$origin_token_addr"
 
     local l1_wrapped_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].wrapped_token_address')
-    log "L1 wrapped token address $l1_wrapped_token_addr"
+    log "🪙 L1 wrapped token address $l1_wrapped_token_addr"
 
     run verify_balance "$l1_rpc_url" "$l1_wrapped_token_addr" "$receiver" 0 "$tokens_amount"
     assert_success

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -338,6 +338,13 @@ setup() {
     assert_success
     local bridge_tx_hash=$output
 
+    run query_contract "$l2_rpc_url" "$l2_erc20_addr" "$balance_of_fn_sig" "$sender_addr"
+    assert_success
+    local l2_erc20_token_sender_balance=$(echo "$output" |
+        tail -n 1 |
+        awk '{print $1}')
+    log "💰 Sender balance ($sender_addr) (ERC20 token L2): $l2_erc20_token_sender_balance [weis]"
+
     # Claim deposit (settle it on the L1)
     echo "==== 🔐 Claiming ERC20 token deposit on L1 ($l1_rpc_url)" >&3
     timeout="180"

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -350,7 +350,7 @@ setup() {
     echo "==== 🔐 Claiming ERC20 token deposit on L1 ($l1_rpc_url)" >&3
     timeout="180"
     claim_frequency="10"
-    run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
+    run claim_bridge_by_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
     assert_success
 
     run wait_for_expected_token "$aggkit_node_url" "$l2_erc20_addr" 15 2 "$l1_rpc_network_id"
@@ -386,7 +386,7 @@ setup() {
     echo "==== 🔐 Claiming deposit on L2 ($l2_rpc_url)" >&3
     timeout="180"
     claim_frequency="10"
-    run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l2_rpc_url" "$bridge_api_url"
+    run claim_bridge_by_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l2_rpc_url" "$bridge_api_url"
     assert_success
 
     echo "==== 💰 Verifying balance on L2 ($l2_rpc_url)" >&3
@@ -416,7 +416,7 @@ setup() {
     echo "==== 🔐 Claiming ERC20 token deposit on L1 ($l1_rpc_url)" >&3
     timeout="180"
     claim_frequency="10"
-    run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
+    run claim_bridge_by_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
     assert_success
 
     echo "==== 💰 Verifying balance on L1 ($l1_rpc_url)" >&3

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -273,7 +273,7 @@ setup() {
     run claim_bridge "$bridge" "$proof" "$l2_rpc_url" 10 10 "$l1_rpc_network_id"
     assert_success
 
-    run wait_for_expected_token "$l1_erc20_addr" 10 2 "$aggkit_node_url" "$l1_rpc_network_id"
+    run wait_for_expected_token "$l1_erc20_addr" 30 2 "$aggkit_node_url" "$l1_rpc_network_id"
     assert_success
     local token_mappings_result=$output
 

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -273,7 +273,7 @@ setup() {
     run claim_bridge "$bridge" "$proof" "$l2_rpc_url" 10 10 "$l1_rpc_network_id"
     assert_success
 
-    run wait_for_expected_token "$l1_erc20_addr" 30 2 "$aggkit_node_url" "$l1_rpc_network_id"
+    run wait_for_expected_token "$l1_erc20_addr" 30 2 "$aggkit_node_url" "$l2_rpc_network_id"
     assert_success
     local token_mappings_result=$output
 

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -331,11 +331,12 @@ setup() {
     meta_bytes="0x"
     run bridge_asset "$l2_erc20_addr" "$l2_rpc_url"
     assert_success
+    local bridge_tx_hash=$output
 
     # Claim deposit (settle it on the L1)
     timeout="180"
     claim_frequency="10"
-    run wait_for_claim "$timeout" "$claim_frequency" "$l1_rpc_url" "bridgeAsset"
+    run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
     assert_success
 
     run wait_for_expected_token "$l2_erc20_addr" 15 2 "$l1_rpc_network_id"
@@ -366,11 +367,12 @@ setup() {
     meta_bytes="0x"
     run bridge_asset "$l1_wrapped_token_addr" "$l1_rpc_url"
     assert_success
+    local bridge_tx_hash=$output
 
     # Claim deposit (settle it on the L2)
     timeout="180"
     claim_frequency="10"
-    run wait_for_claim "$timeout" "$claim_frequency" "$l2_rpc_url" "bridgeAsset"
+    run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l2_rpc_url" "$bridge_api_url"
     assert_success
 
     run verify_balance "$l2_rpc_url" "$l2_erc20_addr" "$receiver" 0 "$tokens_amount"

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -325,8 +325,7 @@ setup() {
     assert_output --regexp "Transaction successful \(transaction hash: 0x[a-fA-F0-9]{64}\)"
 
     # Deposit on L2
-    local receiver=${RECEIVER:-"0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6"}
-    destination_addr=$receiver
+    destination_addr=$sender_addr
     destination_net=$l1_rpc_network_id
     amount=$(cast --to-unit $tokens_amount wei)
     meta_bytes="0x"
@@ -354,10 +353,6 @@ setup() {
 
     # TODO: @Stefan-Ethernal
     # Do another exit to see if this causes any issues (L1 -> L2)
-
-    # Mint ERC20 (wrapped) token on L1
-    run mint_erc20_tokens "$l1_rpc_url" "$l1_wrapped_token_addr" "$sender_private_key" "$sender_addr" "$tokens_amount"
-    assert_success
 
     # Send approve transaction to the ERC20 token on L1
     run send_tx "$l1_rpc_url" "$sender_private_key" "$l1_wrapped_token_addr" "$approve_fn_sig" "$bridge_addr" "$tokens_amount"

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -325,7 +325,7 @@ setup() {
     assert_output --regexp "Transaction successful \(transaction hash: 0x[a-fA-F0-9]{64}\)"
     run query_contract "$l2_rpc_url" "$l2_erc20_addr" "allowance(address owner, address spender)(uint256)" "$sender_addr" "$bridge_addr"
     assert_success
-    log "🔐 Allowance for bridge contract: $output"
+    log "🔐 Allowance for bridge contract: $output [weis]"
 
     # Deposit on L2
     echo "==== 🚀 Depositing ERC20 token on L2 ($l2_rpc_url)" >&3
@@ -355,7 +355,7 @@ setup() {
     local l1_wrapped_token_addr=$(echo "$token_mappings_result" | jq -r '.tokenMappings[0].wrapped_token_address')
     log "🪙  L1 wrapped token address $l1_wrapped_token_addr"
 
-    run verify_balance "$l1_rpc_url" "$l1_wrapped_token_addr" "$receiver" 0 "$tokens_amount"
+    run verify_balance "$l1_rpc_url" "$l1_wrapped_token_addr" "$destination_addr" 0 "$tokens_amount"
     assert_success
 
     # TODO: @Stefan-Ethernal
@@ -370,7 +370,6 @@ setup() {
     # Deposit the L1 wrapped token (bridge L1 -> L2)
     echo "==== 🚀 Depositing L1 wrapped token on L1 ($l1_rpc_url)" >&3
     destination_addr=$sender_addr
-    echo "destination addr: $destination_addr"
     destination_net=$l2_rpc_network_id
     amount=$(cast --to-unit $tokens_amount wei)
     meta_bytes="0x"
@@ -386,6 +385,6 @@ setup() {
     assert_success
 
     echo "==== 💰 Verifying balance on L2 ($l2_rpc_url)" >&3
-    run verify_balance "$l2_rpc_url" "$l2_erc20_addr" "$receiver" "$l2_erc20_token_sender_balance" "$tokens_amount"
+    run verify_balance "$l2_rpc_url" "$l2_erc20_addr" "$destination_addr" "$l2_erc20_token_sender_balance" "$tokens_amount"
     assert_success
 }

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -419,7 +419,7 @@ setup() {
     run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
     assert_success
 
-     echo "==== 💰 Verifying balance on L1 ($l1_rpc_url)" >&3
+    echo "==== 💰 Verifying balance on L1 ($l1_rpc_url)" >&3
     run verify_balance "$l1_rpc_url" "$l1_wrapped_token_addr" "$destination_addr" "$l1_wrapped_token_balance" "$tokens_amount"
     assert_success
 }

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -348,9 +348,19 @@ setup() {
 
     # Claim deposit (settle it on the L1)
     echo "==== 🔐 Claiming ERC20 token deposit on L1 ($l1_rpc_url)" >&3
-    timeout="180"
-    claim_frequency="10"
-    run claim_bridge_by_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
+    run get_bridge "$l2_rpc_network_id" "$bridge_tx_hash" 10 3 "$aggkit_node_url"
+    assert_success
+    local bridge="$output"
+    local deposit_count="$(echo "$bridge" | jq -r '.deposit_count')"
+    run find_l1_info_tree_index_for_bridge "$l2_rpc_network_id" "$deposit_count" 10 5 "$aggkit_node_url"
+    assert_success
+    local l1_info_tree_index="$output"
+    run find_injected_info_after_index "$l1_rpc_network_id" "$l1_info_tree_index" 10 20 "$aggkit_node_url"
+    assert_success
+    run generate_claim_proof "$l2_rpc_network_id" "$deposit_count" "$l1_info_tree_index" 10 5 "$aggkit_node_url"
+    assert_success
+    local proof="$output"
+    run claim_bridge "$bridge" "$proof" "$l1_rpc_url" 10 10 "$l2_rpc_network_id"
     assert_success
 
     run wait_for_expected_token "$aggkit_node_url" "$l2_erc20_addr" 15 2 "$l1_rpc_network_id"
@@ -384,9 +394,19 @@ setup() {
 
     # Claim deposit (settle it on the L2)
     echo "==== 🔐 Claiming deposit on L2 ($l2_rpc_url)" >&3
-    timeout="180"
-    claim_frequency="10"
-    run claim_bridge_by_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l2_rpc_url" "$bridge_api_url"
+    run get_bridge "$l1_rpc_network_id" "$bridge_tx_hash" 10 3 "$aggkit_node_url"
+    assert_success
+    local bridge="$output"
+    local deposit_count="$(echo "$bridge" | jq -r '.deposit_count')"
+    run find_l1_info_tree_index_for_bridge "$l1_rpc_network_id" "$deposit_count" 10 5 "$aggkit_node_url"
+    assert_success
+    local l1_info_tree_index="$output"
+    run find_injected_info_after_index "$l2_rpc_network_id" "$l1_info_tree_index" 10 20 "$aggkit_node_url"
+    assert_success
+    run generate_claim_proof "$l1_rpc_network_id" "$deposit_count" "$l1_info_tree_index" 10 5 "$aggkit_node_url"
+    assert_success
+    local proof="$output"
+    run claim_bridge "$bridge" "$proof" "$l1_rpc_url" 10 10 "$l1_rpc_network_id"
     assert_success
 
     echo "==== 💰 Verifying balance on L2 ($l2_rpc_url)" >&3
@@ -414,9 +434,19 @@ setup() {
 
     # Claim deposit (settle it on the L1)
     echo "==== 🔐 Claiming ERC20 token deposit on L1 ($l1_rpc_url)" >&3
-    timeout="180"
-    claim_frequency="10"
-    run claim_bridge_by_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
+    run get_bridge "$l2_rpc_network_id" "$bridge_tx_hash" 10 3 "$aggkit_node_url"
+    assert_success
+    local bridge="$output"
+    local deposit_count="$(echo "$bridge" | jq -r '.deposit_count')"
+    run find_l1_info_tree_index_for_bridge "$l2_rpc_network_id" "$deposit_count" 10 5 "$aggkit_node_url"
+    assert_success
+    local l1_info_tree_index="$output"
+    run find_injected_info_after_index "$l1_rpc_network_id" "$l1_info_tree_index" 10 20 "$aggkit_node_url"
+    assert_success
+    run generate_claim_proof "$l2_rpc_network_id" "$deposit_count" "$l1_info_tree_index" 10 5 "$aggkit_node_url"
+    assert_success
+    local proof="$output"
+    run claim_bridge "$bridge" "$proof" "$l1_rpc_url" 10 10 "$l2_rpc_network_id"
     assert_success
 
     echo "==== 💰 Verifying balance on L1 ($l1_rpc_url)" >&3

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -273,7 +273,7 @@ setup() {
     run claim_bridge "$bridge" "$proof" "$l2_rpc_url" 10 10 "$l1_rpc_network_id"
     assert_success
 
-    run wait_for_expected_token "$l1_erc20_addr" 30 2 "$aggkit_node_url" "$l2_rpc_network_id"
+    run wait_for_expected_token "$aggkit_node_url" "$l1_erc20_addr" 30 2 "$l2_rpc_network_id"
     assert_success
     local token_mappings_result=$output
 
@@ -353,7 +353,7 @@ setup() {
     run claim_tx_hash "$timeout" "$bridge_tx_hash" "$destination_addr" "$l1_rpc_url" "$bridge_api_url"
     assert_success
 
-    run wait_for_expected_token "$l2_erc20_addr" 15 2 "$l1_rpc_network_id"
+    run wait_for_expected_token "$aggkit_node_url" "$l2_erc20_addr" 15 2 "$l1_rpc_network_id"
     assert_success
     local token_mappings_result=$output
 


### PR DESCRIPTION
## Description

Implement bridging of custom ERC20 token from L2 to L1 and vice versa.

## Steps
1. Deploy mock ERC20 token on L2 network
2. Mint some supply to a sender account (e.g. 10 ETH value of mock ERC20 token)
3. Approve L2 bridge as a spender (e.g. 10 ETH value of mock ERC20 token)
4. Bridge L2 -> L1 (e.g. 1 ETH value of mock ERC20 token)
5. Claim bridge@L1
6. Wrapped token is deployed on L1
7. Approve L1 bridge as spender of the L1 wrapped token (e.g. 1 ETH value of L1 wrapped token)
8. Bridge L1 -> L2 (e.g. 1 ETH value of L1 wrapped token)
9. Claim bridge@L2
10. Bridge L2 -> L1 (e.g. 1 ETH value of mock ERC20 token)
11. Claim bridge@L1

```mermaid
sequenceDiagram
    participant User
    participant L2_Network
    participant L2_Bridge
    participant L1_Network
    participant L1_Bridge

    User->>L2_Network: Deploy mock ERC20 token
    User->>L2_Network: Mint 10 ETH worth of mock ERC20 to sender
    User->>L2_Network: Approve L2_Bridge as spender (10 ETH)
    User->>L2_Bridge: Bridge 1 ETH worth of mock ERC20 (L2 -> L1)
    L2_Bridge->>L1_Bridge: Transfer proof & assets
    User->>L1_Bridge: Claim bridge@L1
    L1_Bridge->>L1_Network: Deploy wrapped token on L1
    User->>L1_Network: Approve L1_Bridge as spender (1 ETH wrapped token)
    User->>L1_Bridge: Bridge 1 ETH wrapped token (L1 -> L2)
    L1_Bridge->>L2_Bridge: Transfer proof & assets
    User->>L2_Bridge: Claim bridge@L2
    User->>L2_Bridge: Bridge 1 ETH mock ERC20 (L2 -> L1)
    L2_Bridge->>L1_Bridge: Transfer proof & assets
    User->>L1_Bridge: Claim bridge@L1
```

Fixes #206 
