### PR TITLE
chore: Fixed dead link in `aggoracle.md`

### DIFF
--- a/docs/aggoracle.md
+++ b/docs/aggoracle.md
@@ -112,7 +112,7 @@ Implements `ChainSender` using Ethereum clients and transaction management.
 - **Contract**: `GlobalExitRootManagerL2SovereignChain.sol`
 - **Function**: `insertGlobalExitRoot`
     - [Source Code](https://github.com/0xPolygonHermez/zkevm-contracts/blob/feature/audit-remediations/contracts/v2/sovereignChains/GlobalExitRootManagerL2SovereignChain.sol#L89-L103)
-- **Bindings**: Available in [cdk-contracts-tooling](https://github.com/0xPolygon/cdk-contracts-tooling/tree/main/contracts/l2-sovereign-chain).
+- **Bindings**: Available in [cdk-contracts-tooling](https://github.com/0xPolygon/cdk-contracts-tooling/tree/main/contracts/pp/l2-sovereign-chain).
 
 ---
 


### PR DESCRIPTION
## Description

Hi! I fixed a broken link to CDK contracts tooling in the AggOracle documentation. The repository structure changed, making the previous path invalid.