### PR TITLE
feat: index sovereign chain L2 bridge contracts events

### DIFF
--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
 	cfgtypes "github.com/agglayer/aggkit/config/types"

--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridgev2"
 	cfgtypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/reorgdetector"

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridgev2"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/reorgdetector"

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -311,6 +311,23 @@ func (s *BridgeSync) GetTokenMappings(ctx context.Context, pageNumber, pageSize 
 	return s.processor.GetTokenMappings(ctx, pageNumber, pageSize)
 }
 
+func (s *BridgeSync) GetLegacyTokenMigrations(
+	ctx context.Context, pageNumber, pageSize uint32) ([]*LegacyTokenMigration, int, error) {
+	if s.processor.isHalted() {
+		return nil, 0, sync.ErrInconsistentState
+	}
+
+	if pageNumber == 0 {
+		return nil, 0, ErrInvalidPageNumber
+	}
+
+	if pageSize == 0 {
+		return nil, 0, ErrInvalidPageSize
+	}
+
+	return s.processor.GetLegacyTokenMigrations(ctx, pageNumber, pageSize)
+}
+
 func (s *BridgeSync) GetProof(ctx context.Context, depositCount uint32, localExitRoot common.Hash) (tree.Proof, error) {
 	if s.processor.isHalted() {
 		return tree.Proof{}, sync.ErrInconsistentState

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -16,9 +16,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// BridgeSyncerType represents the type of bridge syncer
+type BridgeSyncerType int
+
 const (
-	l1BridgeSyncer     = "L1BridgeSyncer"
-	l2BridgeSyncer     = "L2BridgeSyncer"
+	L1BridgeSyncer BridgeSyncerType = iota
+	L2BridgeSyncer
+)
+
+func (b BridgeSyncerType) String() string {
+	return [...]string{"L1BridgeSyncer", "L2BridgeSyncer"}[b]
+}
+
+const (
 	downloadBufferSize = 1000
 )
 
@@ -72,7 +82,7 @@ func NewL1(
 		rd,
 		ethClient,
 		initialBlock,
-		l1BridgeSyncer,
+		L1BridgeSyncer,
 		waitForNewBlocksPeriod,
 		retryAfterErrorPeriod,
 		maxRetryAttemptsAfterError,
@@ -108,7 +118,7 @@ func NewL2(
 		rd,
 		ethClient,
 		initialBlock,
-		l2BridgeSyncer,
+		L2BridgeSyncer,
 		waitForNewBlocksPeriod,
 		retryAfterErrorPeriod,
 		maxRetryAttemptsAfterError,
@@ -127,7 +137,7 @@ func newBridgeSync(
 	rd ReorgDetector,
 	ethClient aggkittypes.EthClienter,
 	initialBlock uint64,
-	syncerID string,
+	syncerID BridgeSyncerType,
 	waitForNewBlocksPeriod time.Duration,
 	retryAfterErrorPeriod time.Duration,
 	maxRetryAttemptsAfterError int,
@@ -135,7 +145,7 @@ func newBridgeSync(
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
 ) (*BridgeSync, error) {
-	logger := log.WithFields("module", syncerID)
+	logger := log.WithFields("module", syncerID.String())
 
 	err := sanityCheckContract(logger, bridge, ethClient)
 	if err != nil {
@@ -143,7 +153,7 @@ func newBridgeSync(
 			bridge.String(), err)
 		return nil, err
 	}
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID, logger)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +181,7 @@ func newBridgeSync(
 		return nil, err
 	}
 	downloader, err := sync.NewEVMDownloader(
-		syncerID,
+		syncerID.String(),
 		ethClient,
 		syncBlockChunkSize,
 		blockFinalityType,
@@ -185,7 +195,7 @@ func newBridgeSync(
 		return nil, err
 	}
 
-	driver, err := sync.NewEVMDriver(rd, processor, downloader, syncerID,
+	driver, err := sync.NewEVMDriver(rd, processor, downloader, syncerID.String(),
 		downloadBufferSize, rh, requireStorageContentCompatibility)
 	if err != nil {
 		return nil, err

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -225,6 +225,11 @@ func buildAppender(client aggkittypes.EthClienter, bridgeAddr common.Address,
 			)
 		}
 
+		calldata, err := extractCalldata(client, bridgeAddr, l.TxHash)
+		if err != nil {
+			return fmt.Errorf("failed to extract the MigrateLegacyToken event calldata (tx hash: %s): %w", l.TxHash, err)
+		}
+
 		b.Events = append(b.Events, Event{LegacyTokenMigration: &LegacyTokenMigration{
 			BlockNum:            b.Num,
 			BlockPos:            uint64(l.Index),
@@ -234,6 +239,7 @@ func buildAppender(client aggkittypes.EthClienter, bridgeAddr common.Address,
 			LegacyTokenAddress:  migrateLegacyTokenEvent.LegacyTokenAddress,
 			UpdatedTokenAddress: migrateLegacyTokenEvent.UpdatedTokenAddress,
 			Amount:              migrateLegacyTokenEvent.Amount,
+			Calldata:            calldata,
 		}})
 
 		return nil

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -56,17 +56,19 @@ func buildAppender(client aggkittypes.EthClienter,
 	bridgeAddr common.Address, syncFullClaims bool) (sync.LogAppenderMap, error) {
 	bridgeContractV1, err := polygonzkevmbridge.NewPolygonzkevmbridge(bridgeAddr, client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create PolygonZkEVMBridge SC binding (bridge addr: %s): %w", bridgeAddr, err)
 	}
 
 	bridgeContractV2, err := polygonzkevmbridgev2.NewPolygonzkevmbridgev2(bridgeAddr, client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create PolygonZkEVMBridgeV2 SC binding (bridge addr: %s): %w",
+			bridgeAddr, err)
 	}
 
 	bridgeSovereignChain, err := bridgel2sovereignchain.NewBridgel2sovereignchain(bridgeAddr, client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create BridgeL2SovereignChain SC binding (bridge addr: %s): %w",
+			bridgeAddr, err)
 	}
 
 	appender := make(sync.LogAppenderMap)

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridge"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/bridgel2sovereignchain"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridge"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/bridgel2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
 	rpcTypes "github.com/0xPolygon/cdk-rpc/types"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/sync"

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -34,6 +34,9 @@ var (
 	migrateLegacyTokenEventSignature = crypto.Keccak256Hash([]byte(
 		"MigrateLegacyToken(address,address,address,uint256)",
 	))
+	removeLegacySovereignTokenEventSignature = crypto.Keccak256Hash([]byte(
+		"RemoveLegacySovereignTokenAddress(address)",
+	))
 
 	claimAssetEtrogMethodID      = common.Hex2Bytes("ccaa2d11")
 	claimMessageEtrogMethodID    = common.Hex2Bytes("f5efcd79")
@@ -240,6 +243,26 @@ func buildAppender(client aggkittypes.EthClienter, bridgeAddr common.Address,
 			UpdatedTokenAddress: migrateLegacyTokenEvent.UpdatedTokenAddress,
 			Amount:              migrateLegacyTokenEvent.Amount,
 			Calldata:            calldata,
+		}})
+
+		return nil
+	}
+
+	appender[removeLegacySovereignTokenEventSignature] = func(b *sync.EVMBlock, l types.Log) error {
+		removeLegacySovereignTokenEvent, err := bridgeSovereignChain.ParseRemoveLegacySovereignTokenAddress(l)
+		if err != nil {
+			return fmt.Errorf(
+				"error parsing log %+v using d.bridgeSovereignChain.ParseRemoveLegacySovereignTokenAddress: %w",
+				l, err,
+			)
+		}
+
+		b.Events = append(b.Events, Event{RemoveLegacyToken: &RemoveLegacyToken{
+			BlockNum:           b.Num,
+			BlockPos:           uint64(l.Index),
+			BlockTimestamp:     b.Timestamp,
+			TxHash:             l.TxHash,
+			LegacyTokenAddress: removeLegacySovereignTokenEvent.SovereignTokenAddress,
 		}})
 
 		return nil

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -209,6 +209,29 @@ func TestBuildAppender(t *testing.T) {
 				return l, nil
 			},
 		},
+		{
+			name:           "removeLegacySovereignTokenAddress appender",
+			eventSignature: removeLegacySovereignTokenEventSignature,
+			callFrame:      call{To: bridgeAddr},
+			logBuilder: func() (types.Log, error) {
+				event, err := bridgeSovereignChainABI.EventByID(removeLegacySovereignTokenEventSignature)
+				if err != nil {
+					return types.Log{}, err
+				}
+
+				sovereignTokenAddr := common.HexToAddress("0x5")
+				data, err := event.Inputs.Pack(sovereignTokenAddr)
+				if err != nil {
+					return types.Log{}, err
+				}
+
+				l := types.Log{
+					Topics: []common.Hash{removeLegacySovereignTokenEventSignature},
+					Data:   data,
+				}
+				return l, nil
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridge"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridgev2"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/bridgel2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridge"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/bridgel2sovereignchain"
 	"github.com/agglayer/aggkit/sync"
 	"github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"

--- a/bridgesync/migrations/bridgesync0003.sql
+++ b/bridgesync/migrations/bridgesync0003.sql
@@ -1,0 +1,7 @@
+-- +migrate Down
+ALTER TABLE token_mapping DROP COLUMN is_not_mintable;
+ALTER TABLE token_mapping DROP COLUMN type NOT NULL;
+
+-- +migrate Up
+ALTER TABLE token_mapping ADD COLUMN is_not_mintable BOOLEAN NOT NULL;
+ALTER TABLE token_mapping ADD COLUMN type SMALLINT NOT NULL;

--- a/bridgesync/migrations/bridgesync0003.sql
+++ b/bridgesync/migrations/bridgesync0003.sql
@@ -1,7 +1,29 @@
 -- +migrate Down
-ALTER TABLE token_mapping DROP COLUMN is_not_mintable;
-ALTER TABLE token_mapping DROP COLUMN type NOT NULL;
+ALTER TABLE token_mapping
+DROP COLUMN is_not_mintable;
+
+ALTER TABLE token_mapping
+DROP COLUMN type NOT NULL;
+
+DROP TABLE IF EXISTS legacy_token_migration;
 
 -- +migrate Up
-ALTER TABLE token_mapping ADD COLUMN is_not_mintable BOOLEAN NOT NULL;
-ALTER TABLE token_mapping ADD COLUMN type SMALLINT NOT NULL;
+ALTER TABLE token_mapping
+ADD COLUMN is_not_mintable BOOLEAN NOT NULL;
+
+ALTER TABLE token_mapping
+ADD COLUMN type SMALLINT NOT NULL;
+
+CREATE TABLE
+    legacy_token_migration (
+        block_num INTEGER NOT NULL REFERENCES block (num) ON DELETE CASCADE,
+        block_pos INTEGER NOT NULL,
+        block_timestamp INTEGER NOT NULL,
+        tx_hash VARCHAR NOT NULL,
+        sender VARCHAR NOT NULL,
+        legacy_token_address VARCHAR NOT NULL,
+        updated_token_address VARCHAR NOT NULL,
+        amount VARCHAR NOT NULL,
+        calldata BLOB,
+        PRIMARY KEY (block_num, block_pos)
+    );

--- a/bridgesync/migrations/bridgesync0003.sql
+++ b/bridgesync/migrations/bridgesync0003.sql
@@ -3,7 +3,7 @@ ALTER TABLE token_mapping
 DROP COLUMN is_not_mintable;
 
 ALTER TABLE token_mapping
-DROP COLUMN type NOT NULL;
+DROP COLUMN token_type;
 
 DROP TABLE IF EXISTS legacy_token_migration;
 
@@ -12,7 +12,7 @@ ALTER TABLE token_mapping
 ADD COLUMN is_not_mintable BOOLEAN NOT NULL;
 
 ALTER TABLE token_mapping
-ADD COLUMN type SMALLINT NOT NULL;
+ADD COLUMN token_type SMALLINT NOT NULL;
 
 CREATE TABLE
     legacy_token_migration (

--- a/bridgesync/migrations/migrations.go
+++ b/bridgesync/migrations/migrations.go
@@ -14,6 +14,9 @@ var mig0001 string
 //go:embed bridgesync0002.sql
 var mig0002 string
 
+//go:embed bridgesync0003.sql
+var mig0003 string
+
 func RunMigrations(dbPath string) error {
 	migrations := []types.Migration{
 		{
@@ -23,6 +26,10 @@ func RunMigrations(dbPath string) error {
 		{
 			ID:  "bridgesync0002",
 			SQL: mig0002,
+		},
+		{
+			ID:  "bridgesync0003",
+			SQL: mig0003,
 		},
 	}
 	migrations = append(migrations, treeMigrations.Migrations...)

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -90,7 +90,7 @@ func TestMigration0002(t *testing.T) {
 			wrapped_token_address,
 			metadata,
 			is_not_mintable,
-			type
+			token_type
 		) VALUES (1, 0, 1739270804, '0xabcd', 2, '0x3', '0x5', NULL, FALSE, 1);
 
 		INSERT INTO bridge (
@@ -139,7 +139,7 @@ func TestMigration0002(t *testing.T) {
 		WrappedTokenAddress common.Address `meddler:"wrapped_token_address,address"`
 		Metadata            []byte         `meddler:"metadata"`
 		IsNotMintable       bool           `meddler:"is_not_mintable"`
-		Type                uint8          `meddler:"type"`
+		Type                uint8          `meddler:"token_type"`
 	}
 
 	err = meddler.QueryRow(db, &tokenMapping,

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -88,8 +88,10 @@ func TestMigration0002(t *testing.T) {
 			origin_network,
 			origin_token_address,
 			wrapped_token_address,
-			metadata
-		) VALUES (1, 0, 1739270804, '0xabcd', 2, '0x3', '0x5', NULL);
+			metadata,
+			is_not_mintable,
+			type
+		) VALUES (1, 0, 1739270804, '0xabcd', 2, '0x3', '0x5', NULL, FALSE, 1);
 
 		INSERT INTO bridge (
 			block_num,
@@ -136,6 +138,8 @@ func TestMigration0002(t *testing.T) {
 		OriginTokenAddress  common.Address `meddler:"origin_token_address,address"`
 		WrappedTokenAddress common.Address `meddler:"wrapped_token_address,address"`
 		Metadata            []byte         `meddler:"metadata"`
+		IsNotMintable       bool           `meddler:"is_not_mintable"`
+		Type                uint8          `meddler:"type"`
 	}
 
 	err = meddler.QueryRow(db, &tokenMapping,
@@ -148,6 +152,8 @@ func TestMigration0002(t *testing.T) {
 	require.Equal(t, uint32(2), tokenMapping.OriginNetwork)
 	require.Equal(t, common.HexToAddress("0x3"), tokenMapping.OriginTokenAddress)
 	require.Equal(t, common.HexToAddress("0x5"), tokenMapping.WrappedTokenAddress)
+	require.Equal(t, false, tokenMapping.IsNotMintable)
+	require.Equal(t, uint8(1), tokenMapping.Type)
 
 	var bridge struct {
 		BlockNum           uint64   `meddler:"block_num"`
@@ -193,4 +199,61 @@ func TestMigration0002(t *testing.T) {
 	require.NotNil(t, claim)
 	require.Equal(t, uint64(1739270804), claim.BlockTimestamp)
 	require.Equal(t, "0x123", claim.FromAddress)
+}
+
+func TestMigrations0003(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "bridgesyncTest0003.sqlite")
+
+	err := RunMigrations(dbPath)
+	require.NoError(t, err)
+	db, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	var legacyTokenMigration struct {
+		BlockNum            uint64         `meddler:"block_num"`
+		BlockPos            uint64         `meddler:"block_pos"`
+		BlockTimestamp      uint64         `meddler:"block_timestamp"`
+		TxHash              common.Hash    `meddler:"tx_hash,hash"`
+		Sender              common.Address `meddler:"sender,address"`
+		LegacyTokenAddress  common.Address `meddler:"legacy_token_address,address"`
+		UpdatedTokenAddress common.Address `meddler:"updated_token_address,address"`
+		Amount              *big.Int       `meddler:"amount,bigint"`
+	}
+
+	_, err = tx.Exec(`
+		INSERT INTO block (num) VALUES (1);
+
+		INSERT INTO legacy_token_migration (
+			block_num,
+			block_pos,
+			block_timestamp,
+			tx_hash,
+			sender,
+			legacy_token_address,
+			updated_token_address,
+			amount,
+			calldata
+		) VALUES (1, 10, 1739270804, '0xabcd', '0x3', '0x5', '0x7', 1000, NULL);
+	`)
+	require.NoError(t, err)
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	err = meddler.QueryRow(db, &legacyTokenMigration,
+		`SELECT * FROM legacy_token_migration`)
+	require.NoError(t, err)
+	require.NotNil(t, legacyTokenMigration)
+	require.Equal(t, uint64(1), legacyTokenMigration.BlockNum)
+	require.Equal(t, uint64(10), legacyTokenMigration.BlockPos)
+	require.Equal(t, uint64(1739270804), legacyTokenMigration.BlockTimestamp)
+	require.Equal(t, common.HexToAddress("0x3"), legacyTokenMigration.Sender)
+	require.Equal(t, common.HexToAddress("0x5"), legacyTokenMigration.LegacyTokenAddress)
+	require.Equal(t, common.HexToAddress("0x7"), legacyTokenMigration.UpdatedTokenAddress)
+	require.Equal(t, big.NewInt(1000), legacyTokenMigration.Amount)
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -50,6 +50,10 @@ var (
 
 	// tableNameRegex is the regex pattern to validate table names
 	tableNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+	// deleteLegacyTokenSQL is the SQL statement to delete legacy token migration event
+	// with specific legacy token address
+	deleteLegacyTokenSQL = fmt.Sprintf("DELETE FROM %s WHERE legacy_token_address = $1", legacyTokenMigrationTableName)
 )
 
 // Bridge is the representation of a bridge event
@@ -773,9 +777,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 
 		if event.RemoveLegacyToken != nil {
-			deleteLegacyTokenStmt := fmt.Sprintf("DELETE FROM %s WHERE legacy_token_address = $1",
-				legacyTokenMigrationTableName)
-			_, err := tx.Exec(deleteLegacyTokenStmt, event.RemoveLegacyToken.LegacyTokenAddress.Hex())
+			_, err := tx.Exec(deleteLegacyTokenSQL, event.RemoveLegacyToken.LegacyTokenAddress.Hex())
 			if err != nil {
 				return err
 			}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -308,7 +308,7 @@ type TokenMapping struct {
 	Metadata            []byte           `meddler:"metadata" json:"metadata"`
 	IsNotMintable       bool             `meddler:"is_not_mintable" json:"is_not_mintable"`
 	Calldata            []byte           `meddler:"calldata" json:"calldata"`
-	Type                TokenMappingType `meddler:"type" json:"type"`
+	Type                TokenMappingType `meddler:"token_type" json:"token_type"`
 }
 
 // MarshalJSON for hex-encoding Metadata and Calldata fields

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -282,17 +282,30 @@ type ClaimResponse struct {
 	FromAddress        common.Address `json:"from_address"`
 }
 
+type TokenMappingType uint8
+
+const (
+	WrappedToken = iota
+	SovereignToken
+)
+
+func (l TokenMappingType) String() string {
+	return [...]string{"WrappedToken", "SovereignToken"}[l]
+}
+
 // TokenMapping representation of a NewWrappedToken event, that is emitted by the bridge contract
 type TokenMapping struct {
-	BlockNum            uint64         `meddler:"block_num" json:"block_num"`
-	BlockPos            uint64         `meddler:"block_pos" json:"block_pos"`
-	BlockTimestamp      uint64         `meddler:"block_timestamp" json:"block_timestamp"`
-	TxHash              common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
-	OriginNetwork       uint32         `meddler:"origin_network" json:"origin_network"`
-	OriginTokenAddress  common.Address `meddler:"origin_token_address,address" json:"origin_token_address"`
-	WrappedTokenAddress common.Address `meddler:"wrapped_token_address,address" json:"wrapped_token_address"`
-	Metadata            []byte         `meddler:"metadata" json:"metadata"`
-	Calldata            []byte         `meddler:"calldata" json:"calldata"`
+	BlockNum            uint64           `meddler:"block_num" json:"block_num"`
+	BlockPos            uint64           `meddler:"block_pos" json:"block_pos"`
+	BlockTimestamp      uint64           `meddler:"block_timestamp" json:"block_timestamp"`
+	TxHash              common.Hash      `meddler:"tx_hash,hash" json:"tx_hash"`
+	OriginNetwork       uint32           `meddler:"origin_network" json:"origin_network"`
+	OriginTokenAddress  common.Address   `meddler:"origin_token_address,address" json:"origin_token_address"`
+	WrappedTokenAddress common.Address   `meddler:"wrapped_token_address,address" json:"wrapped_token_address"`
+	Metadata            []byte           `meddler:"metadata" json:"metadata"`
+	IsNotMintable       bool             `meddler:"is_not_mintable" json:"is_not_mintable"`
+	Calldata            []byte           `meddler:"calldata" json:"calldata"`
+	Type                TokenMappingType `meddler:"type" json:"type"`
 }
 
 // MarshalJSON for hex-encoding Metadata and Calldata fields

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -336,6 +336,7 @@ type LegacyTokenMigration struct {
 	LegacyTokenAddress  common.Address `meddler:"legacy_token_address,address" json:"legacy_token_address"`
 	UpdatedTokenAddress common.Address `meddler:"updated_token_address,address" json:"updated_token_address"`
 	Amount              *big.Int       `meddler:"amount,bigint" json:"amount"`
+	Calldata            []byte         `meddler:"calldata" json:"calldata"`
 }
 
 // Event combination of bridge, claim, token mapping and LegacyTokenMigration events

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -11,7 +11,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridge"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridge"
 	migrationsBridge "github.com/agglayer/aggkit/bridgesync/migrations"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/log"

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1363,3 +1363,29 @@ func TestDecodePreEtrogCalldata(t *testing.T) {
 
 	require.Equal(t, expectedClaim, actualClaim)
 }
+
+func TestTokenMappingTypeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		t        TokenMappingType
+		expected string
+	}{
+		{
+			name:     "WrappedToken",
+			t:        WrappedToken,
+			expected: "WrappedToken",
+		},
+		{
+			name:     "SovereignToken",
+			t:        SovereignToken,
+			expected: "SovereignToken",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.t.String())
+		})
+	}
+}

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1227,6 +1227,14 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 			Metadata:            common.Hex2Bytes(fmt.Sprintf("%x", i+1)),
 		}
 
+		if i%2 == 0 {
+			tokenMappingEvt.Type = WrappedToken
+			tokenMappingEvt.IsNotMintable = false
+		} else {
+			tokenMappingEvt.Type = SovereignToken
+			tokenMappingEvt.IsNotMintable = true
+		}
+
 		block := sync.Block{
 			Num:    uint64(i + 1),
 			Events: []interface{}{Event{TokenMapping: tokenMappingEvt}},

--- a/claimsponsor/evmclaimsponsor.go
+++ b/claimsponsor/evmclaimsponsor.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
 	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
 	configTypes "github.com/agglayer/aggkit/config/types"

--- a/etherman/contracts/base_test.go
+++ b/etherman/contracts/base_test.go
@@ -3,7 +3,7 @@ package contracts_test
 import (
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/etherman/contracts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"

--- a/etherman/contracts/contracts_banana.go
+++ b/etherman/contracts/contracts_banana.go
@@ -1,9 +1,9 @@
 package contracts
 
 import (
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonrollupmanager"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonvalidiumetrog"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonrollupmanager"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonvalidiumetrog"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/etherman/config"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )

--- a/etherman/contracts/contracts_elderberry.go
+++ b/etherman/contracts/contracts_elderberry.go
@@ -1,9 +1,9 @@
 package contracts
 
 import (
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonrollupmanager"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonvalidiumetrog"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonrollupmanager"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonvalidiumetrog"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/etherman/config"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/idataavailabilityprotocol"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/idataavailabilityprotocol"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/etherman/config"
 	"github.com/agglayer/aggkit/etherman/contracts"

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonvalidiumetrog"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonvalidiumetrog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/invopop/jsonschema"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agglayer/aggkit
 go 1.23.7
 
 require (
-	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef
+	github.com/0xPolygon/cdk-contracts-tooling v0.0.2
 	github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.7
 	github.com/ethereum/go-ethereum v1.15.5

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agglayer/aggkit
 go 1.23.7
 
 require (
-	github.com/0xPolygon/cdk-contracts-tooling v0.0.2
+	github.com/0xPolygon/cdk-contracts-tooling v0.0.3
 	github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.7
 	github.com/ethereum/go-ethereum v1.15.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2 h1:/SrOtjqb/NoikelhgOh9jtbagIKRiajXd1oCRudUtPA=
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.3 h1:G7H3UNyDOpoLqDvW9c4lgn2iMnteM1HqUpUAD1gk9VU=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.3/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229 h1:6YhqNQVcXkoxqs5zQVg1bREuoeKvwpffpfoL8QQT+u4=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
 github.com/0xPolygon/zkevm-ethtx-manager v0.2.7 h1:eS2ewz4z+S16ZWQRyci6Y3U9YSR+sx1opB0/NxhmKlQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef h1:DRBrbysjMTyeFRbyo+zoltOTET+vR20CnXc4wupj+qo=
-github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.2 h1:/SrOtjqb/NoikelhgOh9jtbagIKRiajXd1oCRudUtPA=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.2/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229 h1:6YhqNQVcXkoxqs5zQVg1bREuoeKvwpffpfoL8QQT+u4=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
 github.com/0xPolygon/zkevm-ethtx-manager v0.2.7 h1:eS2ewz4z+S16ZWQRyci6Y3U9YSR+sx1opB0/NxhmKlQ=

--- a/l1infotreesync/downloader.go
+++ b/l1infotreesync/downloader.go
@@ -3,8 +3,8 @@ package l1infotreesync
 import (
 	"fmt"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonrollupmanager"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonrollupmanager"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
 	"github.com/ethereum/go-ethereum"

--- a/l1infotreesync/downloader_test.go
+++ b/l1infotreesync/downloader_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	mocks_l1infotreesync "github.com/agglayer/aggkit/l1infotreesync/mocks"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"

--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	aggkittypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/l1infotreesync"

--- a/lastgersync/evmdownloader.go
+++ b/lastgersync/evmdownloader.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/l1infotreesync"

--- a/rpc/bridge_interfaces.go
+++ b/rpc/bridge_interfaces.go
@@ -21,6 +21,8 @@ type Bridger interface {
 		depositCount *uint64,
 	) ([]*bridgesync.BridgeResponse, int, error)
 	GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.TokenMapping, int, error)
+	GetLegacyTokenMigrations(
+		ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.LegacyTokenMigration, int, error)
 	GetClaimsPaged(ctx context.Context, page, pageSize uint32) ([]*bridgesync.ClaimResponse, int, error)
 	GetLastReorgEvent(ctx context.Context) (*bridgesync.LastReorg, error)
 }

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -230,11 +230,11 @@ func TestGetFirstL1InfoTreeIndexForL2Bridge(t *testing.T) {
 	fooErr := errors.New("foo")
 	firstVerified := &l1infotreesync.VerifyBatches{
 		BlockNumber: 10,
-		ExitRoot:    common.HexToHash("alfa"),
+		ExitRoot:    common.HexToHash("a1fa"),
 	}
 	lastVerified := &l1infotreesync.VerifyBatches{
 		BlockNumber: 1000,
-		ExitRoot:    common.HexToHash("alfa"),
+		ExitRoot:    common.HexToHash("a1fa"),
 	}
 	mockHappyPath := func() {
 		// to make this work, assume that block number == l1 info tree index == deposit count
@@ -260,7 +260,7 @@ func TestGetFirstL1InfoTreeIndexForL2Bridge(t *testing.T) {
 				ler, ok := args.Get(1).(common.Hash)
 				require.True(t, ok)
 				index := aggkitcommon.BytesToUint32(ler.Bytes()[28:]) // hash is 32 bytes, uint32 is just 4
-				if ler == common.HexToHash("alfa") {
+				if ler == common.HexToHash("a1fa") {
 					index = uint32(lastVerified.BlockNumber)
 				}
 				rootByLER.Index = index
@@ -480,6 +480,8 @@ func TestGetTokenMappings(t *testing.T) {
 				OriginNetwork:       1,
 				OriginTokenAddress:  common.HexToAddress("0x1"),
 				WrappedTokenAddress: common.HexToAddress("0x2"),
+				Type:                bridgesync.SovereignToken,
+				IsNotMintable:       true,
 				Metadata:            []byte("metadata"),
 			},
 		}

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -444,7 +444,7 @@ func TestGetTokenMappings(t *testing.T) {
 			},
 		}
 
-		bridgeMocks.bridgeL1.On("GetTokenMappings", mock.Anything, page, pageSize).
+		bridgeMocks.bridgeL1.EXPECT().GetTokenMappings(mock.Anything, page, pageSize).
 			Return(tokenMappings, len(tokenMappings), nil)
 
 		result, err := bridgeMocks.bridge.GetTokenMappings(0, &page, &pageSize)
@@ -486,7 +486,7 @@ func TestGetTokenMappings(t *testing.T) {
 			},
 		}
 
-		bridgeMocks.bridgeL2.On("GetTokenMappings", mock.Anything, page, pageSize).
+		bridgeMocks.bridgeL2.EXPECT().GetTokenMappings(mock.Anything, page, pageSize).
 			Return(tokenMappings, len(tokenMappings), nil)
 
 		result, err := bridgeMocks.bridge.GetTokenMappings(networkID, &page, &pageSize)
@@ -506,6 +506,91 @@ func TestGetTokenMappings(t *testing.T) {
 
 		result, err := bridgeMocks.bridge.GetTokenMappings(unsupportedNetworkID, nil, nil)
 		require.ErrorContains(t, err, fmt.Sprintf("failed to get token mappings, unsupported network %d", unsupportedNetworkID))
+		require.Nil(t, result)
+	})
+}
+
+func TestGetLegacyTokenMigrations(t *testing.T) {
+	networkID := uint32(10)
+	bridgeMocks := newBridgeWithMocks(t, networkID)
+
+	t.Run("GetLegacyTokenMigrations for L1 network", func(t *testing.T) {
+		page := uint32(1)
+		pageSize := uint32(10)
+		tokenMigrations := []*bridgesync.LegacyTokenMigration{
+			{
+				BlockNum:            1,
+				BlockPos:            1,
+				BlockTimestamp:      1617184800,
+				TxHash:              common.HexToHash("0x1"),
+				Sender:              common.HexToAddress("0x2"),
+				LegacyTokenAddress:  common.HexToAddress("0x3"),
+				UpdatedTokenAddress: common.HexToAddress("0x4"),
+				Amount:              big.NewInt(100),
+				Calldata:            common.Hex2Bytes("efabcd"),
+			},
+		}
+
+		bridgeMocks.bridgeL1.EXPECT().GetLegacyTokenMigrations(mock.Anything, page, pageSize).
+			Return(tokenMigrations, len(tokenMigrations), nil)
+
+		result, err := bridgeMocks.bridge.GetLegacyTokenMigrations(0, &page, &pageSize)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		tokenMigrationsRes, ok := result.(*LegacyTokenMigrationsResult)
+		require.True(t, ok)
+		require.Equal(t, tokenMigrations, tokenMigrationsRes.TokenMigrations)
+		require.Equal(t, len(tokenMigrationsRes.TokenMigrations), tokenMigrationsRes.Count)
+
+		actualJSON, marshalErr := json.Marshal(tokenMigrationsRes.TokenMigrations)
+		require.NoError(t, marshalErr)
+
+		expectedJSON, marshalErr := json.Marshal(tokenMigrations)
+		require.NoError(t, marshalErr)
+
+		require.JSONEq(t, string(expectedJSON), string(actualJSON))
+
+		bridgeMocks.bridgeL1.AssertExpectations(t)
+	})
+
+	t.Run("GetLegacyTokenMigrations for L2 network", func(t *testing.T) {
+		page := uint32(1)
+		pageSize := uint32(10)
+
+		tokenMigrations := []*bridgesync.LegacyTokenMigration{
+			{
+				BlockNum:            1,
+				BlockPos:            1,
+				BlockTimestamp:      1617184800,
+				TxHash:              common.HexToHash("0x10"),
+				Sender:              common.HexToAddress("0x20"),
+				LegacyTokenAddress:  common.HexToAddress("0x30"),
+				UpdatedTokenAddress: common.HexToAddress("0x40"),
+				Amount:              big.NewInt(10),
+			},
+		}
+
+		bridgeMocks.bridgeL2.EXPECT().GetLegacyTokenMigrations(mock.Anything, page, pageSize).
+			Return(tokenMigrations, len(tokenMigrations), nil)
+
+		result, err := bridgeMocks.bridge.GetLegacyTokenMigrations(networkID, &page, &pageSize)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		tokenMigrationsRes, ok := result.(*LegacyTokenMigrationsResult)
+		require.True(t, ok)
+		require.Equal(t, tokenMigrations, tokenMigrationsRes.TokenMigrations)
+		require.Equal(t, len(tokenMigrations), tokenMigrationsRes.Count)
+
+		bridgeMocks.bridgeL2.AssertExpectations(t)
+	})
+
+	t.Run("GetLegacyTokenMigrations with unsupported network", func(t *testing.T) {
+		unsupportedNetworkID := uint32(999)
+
+		result, err := bridgeMocks.bridge.GetLegacyTokenMigrations(unsupportedNetworkID, nil, nil)
+		require.ErrorContains(t, err, fmt.Sprintf("failed to get legacy token migrations, unsupported network %d", unsupportedNetworkID))
 		require.Nil(t, result)
 	})
 }

--- a/rpc/mocks/mock_bridger.go
+++ b/rpc/mocks/mock_bridger.go
@@ -219,6 +219,73 @@ func (_c *Bridger_GetLastReorgEvent_Call) RunAndReturn(run func(context.Context)
 	return _c
 }
 
+// GetLegacyTokenMigrations provides a mock function with given fields: ctx, pageNumber, pageSize
+func (_m *Bridger) GetLegacyTokenMigrations(ctx context.Context, pageNumber uint32, pageSize uint32) ([]*bridgesync.LegacyTokenMigration, int, error) {
+	ret := _m.Called(ctx, pageNumber, pageSize)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLegacyTokenMigrations")
+	}
+
+	var r0 []*bridgesync.LegacyTokenMigration
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) ([]*bridgesync.LegacyTokenMigration, int, error)); ok {
+		return rf(ctx, pageNumber, pageSize)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) []*bridgesync.LegacyTokenMigration); ok {
+		r0 = rf(ctx, pageNumber, pageSize)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*bridgesync.LegacyTokenMigration)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32) int); ok {
+		r1 = rf(ctx, pageNumber, pageSize)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, uint32, uint32) error); ok {
+		r2 = rf(ctx, pageNumber, pageSize)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// Bridger_GetLegacyTokenMigrations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLegacyTokenMigrations'
+type Bridger_GetLegacyTokenMigrations_Call struct {
+	*mock.Call
+}
+
+// GetLegacyTokenMigrations is a helper method to define mock.On call
+//   - ctx context.Context
+//   - pageNumber uint32
+//   - pageSize uint32
+func (_e *Bridger_Expecter) GetLegacyTokenMigrations(ctx interface{}, pageNumber interface{}, pageSize interface{}) *Bridger_GetLegacyTokenMigrations_Call {
+	return &Bridger_GetLegacyTokenMigrations_Call{Call: _e.mock.On("GetLegacyTokenMigrations", ctx, pageNumber, pageSize)}
+}
+
+func (_c *Bridger_GetLegacyTokenMigrations_Call) Run(run func(ctx context.Context, pageNumber uint32, pageSize uint32)) *Bridger_GetLegacyTokenMigrations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint32), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *Bridger_GetLegacyTokenMigrations_Call) Return(_a0 []*bridgesync.LegacyTokenMigration, _a1 int, _a2 error) *Bridger_GetLegacyTokenMigrations_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *Bridger_GetLegacyTokenMigrations_Call) RunAndReturn(run func(context.Context, uint32, uint32) ([]*bridgesync.LegacyTokenMigration, int, error)) *Bridger_GetLegacyTokenMigrations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetProof provides a mock function with given fields: ctx, depositCount, localExitRoot
 func (_m *Bridger) GetProof(ctx context.Context, depositCount uint32, localExitRoot common.Hash) (types.Proof, error) {
 	ret := _m.Called(ctx, depositCount, localExitRoot)

--- a/test/bats/pp/bridge-e2e.bats
+++ b/test/bats/pp/bridge-e2e.bats
@@ -153,7 +153,7 @@ setup() {
     run generate_claim_proof "$l1_rpc_network_id" "$deposit_count" "$l1_info_tree_index" 10 5 "$aggkit_node_url"
     assert_success
     local proof="$output"
-    run claim_bridge "$bridge" "$proof" "$l2_rpc_url" 10 20 "$l1_rpc_network_id"
+    run claim_bridge "$bridge" "$proof" "$l2_rpc_url" 15 20 "$l1_rpc_network_id"
     assert_success
     local claim_global_index="$output"
 

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/aggoracle"
 	"github.com/agglayer/aggkit/aggoracle/chaingersender"
 	"github.com/agglayer/aggkit/bridgesync"

--- a/test/helpers/simulated.go
+++ b/test/helpers/simulated.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/test/contracts/transparentupgradableproxy"
 	aggkittypes "github.com/agglayer/aggkit/types"


### PR DESCRIPTION
## Description

Index the following sovereign chain bridge contract events:
- `SetSovereignTokenAddress` - expose it via the `bridge_getTokenMappings` JSON RPC endpoint
- `MigrateLegacyToken` - exposed via `bridge_getLegacyTokenMigrations` JSON RPC endpoint
- `RemoveLegacySovereignTokenAddress` - indexed and it reflects the legacy token migrations.

Fixes #298 
