### PR TITLE
feat: add block num

### DIFF
--- a/agglayer/types.go
+++ b/agglayer/types.go
@@ -515,6 +515,21 @@ func (l *L1InfoTreeLeaf) String() string {
 	)
 }
 
+type InsertedGERWithBlockNumber struct {
+	BlockNumber     uint64      `json:"block_number"`
+	InsertedGerLeaf InsertedGer `json:"inserted_ger_leaf"`
+}
+
+type InsertedGer struct {
+	ProofGERToL1Root *MerkleProof    `json:"proof_ger_l1root"`
+	L1Leaf           *L1InfoTreeLeaf `json:"l1_leaf"`
+}
+
+type ImportedBridgeExitWithBlockNumber struct {
+	BlockNumber        uint64              `json:"block_number"`
+	ImportedBridgeExit *ImportedBridgeExit `json:"imported_bridge_exit"`
+}
+
 // Claim is the interface that will be implemented by the different types of claims
 type Claim interface {
 	Type() string

--- a/aggsender/flow_aggchain_prover_test.go
+++ b/aggsender/flow_aggchain_prover_test.go
@@ -120,8 +120,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					agglayer.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: treeTypes.Proof{},
-					}, make(map[common.Hash]*agglayer.ClaimFromMainnnet, 0),
-					[]*agglayer.ImportedBridgeExit{ibe1}).Return(&types.AggchainProof{
+					}, make(map[common.Hash]*agglayer.InsertedGERWithBlockNumber, 0),
+					[]*agglayer.ImportedBridgeExitWithBlockNumber{{ImportedBridgeExit: ibe1}}).Return(&types.AggchainProof{
 					Proof: []byte("some-proof"), StartBlock: 1, EndBlock: 10}, nil)
 			},
 			expectedParams: &types.CertificateBuildParams{
@@ -175,8 +175,11 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					agglayer.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: treeTypes.Proof{},
-					}, make(map[common.Hash]*agglayer.ClaimFromMainnnet, 0),
-					[]*agglayer.ImportedBridgeExit{ibe1, ibe2}).Return(&types.AggchainProof{
+					}, make(map[common.Hash]*agglayer.InsertedGERWithBlockNumber, 0),
+					[]*agglayer.ImportedBridgeExitWithBlockNumber{
+						{ImportedBridgeExit: ibe1, BlockNumber: 6},
+						{ImportedBridgeExit: ibe2, BlockNumber: 9},
+					}).Return(&types.AggchainProof{
 					Proof: []byte("some-proof"), StartBlock: 1, EndBlock: 8}, nil)
 			},
 			expectedParams: &types.CertificateBuildParams{
@@ -225,8 +228,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					agglayer.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: treeTypes.Proof{},
-					}, make(map[common.Hash]*agglayer.ClaimFromMainnnet, 0),
-					[]*agglayer.ImportedBridgeExit{ibe1}).Return(nil, errors.New("some error"))
+					}, make(map[common.Hash]*agglayer.InsertedGERWithBlockNumber, 0),
+					[]*agglayer.ImportedBridgeExitWithBlockNumber{{ImportedBridgeExit: ibe1}}).Return(nil, errors.New("some error"))
 			},
 			expectedError: "error fetching aggchain proof for block range 1 : 10 : some error",
 		},
@@ -261,8 +264,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					agglayer.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: treeTypes.Proof{},
-					}, make(map[common.Hash]*agglayer.ClaimFromMainnnet, 0),
-					[]*agglayer.ImportedBridgeExit{ibe1}).Return(&types.AggchainProof{
+					}, make(map[common.Hash]*agglayer.InsertedGERWithBlockNumber, 0),
+					[]*agglayer.ImportedBridgeExitWithBlockNumber{{ImportedBridgeExit: ibe1}}).Return(&types.AggchainProof{
 					Proof: []byte("some-proof"), StartBlock: 6, EndBlock: 10}, nil)
 			},
 			expectedParams: &types.CertificateBuildParams{
@@ -310,8 +313,11 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					agglayer.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: treeTypes.Proof{},
-					}, make(map[common.Hash]*agglayer.ClaimFromMainnnet, 0),
-					[]*agglayer.ImportedBridgeExit{ibe1, ibe2}).Return(&types.AggchainProof{
+					}, make(map[common.Hash]*agglayer.InsertedGERWithBlockNumber, 0),
+					[]*agglayer.ImportedBridgeExitWithBlockNumber{
+						{ImportedBridgeExit: ibe1, BlockNumber: 8},
+						{ImportedBridgeExit: ibe2, BlockNumber: 9},
+					}).Return(&types.AggchainProof{
 					Proof: []byte("some-proof"), StartBlock: 6, EndBlock: 8}, nil)
 			},
 			expectedParams: &types.CertificateBuildParams{
@@ -583,7 +589,7 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 	testCases := []struct {
 		name           string
 		mockFn         func(*mocks.ChainGERReader, *mocks.L1InfoTreeSyncer)
-		expectedProofs map[common.Hash]*agglayer.ClaimFromMainnnet
+		expectedProofs map[common.Hash]*agglayer.InsertedGERWithBlockNumber
 		expectedError  string
 	}{
 		{
@@ -636,20 +642,23 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 				)
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(1), common.HexToHash("0x2")).Return(treeTypes.Proof{}, nil)
 			},
