### PR TITLE
fix: Reorgdetector 

### DIFF
--- a/reorgdetector/reorgdetector_db.go
+++ b/reorgdetector/reorgdetector_db.go
@@ -26,27 +26,22 @@ func (rd *ReorgDetector) getTrackedBlocks() (map[string]*headersList, error) {
 	}
 	currentID := headersWithID[0].SubscriberID
 	currentHeaders := []header{}
-	for i := 0; i < len(headersWithID); i++ {
-		if i == len(headersWithID)-1 {
-			currentHeaders = append(currentHeaders, header{
-				Num:  headersWithID[i].Num,
-				Hash: headersWithID[i].Hash,
-			})
+	for _, row := range headersWithID {
+		// If the subscriber ID changes, save the current group
+		if row.SubscriberID != currentID {
 			trackedBlocks[currentID] = newHeadersList(currentHeaders...)
-		} else if headersWithID[i].SubscriberID != currentID {
-			trackedBlocks[currentID] = newHeadersList(currentHeaders...)
-			currentHeaders = []header{{
-				Num:  headersWithID[i].Num,
-				Hash: headersWithID[i].Hash,
-			}}
-			currentID = headersWithID[i].SubscriberID
-		} else {
-			currentHeaders = append(currentHeaders, header{
-				Num:  headersWithID[i].Num,
-				Hash: headersWithID[i].Hash,
-			})
+			currentID = row.SubscriberID
+			currentHeaders = nil
 		}
+
+		currentHeaders = append(currentHeaders, header{
+			Num:  row.Num,
+			Hash: row.Hash,
+		})
 	}
+
+	// Add the final group of headers after the loop
+	trackedBlocks[currentID] = newHeadersList(currentHeaders...)
 
 	return trackedBlocks, nil
 }


### PR DESCRIPTION
## Description

The current implementation of `getTrackedBlocks` fails to correctly handle the scenario where the `SubscriberID` changes on the last element of `headersWithID`. Rather than creating a new `HeadersList` for the new `SubscriberID`, it mistakenly adds it to the existing `HeadersList` of a different `SubscriberID`.