### PR TITLE
feat: populate from_address based on tx sender

### DIFF
--- a/bridgesync/claimcalldata_test.go
+++ b/bridgesync/claimcalldata_test.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/test/contracts/claimmock"
 	"github.com/agglayer/aggkit/test/contracts/claimmockcaller"
 	"github.com/agglayer/aggkit/test/contracts/claimmocktest"
@@ -36,7 +35,7 @@ func TestClaimCalldata(t *testing.T) {
 	require.NoError(t, err)
 	claimCallerAddr, _, claimCaller, err := claimmockcaller.DeployClaimmockcaller(auth, client, bridgeAddr)
 	require.NoError(t, err)
-	_, _, claimTest, err := claimmocktest.DeployClaimmocktest(auth, client, bridgeAddr, claimCallerAddr)
+	claimTestAddr, _, claimTest, err := claimmocktest.DeployClaimmocktest(auth, client, bridgeAddr, claimCallerAddr)
 	require.NoError(t, err)
 
 	proofLocal := [tree.DefaultHeight][common.HashLength]byte{}
@@ -59,6 +58,7 @@ func TestClaimCalldata(t *testing.T) {
 		DestinationNetwork:  0,
 		Metadata:            []byte{},
 		GlobalExitRoot:      crypto.Keccak256Hash(common.HexToHash("5ca1e").Bytes(), common.HexToHash("dead").Bytes()),
+		FromAddress:         auth.From,
 	}
 	expectedClaim2 := Claim{
 		OriginNetwork:       87,
@@ -72,6 +72,7 @@ func TestClaimCalldata(t *testing.T) {
 		DestinationNetwork:  0,
 		Metadata:            []byte{},
 		GlobalExitRoot:      crypto.Keccak256Hash(common.HexToHash("5ca1e").Bytes(), common.HexToHash("dead").Bytes()),
+		FromAddress:         auth.From,
 	}
 	expectedClaim3 := Claim{
 		OriginNetwork:       69,
@@ -85,6 +86,7 @@ func TestClaimCalldata(t *testing.T) {
 		DestinationNetwork:  0,
 		Metadata:            []byte{},
 		GlobalExitRoot:      crypto.Keccak256Hash(common.HexToHash("5ca1e").Bytes(), common.HexToHash("dead").Bytes()),
+		FromAddress:         auth.From,
 	}
 	auth.GasLimit = 999999 // for some reason gas estimation fails :(
 
@@ -122,6 +124,7 @@ func TestClaimCalldata(t *testing.T) {
 	// indirect call claim asset
 	expectedClaim.IsMessage = false
 	expectedClaim.GlobalIndex = big.NewInt(422)
+	expectedClaim.FromAddress = claimCallerAddr
 	tx, err = claimCaller.ClaimAsset(
 		auth,
 		proofLocal,
@@ -172,6 +175,7 @@ func TestClaimCalldata(t *testing.T) {
 	// direct call claim message
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(424)
+	expectedClaim.FromAddress = auth.From
 	tx, err = bridgeContract.ClaimMessage(
 		auth,
 		proofLocal,
@@ -200,6 +204,7 @@ func TestClaimCalldata(t *testing.T) {
 	// indirect call claim message
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(425)
+	expectedClaim.FromAddress = claimCallerAddr
 	tx, err = claimCaller.ClaimMessage(
 		auth,
 		proofLocal,
@@ -266,6 +271,7 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
+	expectedClaim2.FromAddress = claimCallerAddr
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err := encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -671,6 +677,7 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim2.GlobalIndex = big.NewInt(427)
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
+	expectedClaim3.FromAddress = claimCallerAddr
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -712,8 +719,10 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
+	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
+	expectedClaim3.FromAddress = claimCallerAddr
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -757,6 +766,7 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
+	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -796,8 +806,10 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
+	// expectedClaim2.FromAddress = auth.From
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
+	// expectedClaim3.FromAddress = auth.From
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -835,6 +847,7 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
+	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -874,6 +887,7 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
+	expectedClaim2.FromAddress = claimCallerAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -950,8 +964,10 @@ func TestClaimCalldata(t *testing.T) {
 	// 1 ok 1 ok 1 ko (indirectx2, indirect, indirectx2) call claim message (same global index)
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(427)
+	expectedClaim.FromAddress = claimTestAddr
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
+	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -1022,6 +1038,7 @@ func TestClaimCalldata(t *testing.T) {
 	// 1 ok 2 ko (indirectx2, indirect, indirectx2) call claim message (same global index)
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(427)
+	expectedClaim.FromAddress = claimCallerAddr
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
 	expectedClaim3.IsMessage = true
@@ -1057,6 +1074,7 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
+	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -1084,7 +1102,6 @@ func TestClaimCalldata(t *testing.T) {
 	})
 
 	for _, tc := range testCases {
-		log.Info(tc.description)
 		t.Run(tc.description, func(t *testing.T) {
 			claimEvent, err := bridgeContract.ParseClaimEvent(tc.log)
 			require.NoError(t, err)
@@ -1098,6 +1115,7 @@ func TestClaimCalldata(t *testing.T) {
 			err = actualClaim.setClaimCalldata(client.Client(), bridgeAddr, tc.log.TxHash)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedClaim, actualClaim)
+			require.Equal(t, tc.expectedClaim.FromAddress, actualClaim.FromAddress)
 		})
 	}
 }

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -299,8 +299,8 @@ func buildRemoveLegacyTokenHandler(contract *bridgel2sovereignchain.Bridgel2sove
 }
 
 type call struct {
-	To    common.Address    `json:"to"`
 	From  common.Address    `json:"from"`
+	To    common.Address    `json:"to"`
 	Value *rpcTypes.ArgBig  `json:"value"`
 	Err   *string           `json:"error"`
 	Input rpcTypes.ArgBytes `json:"input"`

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -344,7 +344,7 @@ func findCall(rootCall call, targetAddr common.Address, callback func(call) (boo
 	return nil, db.ErrNotFound
 }
 
-// extractCall tries to extract the call for the transaction indentified by transaction hash.
+// extractCall tries to extract the call for the transaction identified by transaction hash.
 // It relies on debug_traceTransaction JSON RPC function.
 func extractCall(client aggkittypes.RPCClienter, contractAddr common.Address, txHash common.Hash) (*call, error) {
 	c := &call{To: contractAddr}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -97,7 +97,7 @@ func buildBridgeEventHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev2
 			return fmt.Errorf("error parsing BridgeEvent log %+v: %w", l, err)
 		}
 
-		calldata, err := extractCalldata(client, bridgeAddr, l.TxHash)
+		foundCall, err := extractCall(client, bridgeAddr, l.TxHash)
 		if err != nil {
 			return fmt.Errorf("failed to extract bridge event calldata (tx hash: %s): %w", l.TxHash, err)
 		}
@@ -115,8 +115,8 @@ func buildBridgeEventHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev2
 			DepositCount:       bridgeEvent.DepositCount,
 			BlockTimestamp:     b.Timestamp,
 			TxHash:             l.TxHash,
-			FromAddress:        l.Address,
-			Calldata:           calldata,
+			FromAddress:        foundCall.From,
+			Calldata:           foundCall.Input,
 		}})
 		return nil
 	}
@@ -196,7 +196,7 @@ func buildTokenMappingHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev
 			return fmt.Errorf("error parsing NewWrappedToken event log %+v: %w", l, err)
 		}
 
-		calldata, err := extractCalldata(client, bridgeAddr, l.TxHash)
+		foundCall, err := extractCall(client, bridgeAddr, l.TxHash)
 		if err != nil {
 			return fmt.Errorf("failed to extract the NewWrappedToken event calldata (tx hash: %s): %w", l.TxHash, err)
 		}
@@ -210,7 +210,7 @@ func buildTokenMappingHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev
 			OriginTokenAddress:  tokenMappingEvent.OriginTokenAddress,
 			WrappedTokenAddress: tokenMappingEvent.WrappedTokenAddress,
 			Metadata:            tokenMappingEvent.Metadata,
-			Calldata:            calldata,
+			Calldata:            foundCall.Input,
 			Type:                WrappedToken,
 		}})
 		return nil
@@ -228,7 +228,7 @@ func buildSetSovereignTokenHandler(contract *bridgel2sovereignchain.Bridgel2sove
 			return fmt.Errorf("error parsing SetSovereignTokenAddress event log %+v: %w", l, err)
 		}
 
-		calldata, err := extractCalldata(client, bridgeAddr, l.TxHash)
+		foundCall, err := extractCall(client, bridgeAddr, l.TxHash)
 		if err != nil {
 			return fmt.Errorf("failed to extract the SetSovereignTokenAddress event calldata (tx hash: %s): %w", l.TxHash, err)
 		}
@@ -242,7 +242,7 @@ func buildSetSovereignTokenHandler(contract *bridgel2sovereignchain.Bridgel2sove
 			OriginTokenAddress:  event.OriginTokenAddress,
 			WrappedTokenAddress: event.SovereignTokenAddress,
 			IsNotMintable:       event.IsNotMintable,
-			Calldata:            calldata,
+			Calldata:            foundCall.Input,
 			Type:                SovereignToken,
 		}})
 		return nil
@@ -258,7 +258,7 @@ func buildMigrateLegacyTokenHandler(contract *bridgel2sovereignchain.Bridgel2sov
 			return fmt.Errorf("error parsing MigrateLegacyToken event log %+v: %w", l, err)
 		}
 
-		calldata, err := extractCalldata(client, bridgeAddr, l.TxHash)
+		foundCall, err := extractCall(client, bridgeAddr, l.TxHash)
 		if err != nil {
 			return fmt.Errorf("failed to extract the MigrateLegacyToken event calldata (tx hash: %s): %w", l.TxHash, err)
 		}
@@ -272,7 +272,7 @@ func buildMigrateLegacyTokenHandler(contract *bridgel2sovereignchain.Bridgel2sov
 			LegacyTokenAddress:  event.LegacyTokenAddress,
 			UpdatedTokenAddress: event.UpdatedTokenAddress,
 			Amount:              event.Amount,
-			Calldata:            calldata,
+			Calldata:            foundCall.Input,
 		}})
 		return nil
 	}