-			expectedProofs: map[common.Hash]*agglayer.ClaimFromMainnnet{
+			expectedProofs: map[common.Hash]*agglayer.InsertedGERWithBlockNumber{
 				common.HexToHash("0x1"): {
-					ProofGERToL1Root: &agglayer.MerkleProof{
-						Proof: treeTypes.Proof{},
-						Root:  common.HexToHash("0x2"),
-					},
-					L1Leaf: &agglayer.L1InfoTreeLeaf{
-						L1InfoTreeIndex: 1,
-						RollupExitRoot:  common.HexToHash("0x33"),
-						MainnetExitRoot: common.HexToHash("0x11"),
-						Inner: &agglayer.L1InfoTreeLeafInner{
-							GlobalExitRoot: common.HexToHash("0x1"),
-							BlockHash:      common.HexToHash("0x22"),
-							Timestamp:      112,
+					BlockNumber: 111,
+					InsertedGerLeaf: agglayer.InsertedGer{
+						ProofGERToL1Root: &agglayer.MerkleProof{
+							Proof: treeTypes.Proof{},
+							Root:  common.HexToHash("0x2"),
+						},
+						L1Leaf: &agglayer.L1InfoTreeLeaf{
+							L1InfoTreeIndex: 1,
+							RollupExitRoot:  common.HexToHash("0x33"),
+							MainnetExitRoot: common.HexToHash("0x11"),
+							Inner: &agglayer.L1InfoTreeLeafInner{
+								GlobalExitRoot: common.HexToHash("0x1"),
+								BlockHash:      common.HexToHash("0x22"),
+								Timestamp:      112,
+							},
 						},
 					},
 				},
@@ -695,7 +704,7 @@ func TestGetImportedBridgeExitsForProver(t *testing.T) {
 	testCases := []struct {
 		name          string
 		claims        []bridgesync.Claim
-		expectedExits []*agglayer.ImportedBridgeExit
+		expectedExits []*agglayer.ImportedBridgeExitWithBlockNumber
 		expectedError string
 	}{
 		{
@@ -726,6 +735,7 @@ func TestGetImportedBridgeExitsForProver(t *testing.T) {
 					Amount:             big.NewInt(100),
 					Metadata:           []byte("metadata"),
 					GlobalIndex:        big.NewInt(1),
+					BlockNum:           1,
 				},
 				{
 					IsMessage:          true,
@@ -736,44 +746,51 @@ func TestGetImportedBridgeExitsForProver(t *testing.T) {
 					Amount:             big.NewInt(100),
 					Metadata:           []byte("metadata"),
 					GlobalIndex:        big.NewInt(2),
+					BlockNum:           2,
 				},
 			},
-			expectedExits: []*agglayer.ImportedBridgeExit{
+			expectedExits: []*agglayer.ImportedBridgeExitWithBlockNumber{
 				{
-					BridgeExit: &agglayer.BridgeExit{
-						LeafType: agglayer.LeafTypeAsset,
-						TokenInfo: &agglayer.TokenInfo{
-							OriginNetwork:      1,
-							OriginTokenAddress: common.HexToAddress("0x123"),
+					ImportedBridgeExit: &agglayer.ImportedBridgeExit{
+						BridgeExit: &agglayer.BridgeExit{
+							LeafType: agglayer.LeafTypeAsset,
+							TokenInfo: &agglayer.TokenInfo{
+								OriginNetwork:      1,
+								OriginTokenAddress: common.HexToAddress("0x123"),
+							},
+							DestinationNetwork: 2,
+							DestinationAddress: common.HexToAddress("0x456"),
+							Amount:             big.NewInt(100),
+							Metadata:           []byte("metadata"),
 						},
-						DestinationNetwork: 2,
-						DestinationAddress: common.HexToAddress("0x456"),
-						Amount:             big.NewInt(100),
-						Metadata:           []byte("metadata"),
+						GlobalIndex: &agglayer.GlobalIndex{
+							MainnetFlag: false,
+							RollupIndex: 0,
+							LeafIndex:   1,
+						},
 					},
-					GlobalIndex: &agglayer.GlobalIndex{
-						MainnetFlag: false,
-						RollupIndex: 0,
-						LeafIndex:   1,
-					},
+					BlockNumber: 1,
 				},
 				{
-					BridgeExit: &agglayer.BridgeExit{
-						LeafType: agglayer.LeafTypeMessage,
-						TokenInfo: &agglayer.TokenInfo{
-							OriginNetwork:      1,
-							OriginTokenAddress: common.HexToAddress("0x123"),
+					ImportedBridgeExit: &agglayer.ImportedBridgeExit{
+						BridgeExit: &agglayer.BridgeExit{
+							LeafType: agglayer.LeafTypeMessage,
+							TokenInfo: &agglayer.TokenInfo{
+								OriginNetwork:      1,
+								OriginTokenAddress: common.HexToAddress("0x123"),
+							},
+							DestinationNetwork: 2,
+							DestinationAddress: common.HexToAddress("0x456"),
+							Amount:             big.NewInt(100),
+							Metadata:           []byte("metadata"),
 						},
-						DestinationNetwork: 2,
-						DestinationAddress: common.HexToAddress("0x456"),
-						Amount:             big.NewInt(100),
-						Metadata:           []byte("metadata"),
+						GlobalIndex: &agglayer.GlobalIndex{
+							MainnetFlag: false,
+							RollupIndex: 0,
+							LeafIndex:   2,
+						},
 					},
-					GlobalIndex: &agglayer.GlobalIndex{
-						MainnetFlag: false,
-						RollupIndex: 0,
-						LeafIndex:   2,
-					},
+					BlockNumber: 2,
 				},
 			},
 		},

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -82,7 +82,9 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 	for k, v := range gerLeavesWithBlockNumber {
 		convertedProofGerL1RootSiblings := make([]*agglayerInteropTypesV1Proto.FixedBytes32, treeTypes.DefaultHeight)
 		for i := 0; i < int(treeTypes.DefaultHeight); i++ {
-			convertedProofGerL1RootSiblings[i] = &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.ProofGERToL1Root.Proof[i][:]}
+			convertedProofGerL1RootSiblings[i] = &agglayerInteropTypesV1Proto.FixedBytes32{
+				Value: v.InsertedGerLeaf.ProofGERToL1Root.Proof[i][:],
+			}
 		}
 		convertedGerLeaves[k.String()] = &aggkitProverV1Proto.InsertedGERWithBlockNumber{
 			BlockNumber: v.BlockNumber,
@@ -96,20 +98,26 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 					Rer:             &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.RollupExitRoot[:]},
 					Mer:             &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.MainnetExitRoot[:]},
 					Inner: &agglayerInteropTypesV1Proto.L1InfoTreeLeaf{
-						GlobalExitRoot: &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.Inner.GlobalExitRoot[:]},
-						BlockHash:      &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.Inner.BlockHash[:]},
-						Timestamp:      v.InsertedGerLeaf.L1Leaf.Inner.Timestamp,
+						GlobalExitRoot: &agglayerInteropTypesV1Proto.FixedBytes32{
+							Value: v.InsertedGerLeaf.L1Leaf.Inner.GlobalExitRoot[:],
+						},
+						BlockHash: &agglayerInteropTypesV1Proto.FixedBytes32{
+							Value: v.InsertedGerLeaf.L1Leaf.Inner.BlockHash[:],
+						},
+						Timestamp: v.InsertedGerLeaf.L1Leaf.Inner.Timestamp,
 					},
 				},
 			},
 		}
 	}
 
-	convertedImportedBridgeExitsWithBlockNumber := make([]*aggkitProverV1Proto.ImportedBridgeExitWithBlockNumber, len(importedBridgeExitsWithBlockNumber))
+	convertedImportedBridgeExitsWithBlockNumber := make([]*aggkitProverV1Proto.ImportedBridgeExitWithBlockNumber,
+		len(importedBridgeExitsWithBlockNumber))
 	for i, importedBridgeExitWithBlockNumber := range importedBridgeExitsWithBlockNumber {
 		convertedBridgeExit := &agglayerInteropTypesV1Proto.ImportedBridgeExit{
 			BridgeExit: &agglayerInteropTypesV1Proto.BridgeExit{
-				LeafType: agglayerInteropTypesV1Proto.LeafType(importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.LeafType),
+				LeafType: agglayerInteropTypesV1Proto.LeafType(
+					importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.LeafType),
 				TokenInfo: &agglayerInteropTypesV1Proto.TokenInfo{
 					OriginNetwork: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.TokenInfo.OriginNetwork,
 					OriginTokenAddress: &agglayerInteropTypesV1Proto.FixedBytes20{
@@ -117,9 +125,15 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 					},
 				},
 				DestNetwork: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.DestinationNetwork,
-				DestAddress: &agglayerInteropTypesV1Proto.FixedBytes20{Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.DestinationAddress[:]},
-				Amount:      &agglayerInteropTypesV1Proto.FixedBytes32{Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.Amount.Bytes()},
-				Metadata:    &agglayerInteropTypesV1Proto.FixedBytes32{Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.Metadata},
+				DestAddress: &agglayerInteropTypesV1Proto.FixedBytes20{
+					Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.DestinationAddress[:],
+				},
+				Amount: &agglayerInteropTypesV1Proto.FixedBytes32{
+					Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.Amount.Bytes(),
+				},
+				Metadata: &agglayerInteropTypesV1Proto.FixedBytes32{
+					Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.Metadata,
+				},
 			},
 			GlobalIndex: &agglayerInteropTypesV1Proto.FixedBytes32{
 				Value: bridgesync.GenerateGlobalIndex(

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	agglayerProtobuf "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/protocol/types/v1"
-	aggkitGrpc "buf.build/gen/go/agglayer/provers/grpc/go/aggkit/prover/v1/proverv1grpc"
-	aggkitProtobuf "buf.build/gen/go/agglayer/provers/protocolbuffers/go/aggkit/prover/v1"
+	agglayerInteropTypesV1Proto "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
+	aggkitProverV1Grpc "buf.build/gen/go/agglayer/provers/grpc/go/aggkit/prover/v1/proverv1grpc"
+	aggkitProverV1Proto "buf.build/gen/go/agglayer/provers/protocolbuffers/go/aggkit/prover/v1"
 	agglayer "github.com/agglayer/aggkit/agglayer"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
@@ -25,14 +25,14 @@ type AggchainProofClientInterface interface {
 		l1InfoTreeRootHash common.Hash,
 		l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf,
 		l1InfoTreeMerkleProof agglayer.MerkleProof,
-		gerLeaves map[common.Hash]*agglayer.ClaimFromMainnnet,
-		importedBridgeExits []*agglayer.ImportedBridgeExit,
+		gerLeavesWithBlockNumber map[common.Hash]*agglayer.InsertedGERWithBlockNumber,
+		importedBridgeExitsWithBlockNumber []*agglayer.ImportedBridgeExitWithBlockNumber,
 	) (*types.AggchainProof, error)
 }
 
 // AggchainProofClient provides an implementation for the AggchainProofClient interface
 type AggchainProofClient struct {
-	client aggkitGrpc.AggchainProofServiceClient
+	client aggkitProverV1Grpc.AggchainProofServiceClient
 }
 
 // NewAggchainProofClient initializes a new AggchainProof instance
@@ -42,7 +42,7 @@ func NewAggchainProofClient(serverAddr string) (*AggchainProofClient, error) {
 		return nil, err
 	}
 	return &AggchainProofClient{
-		client: aggkitGrpc.NewAggchainProofServiceClient(grpcClient.conn),
+		client: aggkitProverV1Grpc.NewAggchainProofServiceClient(grpcClient.conn),
 	}, nil
 }
 
@@ -52,100 +52,97 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 	l1InfoTreeRootHash common.Hash,
 	l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf,
 	l1InfoTreeMerkleProof agglayer.MerkleProof,
-	gerLeaves map[common.Hash]*agglayer.ClaimFromMainnnet,
-	importedBridgeExits []*agglayer.ImportedBridgeExit,
+	gerLeavesWithBlockNumber map[common.Hash]*agglayer.InsertedGERWithBlockNumber,
+	importedBridgeExitsWithBlockNumber []*agglayer.ImportedBridgeExitWithBlockNumber,
 ) (*types.AggchainProof, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*TIMEOUT)
 	defer cancel()
 
-	convertedL1InfoTreeLeaf := &agglayerProtobuf.L1InfoTreeLeafWithContext{
-		Inner: &agglayerProtobuf.L1InfoTreeLeaf{
-			GlobalExitRoot: &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeLeaf.GlobalExitRoot[:]},
-			BlockHash:      &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeLeaf.Hash[:]},
+	convertedL1InfoTreeLeaf := &agglayerInteropTypesV1Proto.L1InfoTreeLeafWithContext{
+		Inner: &agglayerInteropTypesV1Proto.L1InfoTreeLeaf{
+			GlobalExitRoot: &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeLeaf.GlobalExitRoot[:]},
+			BlockHash:      &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeLeaf.Hash[:]},
 			Timestamp:      l1InfoTreeLeaf.Timestamp,
 		},
-		Mer:             &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeLeaf.MainnetExitRoot[:]},
-		Rer:             &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeLeaf.RollupExitRoot[:]},
+		Mer:             &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeLeaf.MainnetExitRoot[:]},
+		Rer:             &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeLeaf.RollupExitRoot[:]},
 		L1InfoTreeIndex: l1InfoTreeLeaf.L1InfoTreeIndex,
 	}
 
