### PR TITLE
feat: allow empty certificates for `FEP` (aggchain proof) flow

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -283,7 +283,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 		return nil, fmt.Errorf("error getting certificate build params: %w", err)
 	}
 
-	if certificateParams == nil || len(certificateParams.Bridges) == 0 {
+	if certificateParams == nil {
 		return nil, nil
 	}
 

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -750,14 +750,12 @@ func TestSendCertificate(t *testing.T) {
 			expectedError: "error getting certificate build params",
 		},
 		{
-			name: "no consumed bridges",
+			name: "no new blocks consumed",
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockL1InfoTreeSyncer *mocks.L1InfoTreeSyncer,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
-					Bridges: []bridgesync.Bridge{},
-				}, nil).Once()
+				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(nil, nil).Once()
 			},
 		},
 		{

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -2,6 +2,7 @@ package flows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/aggchainfep"
@@ -127,6 +128,12 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		// use the old logic, where we build the new certificate
 		buildParams, err = a.baseFlow.getCertificateBuildParamsInternal(ctx, true)
 		if err != nil {
+			if errors.Is(err, errNoNewBlocks) {
+				// no new blocks to send a certificate
+				// this is a valid case, so just return nil without error
+				return nil, nil
+			}
+
 			return nil, err
 		}
 	}
@@ -164,7 +171,7 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 // this function is the implementation of the FlowManager interface
 func (a *AggchainProverFlow) BuildCertificate(ctx context.Context,
 	buildParams *types.CertificateBuildParams) (*agglayertypes.Certificate, error) {
-	cert, err := a.buildCertificate(ctx, buildParams, buildParams.LastSentCertificate)
+	cert, err := a.buildCertificate(ctx, buildParams, buildParams.LastSentCertificate, true)
 	if err != nil {
 		return nil, fmt.Errorf("aggchainProverFlow - error building certificate: %w", err)
 	}

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -104,14 +104,6 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 			return nil, fmt.Errorf("aggchainProverFlow - error getting bridges and claims: %w", err)
 		}
 
-		if len(bridges) == 0 {
-			// this should never happen, if it does, we need to investigate
-			// (maybe someone deleted the bridge syncer db, so we might need to wait for it to catch up)
-			// just keep return an error here
-			return nil, fmt.Errorf("aggchainProverFlow - we have an InError certificate: %s, "+
-				"but no bridges to resend the same certificate", lastSentCertificateInfo.String())
-		}
-
 		// we need to resend the same certificate
 		buildParams = &types.CertificateBuildParams{
 			FromBlock:           lastSentCertificateInfo.FromBlock,

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -94,7 +94,11 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		// if the last certificate was in error, we need to resend it
 		a.log.Infof("resending the same InError certificate: %s", lastSentCertificateInfo.String())
 
-		bridges, claims, err := a.getBridgesAndClaims(ctx, lastSentCertificateInfo.FromBlock, lastSentCertificateInfo.ToBlock)
+		bridges, claims, err := a.getBridgesAndClaims(
+			ctx, lastSentCertificateInfo.FromBlock,
+			lastSentCertificateInfo.ToBlock,
+			true,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("aggchainProverFlow - error getting bridges and claims: %w", err)
 		}
@@ -121,15 +125,10 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 
 	if buildParams == nil {
 		// use the old logic, where we build the new certificate
-		buildParams, err = a.baseFlow.getCertificateBuildParamsInternal(ctx)
+		buildParams, err = a.baseFlow.getCertificateBuildParamsInternal(ctx, true)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if buildParams.NumberOfBridges() == 0 {
-		// no bridges so no need to build the certificate
-		return nil, nil
 	}
 
 	if err := a.verifyBuildParams(buildParams); err != nil {
@@ -156,14 +155,6 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 	buildParams, err = adjustBlockRange(buildParams, buildParams.ToBlock, aggchainProof.EndBlock)
 	if err != nil {
 		return nil, err
-	}
-
-	if buildParams.NumberOfBridges() == 0 {
-		// what can happen is that the aggchain prover returned a different range than the one requested
-		// and the bridges were not in that range, so no need to build the certificate
-		a.log.Infof("no bridges consumed, no need to send a certificate from block: %d to block: %d",
-			buildParams.FromBlock, buildParams.ToBlock)
-		return nil, nil
 	}
 
 	return buildParams, nil

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -712,3 +712,116 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 		})
 	}
 }
