### PR TITLE
fix: wait for transaction receipt in a loop in claim calldata test

### DIFF
--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -55,7 +55,7 @@ func TestBridgeCallData(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = waitForReceipt(ctx, client, deployProxyTx.Hash(), 10)
+	_, err = waitForReceipt(ctx, client, deployProxyTx.Hash(), 20)
 	require.NoError(t, err)
 
 	bridgeContract, err := polygonzkevmbridgev2.NewPolygonzkevmbridgev2(bridgeProxyAddr, client)
@@ -99,7 +99,7 @@ func TestBridgeCallData(t *testing.T) {
 	err = client.SendTransaction(ctx, signedFundTx)
 	require.NoError(t, err)
 
-	_, err = waitForReceipt(ctx, client, signedFundTx.Hash(), 10)
+	_, err = waitForReceipt(ctx, client, signedFundTx.Hash(), 20)
 	require.NoError(t, err)
 
 	userBalance, err := client.BalanceAt(ctx, userAuth.From, big.NewInt(int64(etherman.Latest)))
@@ -135,7 +135,13 @@ func TestBridgeCallData(t *testing.T) {
 		amount             = big.NewInt(1000)
 	)
 
-	bridgeAssetInput, err := bridgeABI.Pack("bridgeAsset", destinationNetwork, destinationAddr, amount, zeroAddr, false, []byte{})
+	bridgeAssetInput, err := bridgeABI.Pack("bridgeAsset",
+		destinationNetwork, // destination network id
+		destinationAddr,    // destination address
+		amount,             // amount of tokens being bridged
+		zeroAddr,           // token address
+		false,              // update global exit root
+		[]byte{})           // permit data
 	require.NoError(t, err)
 
 	nonce, err = client.PendingNonceAt(ctx, userAuth.From)
@@ -170,6 +176,7 @@ func TestBridgeCallData(t *testing.T) {
 	maxAttempts := 100
 	attempt := 0
 
+	// wait for bridge event to get indexed
 	for attempt < maxAttempts {
 		bridgeResponse, totalCount, err := bridgeSync.GetBridgesPaged(ctx, page, pageSize, nil)
 		require.NoError(t, err)

--- a/bridgesync/claimcalldata_test.go
+++ b/bridgesync/claimcalldata_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/test/contracts/claimmock"
@@ -110,8 +109,8 @@ func TestClaimCalldata(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err := client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err := waitForReceipt(ctx, client, tx.Hash(), 10)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "direct call to claim asset",
@@ -139,8 +138,8 @@ func TestClaimCalldata(t *testing.T) {
 		false,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "indirect call to claim asset",
@@ -160,8 +159,8 @@ func TestClaimCalldata(t *testing.T) {
 		false,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "indirect call to claim asset bytes",
@@ -188,8 +187,8 @@ func TestClaimCalldata(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "direct call to claim message",
@@ -217,8 +216,8 @@ func TestClaimCalldata(t *testing.T) {
 		false,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "indirect call to claim message",
@@ -238,8 +237,8 @@ func TestClaimCalldata(t *testing.T) {
 		false,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "indirect call to claim message bytes",
@@ -259,7 +258,6 @@ func TestClaimCalldata(t *testing.T) {
 		true,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
 
 	reverted := [2]bool{false, false}
 
@@ -279,8 +277,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim message 1 (same globalIndex)",
@@ -311,8 +309,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim message 1 (diff globalIndex)",
@@ -345,8 +343,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim message (same globalIndex) (1 ok, 1 reverted)",
@@ -371,8 +369,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim message (diff globalIndex) (1 ok, 1 reverted)",
@@ -399,8 +397,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim message (same globalIndex) (reverted,ok)",
@@ -425,8 +423,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim message (diff globalIndex) (reverted,ok)",
@@ -453,8 +451,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim asset 1 (same globalIndex)",
@@ -485,8 +483,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim asset 1 (diff globalIndex)",
@@ -519,8 +517,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim asset (same globalIndex) (1 ok, 1 reverted)",
@@ -545,8 +543,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim asset (diff globalIndex) (1 ok, 1 reverted)",
@@ -573,8 +571,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim asset (same globalIndex) (reverted,ok)",
@@ -599,8 +597,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect call claim asset (diff globalIndex) (reverted,ok)",
@@ -620,8 +618,8 @@ func TestClaimCalldata(t *testing.T) {
 		false,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "indirect + indirect call to claim message bytes",
@@ -648,8 +646,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 indirect + indirect call claim message 1 (same globalIndex)",
@@ -687,8 +685,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "3 ok (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",
@@ -730,8 +728,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "3 ok (indirectx2, indirect, indirectx2) call claim message 1 (diff globalIndex)",
@@ -775,8 +773,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ko 2 ok (indirectx2, indirect, indirectx2) call claim message 1 (diff globalIndex)",
@@ -814,8 +812,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ko 2 ok (indirectx2, indirect, indirectx2) call claim message 1 (diff globalIndex)",
@@ -853,8 +851,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ok 1 ok 1 ko (indirectx2, indirect, indirectx2) call claim message 1 (diff globalIndex)",
@@ -892,8 +890,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ko 2 ok (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",
@@ -931,8 +929,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ko 2 ok (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",
@@ -970,8 +968,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ok 1 ok 1 ko (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",
@@ -1009,8 +1007,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "2 ko 1 ok (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",
@@ -1042,8 +1040,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ok 2 ko (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",
@@ -1075,8 +1073,8 @@ func TestClaimCalldata(t *testing.T) {
 		reverted3,
 	)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
-	r, err = client.TransactionReceipt(ctx, tx.Hash())
+
+	r, err = waitForReceipt(ctx, client, tx.Hash(), 20)
 	require.NoError(t, err)
 	testCases = append(testCases, testCase{
 		description:   "1 ko 1 ok 1 ko (indirectx2, indirect, indirectx2) call claim message 1 (same globalIndex)",

--- a/bridgesync/helpers_test.go
+++ b/bridgesync/helpers_test.go
@@ -22,7 +22,7 @@ import (
 func startGeth(t *testing.T, ctx context.Context, cancelFn context.CancelFunc) (*ethclient.Client, *bind.TransactOpts) {
 	t.Helper()
 
-	log.Debug("starting docker")
+	log.Debug("starting Geth docker container")
 	msg, err := exec.Command("bash", "-l", "-c", "docker compose up -d").CombinedOutput()
 	require.NoError(t, err, string(msg))
 
@@ -31,9 +31,9 @@ func startGeth(t *testing.T, ctx context.Context, cancelFn context.CancelFunc) (
 		cancelFn()
 		msg, err = exec.Command("bash", "-l", "-c", "docker compose down").CombinedOutput()
 		require.NoError(t, err, string(msg))
-		log.Debug("docker is shutted down")
+		log.Debug("Geth docker container is shutted down")
 	})
-	log.Debug("docker started")
+	log.Debug("Geth docker container is started")
 
 	client, err := dialGeth("http://127.0.0.1:8545", 10, time.Second)
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func waitForReceipt(ctx context.Context, client *ethclient.Client, txHash common
 		}
 		receipt, err = client.TransactionReceipt(ctx, txHash)
 		if errors.Is(err, ethereum.NotFound) {
-			time.Sleep(time.Second)
+			time.Sleep(500 * time.Millisecond)
 			attempts++
 			continue
 		} else if err != nil {


### PR DESCRIPTION
## Description

Stabilize the flaky claim calldata test, by waiting for the transaction receipt in a loop (e.g. https://github.com/agglayer/aggkit/actions/runs/13843134128/job/38735246814).

Fixes # (issue)
