### PR TITLE
feat: enable `pprof`

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -148,9 +148,7 @@ func start(cliCtx *cli.Context) error {
 	}
 
 	if cfg.Profiling.ProfilingEnabled {
-		go pprof.StartProfilingHTTPServer(cfg.Profiling)
-	} else {
-		log.Info("Profiling server is disabled")
+		go pprof.StartProfilingHTTPServer(cliCtx.Context, cfg.Profiling)
 	}
 
 	waitSignal(nil)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/lastgersync"
 	"github.com/agglayer/aggkit/log"
+	"github.com/agglayer/aggkit/pprof"
 	"github.com/agglayer/aggkit/prometheus"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/agglayer/aggkit/rpc"
@@ -144,6 +145,12 @@ func start(cliCtx *cli.Context) error {
 		go startPrometheusHTTPServer(cfg.Prometheus)
 	} else {
 		log.Info("Prometheus metrics server is disabled")
+	}
+
+	if cfg.Profiling.ProfilingEnabled {
+		go pprof.StartProfilingHTTPServer(cfg.Profiling)
+	} else {
+		log.Info("Profiling server is disabled")
 	}
 
 	waitSignal(nil)

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/lastgersync"
 	"github.com/agglayer/aggkit/log"
+	"github.com/agglayer/aggkit/pprof"
 	"github.com/agglayer/aggkit/prometheus"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/mitchellh/mapstructure"
@@ -147,6 +148,9 @@ type Config struct {
 
 	// AggchainProofGen is the configuration of the Aggchain Proof Generation Tool
 	AggchainProofGen prover.Config
+
+	// Profiling is the configuration of the profiling service
+	Profiling pprof.Config
 }
 
 // Load loads the configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,9 @@ func TestLoadDefaultConfig(t *testing.T) {
 	require.Equal(t, cfg.AggSender.MaxSubmitCertificateRate.Interval.Duration, time.Hour)
 	require.Equal(t, cfg.L1InfoTreeSync.RequireStorageContentCompatibility, true)
 	require.Equal(t, ethermanconfig.RPCClientConfig{Mode: ethermanconfig.RPCModeBasic, URL: "http://localhost:8123"}, cfg.Common.L2RPC)
+	require.Equal(t, cfg.Profiling.ProfilingEnabled, false)
+	require.Equal(t, cfg.Profiling.ProfilingHost, "localhost")
+	require.Equal(t, cfg.Profiling.ProfilingPort, 6060)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -253,4 +253,9 @@ AggchainProofURL = "{{AggchainProofURL}}"
 SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 GlobalExitRootL2 = "{{L2Config.GlobalExitRootAddr}}"
 GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
+
+[Profiling]
+ProfilingHost = "localhost"
+ProfilingPort = 6060
+ProfilingEnabled = true
 `

--- a/config/default.go
+++ b/config/default.go
@@ -257,5 +257,5 @@ GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
 [Profiling]
 ProfilingHost = "localhost"
 ProfilingPort = 6060
-ProfilingEnabled = true
+ProfilingEnabled = false
 `