+
+func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	createdAt := time.Now().UTC()
+
+	testCases := []struct {
+		name           string
+		mockFn         func(*mocks.L2BridgeSyncer)
+		buildParams    *types.CertificateBuildParams
+		expectedError  string
+		expectedResult *agglayertypes.Certificate
+	}{
+		{
+			name: "error building certificate",
+			mockFn: func(mockL2Syncer *mocks.L2BridgeSyncer) {
+				mockL2Syncer.EXPECT().GetExitRootByIndex(mock.Anything, uint32(0)).Return(treetypes.Root{}, errors.New("some error"))
+			},
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{},
+				Claims:    []bridgesync.Claim{},
+				L1InfoTreeRootFromWhichToProve: &treetypes.Root{
+					Hash:     common.HexToHash("0x1"),
+					BlockNum: 10,
+				},
+			},
+			expectedError: "error building certificate: error getting exit root by index",
+		},
+		{
+			name: "success building certificate",
+			mockFn: func(mockL2Syncer *mocks.L2BridgeSyncer) {
+				mockL2Syncer.EXPECT().GetExitRootByIndex(mock.Anything, uint32(0)).Return(treetypes.Root{Hash: common.HexToHash("0x1")}, nil)
+				mockL2Syncer.EXPECT().OriginNetwork().Return(uint32(1))
+			},
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{},
+				Claims:    []bridgesync.Claim{},
+				CreatedAt: uint32(createdAt.Unix()),
+				L1InfoTreeRootFromWhichToProve: &treetypes.Root{
+					Hash:     common.HexToHash("0x1"),
+					BlockNum: 10,
+				},
+				AggchainProof: &types.AggchainProof{
+					SP1StarkProof: &types.SP1StarkProof{
+						Proof:   []byte("some-proof"),
+						Version: "0.1",
+						Vkey:    []byte("some-vkey"),
+					},
+					LastProvenBlock: 1,
+					EndBlock:        10,
+					CustomChainData: []byte("some-data"),
+					LocalExitRoot:   common.HexToHash("0x1"),
+					AggchainParams:  common.HexToHash("0x2"),
+					Context: map[string][]byte{
+						"key1": []byte("value1"),
+					},
+				},
+			},
+			expectedResult: &agglayertypes.Certificate{
+				NetworkID:           1,
+				Height:              0,
+				NewLocalExitRoot:    common.HexToHash("0x1"),
+				CustomChainData:     []byte("some-data"),
+				Metadata:            types.NewCertificateMetadata(1, 9, uint32(createdAt.Unix())).ToHash(),
+				BridgeExits:         []*agglayertypes.BridgeExit{},
+				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{},
+				PrevLocalExitRoot:   zeroLER,
+				AggchainData: &agglayertypes.AggchainDataProof{
+					Proof:          []byte("some-proof"),
+					Version:        "0.1",
+					Vkey:           []byte("some-vkey"),
+					AggchainParams: common.HexToHash("0x2"),
+					Context: map[string][]byte{
+						"key1": []byte("value1"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockL2Syncer := mocks.NewL2BridgeSyncer(t)
+			if tc.mockFn != nil {
+				tc.mockFn(mockL2Syncer)
+			}
+
+			aggchainFlow := &AggchainProverFlow{
+				baseFlow: &baseFlow{
+					log:      log.WithFields("flowManager", "Test_AggchainProverFlow_BuildCertificate"),
+					l2Syncer: mockL2Syncer,
+				},
+			}
+
+			certificate, err := aggchainFlow.BuildCertificate(ctx, tc.buildParams)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, certificate)
+				require.Equal(t, tc.expectedResult, certificate)
+			}
+		})
+	}
+}

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -69,22 +69,6 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			expectedError: "some error",
 		},
 		{
-			name: "resend InError certificate with no bridges",
-			mockFn: func(mockStorage *mocks.AggSenderStorage,
-				mockL2Syncer *mocks.L2BridgeSyncer,
-				mockProverClient *mocks.AggchainProofClientInterface,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockChainGERReader *mocks.ChainGERReader) {
-				mockStorage.On("GetLastSentCertificate").Return(&types.CertificateInfo{
-					FromBlock: 1,
-					ToBlock:   10,
-					Status:    agglayertypes.InError,
-				}, nil)
-				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{}, nil)
-			},
-			expectedError: "no bridges to resend the same certificate",
-		},
-		{
 			name: "resend InError certificate",
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2Syncer *mocks.L2BridgeSyncer,

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -40,13 +40,14 @@ type baseFlow struct {
 func (f *baseFlow) getBridgesAndClaims(
 	ctx context.Context,
 	fromBlock, toBlock uint64,
+	allowEmptyCert bool,
 ) ([]bridgesync.Bridge, []bridgesync.Claim, error) {
 	bridges, err := f.l2Syncer.GetBridgesPublished(ctx, fromBlock, toBlock)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting bridges: %w", err)
 	}
 
-	if len(bridges) == 0 {
+	if len(bridges) == 0 && !allowEmptyCert {
 		f.log.Infof("no bridges consumed, no need to send a certificate from block: %d to block: %d",
 			fromBlock, toBlock)
 		return nil, nil, nil
@@ -61,7 +62,8 @@ func (f *baseFlow) getBridgesAndClaims(
 }
 
 // getCertificateBuildParamsInternal returns the parameters to build a certificate
-func (f *baseFlow) getCertificateBuildParamsInternal(ctx context.Context) (*types.CertificateBuildParams, error) {
+func (f *baseFlow) getCertificateBuildParamsInternal(
+	ctx context.Context, allowEmptyCert bool) (*types.CertificateBuildParams, error) {
 	lastL2BlockSynced, err := f.l2Syncer.GetLastProcessedBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting last processed block from l2: %w", err)
@@ -83,7 +85,7 @@ func (f *baseFlow) getCertificateBuildParamsInternal(ctx context.Context) (*type
 	fromBlock := previousToBlock + 1
 	toBlock := lastL2BlockSynced
 
-	bridges, claims, err := f.getBridgesAndClaims(ctx, fromBlock, toBlock)
+	bridges, claims, err := f.getBridgesAndClaims(ctx, fromBlock, toBlock, allowEmptyCert)
 	if err != nil {
 		return nil, err
 	}
@@ -98,12 +100,12 @@ func (f *baseFlow) getCertificateBuildParamsInternal(ctx context.Context) (*type
 		CreatedAt:           uint32(time.Now().UTC().Unix()),
 	}
 
-	if buildParams.NumberOfBridges() == 0 {
+	if !allowEmptyCert && buildParams.NumberOfBridges() == 0 {
 		// no bridges so no need to build the certificate
 		return nil, nil
 	}
 
-	buildParams, err = f.limitCertSize(buildParams)
+	buildParams, err = f.limitCertSize(buildParams, allowEmptyCert)
 	if err != nil {
 		return nil, fmt.Errorf("error limitCertSize: %w", err)
 	}
@@ -119,29 +121,28 @@ func (f *baseFlow) verifyBuildParams(fullCert *types.CertificateBuildParams) err
 
 // limitCertSize limits certificate size based on the max size configuration parameter
 // size is expressed in bytes
-func (f *baseFlow) limitCertSize(fullCert *types.CertificateBuildParams) (*types.CertificateBuildParams, error) {
+func (f *baseFlow) limitCertSize(
+	fullCert *types.CertificateBuildParams, allowEmptyCert bool) (*types.CertificateBuildParams, error) {
 	currentCert := fullCert
-	var previousCert *types.CertificateBuildParams
 	var err error
-	for {
-		if currentCert.NumberOfBridges() == 0 {
-			// We can't reduce more the certificate, so this is the minium size
-			f.log.Warnf("We reach the minium size of bridge. Certificate size: %d >max size: %d",
-				previousCert.EstimatedSize(), f.maxCertSize)
-			return previousCert, nil
-		}
 
-		if f.maxCertSize == 0 || currentCert.EstimatedSize() < f.maxCertSize {
+	for {
+		if currentCert.NumberOfBridges() == 0 && !allowEmptyCert {
+			f.log.Warnf("Minimum certificate size reached. Estimated size: %d > max size: %d",
+				currentCert.EstimatedSize(), f.maxCertSize)
 			return currentCert, nil
 		}
 
-		// Minimum size of the certificate
+		if f.maxCertSize == 0 || currentCert.EstimatedSize() <= f.maxCertSize {
+			return currentCert, nil
+		}
+
 		if currentCert.NumberOfBlocks() <= 1 {
-			f.log.Warnf("reach the minium num blocks [%d to %d]. Certificate size: %d >max size: %d",
+			f.log.Warnf("Minimum number of blocks reached [%d to %d]. Estimated size: %d > max size: %d",
 				currentCert.FromBlock, currentCert.ToBlock, currentCert.EstimatedSize(), f.maxCertSize)
 			return currentCert, nil
 		}
-		previousCert = currentCert
+
 		currentCert, err = currentCert.Range(currentCert.FromBlock, currentCert.ToBlock-1)
 		if err != nil {
 			return nil, fmt.Errorf("error reducing certificate: %w", err)

--- a/aggsender/flows/flow_base_test.go
+++ b/aggsender/flows/flow_base_test.go
@@ -1,0 +1,134 @@
+package flows
+
+import (
+	"testing"
+
+	"github.com/agglayer/aggkit/aggsender/types"
+	"github.com/agglayer/aggkit/bridgesync"
+	"github.com/agglayer/aggkit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_baseFlow_limitCertSize(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxCertSize    uint
+		fullCert       *types.CertificateBuildParams
+		allowEmptyCert bool
+		expectedCert   *types.CertificateBuildParams
+		expectedError  string
+	}{
+		{
+			name:        "certificate size within limit",
+			maxCertSize: 1000,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{{}, {}},
+			},
+			allowEmptyCert: false,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{{}, {}},
+			},
+		},
+		{
+			name:        "certificate size exceeds limit",
+			maxCertSize: 500,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{{BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}},
+			},
+			allowEmptyCert: false,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   9,
+				Bridges:   []bridgesync.Bridge{},
+				Claims:    []bridgesync.Claim{},
+			},
+		},
+		{
+			name:        "certificate size exceeds limit with minimum blocks",
+			maxCertSize: 500,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   2,
+				Bridges:   []bridgesync.Bridge{{}},
+			},
+			allowEmptyCert: false,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   2,
+				Bridges:   []bridgesync.Bridge{{}},
+			},
+		},
+		{
+			name:        "empty certificate allowed",
+			maxCertSize: 500,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{},
+			},
+			allowEmptyCert: true,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{},
+			},
+		},
+		{
+			name:        "empty certificate not allowed",
+			maxCertSize: 500,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{},
+			},
+			allowEmptyCert: false,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{},
+			},
+		},
+		{
+			name:        "maxCertSize is 0 with bridges and claims",
+			maxCertSize: 0,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{{}, {}},
+				Claims:    []bridgesync.Claim{{}, {}},
+			},
+			allowEmptyCert: false,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{{}, {}},
+				Claims:    []bridgesync.Claim{{}, {}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &baseFlow{
+				maxCertSize: tt.maxCertSize,
+				log:         log.WithFields("test", t.Name()),
+			}
+
+			result, err := f.limitCertSize(tt.fullCert, tt.allowEmptyCert)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedCert, result)
+			}
+		})
+	}
+}

--- a/aggsender/flows/flow_pp.go
+++ b/aggsender/flows/flow_pp.go
@@ -44,7 +44,7 @@ func NewPPFlow(log types.Logger,
 // GetCertificateBuildParams returns the parameters to build a certificate
 // this function is the implementation of the FlowManager interface
 func (p *PPFlow) GetCertificateBuildParams(ctx context.Context) (*types.CertificateBuildParams, error) {
-	buildParams, err := p.getCertificateBuildParamsInternal(ctx)
+	buildParams, err := p.getCertificateBuildParamsInternal(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/aggsender/flows/flow_pp.go
+++ b/aggsender/flows/flow_pp.go
@@ -2,6 +2,7 @@ package flows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
@@ -46,6 +47,12 @@ func NewPPFlow(log types.Logger,
 func (p *PPFlow) GetCertificateBuildParams(ctx context.Context) (*types.CertificateBuildParams, error) {
 	buildParams, err := p.getCertificateBuildParamsInternal(ctx, false)
 	if err != nil {
+		if errors.Is(err, errNoNewBlocks) {
+			// no new blocks to send a certificate
+			// this is a valid case, so just return nil without error
+			return nil, nil
+		}
+
 		return nil, err
 	}
 
@@ -74,7 +81,7 @@ func (p *PPFlow) GetCertificateBuildParams(ctx context.Context) (*types.Certific
 // this function is the implementation of the FlowManager interface
 func (p *PPFlow) BuildCertificate(ctx context.Context,
 	buildParams *types.CertificateBuildParams) (*agglayertypes.Certificate, error) {
-	certificate, err := p.buildCertificate(ctx, buildParams, buildParams.LastSentCertificate)
+	certificate, err := p.buildCertificate(ctx, buildParams, buildParams.LastSentCertificate, false)
 	if err != nil {
 		return nil, fmt.Errorf("ppFlow - error building certificate: %w", err)
 	}

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -682,7 +682,7 @@ func TestBuildCertificate(t *testing.T) {
 				Claims:                         tt.claims,
 				L1InfoTreeRootFromWhichToProve: &treetypes.Root{Hash: common.HexToHash("0x7891")},
 			}
-			cert, err := flow.buildCertificate(context.Background(), certParam, &tt.lastSentCertificateInfo)
+			cert, err := flow.buildCertificate(context.Background(), certParam, &tt.lastSentCertificateInfo, false)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -911,6 +911,18 @@ func TestGetBridgesAndClaims(t *testing.T) {
 				mockL2Syncer.On("GetClaims", ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{}, nil)
 			},
 			expectedBridges: []bridgesync.Bridge{{}},
+			expectedClaims:  []bridgesync.Claim{},
+		},
+		{
+			name: "allow empty cert",
+			mockFn: func(mockL2Syncer *mocks.L2BridgeSyncer) {
+				mockL2Syncer.On("GetBridgesPublished", ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{}, nil)
+				mockL2Syncer.On("GetClaims", ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{}, nil)
+			},
+			fromBlock:       1,
+			toBlock:         10,
+			allowEmptyCert:  true,
+			expectedBridges: []bridgesync.Bridge{},
 			expectedClaims:  []bridgesync.Claim{},
 		},
 		{

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -867,6 +867,7 @@ func TestGetBridgesAndClaims(t *testing.T) {
 		name            string
 		fromBlock       uint64
 		toBlock         uint64
+		allowEmptyCert  bool
 		mockFn          func(*mocks.L2BridgeSyncer)
 		expectedBridges []bridgesync.Bridge
 		expectedClaims  []bridgesync.Claim
@@ -938,7 +939,7 @@ func TestGetBridgesAndClaims(t *testing.T) {
 
 			tc.mockFn(mockL2Syncer)
 
-			bridges, claims, err := fm.getBridgesAndClaims(ctx, tc.fromBlock, tc.toBlock)
+			bridges, claims, err := fm.getBridgesAndClaims(ctx, tc.fromBlock, tc.toBlock, tc.allowEmptyCert)
 			if tc.expectedError != "" {
 				require.ErrorContains(t, err, tc.expectedError)
 			} else {


### PR DESCRIPTION
## Description

This PR allows sending of empty certificates (certificates without bridge exits and claims) to the `agglayer` in case of `AggchainProof` mode on `aggsender`. This is needed so that `FEP` can work properly on the network.

Fixes # (issue)
