### PR TITLE
fix: resend proof in `AggchainProof` flow

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -311,8 +311,8 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 	}
 	certificateHash, err := a.aggLayerClient.SendCertificate(ctx, certificate)
 	if err != nil {
-		raw, unmarshalErr := json.Marshal(certificate)
-		if unmarshalErr == nil {
+		raw, marshalErr := json.Marshal(certificate)
+		if marshalErr == nil {
 			// we ignore the marshal error, since marshaled certificate is only needed for logging
 			a.log.Errorf("error sending certificate. Err: %w. Certificate: %s", err, string(raw))
 		}

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -11,7 +11,6 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/tree"
-	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/crypto/sha3"
@@ -276,7 +275,7 @@ func (f *baseFlow) getBridgeExits(bridges []bridgesync.Bridge) []*agglayertypes.
 // getImportedBridgeExits converts claims to agglayertypes.ImportedBridgeExit objects and calculates necessary proofs
 func (f *baseFlow) getImportedBridgeExits(
 	ctx context.Context, claims []bridgesync.Claim,
-	rootFromWhichToProve *treetypes.Root,
+	rootFromWhichToProve common.Hash,
 ) ([]*agglayertypes.ImportedBridgeExit, error) {
 	if len(claims) == 0 {
 		// no claims to convert
@@ -297,11 +296,11 @@ func (f *baseFlow) getImportedBridgeExits(
 		importedBridgeExits = append(importedBridgeExits, ibe)
 
 		l1Info, gerToL1Proof, err := f.l1InfoTreeDataQuerier.GetProofForGER(ctx,
-			claim.GlobalExitRoot, rootFromWhichToProve.Hash)
+			claim.GlobalExitRoot, rootFromWhichToProve)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error getting L1 Info tree merkle proof for leaf index: %d and root: %s. Error: %w",
-				l1Info.L1InfoTreeIndex, rootFromWhichToProve.Hash, err,
+				l1Info.L1InfoTreeIndex, rootFromWhichToProve, err,
 			)
 		}
 
@@ -322,7 +321,7 @@ func (f *baseFlow) getImportedBridgeExits(
 					Proof: claim.ProofLocalExitRoot,
 				},
 				ProofGERToL1Root: &agglayertypes.MerkleProof{
-					Root:  rootFromWhichToProve.Hash,
+					Root:  rootFromWhichToProve,
 					Proof: gerToL1Proof,
 				},
 			}
@@ -348,7 +347,7 @@ func (f *baseFlow) getImportedBridgeExits(
 					Proof: claim.ProofRollupExitRoot,
 				},
 				ProofGERToL1Root: &agglayertypes.MerkleProof{
-					Root:  rootFromWhichToProve.Hash,
+					Root:  rootFromWhichToProve,
 					Proof: gerToL1Proof,
 				},
 			}

--- a/aggsender/flows/flow_pp.go
+++ b/aggsender/flows/flow_pp.go
@@ -71,7 +71,7 @@ func (p *PPFlow) GetCertificateBuildParams(ctx context.Context) (*types.Certific
 			return nil, fmt.Errorf("ppFlow - error getting latest finalized L1 info root: %w", err)
 		}
 
-		buildParams.L1InfoTreeRootFromWhichToProve = root
+		buildParams.L1InfoTreeRootFromWhichToProve = root.Hash
 	}
 
 	return buildParams, nil

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -458,7 +458,7 @@ func TestGetImportedBridgeExits(t *testing.T) {
 				l1InfoTreeDataQuerier: mockL1InfoTreeQuery,
 				log:                   log.WithFields("test", "unittest"),
 			}
-			exits, err := flow.getImportedBridgeExits(context.Background(), tt.claims, &treetypes.Root{Hash: common.HexToHash("0x7891")})
+			exits, err := flow.getImportedBridgeExits(context.Background(), tt.claims, common.HexToHash("0x7891"))
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -680,7 +680,7 @@ func TestBuildCertificate(t *testing.T) {
 				ToBlock:                        tt.toBlock,
 				Bridges:                        tt.bridges,
 				Claims:                         tt.claims,
-				L1InfoTreeRootFromWhichToProve: &treetypes.Root{Hash: common.HexToHash("0x7891")},
+				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x7891"),
 			}
 			cert, err := flow.buildCertificate(context.Background(), certParam, &tt.lastSentCertificateInfo, false)
 
@@ -1080,7 +1080,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 						GlobalExitRoot:  calculateGER(common.HexToHash("0x2"), common.HexToHash("0x1")),
 					}},
 				CreatedAt:                      uint32(time.Now().UTC().Unix()),
-				L1InfoTreeRootFromWhichToProve: &treetypes.Root{Hash: common.HexToHash("0x123"), BlockNum: 10},
+				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x123"),
 			},
 		},
 	}

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/agglayer/aggkit/bridgesync"
-	treetypes "github.com/agglayer/aggkit/tree/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
@@ -22,7 +22,7 @@ type CertificateBuildParams struct {
 	CreatedAt                      uint32
 	RetryCount                     int
 	LastSentCertificate            *CertificateInfo
-	L1InfoTreeRootFromWhichToProve *treetypes.Root
+	L1InfoTreeRootFromWhichToProve common.Hash
 	AggchainProof                  *AggchainProof
 }
 


### PR DESCRIPTION
## Description

This PR fixes the way `InError` certificate is resent to the `agglayer` in the new `FEP` (`AggchainProof`) mode on `aggsender`.

Since proof was already generated by the prover, we just need to resend it back to the `agglayer`. No need to call the prover again.

Fixes # (issue)
