### PR TITLE
chore: update Go version to 1.24

### DIFF
--- a/.github/workflows/build-aggkit-image.yml
+++ b/.github/workflows/build-aggkit-image.yml
@@ -5,7 +5,6 @@ on:
       go-version:
         required: true
         type: string
-        default: "1.23.7"
       docker-image-name:
         required: true
         type: string

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         if: ${{ matrix.language == 'go' }}
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Verify Go version
         if: ${{ matrix.language == 'go' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e-multi-chains.yml
+++ b/.github/workflows/test-e2e-multi-chains.yml
@@ -9,7 +9,7 @@ jobs:
   build-aggkit-image:
     uses: ./.github/workflows/build-aggkit-image.yml
     with:
-      go-version: 1.23.x
+      go-version: 1.24.x
       docker-image-name: aggkit
 
   test-e2e:
@@ -29,7 +29,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: Build Tools
       run: make build-tools

--- a/.github/workflows/test-e2e-single-chain.yml
+++ b/.github/workflows/test-e2e-single-chain.yml
@@ -10,7 +10,7 @@ jobs:
   build-aggkit-image:
     uses: ./.github/workflows/build-aggkit-image.yml
     with:
-      go-version: 1.23.x
+      go-version: 1.24.x
       docker-image-name: aggkit
   
   test-e2e:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.7]
+        go-version: [1.24.2]
         goarch: ["amd64"]
     runs-on: amd-runner-2204
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CONTAINER FOR BUILDING BINARY
-FROM --platform=${BUILDPLATFORM} golang:1.23.7 AS build
+FROM --platform=${BUILDPLATFORM} golang:1.24.2 AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agglayer/aggkit
 
-go 1.23.7
+go 1.24
 
 require (
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef


### PR DESCRIPTION
## Description

This PR bumps the go version to `v1.24`.

Fixes #352 
