### PR TITLE
feat: bridge service return consistent error codes

### DIFF
--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	mocksbridgesync "github.com/agglayer/aggkit/bridgesync/mocks"
-	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/etherman"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/agglayer/aggkit/sync"
@@ -264,7 +263,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		pageNum := uint32(5)
 
 		tokenMappings, totalTokenMappings, err := s.GetTokenMappings(context.Background(), pageNum, pageSize)
-		require.ErrorIs(t, err, db.ErrNotFound)
+		require.ErrorContains(t, err, "provided offset is greater than the total token mappings count")
 		require.Equal(t, 0, totalTokenMappings)
 		require.Nil(t, tokenMappings)
 	})
@@ -388,7 +387,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		pageNum := uint32(5)
 
 		tokenMigrations, totalTokenMigrations, err := s.GetLegacyTokenMigrations(context.Background(), pageNum, pageSize)
-		require.ErrorIs(t, err, db.ErrNotFound)
+		require.ErrorContains(t, err, "provided offset is greater than the total legacy token migrations count")
 		require.Equal(t, 0, totalTokenMigrations)
 		require.Nil(t, tokenMigrations)
 	})

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -263,7 +263,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		pageNum := uint32(5)
 
 		tokenMappings, totalTokenMappings, err := s.GetTokenMappings(context.Background(), pageNum, pageSize)
-		require.ErrorContains(t, err, "provided offset is greater than the total token mappings count")
+		require.ErrorContains(t, err, "provided page number is invalid for given page size")
 		require.Equal(t, 0, totalTokenMappings)
 		require.Nil(t, tokenMappings)
 	})
@@ -387,7 +387,8 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		pageNum := uint32(5)
 
 		tokenMigrations, totalTokenMigrations, err := s.GetLegacyTokenMigrations(context.Background(), pageNum, pageSize)
