### PR TITLE
feat: encode bridge and token mapping metadata hex

### DIFF
--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -55,6 +57,18 @@ type Bridge struct {
 	DepositCount       uint32         `meddler:"deposit_count" json:"deposit_count"`
 	TxHash             common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
 	FromAddress        common.Address `meddler:"from_address,address" json:"from_address"`
+}
+
+// MarshalJSON for hex-encoding Metadata field
+func (b *Bridge) MarshalJSON() ([]byte, error) {
+	type Alias Bridge // Prevent recursion
+	return json.Marshal(&struct {
+		Metadata string `json:"metadata"`
+		*Alias
+	}{
+		Metadata: hex.EncodeToString(b.Metadata),
+		Alias:    (*Alias)(b),
+	})
 }
 
 // BridgeResponse is the representation of a bridge event with additional fields
@@ -138,6 +152,18 @@ type TokenMapping struct {
 	OriginTokenAddress  common.Address `meddler:"origin_token_address,address" json:"origin_token_address"`
 	WrappedTokenAddress common.Address `meddler:"wrapped_token_address,address" json:"wrapped_token_address"`
 	Metadata            []byte         `meddler:"metadata" json:"metadata"`
+}
+
+// MarshalJSON for hex-encoding Metadata field
+func (tm *TokenMapping) MarshalJSON() ([]byte, error) {
+	type Alias TokenMapping // Prevent recursion
+	return json.Marshal(&struct {
+		Metadata string `json:"metadata"`
+		*Alias
+	}{
+		Metadata: hex.EncodeToString(tm.Metadata),
+		Alias:    (*Alias)(tm),
+	})
 }
 
 // Event combination of bridge, claim and token mapping events

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -66,7 +66,7 @@ func (b *Bridge) MarshalJSON() ([]byte, error) {
 		Metadata string `json:"metadata"`
 		*Alias
 	}{
-		Metadata: hex.EncodeToString(b.Metadata),
+		Metadata: "0x" + hex.EncodeToString(b.Metadata),
 		Alias:    (*Alias)(b),
 	})
 }
@@ -155,14 +155,14 @@ type TokenMapping struct {
 }
 
 // MarshalJSON for hex-encoding Metadata field