@@ -300,6 +300,7 @@ func buildRemoveLegacyTokenHandler(contract *bridgel2sovereignchain.Bridgel2sove
 
 type call struct {
 	To    common.Address    `json:"to"`
+	From  common.Address    `json:"from"`
 	Value *rpcTypes.ArgBig  `json:"value"`
 	Err   *string           `json:"error"`
 	Input rpcTypes.ArgBytes `json:"input"`
@@ -310,8 +311,8 @@ type tracerCfg struct {
 	Tracer string `json:"tracer"`
 }
 
-// findCalldata traverses the call trace using DFS and either returns calldata or stops when a callback succeeds.
-func findCalldata(rootCall call, targetAddr common.Address, callback func([]byte) (bool, error)) ([]byte, error) {
+// findCall traverses the call trace using DFS and either returns the call or stops when a callback succeeds.
+func findCall(rootCall call, targetAddr common.Address, callback func(call) (bool, error)) (*call, error) {
 	callStack := stack.New()
 	callStack.Push(rootCall)
 
@@ -324,15 +325,15 @@ func findCalldata(rootCall call, targetAddr common.Address, callback func([]byte
 
 		if currentCall.To == targetAddr {
 			if callback != nil {
-				found, err := callback(currentCall.Input)
+				found, err := callback(currentCall)
 				if err != nil {
 					return nil, err
 				}
 				if found {
-					return currentCall.Input, nil
+					return &currentCall, nil
 				}
 			} else {
-				return currentCall.Input, nil
+				return &currentCall, nil
 			}
 		}
 
@@ -343,16 +344,16 @@ func findCalldata(rootCall call, targetAddr common.Address, callback func([]byte
 	return nil, db.ErrNotFound
 }
 
-// extractCalldata tries to extract the calldata for the transaction indentified by transaction hash.
+// extractCall tries to extract the call for the transaction indentified by transaction hash.
 // It relies on debug_traceTransaction JSON RPC function.
-func extractCalldata(client aggkittypes.RPCClienter, contractAddr common.Address, txHash common.Hash) ([]byte, error) {
+func extractCall(client aggkittypes.RPCClienter, contractAddr common.Address, txHash common.Hash) (*call, error) {
 	c := &call{To: contractAddr}
 	err := client.Call(c, debugTraceTxEndpoint, txHash, tracerCfg{Tracer: callTracerType})
 	if err != nil {
 		return nil, err
 	}
 
-	return findCalldata(*c, contractAddr, nil)
+	return findCall(*c, contractAddr, nil)
 }
 
 // setClaimCalldata traces the transaction to find and decode calldata for the given bridge address.
@@ -370,9 +371,9 @@ func (c *Claim) setClaimCalldata(client aggkittypes.RPCClienter, bridge common.A
 		return err
 	}
 
-	_, err = findCalldata(*callFrame, bridge,
-		func(data []byte) (bool, error) {
-			return c.tryDecodeClaimCalldata(data)
+	_, err = findCall(*callFrame, bridge,
+		func(call call) (bool, error) {
+			return c.tryDecodeClaimCalldata(call.From, call.Input)
 		})
 
 	return err
@@ -382,7 +383,7 @@ func (c *Claim) setClaimCalldata(client aggkittypes.RPCClienter, bridge common.A
 // It checks if the method ID corresponds to either the claim asset or claim message methods.
 // If a match is found, it decodes the calldata using the ABI of the bridge contract and updates the claim object.
 // Returns true if the calldata is successfully decoded and matches the expected format, otherwise returns false.
-func (c *Claim) tryDecodeClaimCalldata(input []byte) (bool, error) {
+func (c *Claim) tryDecodeClaimCalldata(senderAddr common.Address, input []byte) (bool, error) {
 	methodID := input[:4]
 	switch {
 	case bytes.Equal(methodID, claimAssetEtrogMethodID):
@@ -403,7 +404,7 @@ func (c *Claim) tryDecodeClaimCalldata(input []byte) (bool, error) {
 			return false, err
 		}
 
-		found, err := c.decodeEtrogCalldata(data)
+		found, err := c.decodeEtrogCalldata(senderAddr, data)
 		if err != nil {
 			return false, err
 		}
@@ -433,7 +434,7 @@ func (c *Claim) tryDecodeClaimCalldata(input []byte) (bool, error) {
 			return false, err
 		}
 
-		found, err := c.decodePreEtrogCalldata(data)
+		found, err := c.decodePreEtrogCalldata(senderAddr, data)
 		if err != nil {
 			return false, err
 		}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -105,6 +105,10 @@ func buildBridgeEventHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev2
 		b.Events = append(b.Events, Event{Bridge: &Bridge{
 			BlockNum:           b.Num,
 			BlockPos:           uint64(l.Index),
+			FromAddress:        foundCall.From,
+			TxHash:             l.TxHash,
+			Calldata:           foundCall.Input,
+			BlockTimestamp:     b.Timestamp,
 			LeafType:           bridgeEvent.LeafType,
 			OriginNetwork:      bridgeEvent.OriginNetwork,
 			OriginAddress:      bridgeEvent.OriginAddress,
@@ -113,10 +117,6 @@ func buildBridgeEventHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev2
 			Amount:             bridgeEvent.Amount,
 			Metadata:           bridgeEvent.Metadata,
 			DepositCount:       bridgeEvent.DepositCount,
-			BlockTimestamp:     b.Timestamp,
-			TxHash:             l.TxHash,
-			FromAddress:        foundCall.From,
-			Calldata:           foundCall.Input,
 		}})
 		return nil
 	}

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -64,7 +64,6 @@ func TestBridgeEventE2E(t *testing.T) {
 		receipt, err := setup.L1Environment.SimBackend.Client().TransactionReceipt(ctx, tx.Hash())
 		require.NoError(t, err)
 		bridge.TxHash = receipt.TxHash
-		bridge.FromAddress = receipt.Logs[0].Address
 		block, err := simulatedClient.BlockByNumber(ctx, new(big.Int).SetUint64(bn))
 		require.NoError(t, err)
 		bridge.BlockTimestamp = block.Time()
@@ -104,7 +103,7 @@ func TestBridgeEventE2E(t *testing.T) {
 	root, err := setup.L1Environment.BridgeSync.GetExitRootByIndex(ctx, expectedBridges[len(expectedBridges)-1].DepositCount)
 	require.NoError(t, err)
 	log.Infof("expectedRoot: %s lastBlock: %d lastFinalized:%d DepositCount:%d ", common.Hash(expectedRoot).Hex(), lastBlock, lb, expectedBridges[len(expectedBridges)-1].DepositCount)
-	for i := 79; i >= 00; i-- {
+	for i := 79; i >= 0; i-- {
 		root, err := setup.L1Environment.BridgeSync.GetExitRootByIndex(ctx, uint32(i))
 		require.NoError(t, err, fmt.Sprintf("DepositCount:%d", i))
 		log.Infof("DepositCount:%d root: %s", i, root.Hash.Hex())

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -146,7 +146,7 @@ type Claim struct {
 }
 
 // decodeEtrogCalldata decodes claim calldata for Etrog fork
-func (c *Claim) decodeEtrogCalldata(data []any) (bool, error) {
+func (c *Claim) decodeEtrogCalldata(senderAddr common.Address, data []any) (bool, error) {
 	// Unpack method inputs. Note that both claimAsset and claimMessage have the same interface
 	// for the relevant parts
 	// claimAsset/claimMessage(
@@ -211,12 +211,13 @@ func (c *Claim) decodeEtrogCalldata(data []any) (bool, error) {
 	}
 
 	c.GlobalExitRoot = crypto.Keccak256Hash(c.MainnetExitRoot.Bytes(), c.RollupExitRoot.Bytes())
+	c.FromAddress = senderAddr
 
 	return true, nil
 }
 
 // decodePreEtrogCalldata decodes the claim calldata for pre-Etrog forks
-func (c *Claim) decodePreEtrogCalldata(data []any) (bool, error) {
+func (c *Claim) decodePreEtrogCalldata(senderAddr common.Address, data []any) (bool, error) {
 	// claimMessage/claimAsset(
 	// 	0: bytes32[32] smtProof,
 	// 	1: uint32 index,
@@ -271,6 +272,7 @@ func (c *Claim) decodePreEtrogCalldata(data []any) (bool, error) {
 	}
 
 	c.GlobalExitRoot = crypto.Keccak256Hash(c.MainnetExitRoot.Bytes(), c.RollupExitRoot.Bytes())
+	c.FromAddress = senderAddr
 
 	return true, nil
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -60,9 +60,11 @@ var (
 type Bridge struct {
 	BlockNum           uint64         `meddler:"block_num" json:"block_num"`
 	BlockPos           uint64         `meddler:"block_pos" json:"block_pos"`
+	FromAddress        common.Address `meddler:"from_address,address" json:"from_address"`
+	TxHash             common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
+	Calldata           []byte         `meddler:"calldata" json:"calldata"`
 	BlockTimestamp     uint64         `meddler:"block_timestamp" json:"block_timestamp"`
 	LeafType           uint8          `meddler:"leaf_type" json:"leaf_type"`
-	FromAddress        common.Address `meddler:"from_address,address" json:"from_address"`
 	OriginNetwork      uint32         `meddler:"origin_network" json:"origin_network"`
 	OriginAddress      common.Address `meddler:"origin_address" json:"origin_address"`
 	DestinationNetwork uint32         `meddler:"destination_network" json:"destination_network"`
@@ -70,8 +72,6 @@ type Bridge struct {
 	Amount             *big.Int       `meddler:"amount,bigint" json:"amount"`
 	Metadata           []byte         `meddler:"metadata" json:"metadata"`
 	DepositCount       uint32         `meddler:"deposit_count" json:"deposit_count"`
-	TxHash             common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
-	Calldata           []byte         `meddler:"calldata" json:"calldata"`
 }
 
 // Cant change the Hash() here after adding BlockTimestamp, TxHash. Might affect previous versions
@@ -128,6 +128,7 @@ type Claim struct {
 	BlockNum            uint64         `meddler:"block_num"`
 	BlockPos            uint64         `meddler:"block_pos"`
 	FromAddress         common.Address `meddler:"from_address,address"`
+	TxHash              common.Hash    `meddler:"tx_hash,hash"`
 	GlobalIndex         *big.Int       `meddler:"global_index,bigint"`
 	OriginNetwork       uint32         `meddler:"origin_network"`
 	OriginAddress       common.Address `meddler:"origin_address"`
@@ -142,7 +143,6 @@ type Claim struct {
 	Metadata            []byte         `meddler:"metadata"`
 	IsMessage           bool           `meddler:"is_message"`
 	BlockTimestamp      uint64         `meddler:"block_timestamp"`
-	TxHash              common.Hash    `meddler:"tx_hash,hash"`
 }
 
 // decodeEtrogCalldata decodes claim calldata for Etrog fork

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -62,6 +62,7 @@ type Bridge struct {
 	BlockPos           uint64         `meddler:"block_pos" json:"block_pos"`
 	BlockTimestamp     uint64         `meddler:"block_timestamp" json:"block_timestamp"`
 	LeafType           uint8          `meddler:"leaf_type" json:"leaf_type"`
+	FromAddress        common.Address `meddler:"from_address,address" json:"from_address"`
 	OriginNetwork      uint32         `meddler:"origin_network" json:"origin_network"`
 	OriginAddress      common.Address `meddler:"origin_address" json:"origin_address"`
 	DestinationNetwork uint32         `meddler:"destination_network" json:"destination_network"`
@@ -70,7 +71,6 @@ type Bridge struct {
 	Metadata           []byte         `meddler:"metadata" json:"metadata"`
 	DepositCount       uint32         `meddler:"deposit_count" json:"deposit_count"`
 	TxHash             common.Hash    `meddler:"tx_hash,hash" json:"tx_hash"`
-	FromAddress        common.Address `meddler:"from_address,address" json:"from_address"`
 	Calldata           []byte         `meddler:"calldata" json:"calldata"`
 }
 
@@ -127,6 +127,7 @@ func (b *BridgeResponse) MarshalJSON() ([]byte, error) {
 type Claim struct {
 	BlockNum            uint64         `meddler:"block_num"`
 	BlockPos            uint64         `meddler:"block_pos"`
+	FromAddress         common.Address `meddler:"from_address,address"`
 	GlobalIndex         *big.Int       `meddler:"global_index,bigint"`
 	OriginNetwork       uint32         `meddler:"origin_network"`
 	OriginAddress       common.Address `meddler:"origin_address"`
@@ -142,7 +143,6 @@ type Claim struct {
 	IsMessage           bool           `meddler:"is_message"`
 	BlockTimestamp      uint64         `meddler:"block_timestamp"`
 	TxHash              common.Hash    `meddler:"tx_hash,hash"`
-	FromAddress         common.Address `meddler:"from_address,address"`
 }
 
 // decodeEtrogCalldata decodes claim calldata for Etrog fork

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1421,6 +1421,7 @@ func TestDecodePreEtrogCalldata_Valid(t *testing.T) {
 	originAddress := common.HexToAddress("0x0a0a")
 	amount := big.NewInt(150)
 	destinationAddr := common.HexToAddress("0x0b0b")
+	zeroAddr := common.HexToAddress("0x0")
 
 	proof := types.Proof{}
 	for i := range types.DefaultHeight {
@@ -1463,7 +1464,7 @@ func TestDecodePreEtrogCalldata_Valid(t *testing.T) {
 	claimAssetData, err := method.Inputs.Unpack(claimAssetInput[4:])
 	require.NoError(t, err)
 
-	isFound, err := actualClaim.decodePreEtrogCalldata(claimAssetData)
+	isFound, err := actualClaim.decodePreEtrogCalldata(zeroAddr, claimAssetData)
 	require.NoError(t, err)
 	require.True(t, isFound)
 
@@ -1504,6 +1505,7 @@ func TestDecodePreEtrogCalldata(t *testing.T) {
 		metadata               = []byte("mock metadata")
 		destinationNetwork     = uint32(1)
 		invalidTypePlaceholder = "invalidType"
+		zeroAddr               = common.HexToAddress("0x0")
 	)
 
 	tests := []struct {
@@ -1660,7 +1662,7 @@ func TestDecodePreEtrogCalldata(t *testing.T) {
 				Metadata:           nil,
 			}
 
-			match, err := claim.decodePreEtrogCalldata(tt.data)
+			match, err := claim.decodePreEtrogCalldata(zeroAddr, tt.data)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -1681,6 +1683,7 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 		metadata               = []byte("mock metadata")
 		destinationNetwork     = uint32(1)
 		invalidTypePlaceholder = "invalidType"
+		zeroAddr               = common.HexToAddress("0x0")
 	)
 
 	tests := []struct {
@@ -1857,7 +1860,7 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			claim := &Claim{GlobalIndex: globalIndex}
 
-			isDecoded, err := claim.decodeEtrogCalldata(tt.data)
+			isDecoded, err := claim.decodeEtrogCalldata(zeroAddr, tt.data)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -528,7 +528,7 @@ func runBridgeSyncL1IfNeeded(
 		cfg.RetryAfterErrorPeriod.Duration,
 		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
-		false,
+		true,
 		cfg.RequireStorageContentCompatibility,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

Populate `from_address` based on the tx sender for bridge and claim transactions.

Fixes #368 