-		require.ErrorContains(t, err, "provided offset is greater than the total legacy token migrations count")
+		require.ErrorContains(t, err,
+			"provided page number is invalid for given page size and total number of legacy token migrations")
 		require.Equal(t, 0, totalTokenMigrations)
 		require.Nil(t, tokenMigrations)
 	})

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -494,10 +494,10 @@ func (p *processor) GetBridgesPaged(
 	}
 	offset := (pageNumber - 1) * pageSize
 	if offset >= uint32(bridgesCount) {
-		p.log.Debugf("offset is greater than total bridges (page number=%d, page size=%d, total bridges=%d)",
-			pageNumber, pageSize, bridgesCount)
-		return nil, 0, fmt.Errorf("provided offset is greater than the total bridges count (offset=%d, total count=%d)",
-			offset, bridgesCount)
+		p.log.Debugf("provided page number is invalid for given page size and total number of bridges"+
+			" (page number=%d, page size=%d, total bridges=%d)", pageNumber, pageSize, bridgesCount)
+		return nil, 0, fmt.Errorf("provided page number is invalid for given page size and total number of bridges"+
+			" (page number=%d, page size=%d, total bridges=%d)", pageNumber, pageSize, bridgesCount)
 	}
 	rows, err := p.queryPaged(tx, offset, pageSize, bridgeTableName, orderByClause, whereClause)
 	if err != nil {
@@ -549,10 +549,10 @@ func (p *processor) GetClaimsPaged(
 
 	offset := (pageNumber - 1) * pageSize
 	if offset >= uint32(claimsCount) {
-		p.log.Debugf("offset is greater than total claims (page number=%d, page size=%d, total claims=%d)",
-			pageNumber, pageSize, claimsCount)
-		return nil, 0, fmt.Errorf("provided offset is greater than the total claims count (offset=%d, total count=%d)",
-			offset, claimsCount)
+		p.log.Debugf("provided page number is invalid for given page size and total number of claims"+
+			" (page number=%d, page size=%d, total claims=%d)", pageNumber, pageSize, claimsCount)
+		return nil, 0, fmt.Errorf("provided page number is invalid for given page size and total number of claims"+
+			" (page number=%d, page size=%d, total claims=%d)", pageNumber, pageSize, claimsCount)
 	}
 
 	orderByClause := "block_num DESC, block_pos DESC"
@@ -609,13 +609,12 @@ func (p *processor) GetLegacyTokenMigrations(
 
 	offset := (pageNumber - 1) * pageSize
 	if offset >= uint32(legacyTokenMigrationsCount) {
-		p.log.Debugf(
-			"offset is greater than the total legacy token migrations "+
-				"(page number=%d, page size=%d, total legacy token migrations=%d)",
-			pageNumber, pageSize, legacyTokenMigrationsCount)
+		p.log.Debugf("provided page number is invalid for given page size and total number of legacy token migrations"+
+			" (page number=%d, page size=%d, total count=%d)", pageNumber, pageSize, legacyTokenMigrationsCount)
 		return nil, 0,
-			fmt.Errorf("provided offset is greater than the total legacy token migrations count (offset=%d, total count=%d)",
-				offset, legacyTokenMigrationsCount)
+			fmt.Errorf("provided page number is invalid for given page size and total number of legacy token migrations"+
+				" (page number=%d, page size=%d, total token migrations=%d)",
+				pageNumber, pageSize, legacyTokenMigrationsCount)
 	}
 
 	orderByClause := "block_num, block_pos DESC"
@@ -851,11 +850,10 @@ func (p *processor) GetTokenMappings(ctx context.Context, pageNumber, pageSize u
 
 	offset := (pageNumber - 1) * pageSize
 	if offset >= uint32(totalTokenMappings) {
-		p.log.Debugf("offset is greater than total token mappings (page number=%d, page size=%d, total token mappings=%d)",
-			pageNumber, pageSize, totalTokenMappings)
-		return nil, 0,
-			fmt.Errorf("provided offset is greater than the total token mappings count (offset=%d, total count=%d)",
-				offset, totalTokenMappings)
+		p.log.Debugf("provided page number is invalid for given page size and total number of token mappings"+
+			" (page number=%d, page size=%d, total token mappings=%d)", pageNumber, pageSize, totalTokenMappings)
+		return nil, 0, fmt.Errorf("provided page number is invalid for given page size and total number of token mappings"+
+			" (page number=%d, page size=%d, total token mappings=%d)", pageNumber, pageSize, totalTokenMappings)
 	}
 
 	tokenMappings, err := p.fetchTokenMappings(ctx, pageSize, offset)

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1065,7 +1065,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			depositCount:    nil,
 			expectedCount:   7,
 			expectedBridges: []*BridgeResponse{},
-			expectedError:   "provided offset is greater than the total",
+			expectedError:   "provided page number is invalid for given page size",
 		},
 		{
 			name:          "t7",
@@ -1189,12 +1189,12 @@ func TestGetClaimsPaged(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name:           "t4: offset is larger than total claims",
+			name:           "t4: invalid page number",
 			pageSize:       3,
 			page:           4,
 			expectedCount:  0,
 			expectedClaims: []*ClaimResponse{},
-			expectedError:  "provided offset is greater than the total",
+			expectedError:  "provided page number is invalid for given page size",
 		},
 	}
 
@@ -1294,7 +1294,7 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 			pageNumber:  6,
 			pageSize:    10,
 			expectedLen: 0,
-			expectedErr: "provided offset is greater than the total",
+			expectedErr: "provided page number is invalid for given page size",
 		},
 	}
 

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -993,7 +993,7 @@ func TestGetBridgesPaged(t *testing.T) {
 		depositCount    *uint64
 		expectedCount   int
 		expectedBridges []*BridgeResponse
-		expectedError   error
+		expectedError   string
 	}{
 		{
 			name:          "t1",
@@ -1004,7 +1004,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			expectedBridges: []*BridgeResponse{
 				{Bridge: Bridge{DepositCount: 6, BlockNum: 7, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[6]},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:          "t2",
@@ -1021,7 +1021,7 @@ func TestGetBridgesPaged(t *testing.T) {
 				{Bridge: Bridge{DepositCount: 1, BlockNum: 2, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[1]},
 				{Bridge: Bridge{DepositCount: 0, BlockNum: 1, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[1]},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:          "t3",
@@ -1034,7 +1034,7 @@ func TestGetBridgesPaged(t *testing.T) {
 				{Bridge: Bridge{DepositCount: 2, BlockNum: 3, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[2]},
 				{Bridge: Bridge{DepositCount: 1, BlockNum: 2, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[1]},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:          "t4",
@@ -1045,7 +1045,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			expectedBridges: []*BridgeResponse{
 				{Bridge: Bridge{DepositCount: 1, BlockNum: 2, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[1]},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:          "t5",
@@ -1056,7 +1056,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			expectedBridges: []*BridgeResponse{
 				{Bridge: Bridge{DepositCount: 1, BlockNum: 2, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[2]},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:            "t6",
@@ -1065,7 +1065,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			depositCount:    nil,
 			expectedCount:   7,
 			expectedBridges: []*BridgeResponse{},
-			expectedError:   db.ErrNotFound,
+			expectedError:   "provided offset is greater than the total",
 		},
 		{
 			name:          "t7",
@@ -1076,7 +1076,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			expectedBridges: []*BridgeResponse{
 				{Bridge: Bridge{DepositCount: 0, BlockNum: 1, Amount: big.NewInt(1)}, BridgeHash: bridgeHashMap[0]},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 	}
 
@@ -1089,8 +1089,8 @@ func TestGetBridgesPaged(t *testing.T) {
 			ctx := context.Background()
 			bridges, count, err := p.GetBridgesPaged(ctx, tc.page, tc.pageSize, tc.depositCount)
 
-			if tc.expectedError != nil {
-				require.Equal(t, tc.expectedError, err)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedBridges, bridges)
@@ -1149,7 +1149,7 @@ func TestGetClaimsPaged(t *testing.T) {
 		page           uint32
 		expectedCount  int
 		expectedClaims []*ClaimResponse
-		expectedError  error
+		expectedError  string
 	}{
 		{
 			name:          "t1",
@@ -1159,7 +1159,7 @@ func TestGetClaimsPaged(t *testing.T) {
 			expectedClaims: []*ClaimResponse{
 				{BlockNum: 5, GlobalIndex: big.NewInt(5), Amount: big.NewInt(1)},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:          "t2",
@@ -1174,7 +1174,7 @@ func TestGetClaimsPaged(t *testing.T) {
 				{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
 				{BlockNum: 1, GlobalIndex: num2, Amount: big.NewInt(1)},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:          "t3",
@@ -1186,7 +1186,7 @@ func TestGetClaimsPaged(t *testing.T) {
 				{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1)},
 				{BlockNum: 1, GlobalIndex: num2, Amount: big.NewInt(1)},
 			},
-			expectedError: nil,
+			expectedError: "",
 		},
 		{
 			name:           "t4: offset is larger than total claims",
@@ -1194,7 +1194,7 @@ func TestGetClaimsPaged(t *testing.T) {
 			page:           4,
 			expectedCount:  0,
 			expectedClaims: []*ClaimResponse{},
-			expectedError:  db.ErrNotFound,
+			expectedError:  "provided offset is greater than the total",
 		},
 	}
 
@@ -1207,8 +1207,8 @@ func TestGetClaimsPaged(t *testing.T) {
 			ctx := context.Background()
 			claims, count, err := p.GetClaimsPaged(ctx, tc.page, tc.pageSize)
 
-			if tc.expectedError != nil {
-				require.Equal(t, tc.expectedError, err)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedClaims, claims)
@@ -1266,35 +1266,35 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 		pageNumber  uint32
 		pageSize    uint32
 		expectedLen int
-		expectedErr error
+		expectedErr string
 	}{
 		{
 			name:        "First page",
 			pageNumber:  1,
 			pageSize:    10,
 			expectedLen: 10,
-			expectedErr: nil,
+			expectedErr: "",
 		},
 		{
 			name:        "Second page",
 			pageNumber:  2,
 			pageSize:    5,
 			expectedLen: 5,
-			expectedErr: nil,
+			expectedErr: "",
 		},
 		{
 			name:        "Last page",
 			pageNumber:  5,
 			pageSize:    10,
 			expectedLen: 10,
-			expectedErr: nil,
+			expectedErr: "",
 		},
 		{
 			name:        "Page out of range",
 			pageNumber:  6,
 			pageSize:    10,
 			expectedLen: 0,
-			expectedErr: db.ErrNotFound,
+			expectedErr: "provided offset is greater than the total",
 		},
 	}
 
@@ -1304,8 +1304,8 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 			t.Parallel()
 
 			result, totalTokenMappings, err := p.GetTokenMappings(context.Background(), tt.pageNumber, tt.pageSize)
-			if tt.expectedErr != nil {
-				require.ErrorIs(t, err, tt.expectedErr)
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Len(t, result, tt.expectedLen)

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -228,8 +228,7 @@ func (b *BridgeEndpoints) L1InfoTreeIndexForBridge(networkID uint32, depositCoun
 		}
 		return l1InfoTreeIndex, nil
 	}
-	return nil, rpc.NewRPCError(
-		rpc.DefaultErrorCode,
+	return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 		fmt.Sprintf("this client does not support network %d", networkID),
 	)
 }
@@ -265,8 +264,7 @@ func (b *BridgeEndpoints) InjectedInfoAfterIndex(networkID uint32, l1InfoTreeInd
 		}
 		return info, nil
 	}
-	return nil, rpc.NewRPCError(
-		rpc.DefaultErrorCode,
+	return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 		fmt.Sprintf("this client does not support network %d", networkID),
 	)
 }
@@ -330,8 +328,7 @@ func (b *BridgeEndpoints) GetBridges(networkID uint32, pageNumber, pageSize *uin
 			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get bridges, error: %s", err))
 		}
 	default:
-		return nil, rpc.NewRPCError(
-			rpc.DefaultErrorCode,
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 			fmt.Sprintf("this client does not support network %d", networkID),
 		)
 	}
@@ -380,8 +377,7 @@ func (b *BridgeEndpoints) GetClaims(networkID uint32, pageNumber, pageSize *uint
 			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get claims, error: %s", err))
 		}
 	default:
-		return nil, rpc.NewRPCError(
-			rpc.DefaultErrorCode,
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 			fmt.Sprintf("this client does not support network %d", networkID),
 		)
 	}
@@ -425,22 +421,19 @@ func (b *BridgeEndpoints) ClaimProof(
 	case networkID == b.networkID:
 		localExitRoot, err := b.l1InfoTree.GetLocalExitRoot(ctx, networkID, info.RollupExitRoot)
 		if err != nil {
-			return nil, rpc.NewRPCError(
-				rpc.DefaultErrorCode,
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
 				fmt.Sprintf("failed to get local exit root from rollup exit tree, error: %s", err),
 			)
 		}
 		proofLocalExitRoot, err = b.bridgeL2.GetProof(ctx, depositCount, localExitRoot)
 		if err != nil {
-			return nil, rpc.NewRPCError(
-				rpc.DefaultErrorCode,
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
 				fmt.Sprintf("failed to get local exit proof, error: %s", err),
 			)
 		}
 
 	default:
-		return nil, rpc.NewRPCError(
-			rpc.DefaultErrorCode,
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 			fmt.Sprintf("this client does not support network %d", networkID),
 		)
 	}
@@ -464,11 +457,10 @@ func (b *BridgeEndpoints) SponsorClaim(claim claimsponsor.Claim) (interface{}, r
 	c.Add(ctx, 1)
 
 	if b.sponsor == nil {
-		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, "this client does not support claim sponsoring")
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode, "this client does not support claim sponsoring")
 	}
 	if claim.DestinationNetwork != b.networkID {
-		return nil, rpc.NewRPCError(
-			rpc.DefaultErrorCode,
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 			fmt.Sprintf("this client only sponsors claims for network %d", b.networkID),
 		)
 	}
@@ -491,7 +483,7 @@ func (b *BridgeEndpoints) GetSponsoredClaimStatus(globalIndex *big.Int) (interfa
 	c.Add(ctx, 1)
 
 	if b.sponsor == nil {
-		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, "this client does not support claim sponsoring")
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode, "this client does not support claim sponsoring")
 	}
 	claim, err := b.sponsor.GetClaim(globalIndex)
 	if err != nil {
@@ -632,8 +624,7 @@ func (b *BridgeEndpoints) GetLastReorgEvent(networkID uint32) (interface{}, rpc.
 			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to last reorg event, error: %s", err))
 		}
 	default:
-		return nil, rpc.NewRPCError(
-			rpc.DefaultErrorCode,
+		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
 			fmt.Sprintf("this client does not support network %d", networkID),
 		)
 	}

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -469,7 +469,7 @@ func (b *BridgeEndpoints) SponsorClaim(claim claimsponsor.Claim) (interface{}, r
 	}
 	if claim.DestinationNetwork != b.networkID {
 		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
-			fmt.Sprintf("this client only sponsors claims for network %d", b.networkID),
+			fmt.Sprintf("this client only sponsors claims for destination network %d", b.networkID),
 		)
 	}
 	if err := b.sponsor.AddClaimToQueue(&claim); err != nil {

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -412,12 +412,10 @@ func (b *BridgeEndpoints) ClaimProof(
 
 	info, err := b.l1InfoTree.GetInfoByIndex(ctx, l1InfoTreeIndex)
 	if err != nil {
-		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get info from the tree: %s", err))
+		return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+			fmt.Sprintf("failed to get l1 info tree leaf for index %d: %s", l1InfoTreeIndex, err))
 	}
-	proofRollupExitRoot, err := b.l1InfoTree.GetRollupExitTreeMerkleProof(ctx, networkID, info.RollupExitRoot)
-	if err != nil {
-		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get rollup exit proof, error: %s", err))
-	}
+
 	var proofLocalExitRoot tree.Proof
 	switch {
 	case networkID == mainnetNetworkID:
@@ -445,6 +443,12 @@ func (b *BridgeEndpoints) ClaimProof(
 			fmt.Sprintf("this client does not support network %d", networkID),
 		)
 	}
+
+	proofRollupExitRoot, err := b.l1InfoTree.GetRollupExitTreeMerkleProof(ctx, networkID, info.RollupExitRoot)
+	if err != nil {
+		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get rollup exit proof, error: %s", err))
+	}
+
 	return types.ClaimProof{
 		ProofLocalExitRoot:  proofLocalExitRoot,
 		ProofRollupExitRoot: proofRollupExitRoot,

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -212,7 +212,7 @@ func (b *BridgeEndpoints) L1InfoTreeIndexForBridge(networkID uint32, depositCoun
 		// as it's expected that it will take some time for the L1 Info tree to be updated
 		if err != nil {
 			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf(
-				"failed to get l1InfoTreeIndex for networkID %d and deposit count %d, error: %s", networkID, depositCount, err),
+				"failed to get l1 info tree index for L1 network and deposit count %d, error: %s", depositCount, err),
 			)
 		}
 		return l1InfoTreeIndex, nil
@@ -229,7 +229,7 @@ func (b *BridgeEndpoints) L1InfoTreeIndexForBridge(networkID uint32, depositCoun
 		return l1InfoTreeIndex, nil
 	}
 	return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
-		fmt.Sprintf("this client does not support network %d", networkID),
+		fmt.Sprintf("this client does not support network (ID=%d)", networkID),
 	)
 }
 

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -495,7 +495,8 @@ func (b *BridgeEndpoints) GetSponsoredClaimStatus(globalIndex *big.Int) (interfa
 	}
 	claim, err := b.sponsor.GetClaim(globalIndex)
 	if err != nil {
-		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get claim status, error: %s", err))
+		return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+			fmt.Sprintf("failed to get claim status for global index %d, error: %s", globalIndex, err))
 	}
 	return claim.Status, nil
 }

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -178,7 +178,7 @@ func (b *BridgeEndpoints) GetLegacyTokenMigrations(
 		if err != nil {
 			return nil,
 				rpc.NewRPCError(rpc.DefaultErrorCode,
-					fmt.Sprintf("failed to get legacy token migrations for L2 network %d, error: %s", networkID, err))
+					fmt.Sprintf("failed to get legacy token migrations for L2 network (ID=%d), error: %s", networkID, err))
 		}
 
 	default:
@@ -620,12 +620,14 @@ func (b *BridgeEndpoints) GetLastReorgEvent(networkID uint32) (interface{}, rpc.
 	case networkID == mainnetNetworkID:
 		reorgEvent, err = b.bridgeL1.GetLastReorgEvent(ctx)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to last reorg event, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get last reorg event for the L1 network, error: %s", err))
 		}
 	case networkID == b.networkID:
 		reorgEvent, err = b.bridgeL2.GetLastReorgEvent(ctx)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to last reorg event, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get last reorg event for the L2 network (ID=%d), error: %s", networkID, err))
 		}
 	default:
 		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -249,18 +249,22 @@ func (b *BridgeEndpoints) InjectedInfoAfterIndex(networkID uint32, l1InfoTreeInd
 	if networkID == mainnetNetworkID {
 		info, err := b.l1InfoTree.GetInfoByIndex(ctx, l1InfoTreeIndex)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get global exit root, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get L1 info tree leaf for index %d, error: %s", l1InfoTreeIndex, err))
 		}
 		return info, nil
 	}
 	if networkID == b.networkID {
 		e, err := b.injectedGERs.GetFirstGERAfterL1InfoTreeIndex(ctx, l1InfoTreeIndex)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get global exit root, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get injected global exit root for L1 info tree index %d, error: %s", l1InfoTreeIndex, err))
 		}
 		info, err := b.l1InfoTree.GetInfoByIndex(ctx, e.L1InfoTreeIndex)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get global exit root, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get L1 info tree leaf for index %d na L2 network (ID=%d), error: %s",
+					e.L1InfoTreeIndex, networkID, err))
 		}
 		return info, nil
 	}

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -116,7 +116,7 @@ func (b *BridgeEndpoints) GetTokenMappings(networkID uint32, pageNumber, pageSiz
 		if err != nil {
 			return nil,
 				rpc.NewRPCError(rpc.DefaultErrorCode,
-					fmt.Sprintf("failed to get token mappings for L2 network %d, error: %s", networkID, err))
+					fmt.Sprintf("failed to get token mappings for the L2 network (ID=%d), error: %s", networkID, err))
 		}
 
 	default:
@@ -320,12 +320,14 @@ func (b *BridgeEndpoints) GetBridges(networkID uint32, pageNumber, pageSize *uin
 	case networkID == mainnetNetworkID:
 		bridges, count, err = b.bridgeL1.GetBridgesPaged(ctx, pageNumberU32, pageSizeU32, depositCount)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get bridges, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get bridges for the L1 network, error: %s", err))
 		}
 	case networkID == b.networkID:
 		bridges, count, err = b.bridgeL2.GetBridgesPaged(ctx, pageNumberU32, pageSizeU32, depositCount)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get bridges, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get bridges for the L2 network (ID=%d), error: %s", networkID, err))
 		}
 	default:
 		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,
@@ -369,12 +371,14 @@ func (b *BridgeEndpoints) GetClaims(networkID uint32, pageNumber, pageSize *uint
 	case networkID == mainnetNetworkID:
 		claims, count, err = b.bridgeL1.GetClaimsPaged(ctx, pageNumberU32, pageSizeU32)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get claims, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get claims for the L1 network, error: %s", err))
 		}
 	case networkID == b.networkID:
 		claims, count, err = b.bridgeL2.GetClaimsPaged(ctx, pageNumberU32, pageSizeU32)
 		if err != nil {
-			return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("failed to get claims, error: %s", err))
+			return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+				fmt.Sprintf("failed to get claims for the L2 network (ID=%d), error: %s", networkID, err))
 		}
 	default:
 		return nil, rpc.NewRPCError(rpc.InvalidRequestErrorCode,

--- a/rpc/bridge_interfaces.go
+++ b/rpc/bridge_interfaces.go
@@ -16,10 +16,7 @@ type Bridger interface {
 	GetProof(ctx context.Context, depositCount uint32, localExitRoot common.Hash) (tree.Proof, error)
 	GetRootByLER(ctx context.Context, ler common.Hash) (*tree.Root, error)
 	GetBridgesPaged(
-		ctx context.Context,
-		pageNumber, pageSize uint32,
-		depositCount *uint64,
-	) ([]*bridgesync.BridgeResponse, int, error)
+		ctx context.Context, pageNumber, pageSize uint32, depositCount *uint64) ([]*bridgesync.BridgeResponse, int, error)
 	GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.TokenMapping, int, error)
 	GetLegacyTokenMigrations(
 		ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.LegacyTokenMigration, int, error)

--- a/rpc/bridge_test.go
+++ b/rpc/bridge_test.go
@@ -1017,7 +1017,7 @@ func TestInjectedInfoAfterIndex(t *testing.T) {
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
 			Return(
-				lastgersync.Event{
+				lastgersync.GlobalExitRootInfo{
 					GlobalExitRoot:  l1InfoTreeLeaf.GlobalExitRoot,
 					L1InfoTreeIndex: l1InfoTreeLeaf.L1InfoTreeIndex,
 				}, nil)
@@ -1059,7 +1059,7 @@ func TestInjectedInfoAfterIndex(t *testing.T) {
 		bridgeMocks = newBridgeWithMocks(t, l2NetworkID)
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
-			Return(lastgersync.Event{}, errors.New(barErrMsg))
+			Return(lastgersync.GlobalExitRootInfo{}, errors.New(barErrMsg))
 
 		result, err := bridgeMocks.bridge.InjectedInfoAfterIndex(l2NetworkID, l1InfoTreeLeaf.L1InfoTreeIndex)
 		require.NotNil(t, err)
@@ -1077,7 +1077,7 @@ func TestInjectedInfoAfterIndex(t *testing.T) {
 
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
-			Return(lastgersync.Event{
+			Return(lastgersync.GlobalExitRootInfo{
 				GlobalExitRoot:  l1InfoTreeLeaf.GlobalExitRoot,
 				L1InfoTreeIndex: l1InfoTreeLeaf.L1InfoTreeIndex,
 			}, nil)

--- a/rpc/openrpc.json
+++ b/rpc/openrpc.json
@@ -43,30 +43,36 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "blockNum": {
+                  "block_num": {
                     "$ref": "#/components/schemas/BlockNumber"
                   },
-                  "blockPos": {
+                  "block_pos": {
                     "$ref": "#/components/schemas/BlockPosition"
                   },
-                  "blockTimestamp": {
+                  "block_timestamp": {
                     "type": "integer",
                     "description": "The unix timestamp for when the block was collated"
                   },
-                  "txHash": {
+                  "tx_hash": {
                     "$ref": "#/components/schemas/Keccak"
                   },
-                  "originNetwork": {
+                  "origin_network": {
                     "$ref": "#/components/schemas/OriginNetwork"
                   },
-                  "originTokenAddress": {
+                  "origin_token_address": {
                     "$ref": "#/components/schemas/OriginTokenAddress"
                   },
-                  "wrappedTokenAddress": {
+                  "wrapped_token_address": {
                     "$ref": "#/components/schemas/Address"
                   },
                   "metadata": {
                     "$ref": "#/components/schemas/Bytes"
+                  },
+                  "calldata": {
+                    "$ref": "#/components/schemas/Bytes"
+                  },
+                  "token_type": {
+                    "$ref": "#/components/schemas/TokenType"
                   }
                 }
               }
@@ -126,25 +132,25 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "blockNum": {
+                  "block_num": {
                     "$ref": "#/components/schemas/BlockNumber"
                   },
-                  "blockPos": {
+                  "block_pos": {
                     "$ref": "#/components/schemas/BlockPosition"
                   },
-                  "leafType": {
+                  "leaf_type": {
                     "$ref": "#/components/schemas/LeafType"
                   },
-                  "originNetwork": {
+                  "origin_network": {
                     "$ref": "#/components/schemas/OriginNetwork"
                   },
-                  "originAddress": {
+                  "origin_address": {
                     "$ref": "#/components/schemas/OriginTokenAddress"
                   },
-                  "destinationNetwork": {
+                  "destination_network": {
                     "$ref": "#/components/schemas/DestinationNetwork"
                   },
-                  "destinationAddress": {
+                  "destination_address": {
                     "$ref": "#/components/schemas/DestinationAddress"
                   },
                   "amount": {
@@ -218,10 +224,10 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "globalIndex": {
+                  "global_index": {
                     "$ref": "#/components/schemas/GlobalIndex"
                   },
-                  "destinationNetwork": {
+                  "destination_network": {
                     "$ref": "#/components/schemas/DestinationNetwork"
                   },
                   "txHash": {
@@ -230,19 +236,19 @@
                   "amount": {
                     "$ref": "#/components/schemas/Amount"
                   },
-                  "blockNum": {
+                  "block_num": {
                     "$ref": "#/components/schemas/BlockNumber"
                   },
                   "fromAddress": {
                     "$ref": "#/components/schemas/Address"
                   },
-                  "destinationAddress": {
+                  "destination_address": {
                     "$ref": "#/components/schemas/DestinationAddress"
                   },
-                  "originAddress": {
+                  "origin_address": {
                     "$ref": "#/components/schemas/OriginTokenAddress"
                   },
-                  "originNetwork": {
+                  "origin_network": {
                     "$ref": "#/components/schemas/OriginNetwork"
                   },
                   "blockTimestamp": {
@@ -255,6 +261,83 @@
             "count": {
               "type": "integer",
               "description": "The total number of claims."
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "bridge_getLegacyTokenMigrations",
+      "summary": "Get Legacy Token Migrations",
+      "description": "Returns the legacy token migrations for the given network.",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/NetworkID"
+        },
+        {
+          "name": "page",
+          "description": "The page number for pagination.",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        },
+        {
+          "name": "pageSize",
+          "description": "The number of items per page for pagination.",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The legacy token migrations result.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "legacyTokenMigrations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "block_num": {
+                    "$ref": "#/components/schemas/BlockNumber"
+                  },
+                  "block_pos": {
+                    "$ref": "#/components/schemas/BlockPosition"
+                  },
+                  "block_timestamp": {
+                    "type": "integer",
+                    "description": "The unix timestamp for when the block was collated"
+                  },
+                  "tx_hash": {
+                    "$ref": "#/components/schemas/Keccak"
+                  },
+                  "sender": {
+                    "$ref": "#/components/schemas/Address"
+                  },
+                  "legacy_token_address": {
+                    "$ref": "#/components/schemas/Address"
+                  },
+                  "updated_token_address": {
+                    "$ref": "#/components/schemas/OriginTokenAddress"
+                  },
+                  "amount": {
+                    "$ref": "#/components/schemas/Integer"
+                  },
+                  "calldata": {
+                    "$ref": "#/components/schemas/Bytes"
+                  }
+                }
+              }
+            },
+            "totalTokenMigrations": {
+              "type": "integer",
+              "description": "The total number of legacy token migrations."
             }
           }
         }
@@ -364,10 +447,14 @@
               "description": "Ending block number of the reorg."
             }
           },
-          "required": ["detected_at", "from_block", "to_block"]
+          "required": [
+            "detected_at",
+            "from_block",
+            "to_block"
+          ]
         }
       }
-    },    
+    },
     {
       "name": "bridge_getSponsoredClaimStatus",
       "summary": "Gets the proof needed to perform a claim for a given bridge",
@@ -427,7 +514,7 @@
         }
       },
       "GlobalIndex": {
-        "name": "globalIndex",
+        "name": "global_index",
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/GlobalIndex"
@@ -472,13 +559,13 @@
         "description": "The hex representation of the Keccak 256 of the RLP encoded block"
       },
       "BlockNumber": {
-        "title": "blockNumber",
+        "title": "block_number",
         "type": "string",
         "description": "The hex representation of the block's height",
         "$ref": "#/components/schemas/Integer"
       },
       "BlockPosition": {
-        "title": "blockPosition",
+        "title": "block_position",
         "type": "string",
         "description": "The hex representation of the position inside the block",
         "$ref": "#/components/schemas/Integer"
@@ -506,10 +593,10 @@
         "type": "object",
         "readOnly": true,
         "properties": {
-          "blockNumber": {
+          "block_number": {
             "$ref": "#/components/schemas/BlockNumber"
           },
-          "blockPosition": {
+          "block_position": {
             "$ref": "#/components/schemas/BlockPosition"
           },
           "previousBlockHash": {
@@ -523,10 +610,10 @@
           "l1InfoTreeIndex": {
             "$ref": "#/components/schemas/L1InfoTreeIndex"
           },
-          "mainnetExitRoot": {
+          "mainnet_exit_root": {
             "$ref": "#/components/schemas/Keccak"
           },
-          "rollupExitRoot": {
+          "rollup_exit_root": {
             "$ref": "#/components/schemas/Keccak"
           },
           "globalExitRoot": {
@@ -572,37 +659,37 @@
         }
       },
       "LeafType": {
-        "title": "leafType",
+        "title": "leaf_type",
         "type": "string",
         "description": "The hex representation of the leaf type",
         "$ref": "#/components/schemas/Integer"
       },
       "GlobalIndex": {
-        "title": "globalIndex",
+        "title": "global_index",
         "type": "string",
         "description": "The hex representation of the global index",
         "$ref": "#/components/schemas/Integer"
       },
       "OriginNetwork": {
-        "title": "originNetwork",
+        "title": "origin_network",
         "type": "string",
         "description": "The hex representation of the origin network ID of the token",
         "$ref": "#/components/schemas/Integer"
       },
       "OriginTokenAddress": {
-        "title": "originTokenAddress",
+        "title": "origin_token_address",
         "type": "string",
         "description": "address of the token on it's origin network",
         "$ref": "#/components/schemas/Address"
       },
       "DestinationNetwork": {
-        "title": "destinationNetwork",
+        "title": "destination_network",
         "type": "string",
         "description": "The hex representation of the destination network ID",
         "$ref": "#/components/schemas/Integer"
       },
       "DestinationAddress": {
-        "title": "destinationAddress",
+        "title": "destination_address",
         "type": "string",
         "description": "address of the receiver of the bridge",
         "$ref": "#/components/schemas/Address"
@@ -622,7 +709,7 @@
         "type": "object",
         "readOnly": true,
         "properties": {
-          "leafType": {
+          "leaf_type": {
             "$ref": "#/components/schemas/LeafType"
           },
           "proofLocalExitRoot": {
@@ -631,25 +718,25 @@
           "proofRollupExitRoot": {
             "$ref": "#/components/schemas/ProofRollupExitRoot"
           },
-          "globalIndex": {
+          "global_index": {
             "$ref": "#/components/schemas/GlobalIndex"
           },
-          "mainnetExitRoot": {
+          "mainnet_exit_root": {
             "$ref": "#/components/schemas/Keccak"
           },
-          "rollupExitRoot": {
+          "rollup_exit_root": {
             "$ref": "#/components/schemas/Keccak"
           },
-          "originNetwork": {
+          "origin_network": {
             "$ref": "#/components/schemas/OriginNetwork"
           },
-          "originTokenAddress": {
+          "origin_token_address": {
             "$ref": "#/components/schemas/OriginTokenAddress"
           },
-          "destinationNetwork": {
+          "destination_network": {
             "$ref": "#/components/schemas/DestinationNetwork"
           },
-          "destinationAddress": {
+          "destination_address": {
             "$ref": "#/components/schemas/DestinationAddress"
           },
           "amount": {
@@ -668,6 +755,18 @@
           "pending",
           "failed",
           "success"
+        ]
+      },
+      "TokenType": {
+        "type": "integer",
+        "description": "Token type: 0 = WrappedToken, 1 = SovereignToken",
+        "enum": [
+          0,
+          1
+        ],
+        "enumNames": [
+          "WrappedToken",
+          "SovereignToken"
         ]
       }
     }


### PR DESCRIPTION
## Description

- Propagate consistent error codes in all endpoints exposed by the bridge service.
- Return empty result set, instead of error in case the result is not found.
- Update the Open RPC definition with the missing `bridge_getLegacyTokenMigrations` function.

Fixes #392 
