### PR TITLE
feat: update `agglayer` API on `aggsender`

### DIFF
--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 
 	node "buf.build/gen/go/agglayer/agglayer/grpc/go/agglayer/node/v1/nodev1grpc"
+	v1nodetypes "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/types/v1"
 	v1 "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/v1"
-	v1Types "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/protocol/types/v1"
+	v1types "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
 	"github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/bridgesync"
 	aggkitCommon "github.com/agglayer/aggkit/common"
@@ -64,17 +65,21 @@ func (a *AgglayerGRPCClient) SendCertificate(ctx context.Context,
 		return common.Hash{}, errUndefinedAggchainData
 	}
 
-	var aggchainDataProto *v1Types.AggchainData
+	var aggchainDataProto *v1types.AggchainData
 
 	switch ad := certificate.AggchainData.(type) {
 	case *types.AggchainDataProof:
-		aggchainDataProto = &v1Types.AggchainData{
-			Data: &v1Types.AggchainData_Generic{
-				Generic: &v1Types.AggchainProof{
-					Proof: &v1Types.AggchainProof_Sp1Stark{
-						Sp1Stark: ad.Proof,
+		aggchainDataProto = &v1types.AggchainData{
+			Data: &v1types.AggchainData_Generic{
+				Generic: &v1types.AggchainProof{
+					Proof: &v1types.AggchainProof_Sp1Stark{
+						Sp1Stark: &v1types.SP1StarkProof{
+							Version: ad.Version,
+							Proof:   ad.Proof,
+							Vkey:    ad.Vkey,
+						},
 					},
-					AggchainParams: &v1Types.FixedBytes32{
+					AggchainParams: &v1types.FixedBytes32{
 						Value: ad.AggchainParams.Bytes(),
 					},
 					Context: ad.Context,
@@ -82,9 +87,9 @@ func (a *AgglayerGRPCClient) SendCertificate(ctx context.Context,
 			},
 		}
 	case *types.AggchainDataSignature:
-		aggchainDataProto = &v1Types.AggchainData{
-			Data: &v1Types.AggchainData_Signature{
-				Signature: &v1Types.FixedBytes65{
+		aggchainDataProto = &v1types.AggchainData{
+			Data: &v1types.AggchainData_Signature{
+				Signature: &v1types.FixedBytes65{
 					Value: ad.Signature,
 				},
 			},
@@ -93,22 +98,22 @@ func (a *AgglayerGRPCClient) SendCertificate(ctx context.Context,
 		return common.Hash{}, errUnknownAggchainData
 	}
 
-	protoCert := &v1Types.Certificate{
+	protoCert := &v1nodetypes.Certificate{
 		NetworkId: certificate.NetworkID,
 		Height:    certificate.Height,
-		PrevLocalExitRoot: &v1Types.FixedBytes32{
+		PrevLocalExitRoot: &v1types.FixedBytes32{
 			Value: certificate.PrevLocalExitRoot.Bytes(),
 		},
-		NewLocalExitRoot: &v1Types.FixedBytes32{
+		NewLocalExitRoot: &v1types.FixedBytes32{
 			Value: certificate.NewLocalExitRoot.Bytes(),
 		},
-		Metadata: &v1Types.FixedBytes32{
+		Metadata: &v1types.FixedBytes32{
 			Value: certificate.Metadata.Bytes(),
 		},
 		CustomChainData:     certificate.CustomChainData,
 		AggchainData:        aggchainDataProto,
-		BridgeExits:         make([]*v1Types.BridgeExit, 0, len(certificate.BridgeExits)),
-		ImportedBridgeExits: make([]*v1Types.ImportedBridgeExit, 0, len(certificate.ImportedBridgeExits)),
+		BridgeExits:         make([]*v1types.BridgeExit, 0, len(certificate.BridgeExits)),
+		ImportedBridgeExits: make([]*v1types.ImportedBridgeExit, 0, len(certificate.ImportedBridgeExits)),
 	}
 
 	for _, be := range certificate.BridgeExits {
@@ -173,8 +178,8 @@ func (a *AgglayerGRPCClient) GetLatestPendingCertificateHeader(
 func (a *AgglayerGRPCClient) GetCertificateHeader(ctx context.Context,
 	certificateID common.Hash) (*types.CertificateHeader, error) {
 	response, err := a.networkStateService.GetCertificateHeader(ctx,
-		&v1.GetCertificateHeaderRequest{CertificateId: &v1Types.CertificateId{
-			Value: &v1Types.FixedBytes32{
+		&v1.GetCertificateHeaderRequest{CertificateId: &v1nodetypes.CertificateId{
+			Value: &v1types.FixedBytes32{
 				Value: certificateID.Bytes(),
 			},
 		},
@@ -187,7 +192,7 @@ func (a *AgglayerGRPCClient) GetCertificateHeader(ctx context.Context,
 }
 
 // convertProtoCertificateHeader converts a proto certificate header to a types certificate header
-func convertProtoCertificateHeader(response *v1Types.CertificateHeader) *types.CertificateHeader {
+func convertProtoCertificateHeader(response *v1nodetypes.CertificateHeader) *types.CertificateHeader {
 	if response == nil {
 		return nil
 	}
@@ -213,30 +218,33 @@ func convertProtoCertificateHeader(response *v1Types.CertificateHeader) *types.C
 }
 
 // convertToProtoBridgeExit converts a bridge exit to a proto bridge exit
-func convertToProtoBridgeExit(be *types.BridgeExit) *v1Types.BridgeExit {
+func convertToProtoBridgeExit(be *types.BridgeExit) *v1types.BridgeExit {
 	if be == nil {
 		return nil
 	}
 
-	protoBridgeExit := &v1Types.BridgeExit{
+	protoBridgeExit := &v1types.BridgeExit{
 		LeafType:    leafTypeToProto(be.LeafType),
 		DestNetwork: be.DestinationNetwork,
-		DestAddress: &v1Types.FixedBytes20{
+		DestAddress: &v1types.FixedBytes20{
 			Value: be.DestinationAddress.Bytes(),
 		},
-		Amount: &v1Types.FixedBytes32{
-			Value: common.BigToHash(be.Amount).Bytes(),
-		},
-		TokenInfo: &v1Types.TokenInfo{
+		TokenInfo: &v1types.TokenInfo{
 			OriginNetwork: be.TokenInfo.OriginNetwork,
-			OriginTokenAddress: &v1Types.FixedBytes20{
+			OriginTokenAddress: &v1types.FixedBytes20{
 				Value: be.TokenInfo.OriginTokenAddress.Bytes(),
 			},
 		},
 	}
 
+	if be.Amount != nil {
+		protoBridgeExit.Amount = &v1types.FixedBytes32{
+			Value: be.Amount.Bytes(),
+		}
+	}
+
 	if len(be.Metadata) > 0 {
-		protoBridgeExit.Metadata = &v1Types.FixedBytes32{
+		protoBridgeExit.Metadata = &v1types.FixedBytes32{
 			Value: common.BytesToHash(be.Metadata).Bytes(),
 		}
 	}
@@ -244,14 +252,14 @@ func convertToProtoBridgeExit(be *types.BridgeExit) *v1Types.BridgeExit {
 	return protoBridgeExit
 }
 
-func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1Types.ImportedBridgeExit, error) {
+func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1types.ImportedBridgeExit, error) {
 	if ibe == nil {
 		return nil, nil
 	}
 
-	importedBridgeExit := &v1Types.ImportedBridgeExit{
+	importedBridgeExit := &v1types.ImportedBridgeExit{
 		BridgeExit: convertToProtoBridgeExit(ibe.BridgeExit),
-		GlobalIndex: &v1Types.FixedBytes32{
+		GlobalIndex: &v1types.FixedBytes32{
 			Value: common.BigToHash(bridgesync.GenerateGlobalIndex(
 				ibe.GlobalIndex.MainnetFlag,
 				ibe.GlobalIndex.RollupIndex,
@@ -261,33 +269,33 @@ func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1Types.I
 
 	switch claimData := ibe.ClaimData.(type) {
 	case *types.ClaimFromMainnnet:
-		importedBridgeExit.Claim = &v1Types.ImportedBridgeExit_Mainnet{
-			Mainnet: &v1Types.ClaimFromMainnet{
-				ProofLeafMer: &v1Types.MerkleProof{
-					Root: &v1Types.FixedBytes32{
+		importedBridgeExit.Claim = &v1types.ImportedBridgeExit_Mainnet{
+			Mainnet: &v1types.ClaimFromMainnet{
+				ProofLeafMer: &v1types.MerkleProof{
+					Root: &v1types.FixedBytes32{
 						Value: claimData.ProofLeafMER.Root.Bytes(),
 					},
 					Siblings: convertToProtoSiblings(claimData.ProofLeafMER.Proof),
 				},
-				ProofGerL1Root: &v1Types.MerkleProof{
-					Root: &v1Types.FixedBytes32{
+				ProofGerL1Root: &v1types.MerkleProof{
+					Root: &v1types.FixedBytes32{
 						Value: claimData.ProofGERToL1Root.Root.Bytes(),
 					},
 					Siblings: convertToProtoSiblings(claimData.ProofGERToL1Root.Proof),
 				},
-				L1Leaf: &v1Types.L1InfoTreeLeafWithContext{
+				L1Leaf: &v1types.L1InfoTreeLeafWithContext{
 					L1InfoTreeIndex: claimData.L1Leaf.L1InfoTreeIndex,
-					Rer: &v1Types.FixedBytes32{
+					Rer: &v1types.FixedBytes32{
 						Value: claimData.L1Leaf.RollupExitRoot.Bytes(),
 					},
-					Mer: &v1Types.FixedBytes32{
+					Mer: &v1types.FixedBytes32{
 						Value: claimData.L1Leaf.MainnetExitRoot.Bytes(),
 					},
-					Inner: &v1Types.L1InfoTreeLeaf{
-						GlobalExitRoot: &v1Types.FixedBytes32{
+					Inner: &v1types.L1InfoTreeLeaf{
+						GlobalExitRoot: &v1types.FixedBytes32{
 							Value: claimData.L1Leaf.Inner.GlobalExitRoot.Bytes(),
 						},
-						BlockHash: &v1Types.FixedBytes32{
+						BlockHash: &v1types.FixedBytes32{
 							Value: claimData.L1Leaf.Inner.BlockHash.Bytes(),
 						},
 						Timestamp: claimData.L1Leaf.Inner.Timestamp,
@@ -296,39 +304,39 @@ func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1Types.I
 			},
 		}
 	case *types.ClaimFromRollup:
-		importedBridgeExit.Claim = &v1Types.ImportedBridgeExit_Rollup{
-			Rollup: &v1Types.ClaimFromRollup{
-				ProofLeafLer: &v1Types.MerkleProof{
-					Root: &v1Types.FixedBytes32{
+		importedBridgeExit.Claim = &v1types.ImportedBridgeExit_Rollup{
+			Rollup: &v1types.ClaimFromRollup{
+				ProofLeafLer: &v1types.MerkleProof{
+					Root: &v1types.FixedBytes32{
 						Value: claimData.ProofLeafLER.Root.Bytes(),
 					},
 					Siblings: convertToProtoSiblings(claimData.ProofLeafLER.Proof),
 				},
-				ProofLerRer: &v1Types.MerkleProof{
-					Root: &v1Types.FixedBytes32{
+				ProofLerRer: &v1types.MerkleProof{
+					Root: &v1types.FixedBytes32{
 						Value: claimData.ProofLERToRER.Root.Bytes(),
 					},
 					Siblings: convertToProtoSiblings(claimData.ProofLERToRER.Proof),
 				},
-				ProofGerL1Root: &v1Types.MerkleProof{
-					Root: &v1Types.FixedBytes32{
+				ProofGerL1Root: &v1types.MerkleProof{
+					Root: &v1types.FixedBytes32{
 						Value: claimData.ProofGERToL1Root.Root.Bytes(),
 					},
 					Siblings: convertToProtoSiblings(claimData.ProofGERToL1Root.Proof),
 				},
-				L1Leaf: &v1Types.L1InfoTreeLeafWithContext{
+				L1Leaf: &v1types.L1InfoTreeLeafWithContext{
 					L1InfoTreeIndex: claimData.L1Leaf.L1InfoTreeIndex,
-					Rer: &v1Types.FixedBytes32{
+					Rer: &v1types.FixedBytes32{
 						Value: claimData.L1Leaf.RollupExitRoot.Bytes(),
 					},
-					Mer: &v1Types.FixedBytes32{
+					Mer: &v1types.FixedBytes32{
 						Value: claimData.L1Leaf.MainnetExitRoot.Bytes(),
 					},
-					Inner: &v1Types.L1InfoTreeLeaf{
-						GlobalExitRoot: &v1Types.FixedBytes32{
+					Inner: &v1types.L1InfoTreeLeaf{
+						GlobalExitRoot: &v1types.FixedBytes32{
 							Value: claimData.L1Leaf.Inner.GlobalExitRoot.Bytes(),
 						},
-						BlockHash: &v1Types.FixedBytes32{
+						BlockHash: &v1types.FixedBytes32{
 							Value: claimData.L1Leaf.Inner.BlockHash.Bytes(),
 						},
 						Timestamp: claimData.L1Leaf.Inner.Timestamp,
@@ -344,11 +352,11 @@ func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1Types.I
 }
 
 // convertToProtoSiblings converts a slice of hashes to a slice of proto fixed bytes 32
-func convertToProtoSiblings(siblings treetypes.Proof) []*v1Types.FixedBytes32 {
-	protoSiblings := make([]*v1Types.FixedBytes32, len(siblings))
+func convertToProtoSiblings(siblings treetypes.Proof) []*v1types.FixedBytes32 {
+	protoSiblings := make([]*v1types.FixedBytes32, len(siblings))
 
 	for i, sibling := range siblings {
-		protoSiblings[i] = &v1Types.FixedBytes32{
+		protoSiblings[i] = &v1types.FixedBytes32{
 			Value: sibling.Bytes(),
 		}
 	}
@@ -357,7 +365,7 @@ func convertToProtoSiblings(siblings treetypes.Proof) []*v1Types.FixedBytes32 {
 }
 
 // nullableBytesToHash converts a nullable byte slice to a hash pointer
-func nullableBytesToHash(b *v1Types.FixedBytes32) *common.Hash {
+func nullableBytesToHash(b *v1types.FixedBytes32) *common.Hash {
 	if b == nil || len(b.Value) == 0 {
 		return nil
 	}
@@ -367,29 +375,29 @@ func nullableBytesToHash(b *v1Types.FixedBytes32) *common.Hash {
 }
 
 // leafTypeToProto converts a leaf type to a proto leaf type
-func leafTypeToProto(leafType types.LeafType) v1Types.LeafType {
+func leafTypeToProto(leafType types.LeafType) v1types.LeafType {
 	switch leafType {
 	case types.LeafTypeAsset:
-		return v1Types.LeafType_LEAF_TYPE_TRANSFER
+		return v1types.LeafType_LEAF_TYPE_TRANSFER
 	case types.LeafTypeMessage:
-		return v1Types.LeafType_LEAF_TYPE_MESSAGE
+		return v1types.LeafType_LEAF_TYPE_MESSAGE
 	default:
-		return v1Types.LeafType_LEAF_TYPE_UNSPECIFIED
+		return v1types.LeafType_LEAF_TYPE_UNSPECIFIED
 	}
 }
 
 // certificateStatusFromProto converts a proto certificate status to a certificate status
-func certificateStatusFromProto(status v1Types.CertificateStatus) types.CertificateStatus {
+func certificateStatusFromProto(status v1nodetypes.CertificateStatus) types.CertificateStatus {
 	switch status {
-	case v1Types.CertificateStatus_CERTIFICATE_STATUS_PENDING:
+	case v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_PENDING:
 		return types.Pending
-	case v1Types.CertificateStatus_CERTIFICATE_STATUS_PROVEN:
+	case v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_PROVEN:
 		return types.Proven
-	case v1Types.CertificateStatus_CERTIFICATE_STATUS_CANDIDATE:
+	case v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_CANDIDATE:
 		return types.Candidate
-	case v1Types.CertificateStatus_CERTIFICATE_STATUS_IN_ERROR:
+	case v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_IN_ERROR:
 		return types.InError
-	case v1Types.CertificateStatus_CERTIFICATE_STATUS_SETTLED:
+	case v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_SETTLED:
 		return types.Settled
 	default:
 		return types.Pending

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -239,7 +239,7 @@ func convertToProtoBridgeExit(be *types.BridgeExit) *v1types.BridgeExit {
 
 	if be.Amount != nil {
 		protoBridgeExit.Amount = &v1types.FixedBytes32{
-			Value: be.Amount.Bytes(),
+			Value: common.BigToHash(be.Amount).Bytes(),
 		}
 	}
 

--- a/agglayer/grpc/agglayer_grpc_client_test.go
+++ b/agglayer/grpc/agglayer_grpc_client_test.go
@@ -7,8 +7,9 @@ import (
 	"math/big"
 	"testing"
 
+	v1nodetypes "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/types/v1"
 	node "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/v1"
-	v1Types "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/protocol/types/v1"
+	v1types "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
 	"github.com/agglayer/aggkit/agglayer/mocks"
 	"github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/tree"
@@ -45,7 +46,7 @@ func TestGetEpochConfiguration(t *testing.T) {
 		}
 
 		expectedResponse := &node.GetEpochConfigurationResponse{
-			EpochConfiguration: &v1Types.EpochConfiguration{
+			EpochConfiguration: &v1nodetypes.EpochConfiguration{
 				GenesisBlock:  1000,
 				EpochDuration: 10,
 			},
@@ -92,24 +93,24 @@ func TestGetLatestPendingCertificateHeader(t *testing.T) {
 		certificateIndex := uint64(1)
 
 		expectedResponse := &node.GetLatestCertificateHeaderResponse{
-			CertificateHeader: &v1Types.CertificateHeader{
+			CertificateHeader: &v1nodetypes.CertificateHeader{
 				NetworkId:        networkID,
 				Height:           100,
 				EpochNumber:      &epoch,
 				CertificateIndex: &certificateIndex,
-				CertificateId: &v1Types.CertificateId{
-					Value: &v1Types.FixedBytes32{
+				CertificateId: &v1nodetypes.CertificateId{
+					Value: &v1types.FixedBytes32{
 						Value: common.HexToHash("0x010203").Bytes(),
 					},
 				},
-				PrevLocalExitRoot: &v1Types.FixedBytes32{
+				PrevLocalExitRoot: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010201").Bytes(),
 				},
-				NewLocalExitRoot: &v1Types.FixedBytes32{
+				NewLocalExitRoot: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010202").Bytes(),
 				},
-				Status: v1Types.CertificateStatus_CERTIFICATE_STATUS_PENDING,
-				Metadata: &v1Types.FixedBytes32{
+				Status: v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_PENDING,
+				Metadata: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x011201").Bytes(),
 				},
 			},
@@ -164,24 +165,24 @@ func TestGetLatestSettledCertificateHeader(t *testing.T) {
 		certificateIndex := uint64(1)
 
 		expectedResponse := &node.GetLatestCertificateHeaderResponse{
-			CertificateHeader: &v1Types.CertificateHeader{
+			CertificateHeader: &v1nodetypes.CertificateHeader{
 				NetworkId:        networkID,
 				Height:           100,
 				EpochNumber:      &epoch,
 				CertificateIndex: &certificateIndex,
-				CertificateId: &v1Types.CertificateId{
-					Value: &v1Types.FixedBytes32{
+				CertificateId: &v1nodetypes.CertificateId{
+					Value: &v1types.FixedBytes32{
 						Value: common.HexToHash("0x010203").Bytes(),
 					},
 				},
-				PrevLocalExitRoot: &v1Types.FixedBytes32{
+				PrevLocalExitRoot: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010201").Bytes(),
 				},
-				NewLocalExitRoot: &v1Types.FixedBytes32{
+				NewLocalExitRoot: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010202").Bytes(),
 				},
-				Status: v1Types.CertificateStatus_CERTIFICATE_STATUS_SETTLED,
-				Metadata: &v1Types.FixedBytes32{
+				Status: v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_SETTLED,
+				Metadata: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x011201").Bytes(),
 				},
 			},
@@ -236,24 +237,24 @@ func TestGetCertificateHeader(t *testing.T) {
 		certificateIndex := uint64(1)
 
 		expectedResponse := &node.GetCertificateHeaderResponse{
-			CertificateHeader: &v1Types.CertificateHeader{
+			CertificateHeader: &v1nodetypes.CertificateHeader{
 				NetworkId:        1,
 				Height:           100,
 				EpochNumber:      &epoch,
 				CertificateIndex: &certificateIndex,
-				CertificateId: &v1Types.CertificateId{
-					Value: &v1Types.FixedBytes32{
+				CertificateId: &v1nodetypes.CertificateId{
+					Value: &v1types.FixedBytes32{
 						Value: certificateID.Bytes(),
 					},
 				},
-				PrevLocalExitRoot: &v1Types.FixedBytes32{
+				PrevLocalExitRoot: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010201").Bytes(),
 				},
-				NewLocalExitRoot: &v1Types.FixedBytes32{
+				NewLocalExitRoot: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010202").Bytes(),
 				},
-				Status: v1Types.CertificateStatus_CERTIFICATE_STATUS_SETTLED,
-				Metadata: &v1Types.FixedBytes32{
+				Status: v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_SETTLED,
+				Metadata: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x011201").Bytes(),
 				},
 			},
@@ -381,12 +382,52 @@ func TestSendCertificate(t *testing.T) {
 						},
 					},
 				},
+				{
+					BridgeExit: &types.BridgeExit{
+						LeafType: types.LeafTypeMessage,
+						TokenInfo: &types.TokenInfo{
+							OriginNetwork:      11,
+							OriginTokenAddress: common.HexToAddress("0x011"),
+						},
+						DestinationNetwork: 22,
+						DestinationAddress: common.HexToAddress("0x012"),
+					},
+					GlobalIndex: &types.GlobalIndex{
+						MainnetFlag: false,
+						RollupIndex: 11,
+						LeafIndex:   2,
+					},
+					ClaimData: &types.ClaimFromRollup{
+						ProofLeafLER: &types.MerkleProof{
+							Root:  common.HexToHash("0x0112"),
+							Proof: tree.EmptyProof,
+						},
+						ProofGERToL1Root: &types.MerkleProof{
+							Root:  common.HexToHash("0x0122"),
+							Proof: tree.EmptyProof,
+						},
+						ProofLERToRER: &types.MerkleProof{
+							Root:  common.HexToHash("0x0123"),
+							Proof: tree.EmptyProof,
+						},
+						L1Leaf: &types.L1InfoTreeLeaf{
+							L1InfoTreeIndex: 2,
+							RollupExitRoot:  common.HexToHash("0x11"),
+							MainnetExitRoot: common.HexToHash("0x12"),
+							Inner: &types.L1InfoTreeLeafInner{
+								GlobalExitRoot: common.HexToHash("0x13"),
+								BlockHash:      common.HexToHash("0x14"),
+								Timestamp:      122222,
+							},
+						},
+					},
+				},
 			},
 		}
 
 		expectedResponse := &node.SubmitCertificateResponse{
-			CertificateId: &v1Types.CertificateId{
-				Value: &v1Types.FixedBytes32{
+			CertificateId: &v1nodetypes.CertificateId{
+				Value: &v1types.FixedBytes32{
 					Value: common.HexToHash("0x010203").Bytes(),
 				},
 			},
@@ -406,22 +447,22 @@ func TestLeafTypeToProto(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    types.LeafType
-		expected v1Types.LeafType
+		expected v1types.LeafType
 	}{
 		{
 			name:     "LeafTypeAsset",
 			input:    types.LeafTypeAsset,
-			expected: v1Types.LeafType_LEAF_TYPE_TRANSFER,
+			expected: v1types.LeafType_LEAF_TYPE_TRANSFER,
 		},
 		{
 			name:     "LeafTypeMessage",
 			input:    types.LeafTypeMessage,
-			expected: v1Types.LeafType_LEAF_TYPE_MESSAGE,
+			expected: v1types.LeafType_LEAF_TYPE_MESSAGE,
 		},
 		{
 			name:     "Default case",
 			input:    types.LeafType(99), // some undefined leaf type
-			expected: v1Types.LeafType_LEAF_TYPE_UNSPECIFIED,
+			expected: v1types.LeafType_LEAF_TYPE_UNSPECIFIED,
 		},
 	}
 
@@ -440,37 +481,37 @@ func TestCertificateStatusFromProto(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		input    v1Types.CertificateStatus
+		input    v1nodetypes.CertificateStatus
 		expected types.CertificateStatus
 	}{
 		{
 			name:     "Pending status",
-			input:    v1Types.CertificateStatus_CERTIFICATE_STATUS_PENDING,
+			input:    v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_PENDING,
 			expected: types.Pending,
 		},
 		{
 			name:     "Proven status",
-			input:    v1Types.CertificateStatus_CERTIFICATE_STATUS_PROVEN,
+			input:    v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_PROVEN,
 			expected: types.Proven,
 		},
 		{
 			name:     "Candidate status",
-			input:    v1Types.CertificateStatus_CERTIFICATE_STATUS_CANDIDATE,
+			input:    v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_CANDIDATE,
 			expected: types.Candidate,
 		},
 		{
 			name:     "InError status",
-			input:    v1Types.CertificateStatus_CERTIFICATE_STATUS_IN_ERROR,
+			input:    v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_IN_ERROR,
 			expected: types.InError,
 		},
 		{
 			name:     "Settled status",
-			input:    v1Types.CertificateStatus_CERTIFICATE_STATUS_SETTLED,
+			input:    v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_SETTLED,
 			expected: types.Settled,
 		},
 		{
 			name:     "Default status",
-			input:    v1Types.CertificateStatus_CERTIFICATE_STATUS_UNSPECIFIED,
+			input:    v1nodetypes.CertificateStatus_CERTIFICATE_STATUS_UNSPECIFIED,
 			expected: types.Pending,
 		},
 	}

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -190,6 +190,8 @@ func (a *AggchainDataSignature) UnmarshalJSON(data []byte) error {
 // This is used in the aggchain prover path
 type AggchainDataProof struct {
 	Proof          []byte            `json:"proof"`
+	Version        string            `json:"version"`
+	Vkey           []byte            `json:"vkey"`
 	AggchainParams common.Hash       `json:"aggchain_params"`
 	Context        map[string][]byte `json:"context"`
 }
@@ -200,10 +202,14 @@ func (a *AggchainDataProof) MarshalJSON() ([]byte, error) {
 		Proof          string            `json:"proof"`
 		AggchainParams string            `json:"aggchain_params"`
 		Context        map[string][]byte `json:"context"`
+		Version        string            `json:"version"`
+		VKey           string            `json:"vkey"`
 	}{
 		Proof:          common.Bytes2Hex(a.Proof),
 		AggchainParams: a.AggchainParams.String(),
 		Context:        a.Context,
+		Version:        a.Version,
+		VKey:           common.Bytes2Hex(a.Vkey),
 	})
 }
 
@@ -213,6 +219,8 @@ func (a *AggchainDataProof) UnmarshalJSON(data []byte) error {
 		Proof          string            `json:"proof"`
 		AggchainParams string            `json:"aggchain_params"`
 		Context        map[string][]byte `json:"context"`
+		Version        string            `json:"version"`
+		VKey           string            `json:"vkey"`
 	}{}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -221,6 +229,8 @@ func (a *AggchainDataProof) UnmarshalJSON(data []byte) error {
 	a.Proof = common.Hex2Bytes(aux.Proof)
 	a.AggchainParams = common.HexToHash(aux.AggchainParams)
 	a.Context = aux.Context
+	a.Version = aux.Version
+	a.Vkey = common.Hex2Bytes(aux.VKey)
 
 	return nil
 }

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1141,8 +1141,10 @@ func TestAggchainDataProof_MarshalUnmarshalJSON(t *testing.T) {
 				Proof:          common.FromHex("0x123456"),
 				AggchainParams: common.HexToHash("0xabcdef"),
 				Context:        map[string][]byte{},
+				Version:        "0.1",
+				Vkey:           common.FromHex("0x123456"),
 			},
-			expected: `{"proof":"123456","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000abcdef","context":{}}`,
+			expected: `{"proof":"123456","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000abcdef","context":{},"version":"0.1","vkey":"123456"}`,
 		},
 		{
 			name: "Empty AggchainDataProof",
@@ -1150,8 +1152,10 @@ func TestAggchainDataProof_MarshalUnmarshalJSON(t *testing.T) {
 				Proof:          []byte{},
 				AggchainParams: common.Hash{},
 				Context:        map[string][]byte{},
+				Version:        "",
+				Vkey:           []byte{},
 			},
-			expected: `{"proof":"","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000000000","context":{}}`,
+			expected: `{"proof":"","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000000000","context":{},"version":"","vkey":""}`,
 		},
 	}
 

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -157,6 +157,8 @@ func (a *AggchainProverFlow) BuildCertificate(ctx context.Context,
 
 	cert.AggchainData = &agglayertypes.AggchainDataProof{
 		Proof:          buildParams.AggchainProof.SP1StarkProof.Proof,
+		Version:        buildParams.AggchainProof.SP1StarkProof.Version,
+		Vkey:           buildParams.AggchainProof.SP1StarkProof.Vkey,
 		AggchainParams: buildParams.AggchainProof.AggchainParams,
 		Context:        buildParams.AggchainProof.Context,
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/agglayer/aggkit
 go 1.24
 
 require (
-	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250228150343-c7b7fef1692a.2
-	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250228150343-c7b7fef1692a.1
+	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250404090611-7f9f451280ee.2
+	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250404090611-7f9f451280ee.1
 	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250403073306-df9b770ff25d.1
 	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250403091637-4fd90e526027.2
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250403091637-4fd90e526027.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250228150343-c7b7fef1692a.2 h1:pnYnk9vgHc78bScfNv3hBHd6tmqJUg64ZZmPunYk550=
 buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250228150343-c7b7fef1692a.2/go.mod h1:XwnIrPbNZN01Tt9NG0xpJiV9F76v+8wLtAeMloJtbgg=
+buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250404090611-7f9f451280ee.2 h1:EpT1tAWPFUIx3cU6dK2leIthBhLOKOw6ympq6hm7Cvg=
+buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250404090611-7f9f451280ee.2/go.mod h1:zl4J37UuoUUcvqdLAkVYqQB5UcWs+DCGC3jbmVRbPzA=
 buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250228150343-c7b7fef1692a.1 h1:ytP1CHl3kqVUV3RiofouLM+8Ij/2OrYoC0OXPgO5DG8=
 buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250228150343-c7b7fef1692a.1/go.mod h1:AORyBne44QocLbS9Zks4hkU3GFtwpYTXcRFdRH5WmqE=
+buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250404090611-7f9f451280ee.1 h1:m42o/q+42p5FDSyRQXXPl3xEnceOi9vjJ1muDeE0HhE=
+buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250404090611-7f9f451280ee.1/go.mod h1:gpKWP3fihl4pBXg3UG+CXgEgDugkVATGVyulVyjR/f8=
 buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250403073306-df9b770ff25d.1 h1:vLqUHNLYJPK4aDHoDOhbo+PwAr9umdqwU2E2Wap2FGE=
 buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250403073306-df9b770ff25d.1/go.mod h1:W3XIAooP7VLR0wAorIvMG2xNYX+C48U9QHfn8uUox3I=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250403091637-4fd90e526027.2 h1:x5UeilSrRauejHuaC4u7e17FX8RKuEK5UT/Q7L2JkSc=

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -4,7 +4,7 @@ deployment_stages:
 args:
   verbosity: debug
   cdk_node_image: aggkit:local
-  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.8
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-hotfix2
   zkevm_contracts_image: leovct/zkevm-contracts:v10.0.0-rc.3-fork.12
   additional_services: []

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -4,7 +4,7 @@ deployment_stages:
 args:
   verbosity: debug
   cdk_node_image: aggkit:local
-  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.8
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-hotfix2
   zkevm_contracts_image: leovct/zkevm-contracts:v10.0.0-rc.3-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12


### PR DESCRIPTION
## Description

This PR updates `agglayer` API for sending certificates. Now the `agglayer` receives `Vkey` and `Version` alongside the `SP1StarkProof` in the certificate.

This data is returned by the `aggkit-prover` to `aggsender` and `aggsender` packs it to a certificate and sends it to `agglayer`.

Fixes # (issue)
