### PR TITLE
fix: upgrade kurtosis config

### DIFF
--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -27,8 +27,8 @@ args:
 
 
   cdk_node_image: aggkit:latest
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-RC1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,3 +1,6 @@
+deployment_stages:
+  deploy_l2_contracts: true
+
 args:
   cdk_node_image: aggkit:latest
   agglayer_image: ghcr.io/agglayer/agglayer:main

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,8 +1,8 @@
 args:
   cdk_node_image: aggkit:latest
   agglayer_image: ghcr.io/agglayer/agglayer:main
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-RC1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -7,7 +7,8 @@ args:
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
-  gas_token_enabled: false
+  gas_token_enabled: true
+  gas_token_address: ""
   zkevm_use_real_verifier: false
   enable_normalcy: true
   verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -10,8 +10,7 @@ args:
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
-  gas_token_enabled: true
-  gas_token_address: ""
+  gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
   verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,3 +1,6 @@
+deployment_stages:
+  deploy_l2_contracts: true
+
 args:
   cdk_node_image: aggkit:latest
   agglayer_image: ghcr.io/agglayer/agglayer:main

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,8 +1,8 @@
 args:
   cdk_node_image: aggkit:latest
   agglayer_image: ghcr.io/agglayer/agglayer:main
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-RC1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -8,5 +8,6 @@ args:
   sequencer_type: erigon
   erigon_strict_mode: false
   gas_token_enabled: true
+  gas_token_address: ""
   agglayer_prover_sp1_key: {{.AGGLAYER_PROVER_SP1_KEY}}
   enable_normalcy: true


### PR DESCRIPTION
## Description

This PR adapts the Kurtosis configuration in the repository, as there are new changes in the https://github.com/0xPolygon/kurtosis-cdk/tree/feat/enable-bridge-service-for-aggkit, which is used as a reference when running the e2e tests in the aggkit.

Fixes # (issue)
