### PR TITLE
feat: pin 1.24.2 go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agglayer/aggkit
 
-go 1.24
+go 1.24.2
 
 require (
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef


### PR DESCRIPTION
## Description

This PR pins specific version 1.24.2 in the `go.mod` file.

Fixes # (issue)
