### PR TITLE
fix: bump zkevm-ethtx-manager to v0.2.9 to fix panic bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
-	github.com/0xPolygon/zkevm-ethtx-manager v0.2.8
+	github.com/0xPolygon/zkevm-ethtx-manager v0.2.9
 	github.com/agglayer/go_signer v0.0.5
 	github.com/ethereum/go-ethereum v1.15.5
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef 
 github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6 h1:FXL/rcO7/GtZ3kRFw+C7J6vmGnl8gcazg+Gh/NVmnas=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.8 h1:asrPnSSW2VUfByTGpvpMmPeM+WS7yYqs/4VFxjNg7Nw=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.8/go.mod h1:1D9OdlaS466k40YmH3KuUnbnlOmKCXnD3mzORIgPuvY=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.9 h1:rAI4mg8BAqtBb4VGKwj8jFd7S9v7hlTrV7IiZ0BdjHw=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.9/go.mod h1:1D9OdlaS466k40YmH3KuUnbnlOmKCXnD3mzORIgPuvY=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7 h1:KJM1QlNZdZjNRS+ajPauD4uG+uaYgItaL+96Om3f8aI=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7/go.mod h1:exl+KHnTN6Y8HG4nSUXni4qKbAug0HjJqpebMSgl72k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
## Description

Bump zkevm-ethtx-manager to v0.2.9 to fix a panic when creating a signer with legacy configuration