--- a/pprof/config.go
+++ b/pprof/config.go
@@ -1,0 +1,12 @@
+package pprof
+
+// Config represents the configuration settings for the profiling server.
+// It includes options to specify the host, port, and whether profiling is enabled.
+type Config struct {
+	// ProfilingHost is the address to bind the profiling server
+	ProfilingHost string `mapstructure:"ProfilingHost"`
+	// ProfilingPort is the port to bind the profiling server
+	ProfilingPort int `mapstructure:"ProfilingPort"`
+	// ProfilingEnabled is the flag to enable/disable the profiling server
+	ProfilingEnabled bool `mapstructure:"ProfilingEnabled"`
+}

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,0 +1,55 @@
+package pprof
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/agglayer/aggkit/log"
+	"github.com/agglayer/aggkit/prometheus"
+)
+
+// StartProfilingHTTPServer starts an HTTP server for profiling using the provided configuration.
+// It sets up endpoints for pprof profiling and listens on the specified host and port.
+// The server includes handlers for various pprof endpoints such as index, profile, cmdline,
+// symbol, and trace. The server's read and header timeouts are set to two minutes.
+//
+// Parameters:
+//   - c (Config): The configuration object containing the profiling host and port.
+//
+// Behavior:
+//   - Logs an error and returns if the TCP listener cannot be created.
+//   - Logs the port on which the profiling server is listening.
+//   - Handles server closure gracefully, logging a warning if the server is stopped
+//     or an error if the connection is closed unexpectedly.
+func StartProfilingHTTPServer(c Config) {
+	const two = 2
+	mux := http.NewServeMux()
+	address := fmt.Sprintf("%s:%d", c.ProfilingHost, c.ProfilingPort)
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		log.Errorf("failed to create tcp listener for profiling: %v", err)
+		return
+	}
+	mux.HandleFunc(prometheus.ProfilingIndexEndpoint, pprof.Index)
+	mux.HandleFunc(prometheus.ProfileEndpoint, pprof.Profile)
+	mux.HandleFunc(prometheus.ProfilingCmdEndpoint, pprof.Cmdline)
+	mux.HandleFunc(prometheus.ProfilingSymbolEndpoint, pprof.Symbol)
+	mux.HandleFunc(prometheus.ProfilingTraceEndpoint, pprof.Trace)
+	profilingServer := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: two * time.Minute,
+		ReadTimeout:       two * time.Minute,
+	}
+	log.Infof("profiling server listening on port %d", c.ProfilingPort)
+	if err := profilingServer.Serve(lis); err != nil {
+		if err == http.ErrServerClosed {
+			log.Warnf("http server for profiling stopped")
+			return
+		}
+		log.Errorf("closed http connection for profiling server: %v", err)
+		return
+	}
+}

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -1,6 +1,7 @@
 package pprof
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -18,8 +19,11 @@ func TestStartProfilingHttpServer(t *testing.T) {
 		ProfilingPort: 6060,
 	}
 
+	context, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Start the profiling server in a separate goroutine
-	go StartProfilingHTTPServer(Config{
+	go StartProfilingHTTPServer(context, Config{
 		ProfilingHost: config.ProfilingHost,
 		ProfilingPort: config.ProfilingPort,
 	})

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -1,0 +1,51 @@
+package pprof
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartProfilingHttpServer(t *testing.T) {
+	// Mock configuration
+	config := Config{
+		ProfilingHost: "127.0.0.1",
+		ProfilingPort: 6060,
+	}
+
+	// Start the profiling server in a separate goroutine
+	go StartProfilingHTTPServer(Config{
+		ProfilingHost: config.ProfilingHost,
+		ProfilingPort: config.ProfilingPort,
+	})
+
+	// Allow some time for the server to start
+	time.Sleep(1 * time.Second)
+
+	// Test if the server is listening
+	address := net.JoinHostPort(config.ProfilingHost, fmt.Sprintf("%d", config.ProfilingPort))
+	conn, err := net.Dial("tcp", address)
+	require.NoError(t, err, "failed to connect to profiling server")
+	conn.Close()
+
+	// Test if the endpoints are accessible
+	endpoints := []string{
+		prometheus.ProfilingIndexEndpoint,
+		prometheus.ProfileEndpoint,
+		prometheus.ProfilingCmdEndpoint,
+		prometheus.ProfilingSymbolEndpoint,
+		prometheus.ProfilingTraceEndpoint,
+	}
+
+	for _, endpoint := range endpoints {
+		resp, err := http.Get("http://" + address + endpoint)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code for endpoint %s: got %d, want %d", endpoint, resp.StatusCode, http.StatusOK)
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
## Description

This PR enables `pprof` profiling on `aggkit` app so that we can run different profiles for easier finding of leaks, weak points, and non-optimized parts of the application.

## Config

A new config is added to the `aggkit`:

```
[Profiling]
ProfilingHost = "localhost"
ProfilingPort = 6060
ProfilingEnabled = true
```

If `ProfilingEnabled` is true, the `pprof` server will start on designated port in the `aggkit` app.


**IMPORTANT NOTE**: The code is taken from `cdk-validium-node`.

Fixes # (issue)