-	convertedMerkleProofSiblings := make([]*agglayerProtobuf.FixedBytes32, treeTypes.DefaultHeight)
+	convertedMerkleProofSiblings := make([]*agglayerInteropTypesV1Proto.FixedBytes32, treeTypes.DefaultHeight)
 	for i := 0; i < int(treeTypes.DefaultHeight); i++ {
-		convertedMerkleProofSiblings[i] = &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeMerkleProof.Proof[i][:]}
+		convertedMerkleProofSiblings[i] = &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeMerkleProof.Proof[i][:]}
 	}
-	convertedMerkleProof := &agglayerProtobuf.MerkleProof{
-		Root:     &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeMerkleProof.Root[:]},
+	convertedMerkleProof := &agglayerInteropTypesV1Proto.MerkleProof{
+		Root:     &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeMerkleProof.Root[:]},
 		Siblings: convertedMerkleProofSiblings,
 	}
 
-	convertedGerLeaves := make(map[string]*agglayerProtobuf.ClaimFromMainnet, 0)
-	for k, v := range gerLeaves {
-		convertedProofLeafMerSiblings := make([]*agglayerProtobuf.FixedBytes32, treeTypes.DefaultHeight)
+	convertedGerLeaves := make(map[string]*aggkitProverV1Proto.InsertedGERWithBlockNumber, 0)
+	for k, v := range gerLeavesWithBlockNumber {
+		convertedProofGerL1RootSiblings := make([]*agglayerInteropTypesV1Proto.FixedBytes32, treeTypes.DefaultHeight)
 		for i := 0; i < int(treeTypes.DefaultHeight); i++ {
-			convertedProofLeafMerSiblings[i] = &agglayerProtobuf.FixedBytes32{Value: v.ProofLeafMER.Proof[i][:]}
+			convertedProofGerL1RootSiblings[i] = &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.ProofGERToL1Root.Proof[i][:]}
 		}
-		convertedProofGerL1RootSiblings := make([]*agglayerProtobuf.FixedBytes32, treeTypes.DefaultHeight)
-		for i := 0; i < int(treeTypes.DefaultHeight); i++ {
-			convertedProofGerL1RootSiblings[i] = &agglayerProtobuf.FixedBytes32{Value: v.ProofLeafMER.Proof[i][:]}
-		}
-		convertedGerLeaves[k.String()] = &agglayerProtobuf.ClaimFromMainnet{
-			ProofLeafMer: &agglayerProtobuf.MerkleProof{
-				Root:     &agglayerProtobuf.FixedBytes32{Value: v.ProofLeafMER.Root[:]},
-				Siblings: convertedProofLeafMerSiblings,
-			},
-			ProofGerL1Root: &agglayerProtobuf.MerkleProof{
-				Root:     &agglayerProtobuf.FixedBytes32{Value: v.ProofGERToL1Root.Root[:]},
-				Siblings: convertedProofGerL1RootSiblings,
-			},
-			L1Leaf: &agglayerProtobuf.L1InfoTreeLeafWithContext{
-				L1InfoTreeIndex: v.L1Leaf.L1InfoTreeIndex,
-				Rer:             &agglayerProtobuf.FixedBytes32{Value: v.L1Leaf.RollupExitRoot[:]},
-				Mer:             &agglayerProtobuf.FixedBytes32{Value: v.L1Leaf.MainnetExitRoot[:]},
-				Inner: &agglayerProtobuf.L1InfoTreeLeaf{
-					GlobalExitRoot: &agglayerProtobuf.FixedBytes32{Value: v.L1Leaf.Inner.GlobalExitRoot[:]},
-					BlockHash:      &agglayerProtobuf.FixedBytes32{Value: v.L1Leaf.Inner.BlockHash[:]},
-					Timestamp:      v.L1Leaf.Inner.Timestamp,
+		convertedGerLeaves[k.String()] = &aggkitProverV1Proto.InsertedGERWithBlockNumber{
+			BlockNumber: v.BlockNumber,
+			InsertedGerLeaf: &aggkitProverV1Proto.InsertedGER{
+				ProofGerL1Root: &agglayerInteropTypesV1Proto.MerkleProof{
+					Root:     &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.ProofGERToL1Root.Root[:]},
+					Siblings: convertedProofGerL1RootSiblings,
+				},
+				L1Leaf: &agglayerInteropTypesV1Proto.L1InfoTreeLeafWithContext{
+					L1InfoTreeIndex: v.InsertedGerLeaf.L1Leaf.L1InfoTreeIndex,
+					Rer:             &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.RollupExitRoot[:]},
+					Mer:             &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.MainnetExitRoot[:]},
+					Inner: &agglayerInteropTypesV1Proto.L1InfoTreeLeaf{
+						GlobalExitRoot: &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.Inner.GlobalExitRoot[:]},
+						BlockHash:      &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.InsertedGerLeaf.L1Leaf.Inner.BlockHash[:]},
+						Timestamp:      v.InsertedGerLeaf.L1Leaf.Inner.Timestamp,
+					},
 				},
 			},
 		}
 	}
 
