### PR TITLE
feat: update `cdk-contracts-tooling` reference

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -16,21 +16,9 @@ packages:
         config:
           mockname: AgglayerClientMock
           filename: mock_agglayer_client.go
-  github.com/agglayer/aggkit/aggoracle/chaingersender:
+  github.com/agglayer/aggkit/aggoracle/types:
     config:
-    interfaces:
-      EthTxManager:
-        configs:
-          - mockname: EthTxManagerMock
-            filename: mock_ethtxmanager.go
-          - mockname: EthTxManagerMock
-            filename: mock_ethtxmanager.go
-            dir: "{{ .InterfaceDir }}/../../test/helpers"
-            outpkg: "helpers"
-      L2GERManagerContract:
-        config:
-          mockname: L2GERManagerMock
-          filename: mock_l2germanager.go
+      all: true
   github.com/agglayer/aggkit/aggsender/db:
     config:
       all: true

--- a/aggoracle/chaingerreader/evm.go
+++ b/aggoracle/chaingerreader/evm.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	"github.com/agglayer/aggkit/aggoracle/types"
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -23,6 +23,7 @@ func NewEVMChainGERReader(l2GERManagerAddr common.Address, l2Client types.EthCli
 	if err != nil {
 		return nil, err
 	}
+
 	return newEVMChainGERReader(l2GERManager, l2GERManagerAddr)
 }
 
@@ -52,7 +53,7 @@ func (e *EVMChainGERReader) GetInjectedGERsForRange(ctx context.Context,
 		return nil, fmt.Errorf("invalid block range: fromBlock(%d) > toBlock(%d)", fromBlock, toBlock)
 	}
 
