### PR TITLE
feat: unpack `grpc` errors

### DIFF
--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -14,7 +14,6 @@ import (
 	aggkitCommon "github.com/agglayer/aggkit/common"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
 var (
@@ -23,7 +22,6 @@ var (
 )
 
 type AgglayerGRPCClient struct {
-	errdetails.ErrorInfo
 	networkStateService node.NodeStateServiceClient
 	cfgService          node.ConfigurationServiceClient
 	submissionService   node.CertificateSubmissionServiceClient

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -14,6 +14,7 @@ import (
 	aggkitCommon "github.com/agglayer/aggkit/common"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
 var (
@@ -22,6 +23,7 @@ var (
 )
 
 type AgglayerGRPCClient struct {
+	errdetails.ErrorInfo
 	networkStateService node.NodeStateServiceClient
 	cfgService          node.ConfigurationServiceClient
 	submissionService   node.CertificateSubmissionServiceClient
@@ -48,7 +50,7 @@ func NewAgglayerGRPCClient(serverAddr string) (*AgglayerGRPCClient, error) {
 func (a *AgglayerGRPCClient) GetEpochConfiguration(ctx context.Context) (*types.ClockConfiguration, error) {
 	response, err := a.cfgService.GetEpochConfiguration(ctx, &v1.GetEpochConfigurationRequest{})
 	if err != nil {
-		return nil, err
+		return nil, aggkitCommon.RepackGRPCErrorWithDetails(err)
 	}
 
 	return &types.ClockConfiguration{
@@ -134,7 +136,7 @@ func (a *AgglayerGRPCClient) SendCertificate(ctx context.Context,
 	})
 
 	if err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, aggkitCommon.RepackGRPCErrorWithDetails(err)
 	}
 
 	return common.BytesToHash(response.CertificateId.Value.Value), nil
@@ -151,7 +153,7 @@ func (a *AgglayerGRPCClient) GetLatestSettledCertificateHeader(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, aggkitCommon.RepackGRPCErrorWithDetails(err)
 	}
 
 	return convertProtoCertificateHeader(response.CertificateHeader), nil
@@ -168,7 +170,7 @@ func (a *AgglayerGRPCClient) GetLatestPendingCertificateHeader(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, aggkitCommon.RepackGRPCErrorWithDetails(err)
 	}
 
 	return convertProtoCertificateHeader(response.CertificateHeader), nil
@@ -185,7 +187,7 @@ func (a *AgglayerGRPCClient) GetCertificateHeader(ctx context.Context,
 		},
 		})
 	if err != nil {
-		return nil, err
+		return nil, aggkitCommon.RepackGRPCErrorWithDetails(err)
 	}
 
 	return convertProtoCertificateHeader(response.CertificateHeader), nil

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -72,14 +72,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	signer, err := signer.NewSigner(ctx, 0, cfg.AggsenderPrivateKey, aggkitcommon.AGGSENDER, logger)
-	if err != nil {
-		return nil, fmt.Errorf("error NewSigner. Err: %w", err)
-	}
-	err = signer.Initialize(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error signer.Initialize. Err: %w", err)
-	}
+
 	rateLimit := aggkitcommon.NewRateLimit(cfg.MaxSubmitCertificateRate)
 
 	var (
@@ -107,6 +100,15 @@ func New(
 			return nil, fmt.Errorf("error creating aggchain prover flow: %w", err)
 		}
 	} else {
+		signer, err := signer.NewSigner(ctx, 0, cfg.AggsenderPrivateKey, aggkitcommon.AGGSENDER, logger)
+		if err != nil {
+			return nil, fmt.Errorf("error NewSigner. Err: %w", err)
+		}
+		err = signer.Initialize(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error signer.Initialize. Err: %w", err)
+		}
+
 		flowManager = flows.NewPPFlow(
 			logger, cfg.MaxCertSize, cfg.BridgeMetadataAsHash,
 			storage, l1InfoTreeSyncer, l2Syncer, l1Client, signer)

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -13,7 +13,7 @@ import (
 	agglayer "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
-	aggkitCommon "github.com/agglayer/aggkit/common"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
 	treetypes "github.com/agglayer/aggkit/tree/types"
@@ -46,7 +46,7 @@ type AggchainProofClient struct {
 func NewAggchainProofClient(serverAddr string,
 	generateProofTimeout time.Duration) (*AggchainProofClient, error) {
 	addr := strings.TrimPrefix(serverAddr, "http://")
-	grpcClient, err := aggkitCommon.NewClient(addr)
+	grpcClient, err := aggkitcommon.NewClient(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 
 	resp, err := c.client.GenerateAggchainProof(ctx, request)
 	if err != nil {
-		return nil, err
+		return nil, aggkitcommon.RepackGRPCErrorWithDetails(err)
 	}
 
 	proof, ok := resp.AggchainProof.Proof.(*agglayerInteropTypesV1Proto.AggchainProof_Sp1Stark)

--- a/common/grpc_client.go
+++ b/common/grpc_client.go
@@ -54,8 +54,7 @@ func RepackGRPCErrorWithDetails(err error) error {
 				for k, v := range info.Metadata {
 					detail += fmt.Sprintf("%s: %s, ", k, v)
 				}
-				// Remove trailing comma and space
-				detail = detail[:len(detail)-2] + "}"
+				detail = strings.TrimSuffix(detail, ", ") + "}"
 			}
 
 			detailStr := fmt.Sprintf("Reason: %s, Domain: %s. %s", info.Reason, info.Domain, detail)

--- a/common/grpc_client.go
+++ b/common/grpc_client.go
@@ -1,8 +1,13 @@
 package common
 
 import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 // Client holds the gRPC connection and services
@@ -31,4 +36,42 @@ func (c *Client) Conn() *grpc.ClientConn {
 // Close closes the gRPC connection
 func (c *Client) Close() error {
 	return c.conn.Close()
+}
+
+// RepackGRPCErrorWithDetails extracts *status.Status and formats ErrorInfo details into a single error
+func RepackGRPCErrorWithDetails(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return err // Not a gRPC status error
+	}
+
+	var detailStrs []string
+	for _, d := range st.Details() {
+		if info, ok := d.(*errdetails.ErrorInfo); ok {
+			var detail string
+			if len(info.Metadata) > 0 {
+				detail += ", Metadata: {"
+				for k, v := range info.Metadata {
+					detail += fmt.Sprintf("%s: %s, ", k, v)
+				}
+				// Remove trailing comma and space
+				detail = detail[:len(detail)-2] + "}"
+			}
+
+			detailStr := fmt.Sprintf("Reason: %s, Domain: %s. %s", info.Reason, info.Domain, detail)
+			detailStrs = append(detailStrs, detailStr)
+		} else {
+			detailStrs = append(detailStrs, fmt.Sprintf("%+v", d))
+		}
+	}
+
+	return fmt.Errorf("%s - Details: %s", st.Message(), joinDetails(detailStrs))
+}
+
+// joinDetails joins detail strings with a separator
+func joinDetails(details []string) string {
+	if len(details) == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("[%s]", strings.Join(details, ";"))
 }

--- a/common/grpc_client_test.go
+++ b/common/grpc_client_test.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRepackGRPCErrorWithDetails(t *testing.T) {
+	t.Run("NonGRPCError", func(t *testing.T) {
+		err := errors.New("non-gRPC error")
+		result := RepackGRPCErrorWithDetails(err)
+		require.ErrorIs(t, err, result)
+	})
+
+	t.Run("GRPCErrorWithoutDetails", func(t *testing.T) {
+		st := status.New(codes.InvalidArgument, "invalid argument")
+		err := st.Err()
+		result := RepackGRPCErrorWithDetails(err)
+		expected := "invalid argument - Details: none"
+		require.Equal(t, expected, result.Error())
+	})
+
+	t.Run("GRPCErrorWithDetails", func(t *testing.T) {
+		st := status.New(codes.InvalidArgument, "invalid argument")
+		detail := &errdetails.ErrorInfo{
+			Reason:   "InvalidInput",
+			Domain:   "example.com",
+			Metadata: map[string]string{"field": "value"},
+		}
+		stWithDetails, err := st.WithDetails(detail)
+		require.NoError(t, err)
+
+		result := RepackGRPCErrorWithDetails(stWithDetails.Err())
+		expected := "invalid argument - Details: [Reason: InvalidInput, Domain: example.com. , Metadata: {field: value}]"
+		require.Equal(t, expected, result.Error())
+	})
+
+	t.Run("GRPCErrorWithMultipleDetails", func(t *testing.T) {
+		st := status.New(codes.InvalidArgument, "invalid argument")
+		detail1 := &errdetails.ErrorInfo{
+			Reason:   "InvalidInput",
+			Domain:   "example.com",
+			Metadata: map[string]string{"field1": "value1"},
+		}
+		detail2 := &errdetails.ErrorInfo{
+			Reason:   "AnotherReason",
+			Domain:   "another.com",
+			Metadata: map[string]string{"field2": "value2"},
+		}
+		stWithDetails, err := st.WithDetails(detail1, detail2)
+		require.NoError(t, err)
+
+		result := RepackGRPCErrorWithDetails(stWithDetails.Err())
+		expected := "invalid argument - Details: [Reason: InvalidInput, Domain: example.com. , Metadata: {field1: value1};Reason: AnotherReason, Domain: another.com. , Metadata: {field2: value2}]"
+		require.Equal(t, expected, result.Error())
+	})
+}

--- a/test/config/aggkit-node-config.toml.template
+++ b/test/config/aggkit-node-config.toml.template
@@ -28,7 +28,9 @@ Outputs = ["stderr"]
 BridgeAddr = "{{.zkevm_L2_bridge_address}}"
        
 [AggSender]
+AggchainProofURL="{{.aggkit_prover_grpc_url}}"
 CheckStatusCertificateInterval = "1s"
+Mode = "AggchainProof"
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1m"


### PR DESCRIPTION
## Description

Errors returned by `aggkit prover` and `agglayer` are in the `google ErrorInfo` format:
- spec: https://google.aip.dev/193#error_model
- definition: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto

so we can easily unpack them to now details of the messages and why the calls failed.

This PR also moves initialization of the signer private key in `aggsender` only if the `aggsender.Mode` is `PessimisticProof`, since the `AggchainProof` mode does not require a signer. This also enables users to not define the signer in the case of `AggchainProof` mode, since it is not needed.

Fixes # (issue)