-	convertedImportedBridgeExits := make([]*agglayerProtobuf.ImportedBridgeExit, len(importedBridgeExits))
-	for i, importedBridgeExit := range importedBridgeExits {
-		convertedBridgeExit := &agglayerProtobuf.BridgeExit{
-			LeafType: agglayerProtobuf.LeafType(importedBridgeExit.BridgeExit.LeafType),
-			TokenInfo: &agglayerProtobuf.TokenInfo{
-				OriginNetwork: importedBridgeExit.BridgeExit.TokenInfo.OriginNetwork,
-				OriginTokenAddress: &agglayerProtobuf.FixedBytes20{
-					Value: importedBridgeExit.BridgeExit.TokenInfo.OriginTokenAddress[:],
+	convertedImportedBridgeExitsWithBlockNumber := make([]*aggkitProverV1Proto.ImportedBridgeExitWithBlockNumber, len(importedBridgeExitsWithBlockNumber))
+	for i, importedBridgeExitWithBlockNumber := range importedBridgeExitsWithBlockNumber {
+		convertedBridgeExit := &agglayerInteropTypesV1Proto.ImportedBridgeExit{
+			BridgeExit: &agglayerInteropTypesV1Proto.BridgeExit{
+				LeafType: agglayerInteropTypesV1Proto.LeafType(importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.LeafType),
+				TokenInfo: &agglayerInteropTypesV1Proto.TokenInfo{
+					OriginNetwork: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.TokenInfo.OriginNetwork,
+					OriginTokenAddress: &agglayerInteropTypesV1Proto.FixedBytes20{
+						Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.TokenInfo.OriginTokenAddress[:],
+					},
 				},
+				DestNetwork: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.DestinationNetwork,
+				DestAddress: &agglayerInteropTypesV1Proto.FixedBytes20{Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.DestinationAddress[:]},
+				Amount:      &agglayerInteropTypesV1Proto.FixedBytes32{Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.Amount.Bytes()},
+				Metadata:    &agglayerInteropTypesV1Proto.FixedBytes32{Value: importedBridgeExitWithBlockNumber.ImportedBridgeExit.BridgeExit.Metadata},
 			},
-			DestNetwork: importedBridgeExit.BridgeExit.DestinationNetwork,
-			DestAddress: &agglayerProtobuf.FixedBytes20{Value: importedBridgeExit.BridgeExit.DestinationAddress[:]},
-			Amount:      &agglayerProtobuf.FixedBytes32{Value: importedBridgeExit.BridgeExit.Amount.Bytes()},
-			Metadata:    &agglayerProtobuf.FixedBytes32{Value: importedBridgeExit.BridgeExit.Metadata},
+			GlobalIndex: &agglayerInteropTypesV1Proto.FixedBytes32{
+				Value: bridgesync.GenerateGlobalIndex(
+					importedBridgeExitWithBlockNumber.ImportedBridgeExit.GlobalIndex.MainnetFlag,
+					importedBridgeExitWithBlockNumber.ImportedBridgeExit.GlobalIndex.RollupIndex,
+					importedBridgeExitWithBlockNumber.ImportedBridgeExit.GlobalIndex.LeafIndex,
+				).Bytes(),
+			},
 		}
-		convertedGlobalIndex := &agglayerProtobuf.FixedBytes32{
-			Value: bridgesync.GenerateGlobalIndex(
-				importedBridgeExit.GlobalIndex.MainnetFlag,
-				importedBridgeExit.GlobalIndex.RollupIndex,
-				importedBridgeExit.GlobalIndex.LeafIndex,
-			).Bytes(),
-		}
-		convertedImportedBridgeExits[i] = &agglayerProtobuf.ImportedBridgeExit{
-			BridgeExit:  convertedBridgeExit,
-			GlobalIndex: convertedGlobalIndex,
+		convertedImportedBridgeExitsWithBlockNumber[i] = &aggkitProverV1Proto.ImportedBridgeExitWithBlockNumber{
+			ImportedBridgeExit: convertedBridgeExit,
+			BlockNumber:        importedBridgeExitWithBlockNumber.BlockNumber,
 		}
 	}
 
-	resp, err := c.client.GenerateAggchainProof(ctx, &aggkitProtobuf.GenerateAggchainProofRequest{
+	resp, err := c.client.GenerateAggchainProof(ctx, &aggkitProverV1Proto.GenerateAggchainProofRequest{
 		StartBlock:            startBlock,
 		MaxEndBlock:           maxEndBlock,
-		L1InfoTreeRootHash:    &agglayerProtobuf.FixedBytes32{Value: l1InfoTreeRootHash.Bytes()},
+		L1InfoTreeRootHash:    &agglayerInteropTypesV1Proto.FixedBytes32{Value: l1InfoTreeRootHash.Bytes()},
 		L1InfoTreeLeaf:        convertedL1InfoTreeLeaf,
 		L1InfoTreeMerkleProof: convertedMerkleProof,
 		GerLeaves:             convertedGerLeaves,
-		ImportedBridgeExits:   convertedImportedBridgeExits,
+		ImportedBridgeExits:   convertedImportedBridgeExitsWithBlockNumber,
 	})
 	if err != nil {
 		return nil, err

--- a/aggsender/grpc/aggchain_proof_client_test.go
+++ b/aggsender/grpc/aggchain_proof_client_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	agglayerProtobuf "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/protocol/types/v1"
-	aggkitProtobuf "buf.build/gen/go/agglayer/provers/protocolbuffers/go/aggkit/prover/v1"
+	agglayerInteropTypesV1Proto "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
+	aggkitProverV1Proto "buf.build/gen/go/agglayer/provers/protocolbuffers/go/aggkit/prover/v1"
 	agglayer "github.com/agglayer/aggkit/agglayer"
 	aggkitProverMocks "github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/l1infotreesync"
@@ -18,11 +18,11 @@ func TestGenerateAggchainProof_Success(t *testing.T) {
 	mockClient := aggkitProverMocks.NewAggchainProofServiceClient(t)
 	client := &AggchainProofClient{client: mockClient}
 
-	expectedResponse := &aggkitProtobuf.GenerateAggchainProofResponse{
+	expectedResponse := &aggkitProverV1Proto.GenerateAggchainProofResponse{
 		AggchainProof:     []byte("dummy-proof"),
 		StartBlock:        100,
 		EndBlock:          200,
-		LocalExitRootHash: &agglayerProtobuf.FixedBytes32{Value: common.Hash{}.Bytes()},
+		LocalExitRootHash: &agglayerInteropTypesV1Proto.FixedBytes32{Value: common.Hash{}.Bytes()},
 		CustomChainData:   []byte{},
 	}
 
@@ -53,7 +53,7 @@ func TestGenerateAggchainProof_Error(t *testing.T) {
 
 	expectedError := errors.New("Generate error")
 
-	mockClient.On("GenerateAggchainProof", mock.Anything, mock.Anything).Return((*aggkitProtobuf.GenerateAggchainProofResponse)(nil), expectedError)
+	mockClient.On("GenerateAggchainProof", mock.Anything, mock.Anything).Return((*aggkitProverV1Proto.GenerateAggchainProofResponse)(nil), expectedError)
 
 	result, err := client.GenerateAggchainProof(
 		300,
@@ -67,46 +67,48 @@ func TestGenerateAggchainProof_Error(t *testing.T) {
 			Root:  common.HexToHash("0x3"),
 			Proof: [32]common.Hash{common.HexToHash("0x4")},
 		},
-		map[common.Hash]*agglayer.ClaimFromMainnnet{
+		map[common.Hash]*agglayer.InsertedGERWithBlockNumber{
 			common.HexToHash("0x5"): {
-				ProofLeafMER: &agglayer.MerkleProof{
-					Root:  common.HexToHash("0x6"),
-					Proof: [32]common.Hash{common.HexToHash("0x7")},
-				},
-				ProofGERToL1Root: &agglayer.MerkleProof{
-					Root:  common.HexToHash("0x8"),
-					Proof: [32]common.Hash{common.HexToHash("0x9")},
-				},
-				L1Leaf: &agglayer.L1InfoTreeLeaf{
-					Inner: &agglayer.L1InfoTreeLeafInner{
-						GlobalExitRoot: common.HexToHash("0xa"),
-						BlockHash:      common.HexToHash("0xb"),
-						Timestamp:      1,
+				BlockNumber: 1,
+				InsertedGerLeaf: agglayer.InsertedGer{
+					ProofGERToL1Root: &agglayer.MerkleProof{
+						Root:  common.HexToHash("0x8"),
+						Proof: [32]common.Hash{common.HexToHash("0x9")},
 					},
-					L1InfoTreeIndex: 4,
-					MainnetExitRoot: common.HexToHash("0xb"),
-					RollupExitRoot:  common.HexToHash("0xc"),
+					L1Leaf: &agglayer.L1InfoTreeLeaf{
+						Inner: &agglayer.L1InfoTreeLeafInner{
+							GlobalExitRoot: common.HexToHash("0xa"),
+							BlockHash:      common.HexToHash("0xb"),
+							Timestamp:      1,
+						},
+						L1InfoTreeIndex: 4,
+						MainnetExitRoot: common.HexToHash("0xb"),
+						RollupExitRoot:  common.HexToHash("0xc"),
+					},
 				},
 			},
 		},
-		[]*agglayer.ImportedBridgeExit{
+		[]*agglayer.ImportedBridgeExitWithBlockNumber{
 			{
-				BridgeExit: &agglayer.BridgeExit{
-					LeafType:           1,
-					DestinationNetwork: 1,
-					DestinationAddress: common.HexToAddress("0x1"),
-					Amount:             common.Big1,
-					Metadata:           []byte("metadata"),
-					IsMetadataHashed:   false,
-					TokenInfo: &agglayer.TokenInfo{
-						OriginNetwork:      1,
-						OriginTokenAddress: common.HexToAddress("0x2"),
+				BlockNumber: 1,
+				ImportedBridgeExit: &agglayer.ImportedBridgeExit{
+					BridgeExit: &agglayer.BridgeExit{
+						LeafType:           1,
+						DestinationNetwork: 1,
+						DestinationAddress: common.HexToAddress("0x1"),
+						Amount:             common.Big1,
+						Metadata:           []byte("metadata"),
+						IsMetadataHashed:   false,
+						TokenInfo: &agglayer.TokenInfo{
+							OriginNetwork:      1,
+							OriginTokenAddress: common.HexToAddress("0x2"),
+						},
 					},
-				},
-				GlobalIndex: &agglayer.GlobalIndex{
-					MainnetFlag: true,
-					RollupIndex: 1,
-					LeafIndex:   1,
+					GlobalIndex: &agglayer.GlobalIndex{
+						MainnetFlag: true,
+						RollupIndex: 1,
+						LeafIndex:   1,
+					},
 				},
 			},
 		},

--- a/aggsender/mocks/mock_aggchain_proof_client_interface.go
+++ b/aggsender/mocks/mock_aggchain_proof_client_interface.go
@@ -26,9 +26,9 @@ func (_m *AggchainProofClientInterface) EXPECT() *AggchainProofClientInterface_E
 	return &AggchainProofClientInterface_Expecter{mock: &_m.Mock}
 }
 
-// GenerateAggchainProof provides a mock function with given fields: startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeaves, importedBridgeExits
-func (_m *AggchainProofClientInterface) GenerateAggchainProof(startBlock uint64, maxEndBlock uint64, l1InfoTreeRootHash common.Hash, l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf, l1InfoTreeMerkleProof agglayer.MerkleProof, gerLeaves map[common.Hash]*agglayer.ClaimFromMainnnet, importedBridgeExits []*agglayer.ImportedBridgeExit) (*types.AggchainProof, error) {
-	ret := _m.Called(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeaves, importedBridgeExits)
+// GenerateAggchainProof provides a mock function with given fields: startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeavesWithBlockNumber, importedBridgeExitsWithBlockNumber
+func (_m *AggchainProofClientInterface) GenerateAggchainProof(startBlock uint64, maxEndBlock uint64, l1InfoTreeRootHash common.Hash, l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf, l1InfoTreeMerkleProof agglayer.MerkleProof, gerLeavesWithBlockNumber map[common.Hash]*agglayer.InsertedGERWithBlockNumber, importedBridgeExitsWithBlockNumber []*agglayer.ImportedBridgeExitWithBlockNumber) (*types.AggchainProof, error) {
+	ret := _m.Called(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeavesWithBlockNumber, importedBridgeExitsWithBlockNumber)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateAggchainProof")
@@ -36,19 +36,19 @@ func (_m *AggchainProofClientInterface) GenerateAggchainProof(startBlock uint64,
 
 	var r0 *types.AggchainProof
 	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.ClaimFromMainnnet, []*agglayer.ImportedBridgeExit) (*types.AggchainProof, error)); ok {
-		return rf(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeaves, importedBridgeExits)
+	if rf, ok := ret.Get(0).(func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.InsertedGERWithBlockNumber, []*agglayer.ImportedBridgeExitWithBlockNumber) (*types.AggchainProof, error)); ok {
+		return rf(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeavesWithBlockNumber, importedBridgeExitsWithBlockNumber)
 	}
-	if rf, ok := ret.Get(0).(func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.ClaimFromMainnnet, []*agglayer.ImportedBridgeExit) *types.AggchainProof); ok {
-		r0 = rf(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeaves, importedBridgeExits)
+	if rf, ok := ret.Get(0).(func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.InsertedGERWithBlockNumber, []*agglayer.ImportedBridgeExitWithBlockNumber) *types.AggchainProof); ok {
+		r0 = rf(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeavesWithBlockNumber, importedBridgeExitsWithBlockNumber)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.AggchainProof)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.ClaimFromMainnnet, []*agglayer.ImportedBridgeExit) error); ok {
-		r1 = rf(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeaves, importedBridgeExits)
+	if rf, ok := ret.Get(1).(func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.InsertedGERWithBlockNumber, []*agglayer.ImportedBridgeExitWithBlockNumber) error); ok {
+		r1 = rf(startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeavesWithBlockNumber, importedBridgeExitsWithBlockNumber)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -67,15 +67,15 @@ type AggchainProofClientInterface_GenerateAggchainProof_Call struct {
 //   - l1InfoTreeRootHash common.Hash
 //   - l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf
 //   - l1InfoTreeMerkleProof agglayer.MerkleProof
-//   - gerLeaves map[common.Hash]*agglayer.ClaimFromMainnnet
-//   - importedBridgeExits []*agglayer.ImportedBridgeExit
-func (_e *AggchainProofClientInterface_Expecter) GenerateAggchainProof(startBlock interface{}, maxEndBlock interface{}, l1InfoTreeRootHash interface{}, l1InfoTreeLeaf interface{}, l1InfoTreeMerkleProof interface{}, gerLeaves interface{}, importedBridgeExits interface{}) *AggchainProofClientInterface_GenerateAggchainProof_Call {
-	return &AggchainProofClientInterface_GenerateAggchainProof_Call{Call: _e.mock.On("GenerateAggchainProof", startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeaves, importedBridgeExits)}
+//   - gerLeavesWithBlockNumber map[common.Hash]*agglayer.InsertedGERWithBlockNumber
+//   - importedBridgeExitsWithBlockNumber []*agglayer.ImportedBridgeExitWithBlockNumber
+func (_e *AggchainProofClientInterface_Expecter) GenerateAggchainProof(startBlock interface{}, maxEndBlock interface{}, l1InfoTreeRootHash interface{}, l1InfoTreeLeaf interface{}, l1InfoTreeMerkleProof interface{}, gerLeavesWithBlockNumber interface{}, importedBridgeExitsWithBlockNumber interface{}) *AggchainProofClientInterface_GenerateAggchainProof_Call {
+	return &AggchainProofClientInterface_GenerateAggchainProof_Call{Call: _e.mock.On("GenerateAggchainProof", startBlock, maxEndBlock, l1InfoTreeRootHash, l1InfoTreeLeaf, l1InfoTreeMerkleProof, gerLeavesWithBlockNumber, importedBridgeExitsWithBlockNumber)}
 }
 
-func (_c *AggchainProofClientInterface_GenerateAggchainProof_Call) Run(run func(startBlock uint64, maxEndBlock uint64, l1InfoTreeRootHash common.Hash, l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf, l1InfoTreeMerkleProof agglayer.MerkleProof, gerLeaves map[common.Hash]*agglayer.ClaimFromMainnnet, importedBridgeExits []*agglayer.ImportedBridgeExit)) *AggchainProofClientInterface_GenerateAggchainProof_Call {
+func (_c *AggchainProofClientInterface_GenerateAggchainProof_Call) Run(run func(startBlock uint64, maxEndBlock uint64, l1InfoTreeRootHash common.Hash, l1InfoTreeLeaf l1infotreesync.L1InfoTreeLeaf, l1InfoTreeMerkleProof agglayer.MerkleProof, gerLeavesWithBlockNumber map[common.Hash]*agglayer.InsertedGERWithBlockNumber, importedBridgeExitsWithBlockNumber []*agglayer.ImportedBridgeExitWithBlockNumber)) *AggchainProofClientInterface_GenerateAggchainProof_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(uint64), args[1].(uint64), args[2].(common.Hash), args[3].(l1infotreesync.L1InfoTreeLeaf), args[4].(agglayer.MerkleProof), args[5].(map[common.Hash]*agglayer.ClaimFromMainnnet), args[6].([]*agglayer.ImportedBridgeExit))
+		run(args[0].(uint64), args[1].(uint64), args[2].(common.Hash), args[3].(l1infotreesync.L1InfoTreeLeaf), args[4].(agglayer.MerkleProof), args[5].(map[common.Hash]*agglayer.InsertedGERWithBlockNumber), args[6].([]*agglayer.ImportedBridgeExitWithBlockNumber))
 	})
 	return _c
 }
@@ -85,7 +85,7 @@ func (_c *AggchainProofClientInterface_GenerateAggchainProof_Call) Return(_a0 *t
 	return _c
 }
 
-func (_c *AggchainProofClientInterface_GenerateAggchainProof_Call) RunAndReturn(run func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.ClaimFromMainnnet, []*agglayer.ImportedBridgeExit) (*types.AggchainProof, error)) *AggchainProofClientInterface_GenerateAggchainProof_Call {
+func (_c *AggchainProofClientInterface_GenerateAggchainProof_Call) RunAndReturn(run func(uint64, uint64, common.Hash, l1infotreesync.L1InfoTreeLeaf, agglayer.MerkleProof, map[common.Hash]*agglayer.InsertedGERWithBlockNumber, []*agglayer.ImportedBridgeExitWithBlockNumber) (*types.AggchainProof, error)) *AggchainProofClientInterface_GenerateAggchainProof_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/agglayer/aggkit
 go 1.23.7
 
 require (
-	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.5-20250228150343-c7b7fef1692a.1
-	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250225123212-0efa67e44aed.2
-	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.5-20250225123212-0efa67e44aed.1
+	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.5-20250317150713-743b25629858.1
+	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250317202126-66664af16d41.2
+	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.5-20250317202126-66664af16d41.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.5-20250228150343-c7b7fef1692a.1 h1:+ZcEKqPU6gU02yEB37tAfSoSI/ZQjsfCAtiRY64IKOM=
-buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.5-20250228150343-c7b7fef1692a.1/go.mod h1:LlC7zuJR8Wh5nvaG6f44/Q1TRICyKMhFtBbqKREh12Q=
-buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250225123212-0efa67e44aed.2 h1:skdv7ixBBICZNsvem6gufw+0iMcOJo82nSrJ2R0b4fs=
-buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250225123212-0efa67e44aed.2/go.mod h1:AzKur1kRizuDbzxsyp3W7AP5mhNQk+Una+deplt2zl8=
-buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.5-20250225123212-0efa67e44aed.1 h1:S+ovLGa00/aUuS9noD5QjxipYBumF/qL1S4528WS+VE=
-buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.5-20250225123212-0efa67e44aed.1/go.mod h1:iFwHn6XSIETvko7RsOFT25w0QHHPTTzQirUAvIJQLtw=
+buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.5-20250317150713-743b25629858.1 h1:bTpkCKMtL1lU8ROthasIf763ozCoy0li0NoNFDLU0yw=
+buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.5-20250317150713-743b25629858.1/go.mod h1:eWCx2HrNz9FEo3sLgsOnf3qIpMFiF8B2xT9G7PJcoyg=
+buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250317202126-66664af16d41.2 h1:fxSnrl1FVP2p00zqX0cshhbgduT9po4uWvFsi3z+I2I=
+buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250317202126-66664af16d41.2/go.mod h1:0OK89uNX1DutCaiHfr+Jv88719M9eO1SNfmdmp2WEjk=
+buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.5-20250317202126-66664af16d41.1 h1:dg7d9oY21e1xYIWPrmjgYjSQhSPTiIFSBkHDqjwRspc=
+buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.5-20250317202126-66664af16d41.1/go.mod h1:RY7lwMDFzGmUWeCy9OnXWooLfVD1OxYUCYyAvsPTJoI=
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861 h1:G21RAhtWCgy/dv/t1ed3ROJ7+rBgdlovzyz6rTh4FLs=
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861/go.mod h1:HGx8hRdvtcAZZaFHZylN9B8lOZkxM+NrVvOdzw4jQEY=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6 h1:FXL/rcO7/GtZ3kRFw+C7J6vmGnl8gcazg+Gh/NVmnas=


### PR DESCRIPTION
This PR adds `BlockNumber` fields to `inserted GERs` and `Imported Bridge Exits` that are sent to the `aggkit prover` to generate proof.

Fixes #304 