-	iter, err := e.l2GERManager.FilterInsertGlobalExitRoot(
+	iter, err := e.l2GERManager.FilterUpdateHashChainValue(
 		&bind.FilterOpts{
 			Context: ctx,
 			Start:   fromBlock,

--- a/aggoracle/chaingerreader/evm_test.go
+++ b/aggoracle/chaingerreader/evm_test.go
@@ -63,7 +63,7 @@ func TestGetInjectedGERsForRange(t *testing.T) {
 
 		toBlock := uint64(10)
 		mockL2GERManager := mocks.NewL2GERManagerContract(t)
-		mockL2GERManager.On("FilterInsertGlobalExitRoot", &bind.FilterOpts{
+		mockL2GERManager.On("FilterUpdateHashChainValue", &bind.FilterOpts{
 			Context: ctx,
 			Start:   1,
 			End:     &toBlock,

--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
 	"github.com/agglayer/aggkit/aggoracle/types"

--- a/aggoracle/mocks/mock_l2_ger_manager_contract.go
+++ b/aggoracle/mocks/mock_l2_ger_manager_contract.go
@@ -8,7 +8,7 @@ import (
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	common "github.com/ethereum/go-ethereum/common"
 
-	globalexitrootmanagerl2sovereignchain "github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	globalexitrootmanagerl2sovereignchain "github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -84,24 +84,24 @@ func (_c *L2GERManagerContract_BridgeAddress_Call) RunAndReturn(run func(*bind.C
 	return _c
 }
 
-// FilterInsertGlobalExitRoot provides a mock function with given fields: opts, newGlobalExitRoot, newHashChainValue
-func (_m *L2GERManagerContract) FilterInsertGlobalExitRoot(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator, error) {
+// FilterUpdateHashChainValue provides a mock function with given fields: opts, newGlobalExitRoot, newHashChainValue
+func (_m *L2GERManagerContract) FilterUpdateHashChainValue(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator, error) {
 	ret := _m.Called(opts, newGlobalExitRoot, newHashChainValue)
 
 	if len(ret) == 0 {
-		panic("no return value specified for FilterInsertGlobalExitRoot")
+		panic("no return value specified for FilterUpdateHashChainValue")
 	}
 
-	var r0 *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator
+	var r0 *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*bind.FilterOpts, [][32]byte, [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator, error)); ok {
+	if rf, ok := ret.Get(0).(func(*bind.FilterOpts, [][32]byte, [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator, error)); ok {
 		return rf(opts, newGlobalExitRoot, newHashChainValue)
 	}
-	if rf, ok := ret.Get(0).(func(*bind.FilterOpts, [][32]byte, [][32]byte) *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator); ok {
+	if rf, ok := ret.Get(0).(func(*bind.FilterOpts, [][32]byte, [][32]byte) *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator); ok {
 		r0 = rf(opts, newGlobalExitRoot, newHashChainValue)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator)
+			r0 = ret.Get(0).(*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator)
 		}
 	}
 
@@ -114,32 +114,32 @@ func (_m *L2GERManagerContract) FilterInsertGlobalExitRoot(opts *bind.FilterOpts
 	return r0, r1
 }
 
-// L2GERManagerContract_FilterInsertGlobalExitRoot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FilterInsertGlobalExitRoot'
-type L2GERManagerContract_FilterInsertGlobalExitRoot_Call struct {
+// L2GERManagerContract_FilterUpdateHashChainValue_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FilterUpdateHashChainValue'
+type L2GERManagerContract_FilterUpdateHashChainValue_Call struct {
 	*mock.Call
 }
 
-// FilterInsertGlobalExitRoot is a helper method to define mock.On call
+// FilterUpdateHashChainValue is a helper method to define mock.On call
 //   - opts *bind.FilterOpts
 //   - newGlobalExitRoot [][32]byte
 //   - newHashChainValue [][32]byte
-func (_e *L2GERManagerContract_Expecter) FilterInsertGlobalExitRoot(opts interface{}, newGlobalExitRoot interface{}, newHashChainValue interface{}) *L2GERManagerContract_FilterInsertGlobalExitRoot_Call {
-	return &L2GERManagerContract_FilterInsertGlobalExitRoot_Call{Call: _e.mock.On("FilterInsertGlobalExitRoot", opts, newGlobalExitRoot, newHashChainValue)}
+func (_e *L2GERManagerContract_Expecter) FilterUpdateHashChainValue(opts interface{}, newGlobalExitRoot interface{}, newHashChainValue interface{}) *L2GERManagerContract_FilterUpdateHashChainValue_Call {
+	return &L2GERManagerContract_FilterUpdateHashChainValue_Call{Call: _e.mock.On("FilterUpdateHashChainValue", opts, newGlobalExitRoot, newHashChainValue)}
 }
 
-func (_c *L2GERManagerContract_FilterInsertGlobalExitRoot_Call) Run(run func(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte)) *L2GERManagerContract_FilterInsertGlobalExitRoot_Call {
+func (_c *L2GERManagerContract_FilterUpdateHashChainValue_Call) Run(run func(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte)) *L2GERManagerContract_FilterUpdateHashChainValue_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(*bind.FilterOpts), args[1].([][32]byte), args[2].([][32]byte))
 	})
 	return _c
 }
 
-func (_c *L2GERManagerContract_FilterInsertGlobalExitRoot_Call) Return(_a0 *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator, _a1 error) *L2GERManagerContract_FilterInsertGlobalExitRoot_Call {
+func (_c *L2GERManagerContract_FilterUpdateHashChainValue_Call) Return(_a0 *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator, _a1 error) *L2GERManagerContract_FilterUpdateHashChainValue_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *L2GERManagerContract_FilterInsertGlobalExitRoot_Call) RunAndReturn(run func(*bind.FilterOpts, [][32]byte, [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator, error)) *L2GERManagerContract_FilterInsertGlobalExitRoot_Call {
+func (_c *L2GERManagerContract_FilterUpdateHashChainValue_Call) RunAndReturn(run func(*bind.FilterOpts, [][32]byte, [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator, error)) *L2GERManagerContract_FilterUpdateHashChainValue_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggoracle/types/types.go
+++ b/aggoracle/types/types.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -40,6 +40,6 @@ type EthTxManager interface {
 type L2GERManagerContract interface {
 	GlobalExitRootMap(opts *bind.CallOpts, ger [common.HashLength]byte) (*big.Int, error)
 	BridgeAddress(*bind.CallOpts) (common.Address, error)
-	FilterInsertGlobalExitRoot(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte) (
-		*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainInsertGlobalExitRootIterator, error)
+	FilterUpdateHashChainValue(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte) (
+		*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator, error)
 }

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridgev2"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -6,8 +6,8 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevmbridge"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridge"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
 	rpcTypes "github.com/0xPolygon/cdk-rpc/types"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/sync"

--- a/claimsponsor/evmclaimsponsor.go
+++ b/claimsponsor/evmclaimsponsor.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
 	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
 	configTypes "github.com/agglayer/aggkit/config/types"

--- a/etherman/contracts/base_test.go
+++ b/etherman/contracts/base_test.go
@@ -3,7 +3,7 @@ package contracts_test
 import (
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/etherman/contracts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"

--- a/etherman/contracts/contracts_banana.go
+++ b/etherman/contracts/contracts_banana.go
@@ -1,9 +1,9 @@
 package contracts
 
 import (
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonrollupmanager"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonvalidiumetrog"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/banana/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonrollupmanager"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonvalidiumetrog"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/banana/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/etherman/config"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )

--- a/etherman/contracts/contracts_elderberry.go
+++ b/etherman/contracts/contracts_elderberry.go
@@ -1,9 +1,9 @@
 package contracts
 
 import (
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonrollupmanager"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonvalidiumetrog"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonrollupmanager"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonvalidiumetrog"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/etherman/config"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/idataavailabilityprotocol"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/idataavailabilityprotocol"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/etherman/config"
 	"github.com/agglayer/aggkit/etherman/contracts"

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonvalidiumetrog"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/elderberry/polygonvalidiumetrog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/invopop/jsonschema"
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250317150713-743b25629858.1
 	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250327122651-3ea16e24e202.2
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250327122651-3ea16e24e202.1
-	github.com/0xPolygon/cdk-contracts-tooling v0.0.3-0.20250401113833-4b09a77b0ee8
+	github.com/0xPolygon/cdk-contracts-tooling v0.0.3
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.5
 	github.com/ethereum/go-ethereum v1.15.5

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250317150713-743b25629858.1
 	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250327122651-3ea16e24e202.2
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250327122651-3ea16e24e202.1
-	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861
+	github.com/0xPolygon/cdk-contracts-tooling v0.0.3-0.20250401113833-4b09a77b0ee8
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.5
 	github.com/ethereum/go-ethereum v1.15.5

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250327122651-3ea1
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250327122651-3ea16e24e202.1/go.mod h1:ejSvLmpUKsnokaT4/eqLdg/5lK4X/2PogSBbqx+DAPg=
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861 h1:G21RAhtWCgy/dv/t1ed3ROJ7+rBgdlovzyz6rTh4FLs=
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861/go.mod h1:HGx8hRdvtcAZZaFHZylN9B8lOZkxM+NrVvOdzw4jQEY=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.3-0.20250401113833-4b09a77b0ee8 h1:N4imytYXFEx7MYsoamYuKF3hH2HC3U4dWpIGDyidKBE=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.3-0.20250401113833-4b09a77b0ee8/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6 h1:FXL/rcO7/GtZ3kRFw+C7J6vmGnl8gcazg+Gh/NVmnas=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
 github.com/0xPolygon/zkevm-ethtx-manager v0.2.5 h1:t6vLS597OjPcoZzvpGXooIy+ANQEX6LoxYBenRmu15I=

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,8 @@ buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250327122651-3ea16e24e202.2 h
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250327122651-3ea16e24e202.2/go.mod h1:xm3a1yJlOWaCjcjn2qDENhrctTURS2mMFUJfJJasMIE=
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250327122651-3ea16e24e202.1 h1:DiFgGr/wgQa2xklwq0OY2x3WGfb38m8L2FbHmgKKbu0=
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250327122651-3ea16e24e202.1/go.mod h1:ejSvLmpUKsnokaT4/eqLdg/5lK4X/2PogSBbqx+DAPg=
-github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861 h1:G21RAhtWCgy/dv/t1ed3ROJ7+rBgdlovzyz6rTh4FLs=
-github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20250212122525-ec44fb65e861/go.mod h1:HGx8hRdvtcAZZaFHZylN9B8lOZkxM+NrVvOdzw4jQEY=
-github.com/0xPolygon/cdk-contracts-tooling v0.0.3-0.20250401113833-4b09a77b0ee8 h1:N4imytYXFEx7MYsoamYuKF3hH2HC3U4dWpIGDyidKBE=
-github.com/0xPolygon/cdk-contracts-tooling v0.0.3-0.20250401113833-4b09a77b0ee8/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.3 h1:G7H3UNyDOpoLqDvW9c4lgn2iMnteM1HqUpUAD1gk9VU=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.3/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6 h1:FXL/rcO7/GtZ3kRFw+C7J6vmGnl8gcazg+Gh/NVmnas=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
 github.com/0xPolygon/zkevm-ethtx-manager v0.2.5 h1:t6vLS597OjPcoZzvpGXooIy+ANQEX6LoxYBenRmu15I=

--- a/l1infotreesync/downloader.go
+++ b/l1infotreesync/downloader.go
@@ -3,8 +3,8 @@ package l1infotreesync
 import (
 	"fmt"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonrollupmanager"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonrollupmanager"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
 	"github.com/ethereum/go-ethereum"

--- a/l1infotreesync/downloader_test.go
+++ b/l1infotreesync/downloader_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	mocks_l1infotreesync "github.com/agglayer/aggkit/l1infotreesync/mocks"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"

--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	aggkittypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/l1infotreesync"

--- a/lastgersync/evmdownloader.go
+++ b/lastgersync/evmdownloader.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/l1infotreesync"

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
 	"github.com/agglayer/aggkit/aggoracle"
 	"github.com/agglayer/aggkit/aggoracle/chaingersender"
 	"github.com/agglayer/aggkit/bridgesync"

--- a/test/helpers/mock_ethtxmanager.go
+++ b/test/helpers/mock_ethtxmanager.go
@@ -3,11 +3,10 @@
 package helpers
 
 import (
+	context "context"
 	big "math/big"
 
 	common "github.com/ethereum/go-ethereum/common"
-
-	context "context"
 
 	mock "github.com/stretchr/testify/mock"
 

--- a/test/helpers/simulated.go
+++ b/test/helpers/simulated.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/test/contracts/transparentupgradableproxy"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"


### PR DESCRIPTION
## Description

This PR updates the reference to `cdk-contracts-tooling` repo, and changes the way we read the injected GERs in the `aggoracle/chaingerreader` package, since the event for inserting a `GER` in `L2` changed on the new contracts version.

Rest of the changes are just update of the packages that reference packages of `cdk-contracts-tooling` repo.

Fixes # (issue)
