### PR TITLE
fix: injected GER with block number

### DIFF
--- a/aggoracle/chaingerreader/evm_test.go
+++ b/aggoracle/chaingerreader/evm_test.go
@@ -87,7 +87,7 @@ func TestGetInjectedGERsForRange(t *testing.T) {
 		tx, err := setup.GERContract.InsertGlobalExitRoot(setup.Auth, common.HexToHash("0x1234567890abcdef1234567890abcdef12345678"))
 		require.NoError(t, err)
 
-		// commit one block
+		// commit one block so the current block is block 6
 		setup.SimBackend.Commit()
 
 		receipt, err := setup.SimBackend.Client().TransactionReceipt(ctx, tx.Hash())
@@ -97,6 +97,6 @@ func TestGetInjectedGERsForRange(t *testing.T) {
 		injectedGERs, err := gerReader.GetInjectedGERsForRange(ctx, 1, 10)
 		require.NoError(t, err)
 		require.Len(t, injectedGERs, 1)
-		require.Equal(t, common.HexToHash("0x1234567890abcdef1234567890abcdef12345678"), injectedGERs[0])
+		require.Equal(t, common.HexToHash("0x1234567890abcdef1234567890abcdef12345678"), injectedGERs[6][0])
 	})
 }

--- a/aggsender/flow_aggchain_prover_test.go
+++ b/aggsender/flow_aggchain_prover_test.go
@@ -120,7 +120,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(10), common.HexToHash("0x1")).Return(
 					treetypes.Proof{}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", mock.Anything).Return(&l1infotreesync.L1InfoTreeLeaf{}, nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(1), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -184,7 +184,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(10), common.HexToHash("0x1")).Return(
 					treetypes.Proof{}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", mock.Anything).Return(&l1infotreesync.L1InfoTreeLeaf{}, nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(1), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -252,7 +252,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(10), common.HexToHash("0x1")).Return(
 					treetypes.Proof{}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", mock.Anything).Return(&l1infotreesync.L1InfoTreeLeaf{}, nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(1), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -296,7 +296,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(10), common.HexToHash("0x1")).Return(
 					treetypes.Proof{}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", mock.Anything).Return(&l1infotreesync.L1InfoTreeLeaf{}, nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return([]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(6), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -354,7 +354,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(10), common.HexToHash("0x1")).Return(
 					treetypes.Proof{}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", mock.Anything).Return(&l1infotreesync.L1InfoTreeLeaf{}, nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return([]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(6), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -658,7 +658,9 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "error getting L1 Info tree leaf by global exit root",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{common.HexToHash("0x1")}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{
+					1: {common.HexToHash("0x1")},
+				}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", common.HexToHash("0x1")).Return(nil, errors.New("some error"))
 			},
 			expectedError: "error getting L1 Info tree leaf by global exit root 0x0000000000000000000000000000000000000000000000000000000000000001: some error",
@@ -666,7 +668,9 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "error getting L1 Info tree merkle proof from index to root",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{common.HexToHash("0x1")}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{
+					1: {common.HexToHash("0x1")},
+				}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", common.HexToHash("0x1")).Return(&l1infotreesync.L1InfoTreeLeaf{L1InfoTreeIndex: 0}, nil)
 				mockL1InfoTreeSyncer.On("GetL1InfoTreeMerkleProofFromIndexToRoot", ctx, uint32(0), common.HexToHash("0x2")).Return(treetypes.Proof{}, errors.New("some error"))
 			},
@@ -675,7 +679,9 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "error injected GER l1 info tree index greater than the finalized l1 info tree root",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{common.HexToHash("0x1")}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{
+					1: {common.HexToHash("0x1")},
+				}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", common.HexToHash("0x1")).Return(&l1infotreesync.L1InfoTreeLeaf{L1InfoTreeIndex: 11}, nil)
 			},
 			expectedError: "is higher than the last finalized l1 info tree root",
@@ -683,7 +689,9 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "success",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return([]common.Hash{common.HexToHash("0x1")}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{
+					111: {common.HexToHash("0x1")},
+				}, nil)
 				mockL1InfoTreeSyncer.On("GetInfoByGlobalExitRoot", common.HexToHash("0x1")).Return(
 					&l1infotreesync.L1InfoTreeLeaf{
 						L1InfoTreeIndex:   1,

--- a/aggsender/mocks/mock_chain_ger_reader.go
+++ b/aggsender/mocks/mock_chain_ger_reader.go
@@ -24,23 +24,23 @@ func (_m *ChainGERReader) EXPECT() *ChainGERReader_Expecter {
 }
 
 // GetInjectedGERsForRange provides a mock function with given fields: ctx, fromBlock, toBlock
-func (_m *ChainGERReader) GetInjectedGERsForRange(ctx context.Context, fromBlock uint64, toBlock uint64) ([]common.Hash, error) {
+func (_m *ChainGERReader) GetInjectedGERsForRange(ctx context.Context, fromBlock uint64, toBlock uint64) (map[uint64][]common.Hash, error) {
 	ret := _m.Called(ctx, fromBlock, toBlock)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInjectedGERsForRange")
 	}
 
-	var r0 []common.Hash
+	var r0 map[uint64][]common.Hash
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) ([]common.Hash, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) (map[uint64][]common.Hash, error)); ok {
 		return rf(ctx, fromBlock, toBlock)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) []common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) map[uint64][]common.Hash); ok {
 		r0 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Hash)
+			r0 = ret.Get(0).(map[uint64][]common.Hash)
 		}
 	}
 
@@ -73,12 +73,12 @@ func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Return(_a0 []common.Hash, _a1 error) *ChainGERReader_GetInjectedGERsForRange_Call {
+func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Return(_a0 map[uint64][]common.Hash, _a1 error) *ChainGERReader_GetInjectedGERsForRange_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ChainGERReader_GetInjectedGERsForRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) ([]common.Hash, error)) *ChainGERReader_GetInjectedGERsForRange_Call {
+func (_c *ChainGERReader_GetInjectedGERsForRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) (map[uint64][]common.Hash, error)) *ChainGERReader_GetInjectedGERsForRange_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -58,7 +58,7 @@ type L2BridgeSyncer interface {
 
 // ChainGERReader is an interface defining functions that an ChainGERReader should implement
 type ChainGERReader interface {
-	GetInjectedGERsForRange(ctx context.Context, fromBlock, toBlock uint64) ([]common.Hash, error)
+	GetInjectedGERsForRange(ctx context.Context, fromBlock, toBlock uint64) (map[uint64][]common.Hash, error)
 }
 
 // EthClient is an interface defining functions that an EthClient should implement


### PR DESCRIPTION
## Description

This PR fixes the sending of `ProvenInsertedGERWithBlockNumber` when asking for `aggchain proof` from the `aggkit prover`.

These `ProvenInsertedGERWithBlockNumber` are injected GERs on L2 for which the `aggsender` generates proofs on a finalized l1 info tree root, but they need the L2 block to be sent in which they were included so that the prover, if the need arises, can cut the range accordingly.

Fixes # (issue)
