### PR TITLE
fix: bats

### DIFF
--- a/test/bats/helpers/common-multi_cdk-setup.bash
+++ b/test/bats/helpers/common-multi_cdk-setup.bash
@@ -7,8 +7,8 @@ _common_multi_setup() {
     readonly target_address=0xbecE3a31343c6019CDE0D5a4dF2AF8Df17ebcB0f
     readonly target_private_key=0x51caa196504216b1730280feb63ddd8c5ae194d13e57e58d559f1f1dc3eda7c9
 
-    kurtosis service exec $enclave contracts-001 "cat /opt/zkevm/combined-001.json" | tail -n +2 | jq '.' >combined-001.json
-    kurtosis service exec $enclave contracts-002 "cat /opt/zkevm/combined-002.json" | tail -n +2 | jq '.' >combined-002.json
+    kurtosis service exec $enclave contracts-001 "cat /opt/zkevm/combined-001.json" | jq '.' >combined-001.json
+    kurtosis service exec $enclave contracts-002 "cat /opt/zkevm/combined-002.json" | jq '.' >combined-002.json
 
     readonly private_key="0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
     readonly eth_address=$(cast wallet address --private-key $private_key)
@@ -18,7 +18,7 @@ _common_multi_setup() {
     readonly bridge_address=$(cat combined-001.json | jq -r .polygonZkEVMBridgeAddress)
     readonly pol_address=$(cat combined-001.json | jq -r .polTokenAddress)
     readonly rollup_params_file=/opt/zkevm/create_rollup_parameters.json
-    run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | tail -n +2 | jq -r '.gasTokenAddress'"
+    run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | jq -r '.gasTokenAddress'"
     assert_success
     readonly gas_token_addr=$output
     readonly l2_pp1b_url=$(kurtosis port print $enclave zkevm-bridge-service-001 rpc)

--- a/test/bats/pp/bridge-e2e-msg.bats
+++ b/test/bats/pp/bridge-e2e-msg.bats
@@ -9,7 +9,7 @@ setup() {
         echo "BRIDGE_ADDRESS env variable is not provided, resolving the bridge address from the Kurtosis CDK '$combined_json_file'" >&3
 
         # Fetching the combined JSON output and filtering to get polygonZkEVMBridgeAddress
-        combined_json_output=$($contracts_service_wrapper "cat $combined_json_file" | tail -n +2)
+        combined_json_output=$($contracts_service_wrapper "cat $combined_json_file")
         bridge_default_address=$(echo "$combined_json_output" | jq -r .polygonZkEVMBridgeAddress)
         BRIDGE_ADDRESS=$bridge_default_address
     fi
@@ -28,7 +28,7 @@ setup() {
     else
         echo "GAS_TOKEN_ADDR not provided, retrieving from rollup parameters file." >&3
         readonly rollup_params_file=/opt/zkevm/create_rollup_parameters.json
-        run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | tail -n +2 | jq -r '.gasTokenAddress'"
+        run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | jq -r '.gasTokenAddress'"
         assert_success
         assert_output --regexp "0x[a-fA-F0-9]{40}"
         gas_token_addr=$output

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -10,7 +10,7 @@ setup() {
         echo "BRIDGE_ADDRESS env variable is not provided, resolving the bridge address from the Kurtosis CDK '$combined_json_file'" >&3
 
         # Fetching the combined JSON output and filtering to get polygonZkEVMBridgeAddress
-        combined_json_output=$($contracts_service_wrapper "cat $combined_json_file" | tail -n +2)
+        combined_json_output=$($contracts_service_wrapper "cat $combined_json_file")
         bridge_default_address=$(echo "$combined_json_output" | jq -r .polygonZkEVMBridgeAddress)
         BRIDGE_ADDRESS=$bridge_default_address
     fi
@@ -29,7 +29,7 @@ setup() {
     else
         echo "GAS_TOKEN_ADDR not provided, retrieving from rollup parameters file." >&3
         readonly rollup_params_file=/opt/zkevm/create_rollup_parameters.json
-        run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | tail -n +2 | jq -r '.gasTokenAddress'"
+        run bash -c "$contracts_service_wrapper 'cat $rollup_params_file' | jq -r '.gasTokenAddress'"
         assert_success
         assert_output --regexp "0x[a-fA-F0-9]{40}"
         gas_token_addr=$output

--- a/test/bats/pp/e2e-pp.bats
+++ b/test/bats/pp/e2e-pp.bats
@@ -8,7 +8,7 @@ setup() {
         echo "BRIDGE_ADDRESS env variable is not provided, resolving the bridge address from the Kurtosis CDK '$combined_json_file'" >&3
 
         # Fetching the combined JSON output and filtering to get polygonZkEVMBridgeAddress
-        combined_json_output=$($contracts_service_wrapper "cat $combined_json_file" | tail -n +2)
+        combined_json_output=$($contracts_service_wrapper "cat $combined_json_file")
         bridge_default_address=$(echo "$combined_json_output" | jq -r .polygonZkEVMBridgeAddress)
         BRIDGE_ADDRESS=$bridge_default_address
     fi


### PR DESCRIPTION
## Description

The` tail -n +2` command was truncating the first line of the JSON file, causing parsing errors with `jq` when running locally. This update removes `tail -n +2` to ensure tests work correctly in the local environment.