### PR TITLE
fix: optimize `Range` function on `CertificateBuildParams`

### DIFF
--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -40,11 +41,17 @@ func (c *CertificateBuildParams) Range(fromBlock, toBlock uint64) (*CertificateB
 	if c.FromBlock > fromBlock || c.ToBlock < toBlock {
 		return nil, fmt.Errorf("invalid range")
 	}
+
+	span := toBlock - fromBlock + 1
+	fullSpan := c.ToBlock - c.FromBlock + 1
+
 	newCert := &CertificateBuildParams{
-		FromBlock:                      fromBlock,
-		ToBlock:                        toBlock,
-		Bridges:                        make([]bridgesync.Bridge, 0),
-		Claims:                         make([]bridgesync.Claim, 0),
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Bridges: make([]bridgesync.Bridge, 0,
+			aggkitcommon.EstimateSliceCapacity(len(c.Bridges), span, fullSpan)),
+		Claims: make([]bridgesync.Claim, 0,
+			aggkitcommon.EstimateSliceCapacity(len(c.Claims), span, fullSpan)),
 		CreatedAt:                      c.CreatedAt,
 		RetryCount:                     c.RetryCount,
 		LastSentCertificate:            c.LastSentCertificate,

--- a/common/common.go
+++ b/common/common.go
@@ -132,3 +132,21 @@ func BigIntToLittleEndianBytes(n *big.Int) []byte {
 
 	return leBytes
 }
+
+// EstimateSliceCapacity estimates the capacity of a slice based on the total number
+// of elements, the span of interest, and the full span of the range.
+//
+// Parameters:
+//   - total: The total number of elements.
+//   - span: The span of interest within the range.
+//   - fullSpan: The full span of the range.
+//
+// Returns:
+//   - An integer representing the estimated slice capacity. If fullSpan is 0, the
+//     function returns 0 to avoid division by zero.
+func EstimateSliceCapacity(total int, span, fullSpan uint64) int {
+	if fullSpan == 0 {
+		return 0
+	}
+	return int((uint64(total) * span) / fullSpan)
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -59,3 +59,83 @@ func TestAsLittleEndianSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestEstimateSliceCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		total    int
+		span     uint64
+		fullSpan uint64
+		expected int
+	}{
+		{
+			name:     "Zero fullSpan",
+			total:    100,
+			span:     50,
+			fullSpan: 0,
+			expected: 0,
+		},
+		{
+			name:     "Zero total",
+			total:    0,
+			span:     50,
+			fullSpan: 100,
+			expected: 0,
+		},
+		{
+			name:     "Zero span",
+			total:    100,
+			span:     0,
+			fullSpan: 100,
+			expected: 0,
+		},
+		{
+			name:     "Normal case",
+			total:    100,
+			span:     50,
+			fullSpan: 100,
+			expected: 50,
+		},
+		{
+			name:     "Span equals fullSpan",
+			total:    100,
+			span:     100,
+			fullSpan: 100,
+			expected: 100,
+		},
+		{
+			name:     "Span greater than fullSpan",
+			total:    100,
+			span:     150,
+			fullSpan: 100,
+			expected: 150,
+		},
+		{
+			name:     "Large values",
+			total:    1_000_000,
+			span:     500_000,
+			fullSpan: 1_000_000,
+			expected: 500_000,
+		},
+		{
+			name:     "random values test",
+			total:    57,
+			span:     198,
+			fullSpan: 213,
+			expected: 52,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := EstimateSliceCapacity(tt.total, tt.span, tt.fullSpan)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR optimizes the `Range()` on `CertificateBuildParams` struct which cuts the claims and bridges from the certificate based on the new range gotten from the prover.

The function now estimates the capacity of new slices to minimize the memory and CPU overhead.

Fixes # (issue)
