### PR TITLE
feat: `op` start block config

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -93,7 +93,8 @@ func New(
 		}
 
 		flowManager, err = flows.NewAggchainProverFlow(
-			logger, cfg.MaxCertSize, cfg.BridgeMetadataAsHash, cfg.GlobalExitRootL2Addr,
+			logger, cfg.MaxCertSize, cfg.BridgeMetadataAsHash,
+			cfg.GlobalExitRootL2Addr, cfg.SovereignRollupAddr,
 			aggchainProofClient, storage,
 			l1InfoTreeSyncer, l2Syncer, l1Client, l2Client)
 		if err != nil {

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -63,7 +63,7 @@ func TestConfigString(t *testing.T) {
 		"AggchainProofURL: \n" +
 		"Mode: PP\n" +
 		"CheckStatusCertificateInterval: 0s\n" +
-		"RetryCertImmediatelyAfterInError: false\n" +
+		"RetryCertAfterInError: false\n" +
 		"MaxSubmitRate: RateLimitConfig{Unlimited}\n" +
 		"MaxEpochPercentageAllowedToSendCertificate: 0\n" +
 		"GenerateAggchainProofTimeout: 1s\n" +

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -50,6 +50,7 @@ func TestConfigString(t *testing.T) {
 		EpochNotificationPercentage:  50,
 		Mode:                         "PP",
 		GenerateAggchainProofTimeout: types.Duration{Duration: time.Second},
+		SovereignRollupAddr:          common.HexToAddress("0x1"),
 	}
 
 	expected := "StoragePath: /path/to/storage\n" +
@@ -65,7 +66,8 @@ func TestConfigString(t *testing.T) {
 		"RetryCertImmediatelyAfterInError: false\n" +
 		"MaxSubmitRate: RateLimitConfig{Unlimited}\n" +
 		"MaxEpochPercentageAllowedToSendCertificate: 0\n" +
-		"GenerateAggchainProofTimeout: 1s\n"
+		"GenerateAggchainProofTimeout: 1s\n" +
+		"SovereignRollupAddr: 0x0000000000000000000000000000000000000001\n"
 
 	require.Equal(t, expected, config.String())
 }

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -67,6 +67,8 @@ type Config struct {
 	GlobalExitRootL2Addr ethCommon.Address `mapstructure:"GlobalExitRootL2"`
 	// GenerateAggchainProofTimeout is the timeout to wait for the aggkit-prover to generate the AggchainProof
 	GenerateAggchainProofTimeout types.Duration `mapstructure:"GenerateAggchainProofTimeout"`
+	// SovereignRollupAddr is the address of the sovereign rollup contract on L1
+	SovereignRollupAddr ethCommon.Address `mapstructure:"SovereignRollupAddr"`
 	// RequireStorageContentCompatibility is true it's mandatory that data stored in the database
 	// is compatible with the running environment
 	RequireStorageContentCompatibility bool `mapstructure:"RequireStorageContentCompatibility"`
@@ -92,5 +94,6 @@ func (c Config) String() string {
 		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n" +
 		"MaxEpochPercentageAllowedToSendCertificate: " +
 		fmt.Sprintf("%d", c.MaxEpochPercentageAllowedToSendCertificate) + "\n" +
-		"GenerateAggchainProofTimeout: " + c.GenerateAggchainProofTimeout.String() + "\n"
+		"GenerateAggchainProofTimeout: " + c.GenerateAggchainProofTimeout.String() + "\n" +
+		"SovereignRollupAddr: " + c.SovereignRollupAddr.Hex() + "\n"
 }

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -90,7 +90,7 @@ func (c Config) String() string {
 		"AggchainProofURL: " + c.AggchainProofURL + "\n" +
 		"Mode: " + c.Mode + "\n" +
 		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
-		"RetryCertImmediatelyAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
+		"RetryCertAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
 		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n" +
 		"MaxEpochPercentageAllowedToSendCertificate: " +
 		fmt.Sprintf("%d", c.MaxEpochPercentageAllowedToSendCertificate) + "\n" +

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -14,7 +14,6 @@ import (
 	"github.com/agglayer/aggkit/bridgesync"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
-	"google.golang.org/grpc/status"
 )
 
 // AggchainProverFlow is a struct that holds the logic for the AggchainProver prover type flow
@@ -315,14 +314,8 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 		importedBridgeExits,
 	)
 	if err != nil {
-		msg := err.Error()
-
-		errS, ok := status.FromError(err)
-		if ok {
-			msg = errS.Message()
-		}
-
-		return nil, nil, fmt.Errorf(`error fetching aggchain proof for block range %d : %d: %s. Message sent: 
+		return nil, nil, fmt.Errorf(`error fetching aggchain proof for lastProvenBlock: %d, maxEndBlock: %d: %w. 
+			Message sent: 
 			lastProvenBlock: %d,
 			toBlock: %d,
 			root.Hash: %s,
@@ -334,7 +327,7 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 			injectedGERsProofs: %+v,
 			importedBridgeExits: %+v,
 		`,
-			fromBlock, toBlock, msg,
+			lastProvenBlock, toBlock, err,
 			lastProvenBlock,
 			toBlock,
 			root.Hash,

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -144,9 +144,9 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		return nil, fmt.Errorf("aggchainProverFlow - error generating aggchain proof: %w", err)
 	}
 
-	a.log.Infof("aggchainProverFlow - fetched auth proof: %s Range %d : %d from aggchain prover. Requested range: %d : %d",
-		aggchainProof.SP1StarkProof.Proof, buildParams.FromBlock, aggchainProof.EndBlock,
-		buildParams.FromBlock, buildParams.ToBlock)
+	a.log.Infof("aggchainProverFlow - fetched auth proof for lastProvenBlock: %d, maxEndBlock: %d "+
+		"from aggchain prover. End block gotten from the prover: %d",
+		lastProvenBlock, buildParams.ToBlock, aggchainProof.EndBlock)
 
 	// set the root from which to generate merkle proofs for each claim
 	// this is crucial since Aggchain Prover will use this root to generate the proofs as well

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -56,7 +56,7 @@ func NewAggchainProverFlow(log types.Logger,
 		return nil, fmt.Errorf("aggchainProverFlow - error creating L2Etherman: %w", err)
 	}
 
-	startL2Block, err := getL2StartBlock(gerL2Address, l1Client)
+	startL2Block, err := getL2StartBlock(sovereignRollupAddr, l1Client)
 	if err != nil {
 		return nil, fmt.Errorf("aggchainProverFlow - error reading sovereign rollup: %w", err)
 	}

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/aggchainfep"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggoracle/chaingerreader"
 	"github.com/agglayer/aggkit/aggsender/db"
@@ -24,11 +25,26 @@ type AggchainProverFlow struct {
 	gerReader           types.ChainGERReader
 }
 
+func getL2StartBlock(sovereignRollupAddr common.Address, l1Client types.EthClient) (uint64, error) {
+	a, err := aggchainfep.NewAggchainfepCaller(sovereignRollupAddr, l1Client)
+	if err != nil {
+		return 0, fmt.Errorf("aggchainProverFlow - error creating sovereign rollup caller: %w", err)
+	}
+
+	startL2Block, err := a.StartingBlockNumber(nil)
+	if err != nil {
+		return 0, fmt.Errorf("aggchainProverFlow - error getting starting block number: %w", err)
+	}
+
+	return startL2Block.Uint64(), nil
+}
+
 // NewAggchainProverFlow returns a new instance of the AggchainProverFlow
 func NewAggchainProverFlow(log types.Logger,
 	maxCertSize uint,
 	bridgeMetaDataAsHash bool,
 	gerL2Address common.Address,
+	sovereignRollupAddr common.Address,
 	aggkitProverClient grpc.AggchainProofClientInterface,
 	storage db.AggSenderStorage,
 	l1InfoTreeSyncer types.L1InfoTreeSyncer,
@@ -40,6 +56,11 @@ func NewAggchainProverFlow(log types.Logger,
 		return nil, fmt.Errorf("aggchainProverFlow - error creating L2Etherman: %w", err)
 	}
 
+	startL2Block, err := getL2StartBlock(gerL2Address, l1Client)
+	if err != nil {
+		return nil, fmt.Errorf("aggchainProverFlow - error reading sovereign rollup: %w", err)
+	}
+
 	return &AggchainProverFlow{
 		gerReader:           gerReader,
 		aggchainProofClient: aggkitProverClient,
@@ -49,6 +70,7 @@ func NewAggchainProverFlow(log types.Logger,
 			storage:               storage,
 			l1InfoTreeDataQuerier: l1infotreequery.NewL1InfoTreeDataQuerier(l1Client, l1InfoTreeSyncer),
 			maxCertSize:           maxCertSize,
+			startL2Block:          startL2Block,
 			bridgeMetaDataAsHash:  bridgeMetaDataAsHash,
 		},
 	}, nil
@@ -115,8 +137,10 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		return nil, fmt.Errorf("aggchainProverFlow - error verifying build params: %w", err)
 	}
 
+	lastProvenBlock := a.getLastProvenBlock(buildParams.FromBlock)
+
 	aggchainProof, rootFromWhichToProveClaims, err := a.GenerateAggchainProof(
-		ctx, buildParams.FromBlock, buildParams.ToBlock, buildParams.Claims)
+		ctx, lastProvenBlock, buildParams.ToBlock, buildParams.Claims)
 	if err != nil {
 		return nil, fmt.Errorf("aggchainProverFlow - error generating aggchain proof: %w", err)
 	}
@@ -253,7 +277,7 @@ func adjustBlockRange(buildParams *types.CertificateBuildParams,
 // GenerateAggchainProof calls the aggkit prover to generate the aggchain proof for the given block range
 func (a *AggchainProverFlow) GenerateAggchainProof(
 	ctx context.Context,
-	fromBlock, toBlock uint64,
+	lastProvenBlock, toBlock uint64,
 	claims []bridgesync.Claim,
 ) (*types.AggchainProof, *treetypes.Root, error) {
 	proof, leaf, root, err := a.l1InfoTreeDataQuerier.GetFinalizedL1InfoTreeData(ctx)
@@ -267,6 +291,7 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 			"finalized L1 Info tree root: %s with index: %d: %w", root.Hash, root.Index, err)
 	}
 
+	fromBlock := lastProvenBlock + 1
 	injectedGERsProofs, err := a.getInjectedGERsProofs(ctx, root, fromBlock, toBlock)
 	if err != nil {
 		return nil, nil, fmt.Errorf("aggchainProverFlow - error getting injected GERs proofs: %w", err)
@@ -275,12 +300,6 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 	importedBridgeExits, err := a.getImportedBridgeExitsForProver(claims)
 	if err != nil {
 		return nil, nil, fmt.Errorf("aggchainProverFlow - error getting imported bridge exits for prover: %w", err)
-	}
-
-	lastProvenBlock := fromBlock
-	if lastProvenBlock > 0 {
-		// if we had previous proofs, the last proven block is the one before the first block in the range
-		lastProvenBlock--
 	}
 
 	aggchainProof, err := a.aggchainProofClient.GenerateAggchainProof(
@@ -328,4 +347,14 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 	}
 
 	return aggchainProof, root, nil
+}
+
+func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64) uint64 {
+	if fromBlock == 0 {
+		// if this is the first certificate, we need to start from the starting L2 block
+		// that we got from the sovereign rollup
+		return a.startL2Block
+	}
+
+	return fromBlock - 1
 }

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -278,7 +278,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					}, make(map[common.Hash]*agglayertypes.ProvenInsertedGERWithBlockNumber, 0),
 					[]*agglayertypes.ImportedBridgeExitWithBlockNumber{{ImportedBridgeExit: ibe1}}).Return(nil, errors.New("some error"))
 			},
-			expectedError: "error fetching aggchain proof for block range 1 : 10: some error",
+			expectedError: "error fetching aggchain proof for lastProvenBlock: 0, maxEndBlock: 10: some error",
 		},
 		{
 			name: "success fetching aggchain proof for new certificate",

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -681,3 +681,49 @@ func TestGetImportedBridgeExitsForProver(t *testing.T) {
 		})
 	}
 }
+
+func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		fromBlock      uint64
+		startL2Block   uint64
+		expectedResult uint64
+	}{
+		{
+			name:           "fromBlock is 0, return startL2Block",
+			fromBlock:      0,
+			startL2Block:   1,
+			expectedResult: 1,
+		},
+		{
+			name:           "fromBlock is 0, startL2Block is 0",
+			fromBlock:      0,
+			startL2Block:   0,
+			expectedResult: 0,
+		},
+		{
+			name:           "fromBlock is greater than 0",
+			fromBlock:      10,
+			startL2Block:   1,
+			expectedResult: 9,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			flow := &AggchainProverFlow{
+				baseFlow: &baseFlow{
+					startL2Block: tc.startL2Block,
+				},
+			}
+
+			result := flow.getLastProvenBlock(tc.fromBlock)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -33,6 +33,7 @@ type baseFlow struct {
 
 	maxCertSize          uint
 	bridgeMetaDataAsHash bool
+	startL2Block         uint64
 }
 
 // getBridgesAndClaims returns the bridges and claims consumed from the L2 fromBlock to toBlock
@@ -71,7 +72,7 @@ func (f *baseFlow) getCertificateBuildParamsInternal(ctx context.Context) (*type
 		return nil, err
 	}
 
-	previousToBlock, retryCount := getLastSentBlockAndRetryCount(lastSentCertificateInfo)
+	previousToBlock, retryCount := f.getLastSentBlockAndRetryCount(lastSentCertificateInfo)
 
 	if previousToBlock >= lastL2BlockSynced {
 		f.log.Infof("no new blocks to send a certificate, last certificate block: %d, last L2 block: %d",
@@ -412,10 +413,11 @@ func (f *baseFlow) verifyClaimGERs(claims []bridgesync.Claim) error {
 }
 
 // getLastSentBlockAndRetryCount returns the last sent block of the last sent certificate
-// if there is no previosly sent certificate, it returns 0 and 0
-func getLastSentBlockAndRetryCount(lastSentCertificateInfo *types.CertificateInfo) (uint64, int) {
+// if there is no previosly sent certificate, it returns startL2Block and 0
+func (f *baseFlow) getLastSentBlockAndRetryCount(lastSentCertificateInfo *types.CertificateInfo) (uint64, int) {
 	if lastSentCertificateInfo == nil {
-		return 0, 0
+		// this is the first certificate so we start from what we have set in start L2 block
+		return f.startL2Block, 0
 	}
 
 	retryCount := 0

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -1114,12 +1114,21 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 		name                    string
 		lastSentCertificateInfo *types.CertificateInfo
 		expectedBlock           uint64
+		startL2Block            uint64
 		expectedRetryCount      int
 	}{
 		{
-			name:                    "No last sent certificate",
+			name:                    "No last sent certificate, start block is 0",
 			lastSentCertificateInfo: nil,
 			expectedBlock:           0,
+			startL2Block:            0,
+			expectedRetryCount:      0,
+		},
+		{
+			name:                    "No last sent certificate, start block is 1000",
+			lastSentCertificateInfo: nil,
+			expectedBlock:           1000,
+			startL2Block:            1000,
 			expectedRetryCount:      0,
 		},
 		{
@@ -1161,7 +1170,9 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			block, retryCount := getLastSentBlockAndRetryCount(tt.lastSentCertificateInfo)
+			baseFlow := &baseFlow{startL2Block: tt.startL2Block}
+
+			block, retryCount := baseFlow.getLastSentBlockAndRetryCount(tt.lastSentCertificateInfo)
 
 			require.Equal(t, tt.expectedBlock, block)
 			require.Equal(t, tt.expectedRetryCount, retryCount)

--- a/aggsender/prover/proof_generation_tool.go
+++ b/aggsender/prover/proof_generation_tool.go
@@ -25,7 +25,7 @@ type AggchainProofFlow interface {
 	// GenerateAggchainProof generates an Aggchain proof
 	GenerateAggchainProof(
 		ctx context.Context,
-		fromBlock, toBlock uint64,
+		lastProvenBlock, toBlock uint64,
 		claims []bridgesync.Claim) (*types.AggchainProof, *treetypes.Root, error)
 }
 
@@ -40,6 +40,9 @@ type Config struct {
 
 	// GenerateAggchainProofTimeout is the timeout to wait for the aggkit-prover to generate the AggchainProof
 	GenerateAggchainProofTimeout configtypes.Duration `mapstructure:"GenerateAggchainProofTimeout"`
+
+	// SovereignRollupAddr is the address of the sovereign rollup contract on L1
+	SovereignRollupAddr common.Address `mapstructure:"SovereignRollupAddr"`
 }
 
 // AggchainProofGenerationTool is a tool to generate Aggchain proofs
@@ -70,7 +73,8 @@ func NewAggchainProofGenerationTool(
 
 	aggchainProverFlow, err := flows.NewAggchainProverFlow(
 		logger,
-		0, false, cfg.GlobalExitRootL2Addr,
+		0, false,
+		cfg.GlobalExitRootL2Addr, cfg.SovereignRollupAddr,
 		aggchainProofClient,
 		nil,
 		l1InfoTreeSyncer,
@@ -143,7 +147,7 @@ func (a *AggchainProofGenerationTool) GenerateAggchainProof(
 
 	aggchainProof, _, err := a.flow.GenerateAggchainProof(
 		ctx,
-		fromBlock,
+		lastProvenBlock,
 		maxEndBlock,
 		claims,
 	)

--- a/aggsender/prover/proof_generation_tool_test.go
+++ b/aggsender/prover/proof_generation_tool_test.go
@@ -35,7 +35,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 			) {
 				mockL2Syncer.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(20), nil)
 				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{}, nil)
-				mockFlow.EXPECT().GenerateAggchainProof(ctx, uint64(1), uint64(10), []bridgesync.Claim{}).Return(
+				mockFlow.EXPECT().GenerateAggchainProof(ctx, uint64(0), uint64(10), []bridgesync.Claim{}).Return(
 					&types.AggchainProof{SP1StarkProof: &types.SP1StarkProof{Proof: []byte("proof")}}, nil, nil)
 			},
 			expectedProof: &types.SP1StarkProof{Proof: []byte("proof")},
@@ -72,7 +72,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 			) {
 				mockL2Syncer.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(20), nil)
 				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{}, nil)
-				mockFlow.EXPECT().GenerateAggchainProof(ctx, uint64(1), uint64(10), []bridgesync.Claim{}).Return(
+				mockFlow.EXPECT().GenerateAggchainProof(ctx, uint64(0), uint64(10), []bridgesync.Claim{}).Return(
 					nil, nil, errors.New("test error"))
 			},
 			expectedError: "error generating Aggchain proof",
@@ -86,7 +86,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			fromBlock := uint64(0)
+			lastProvenBlock := uint64(0)
 			toBlock := uint64(10)
 
 			mockLogger := log.WithFields("test", tt.name)
@@ -103,7 +103,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 
 			tt.setupMocks(ctx, mockL2Syncer, mockAggchainProofClient, mockFlow)
 
-			proof, err := tool.GenerateAggchainProof(ctx, fromBlock, toBlock)
+			proof, err := tool.GenerateAggchainProof(ctx, lastProvenBlock, toBlock)
 			if tt.expectedError != "" {
 				require.ErrorContains(t, err, tt.expectedError)
 			} else {

--- a/config/default.go
+++ b/config/default.go
@@ -232,7 +232,7 @@ AggchainProofURL = "{{AggchainProofURL}}"
 # PessimisticProof or AggchainProver
 Mode = "PessimisticProof"
 CheckStatusCertificateInterval = "5m"
-RetryCertInmediatlyAfterInError = true
+RetryCertAfterInError = false
 GlobalExitRootL2="{{L2Config.GlobalExitRootAddr}}"
 # Don't send certificate over 80% of the epoch
 MaxEpochPercentageAllowedToSendCertificate=80

--- a/config/default.go
+++ b/config/default.go
@@ -237,6 +237,7 @@ GlobalExitRootL2="{{L2Config.GlobalExitRootAddr}}"
 # Don't send certificate over 80% of the epoch
 MaxEpochPercentageAllowedToSendCertificate=80
 GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
+SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
@@ -249,6 +250,7 @@ Port = 9091
 
 [AggchainProofGen]
 AggchainProofURL = "{{AggchainProofURL}}"
+SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 GlobalExitRootL2 = "{{L2Config.GlobalExitRootAddr}}"
 GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
 `


### PR DESCRIPTION
## Description

This PR adds the logic to read the start block on L2 from the `soverign rollup` contract from which proofs will be generated and certificates created.

For this purpose, we added a `SovereignRollupAddr` field to the `aggsender` config, which is needed for the `AggchainProof` mode of the `aggsender`.

Fixes # (issue)
