### PR TITLE
feat: add block index to injected GERs we send to the prover

### DIFF
--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -659,6 +659,7 @@ func (l *L1InfoTreeLeaf) String() string {
 type ProvenInsertedGERWithBlockNumber struct {
 	BlockNumber           uint64            `json:"block_number"`
 	ProvenInsertedGERLeaf ProvenInsertedGER `json:"inserted_ger_leaf"`
+	BlockIndex            uint              `json:"block_index"`
 }
 
 type ProvenInsertedGER struct {

--- a/aggoracle/chaingerreader/evm_test.go
+++ b/aggoracle/chaingerreader/evm_test.go
@@ -97,6 +97,6 @@ func TestGetInjectedGERsForRange(t *testing.T) {
 		injectedGERs, err := gerReader.GetInjectedGERsForRange(ctx, 1, 10)
 		require.NoError(t, err)
 		require.Len(t, injectedGERs, 1)
-		require.Equal(t, common.HexToHash("0x1234567890abcdef1234567890abcdef12345678"), injectedGERs[6][0])
+		require.Equal(t, common.HexToHash("0x1234567890abcdef1234567890abcdef12345678"), injectedGERs[6][0].GlobalExitRoot)
 	})
 }

--- a/aggoracle/chaingerreader/evm_test.go
+++ b/aggoracle/chaingerreader/evm_test.go
@@ -94,9 +94,31 @@ func TestGetInjectedGERsForRange(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 
+		expectedGER := common.HexToHash("0x1234567890abcdef1234567890abcdef12345678")
+
 		injectedGERs, err := gerReader.GetInjectedGERsForRange(ctx, 1, 10)
 		require.NoError(t, err)
 		require.Len(t, injectedGERs, 1)
-		require.Equal(t, common.HexToHash("0x1234567890abcdef1234567890abcdef12345678"), injectedGERs[6][0].GlobalExitRoot)
+
+		ger, exists := injectedGERs[expectedGER]
+		require.True(t, exists)
+		require.Equal(t, expectedGER, ger.GlobalExitRoot)
+
+		// commit one block so the current block is block 7
+		setup.SimBackend.Commit()
+
+		tx, err = setup.GERContract.RemoveGlobalExitRoots(setup.Auth, [][32]byte{expectedGER})
+		require.NoError(t, err)
+
+		// commit one block so the current block is block 8
+		setup.SimBackend.Commit()
+
+		receipt, err = setup.SimBackend.Client().TransactionReceipt(ctx, tx.Hash())
+		require.NoError(t, err)
+		require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
+
+		injectedGERs, err = gerReader.GetInjectedGERsForRange(ctx, 1, 10)
+		require.NoError(t, err)
+		require.Empty(t, injectedGERs)
 	})
 }

--- a/aggoracle/mocks/mock_l2_ger_manager_contract.go
+++ b/aggoracle/mocks/mock_l2_ger_manager_contract.go
@@ -144,6 +144,66 @@ func (_c *L2GERManagerContract_FilterUpdateHashChainValue_Call) RunAndReturn(run
 	return _c
 }
 