-func (tm *TokenMapping) MarshalJSON() ([]byte, error) {
+func (t *TokenMapping) MarshalJSON() ([]byte, error) {
 	type Alias TokenMapping // Prevent recursion
 	return json.Marshal(&struct {
 		Metadata string `json:"metadata"`
 		*Alias
 	}{
-		Metadata: hex.EncodeToString(tm.Metadata),
-		Alias:    (*Alias)(tm),
+		Metadata: "0x" + hex.EncodeToString(t.Metadata),
+		Alias:    (*Alias)(t),
 	})
 }
 

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1199,6 +1199,7 @@ func TestGetTokenMapping(t *testing.T) {
 			OriginNetwork:       uint32(i),
 			OriginTokenAddress:  common.HexToAddress(fmt.Sprintf("%d", i)),
 			WrappedTokenAddress: common.HexToAddress(fmt.Sprintf("%d", i+1)),
+			Metadata:            common.Hex2Bytes(fmt.Sprintf("%x", i+1)),
 		}
 
 		block := sync.Block{

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -80,26 +80,21 @@ type TokenMappingsResult struct {
 
 // GetTokenMappings returns the token mappings for the given network
 func (b *BridgeEndpoints) GetTokenMappings(networkID uint32, pageNumber, pageSize *uint32) (interface{}, rpc.Error) {
-	b.logger.Debugf("GetTokenMappings invoked (network id=%d, page number=%v, page size=%v)",
-		networkID, pageNumber, pageSize)
+	b.logger.Debugf("GetTokenMappings request received (network id=%d)", networkID)
 
-	ctx, cancel := context.WithTimeout(context.Background(), b.readTimeout)
+	ctx, cancel, pageNumberU32, pageSizeU32, setupErr := b.setupRequest(pageNumber, pageSize, "get_token_mappings")
+	if setupErr != nil {
+		return nil, setupErr
+	}
 	defer cancel()
 
-	c, merr := b.meter.Int64Counter("get_token_mappings")
-	if merr != nil {
-		b.logger.Warnf("failed to create get_token_mappings counter: %s", merr)
-	}
-	c.Add(ctx, 1)
-
-	pageNumberU32, pageSizeU32, err := validatePaginationParams(pageNumber, pageSize)
-	if err != nil {
-		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode, err.Error())
-	}
+	b.logger.Debugf("fetching token mappings (network id=%d, page number=%d, page size=%d)",
+		networkID, pageNumberU32, pageSizeU32)
 
 	var (
 		tokenMappings      []*bridgesync.TokenMapping
 		tokenMappingsCount int
+		err                error
 	)
 
 	switch {
@@ -239,11 +234,16 @@ func (b *BridgeEndpoints) GetBridges(
 	pageNumber, pageSize *uint32,
 	depositCount *uint64,
 ) (interface{}, rpc.Error) {
+	b.logger.Debugf("GetBridges request received (network id=%d)", networkID)
+
 	ctx, cancel, pageNumberU32, pageSizeU32, setupErr := b.setupRequest(pageNumber, pageSize, "get_bridges")
 	if setupErr != nil {
 		return nil, setupErr
 	}
 	defer cancel()
+
+	b.logger.Debugf("fetching bridges (network id=%d, page number=%d, page size=%d)",
+		networkID, pageNumberU32, pageSizeU32)
 
 	var (
 		bridges []*bridgesync.BridgeResponse
@@ -283,11 +283,16 @@ type ClaimsResult struct {
 func (b *BridgeEndpoints) GetClaims(networkID uint32,
 	pageNumber, pageSize *uint32,
 ) (interface{}, rpc.Error) {
+	b.logger.Debugf("GetClaims request received (network id=%d)", networkID)
+
 	ctx, cancel, pageNumberU32, pageSizeU32, setupErr := b.setupRequest(pageNumber, pageSize, "get_claims")
 	if setupErr != nil {
 		return nil, setupErr
 	}
 	defer cancel()
+
+	b.logger.Debugf("fetching claims (network id=%d, page number=%d, page size=%d)",
+		networkID, pageNumberU32, pageSizeU32)
 
 	var (
 		claims []*bridgesync.ClaimResponse

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -438,7 +439,7 @@ func TestGetTokenMappings(t *testing.T) {
 				OriginNetwork:       1,
 				OriginTokenAddress:  common.HexToAddress("0x1"),
 				WrappedTokenAddress: common.HexToAddress("0x2"),
-				Metadata:            []byte("metadata"),
+				Metadata:            common.Hex2Bytes("abcd"),
 			},
 		}
 
@@ -453,6 +454,14 @@ func TestGetTokenMappings(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, tokenMappings, tokenMappingsResult.TokenMappings)
 		require.Equal(t, len(tokenMappingsResult.TokenMappings), tokenMappingsResult.Count)
+
+		actualJSON, marshalErr := json.Marshal(tokenMappingsResult.TokenMappings)
+		require.NoError(t, marshalErr)
+
+		expectedJSON, marshalErr := json.Marshal(tokenMappings)
+		require.NoError(t, marshalErr)
+
+		require.JSONEq(t, string(expectedJSON), string(actualJSON))
 
 		bridgeMocks.bridgeL1.AssertExpectations(t)
 	})
@@ -542,7 +551,7 @@ func TestGetBridges(t *testing.T) {
 					DestinationAddress: common.HexToAddress("0x2"),
 					Amount:             common.Big0,
 					DepositCount:       0,
-					Metadata:           []byte("metadata"),
+					Metadata:           common.Hex2Bytes("deadbeef"),
 				},
 			},
 		}
@@ -558,6 +567,14 @@ func TestGetBridges(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, bridges, bridgesResult.Bridges)
 		require.Equal(t, len(bridgesResult.Bridges), bridgesResult.Count)
+
+		actualJSON, marshalErr := json.Marshal(bridgesResult.Bridges)
+		require.NoError(t, marshalErr)
+
+		expectedJSON, marshalErr := json.Marshal(bridges)
+		require.NoError(t, marshalErr)
+
+		require.JSONEq(t, string(expectedJSON), string(actualJSON))
 
 		bridgeMocks.bridgeL1.AssertExpectations(t)
 	})


### PR DESCRIPTION
## Description

This PR encodes the metadata fields in the bridge and token mappings in a hex format.

Fixes # (issue)