+// FilterUpdateRemovalHashChainValue provides a mock function with given fields: opts, removedGlobalExitRoot, newRemovalHashChainValue
+func (_m *L2GERManagerContract) FilterUpdateRemovalHashChainValue(opts *bind.FilterOpts, removedGlobalExitRoot [][32]byte, newRemovalHashChainValue [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator, error) {
+	ret := _m.Called(opts, removedGlobalExitRoot, newRemovalHashChainValue)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FilterUpdateRemovalHashChainValue")
+	}
+
+	var r0 *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*bind.FilterOpts, [][32]byte, [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator, error)); ok {
+		return rf(opts, removedGlobalExitRoot, newRemovalHashChainValue)
+	}
+	if rf, ok := ret.Get(0).(func(*bind.FilterOpts, [][32]byte, [][32]byte) *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator); ok {
+		r0 = rf(opts, removedGlobalExitRoot, newRemovalHashChainValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*bind.FilterOpts, [][32]byte, [][32]byte) error); ok {
+		r1 = rf(opts, removedGlobalExitRoot, newRemovalHashChainValue)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FilterUpdateRemovalHashChainValue'
+type L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call struct {
+	*mock.Call
+}
+
+// FilterUpdateRemovalHashChainValue is a helper method to define mock.On call
+//   - opts *bind.FilterOpts
+//   - removedGlobalExitRoot [][32]byte
+//   - newRemovalHashChainValue [][32]byte
+func (_e *L2GERManagerContract_Expecter) FilterUpdateRemovalHashChainValue(opts interface{}, removedGlobalExitRoot interface{}, newRemovalHashChainValue interface{}) *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call {
+	return &L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call{Call: _e.mock.On("FilterUpdateRemovalHashChainValue", opts, removedGlobalExitRoot, newRemovalHashChainValue)}
+}
+
+func (_c *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call) Run(run func(opts *bind.FilterOpts, removedGlobalExitRoot [][32]byte, newRemovalHashChainValue [][32]byte)) *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*bind.FilterOpts), args[1].([][32]byte), args[2].([][32]byte))
+	})
+	return _c
+}
+
+func (_c *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call) Return(_a0 *globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator, _a1 error) *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call) RunAndReturn(run func(*bind.FilterOpts, [][32]byte, [][32]byte) (*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator, error)) *L2GERManagerContract_FilterUpdateRemovalHashChainValue_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GlobalExitRootMap provides a mock function with given fields: opts, ger
 func (_m *L2GERManagerContract) GlobalExitRootMap(opts *bind.CallOpts, ger [32]byte) (*big.Int, error) {
 	ret := _m.Called(opts, ger)

--- a/aggoracle/types/types.go
+++ b/aggoracle/types/types.go
@@ -42,4 +42,11 @@ type L2GERManagerContract interface {
 	BridgeAddress(*bind.CallOpts) (common.Address, error)
 	FilterUpdateHashChainValue(opts *bind.FilterOpts, newGlobalExitRoot [][32]byte, newHashChainValue [][32]byte) (
 		*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateHashChainValueIterator, error)
+	FilterUpdateRemovalHashChainValue(
+		opts *bind.FilterOpts,
+		removedGlobalExitRoot [][32]byte,
+		newRemovalHashChainValue [][32]byte) (
+		*globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainUpdateRemovalHashChainValueIterator,
+		error,
+	)
 }

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -206,14 +206,15 @@ func (a *AggchainProverFlow) getInjectedGERsProofs(
 	proofs := make(map[common.Hash]*agglayertypes.ProvenInsertedGERWithBlockNumber, len(injectedGERs))
 
 	for blockNum, gerHashes := range injectedGERs {
-		for _, gerHash := range gerHashes {
-			info, proof, err := a.l1InfoTreeDataQuerier.GetProofForGER(ctx, gerHash, finalizedL1InfoTreeRoot.Hash)
+		for _, ger := range gerHashes {
+			info, proof, err := a.l1InfoTreeDataQuerier.GetProofForGER(ctx, ger.GlobalExitRoot, finalizedL1InfoTreeRoot.Hash)
 			if err != nil {
-				return nil, fmt.Errorf("aggchainProverFlow - error getting proof for GER: %s: %w", gerHash.String(), err)
+				return nil, fmt.Errorf("aggchainProverFlow - error getting proof for GER: %s: %w", ger.GlobalExitRoot.String(), err)
 			}
 
-			proofs[gerHash] = &agglayertypes.ProvenInsertedGERWithBlockNumber{
+			proofs[ger.GlobalExitRoot] = &agglayertypes.ProvenInsertedGERWithBlockNumber{
 				BlockNumber: blockNum,
+				BlockIndex:  ger.BlockIndex,
 				ProvenInsertedGERLeaf: agglayertypes.ProvenInsertedGER{
 					ProofGERToL1Root: &agglayertypes.MerkleProof{Root: finalizedL1InfoTreeRoot.Hash, Proof: proof},
 					L1Leaf: &agglayertypes.L1InfoTreeLeaf{

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -205,30 +205,28 @@ func (a *AggchainProverFlow) getInjectedGERsProofs(
 
 	proofs := make(map[common.Hash]*agglayertypes.ProvenInsertedGERWithBlockNumber, len(injectedGERs))
 
-	for blockNum, gerHashes := range injectedGERs {
-		for _, ger := range gerHashes {
-			info, proof, err := a.l1InfoTreeDataQuerier.GetProofForGER(ctx, ger.GlobalExitRoot, finalizedL1InfoTreeRoot.Hash)
-			if err != nil {
-				return nil, fmt.Errorf("aggchainProverFlow - error getting proof for GER: %s: %w", ger.GlobalExitRoot.String(), err)
-			}
+	for ger, injectedGER := range injectedGERs {
+		info, proof, err := a.l1InfoTreeDataQuerier.GetProofForGER(ctx, ger, finalizedL1InfoTreeRoot.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("aggchainProverFlow - error getting proof for GER: %s: %w", ger.String(), err)
+		}
 
-			proofs[ger.GlobalExitRoot] = &agglayertypes.ProvenInsertedGERWithBlockNumber{
-				BlockNumber: blockNum,
-				BlockIndex:  ger.BlockIndex,
-				ProvenInsertedGERLeaf: agglayertypes.ProvenInsertedGER{
-					ProofGERToL1Root: &agglayertypes.MerkleProof{Root: finalizedL1InfoTreeRoot.Hash, Proof: proof},
-					L1Leaf: &agglayertypes.L1InfoTreeLeaf{
-						L1InfoTreeIndex: info.L1InfoTreeIndex,
-						RollupExitRoot:  info.RollupExitRoot,
-						MainnetExitRoot: info.MainnetExitRoot,
-						Inner: &agglayertypes.L1InfoTreeLeafInner{
-							GlobalExitRoot: info.GlobalExitRoot,
-							BlockHash:      info.PreviousBlockHash,
-							Timestamp:      info.Timestamp,
-						},
+		proofs[ger] = &agglayertypes.ProvenInsertedGERWithBlockNumber{
+			BlockNumber: injectedGER.BlockNumber,
+			BlockIndex:  injectedGER.BlockIndex,
+			ProvenInsertedGERLeaf: agglayertypes.ProvenInsertedGER{
+				ProofGERToL1Root: &agglayertypes.MerkleProof{Root: finalizedL1InfoTreeRoot.Hash, Proof: proof},
+				L1Leaf: &agglayertypes.L1InfoTreeLeaf{
+					L1InfoTreeIndex: info.L1InfoTreeIndex,
+					RollupExitRoot:  info.RollupExitRoot,
+					MainnetExitRoot: info.MainnetExitRoot,
+					Inner: &agglayertypes.L1InfoTreeLeafInner{
+						GlobalExitRoot: info.GlobalExitRoot,
+						BlockHash:      info.PreviousBlockHash,
+						Timestamp:      info.Timestamp,
 					},
 				},
-			}
+			},
 		}
 	}
 

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggoracle/chaingerreader"
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
@@ -120,7 +121,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					nil,
 				)
 				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(0), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -191,7 +192,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					nil,
 				)
 				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(0), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -266,7 +267,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					nil,
 				)
 				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(0), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -313,7 +314,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					nil,
 				)
 				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(5), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -378,7 +379,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					nil,
 				)
 				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]common.Hash{}, nil)
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
 				mockProverClient.On("GenerateAggchainProof", uint64(5), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -479,8 +480,8 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "error getting proof for GER",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{
-					1: {common.HexToHash("0x1")},
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{
+					1: {{GlobalExitRoot: common.HexToHash("0x1")}},
 				}, nil)
 				mockL1InfoTreeQuery.On("GetProofForGER", ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(nil, treetypes.Proof{}, errors.New("some error"))
 			},
@@ -489,8 +490,8 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "success",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]common.Hash{
-					111: {common.HexToHash("0x1")},
+				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{
+					111: {{GlobalExitRoot: common.HexToHash("0x1")}},
 				}, nil)
 				mockL1InfoTreeQuery.On("GetProofForGER", ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(
 					&l1infotreesync.L1InfoTreeLeaf{

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -64,7 +64,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockProverClient *mocks.AggchainProofClientInterface,
 				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
 				mockChainGERReader *mocks.ChainGERReader) {
-				mockStorage.On("GetLastSentCertificate").Return(nil, errors.New("some error"))
+				mockStorage.EXPECT().GetLastSentCertificate().Return(nil, errors.New("some error"))
 			},
 			expectedError: "some error",
 		},
@@ -95,20 +95,20 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.On("GetLastSentCertificate").Return(&types.CertificateInfo{
+				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{
 					FromBlock: 1,
 					ToBlock:   10,
 					Status:    agglayertypes.InError,
 				}, nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
-				mockL2Syncer.On("GetClaims", ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{
+				mockL2Syncer.EXPECT().GetBridgesPublished(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
 						GlobalExitRoot:  ger,
 						MainnetExitRoot: mer,
 						RollupExitRoot:  rer,
 					}}, nil)
-				mockL1InfoDataQuery.On("GetFinalizedL1InfoTreeData", ctx).Return(
+				mockL1InfoDataQuery.EXPECT().GetFinalizedL1InfoTreeData(ctx).Return(
 					treetypes.Proof{},
 					&l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -120,9 +120,9 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					},
 					nil,
 				)
-				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
-				mockProverClient.On("GenerateAggchainProof", uint64(0), uint64(10),
+				mockL1InfoDataQuery.EXPECT().CheckIfClaimsArePartOfFinalizedL1InfoTree(mock.Anything, mock.Anything).Return(nil)
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{}, nil)
+				mockProverClient.EXPECT().GenerateAggchainProof(uint64(0), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
 						Hash:        common.HexToHash("0x2"),
@@ -169,17 +169,17 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.On("GetLastSentCertificate").Return(&types.CertificateInfo{
+				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{
 					FromBlock: 1,
 					ToBlock:   10,
 					Status:    agglayertypes.InError,
 				}, nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{
+				mockL2Syncer.EXPECT().GetBridgesPublished(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{
 					{BlockNum: 5}, {BlockNum: 10}}, nil)
-				mockL2Syncer.On("GetClaims", ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{
 					{BlockNum: 6, GlobalIndex: big.NewInt(1), GlobalExitRoot: ger, MainnetExitRoot: mer, RollupExitRoot: rer},
 					{BlockNum: 9, GlobalIndex: big.NewInt(2), GlobalExitRoot: ger, MainnetExitRoot: mer, RollupExitRoot: rer}}, nil)
-				mockL1InfoDataQuery.On("GetFinalizedL1InfoTreeData", ctx).Return(
+				mockL1InfoDataQuery.EXPECT().GetFinalizedL1InfoTreeData(ctx).Return(
 					treetypes.Proof{},
 					&l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -191,9 +191,9 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					},
 					nil,
 				)
-				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
-				mockProverClient.On("GenerateAggchainProof", uint64(0), uint64(10),
+				mockL1InfoDataQuery.EXPECT().CheckIfClaimsArePartOfFinalizedL1InfoTree(mock.Anything, mock.Anything).Return(nil)
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{}, nil)
+				mockProverClient.EXPECT().GenerateAggchainProof(uint64(0), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
 						Hash:        common.HexToHash("0x2"),
@@ -244,17 +244,17 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.On("GetLastSentCertificate").Return(nil, nil).Twice()
+				mockStorage.EXPECT().GetLastSentCertificate().Return(nil, nil).Twice()
 				mockL2Syncer.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
-				mockL2Syncer.On("GetClaims", ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{
+				mockL2Syncer.EXPECT().GetBridgesPublished(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
 						GlobalExitRoot:  ger,
 						MainnetExitRoot: mer,
 						RollupExitRoot:  rer,
 					}}, nil)
-				mockL1InfoDataQuery.On("GetFinalizedL1InfoTreeData", ctx).Return(
+				mockL1InfoDataQuery.EXPECT().GetFinalizedL1InfoTreeData(ctx).Return(
 					treetypes.Proof{},
 					&l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -266,9 +266,9 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					},
 					nil,
 				)
-				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
-				mockProverClient.On("GenerateAggchainProof", uint64(0), uint64(10),
+				mockL1InfoDataQuery.EXPECT().CheckIfClaimsArePartOfFinalizedL1InfoTree(mock.Anything, mock.Anything).Return(nil)
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{}, nil)
+				mockProverClient.EXPECT().GenerateAggchainProof(uint64(0), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
 						Hash:        common.HexToHash("0x2"),
@@ -292,16 +292,16 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.On("GetLastSentCertificate").Return(&types.CertificateInfo{ToBlock: 5}, nil).Twice()
+				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 5}, nil).Twice()
 				mockL2Syncer.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
-				mockL2Syncer.On("GetClaims", ctx, uint64(6), uint64(10)).Return([]bridgesync.Claim{{
+				mockL2Syncer.EXPECT().GetBridgesPublished(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{{}}, nil)
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Claim{{
 					GlobalIndex:     big.NewInt(1),
 					GlobalExitRoot:  ger,
 					MainnetExitRoot: mer,
 					RollupExitRoot:  rer,
 				}}, nil)
-				mockL1InfoDataQuery.On("GetFinalizedL1InfoTreeData", ctx).Return(
+				mockL1InfoDataQuery.EXPECT().GetFinalizedL1InfoTreeData(ctx).Return(
 					treetypes.Proof{},
 					&l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -313,9 +313,9 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					},
 					nil,
 				)
-				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
-				mockProverClient.On("GenerateAggchainProof", uint64(5), uint64(10),
+				mockL1InfoDataQuery.EXPECT().CheckIfClaimsArePartOfFinalizedL1InfoTree(mock.Anything, mock.Anything).Return(nil)
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(6), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{}, nil)
+				mockProverClient.EXPECT().GenerateAggchainProof(uint64(5), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
 						Hash:        common.HexToHash("0x2"),
@@ -359,14 +359,14 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.On("GetLastSentCertificate").Return(&types.CertificateInfo{ToBlock: 5}, nil).Twice()
+				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 5}, nil).Twice()
 				mockL2Syncer.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{
+				mockL2Syncer.EXPECT().GetBridgesPublished(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{
 					{BlockNum: 6}, {BlockNum: 10}}, nil)
-				mockL2Syncer.On("GetClaims", ctx, uint64(6), uint64(10)).Return([]bridgesync.Claim{
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Claim{
 					{BlockNum: 8, GlobalIndex: big.NewInt(1), GlobalExitRoot: ger, MainnetExitRoot: mer, RollupExitRoot: rer},
 					{BlockNum: 9, GlobalIndex: big.NewInt(2), GlobalExitRoot: ger, MainnetExitRoot: mer, RollupExitRoot: rer}}, nil)
-				mockL1InfoDataQuery.On("GetFinalizedL1InfoTreeData", ctx).Return(
+				mockL1InfoDataQuery.EXPECT().GetFinalizedL1InfoTreeData(ctx).Return(
 					treetypes.Proof{},
 					&l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
@@ -378,9 +378,9 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					},
 					nil,
 				)
-				mockL1InfoDataQuery.On("CheckIfClaimsArePartOfFinalizedL1InfoTree", mock.Anything, mock.Anything).Return(nil)
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(6), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{}, nil)
-				mockProverClient.On("GenerateAggchainProof", uint64(5), uint64(10),
+				mockL1InfoDataQuery.EXPECT().CheckIfClaimsArePartOfFinalizedL1InfoTree(mock.Anything, mock.Anything).Return(nil)
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(6), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{}, nil)
+				mockProverClient.EXPECT().GenerateAggchainProof(uint64(5), uint64(10),
 					common.HexToHash("0x1"), l1infotreesync.L1InfoTreeLeaf{
 						BlockNumber: l1Header.Number.Uint64(),
 						Hash:        common.HexToHash("0x2"),
@@ -473,27 +473,27 @@ func Test_AggchainProverFlow_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "error getting injected GERs for range",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(nil, errors.New("some error"))
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(nil, errors.New("some error"))
 			},
 			expectedError: "error getting injected GERs for range 1 : 10: some error",
 		},
 		{
 			name: "error getting proof for GER",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{
-					1: {{GlobalExitRoot: common.HexToHash("0x1")}},
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{
+					common.HexToHash("0x1"): {GlobalExitRoot: common.HexToHash("0x1")},
 				}, nil)
-				mockL1InfoTreeQuery.On("GetProofForGER", ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(nil, treetypes.Proof{}, errors.New("some error"))
+				mockL1InfoTreeQuery.EXPECT().GetProofForGER(ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(nil, treetypes.Proof{}, errors.New("some error"))
 			},
 			expectedError: "error getting proof for GER: 0x0000000000000000000000000000000000000000000000000000000000000001: some error",
 		},
 		{
 			name: "success",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				mockChainGERReader.On("GetInjectedGERsForRange", ctx, uint64(1), uint64(10)).Return(map[uint64][]chaingerreader.InjectedGER{
-					111: {{GlobalExitRoot: common.HexToHash("0x1")}},
+				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]chaingerreader.InjectedGER{
+					common.HexToHash("0x1"): {GlobalExitRoot: common.HexToHash("0x1"), BlockNumber: 111},
 				}, nil)
-				mockL1InfoTreeQuery.On("GetProofForGER", ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(
+				mockL1InfoTreeQuery.EXPECT().GetProofForGER(ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(
 					&l1infotreesync.L1InfoTreeLeaf{
 						L1InfoTreeIndex:   1,
 						BlockNumber:       111,

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -96,6 +96,7 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 		}
 		convertedGerLeaves[k.String()] = &aggkitProverV1Proto.ProvenInsertedGERWithBlockNumber{
 			BlockNumber: v.BlockNumber,
+			BlockIndex:  uint64(v.BlockIndex),
 			ProvenInsertedGer: &aggkitProverV1Proto.ProvenInsertedGER{
 				ProofGerL1Root: &agglayerInteropTypesV1Proto.MerkleProof{
 					Root:     &agglayerInteropTypesV1Proto.FixedBytes32{Value: v.ProvenInsertedGERLeaf.ProofGERToL1Root.Root[:]},

--- a/aggsender/mocks/mock_chain_ger_reader.go
+++ b/aggsender/mocks/mock_chain_ger_reader.go
@@ -3,9 +3,10 @@
 package mocks
 
 import (
-	context "context"
-
 	chaingerreader "github.com/agglayer/aggkit/aggoracle/chaingerreader"
+	common "github.com/ethereum/go-ethereum/common"
+
+	context "context"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -24,23 +25,23 @@ func (_m *ChainGERReader) EXPECT() *ChainGERReader_Expecter {
 }
 
 // GetInjectedGERsForRange provides a mock function with given fields: ctx, fromBlock, toBlock
-func (_m *ChainGERReader) GetInjectedGERsForRange(ctx context.Context, fromBlock uint64, toBlock uint64) (map[uint64][]chaingerreader.InjectedGER, error) {
+func (_m *ChainGERReader) GetInjectedGERsForRange(ctx context.Context, fromBlock uint64, toBlock uint64) (map[common.Hash]chaingerreader.InjectedGER, error) {
 	ret := _m.Called(ctx, fromBlock, toBlock)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInjectedGERsForRange")
 	}
 
-	var r0 map[uint64][]chaingerreader.InjectedGER
+	var r0 map[common.Hash]chaingerreader.InjectedGER
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) (map[uint64][]chaingerreader.InjectedGER, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) (map[common.Hash]chaingerreader.InjectedGER, error)); ok {
 		return rf(ctx, fromBlock, toBlock)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) map[uint64][]chaingerreader.InjectedGER); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) map[common.Hash]chaingerreader.InjectedGER); ok {
 		r0 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[uint64][]chaingerreader.InjectedGER)
+			r0 = ret.Get(0).(map[common.Hash]chaingerreader.InjectedGER)
 		}
 	}
 
@@ -73,12 +74,12 @@ func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Return(_a0 map[uint64][]chaingerreader.InjectedGER, _a1 error) *ChainGERReader_GetInjectedGERsForRange_Call {
+func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Return(_a0 map[common.Hash]chaingerreader.InjectedGER, _a1 error) *ChainGERReader_GetInjectedGERsForRange_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ChainGERReader_GetInjectedGERsForRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) (map[uint64][]chaingerreader.InjectedGER, error)) *ChainGERReader_GetInjectedGERsForRange_Call {
+func (_c *ChainGERReader_GetInjectedGERsForRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) (map[common.Hash]chaingerreader.InjectedGER, error)) *ChainGERReader_GetInjectedGERsForRange_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_chain_ger_reader.go
+++ b/aggsender/mocks/mock_chain_ger_reader.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	common "github.com/ethereum/go-ethereum/common"
+	chaingerreader "github.com/agglayer/aggkit/aggoracle/chaingerreader"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -24,23 +24,23 @@ func (_m *ChainGERReader) EXPECT() *ChainGERReader_Expecter {
 }
 
 // GetInjectedGERsForRange provides a mock function with given fields: ctx, fromBlock, toBlock
-func (_m *ChainGERReader) GetInjectedGERsForRange(ctx context.Context, fromBlock uint64, toBlock uint64) (map[uint64][]common.Hash, error) {
+func (_m *ChainGERReader) GetInjectedGERsForRange(ctx context.Context, fromBlock uint64, toBlock uint64) (map[uint64][]chaingerreader.InjectedGER, error) {
 	ret := _m.Called(ctx, fromBlock, toBlock)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInjectedGERsForRange")
 	}
 
-	var r0 map[uint64][]common.Hash
+	var r0 map[uint64][]chaingerreader.InjectedGER
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) (map[uint64][]common.Hash, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) (map[uint64][]chaingerreader.InjectedGER, error)); ok {
 		return rf(ctx, fromBlock, toBlock)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) map[uint64][]common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) map[uint64][]chaingerreader.InjectedGER); ok {
 		r0 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[uint64][]common.Hash)
+			r0 = ret.Get(0).(map[uint64][]chaingerreader.InjectedGER)
 		}
 	}
 
@@ -73,12 +73,12 @@ func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Return(_a0 map[uint64][]common.Hash, _a1 error) *ChainGERReader_GetInjectedGERsForRange_Call {
+func (_c *ChainGERReader_GetInjectedGERsForRange_Call) Return(_a0 map[uint64][]chaingerreader.InjectedGER, _a1 error) *ChainGERReader_GetInjectedGERsForRange_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ChainGERReader_GetInjectedGERsForRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) (map[uint64][]common.Hash, error)) *ChainGERReader_GetInjectedGERsForRange_Call {
+func (_c *ChainGERReader_GetInjectedGERsForRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) (map[uint64][]chaingerreader.InjectedGER, error)) *ChainGERReader_GetInjectedGERsForRange_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggoracle/chaingerreader"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/l1infotreesync"
@@ -60,7 +61,9 @@ type L2BridgeSyncer interface {
 
 // ChainGERReader is an interface defining functions that an ChainGERReader should implement
 type ChainGERReader interface {
-	GetInjectedGERsForRange(ctx context.Context, fromBlock, toBlock uint64) (map[uint64][]common.Hash, error)
+	GetInjectedGERsForRange(
+		ctx context.Context,
+		fromBlock, toBlock uint64) (map[uint64][]chaingerreader.InjectedGER, error)
 }
 
 // L1InfoTreeDataQuerier is an interface defining functions that an L1InfoTreeDataQuerier should implement

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -63,7 +63,7 @@ type L2BridgeSyncer interface {
 type ChainGERReader interface {
 	GetInjectedGERsForRange(
 		ctx context.Context,
-		fromBlock, toBlock uint64) (map[uint64][]chaingerreader.InjectedGER, error)
+		fromBlock, toBlock uint64) (map[common.Hash]chaingerreader.InjectedGER, error)
 }
 
 // L1InfoTreeDataQuerier is an interface defining functions that an L1InfoTreeDataQuerier should implement

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250404090611-7f9f451280ee.2
 	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.6-20250404090611-7f9f451280ee.1
 	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250403073306-df9b770ff25d.1
-	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250403091637-4fd90e526027.2
-	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250403091637-4fd90e526027.1
+	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250414085509-fe25425e2577.2
+	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250414085509-fe25425e2577.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.3
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.7

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,12 @@ buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250403073306-df9b
 buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.6-20250403073306-df9b770ff25d.1/go.mod h1:W3XIAooP7VLR0wAorIvMG2xNYX+C48U9QHfn8uUox3I=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250403091637-4fd90e526027.2 h1:x5UeilSrRauejHuaC4u7e17FX8RKuEK5UT/Q7L2JkSc=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250403091637-4fd90e526027.2/go.mod h1:rgXdXPca3EdzI4ezKayCV4FTPR6MiWszzxf9Y+ijBO4=
+buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250414085509-fe25425e2577.2 h1:s6hlTZXUPHEmxuV0GFUnxa5v2G1WHmBJjKc+4lXqARI=
+buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250414085509-fe25425e2577.2/go.mod h1:5gMb0R6U8AQfo5MaQvbk3RUgahEEihv59uxdNHO/eR4=
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250403091637-4fd90e526027.1 h1:UaADVvP+GRT+4X1YkujDekpP1QDWTRnvb759CmpQFJg=
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250403091637-4fd90e526027.1/go.mod h1:HmgyhK8tLa4cfrt+7L5w+cE8b/wnricASyRn2CvfpuE=
+buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250414085509-fe25425e2577.1 h1:82Z67gXqioNcr6DL3VZDCBqIeuukBuc/UC72S1kAp0M=
+buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250414085509-fe25425e2577.1/go.mod h1:HmgyhK8tLa4cfrt+7L5w+cE8b/wnricASyRn2CvfpuE=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.116.0 h1:B3fRrSDkLRt5qSHWe40ERJvhvnQwdZiHu0bJOpldweE=
 cloud.google.com/go v0.116.0/go.mod h1:cEPSRWPzZEswwdr9BxE6ChEn01dWlTaF05LiC2Xs70U=


### PR DESCRIPTION
## Description

This PR adds the `block index` field to the `ProvenInsertedGERWithBlockNumber` and sends it to the `aggkit prover` so that the prover can properly sort the injected GERs when building a proof.

Fixes # (issue)
