### PR TITLE
fix: `PP` to `FEP` upgrade `startBlock`

### DIFF
--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -150,7 +150,7 @@ func (a *AggchainProverFlow) verifyBuildParamsAndGenerateProof(
 		return nil, fmt.Errorf("aggchainProverFlow - error verifying build params: %w", err)
 	}
 
-	lastProvenBlock := a.getLastProvenBlock(buildParams.FromBlock)
+	lastProvenBlock := a.getLastProvenBlock(buildParams.FromBlock, buildParams.LastSentCertificate)
 
 	aggchainProof, rootFromWhichToProveClaims, err := a.GenerateAggchainProof(
 		ctx, lastProvenBlock, buildParams.ToBlock, buildParams.Claims)
@@ -343,9 +343,11 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 	return aggchainProof, root, nil
 }
 
-func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64) uint64 {
-	if fromBlock == 0 {
+func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64, lastCertificate *types.CertificateInfo) uint64 {
+	if fromBlock == 0 || (lastCertificate != nil && lastCertificate.ToBlock < a.startL2Block) {
 		// if this is the first certificate, we need to start from the starting L2 block
+		// that we got from the sovereign rollup
+		// if the last certificate is settled on PP, the last proven block is the starting L2 block
 		// that we got from the sovereign rollup
 		return a.startL2Block
 	}

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -661,10 +661,11 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name           string
-		fromBlock      uint64
-		startL2Block   uint64
-		expectedResult uint64
+		name                string
+		fromBlock           uint64
+		startL2Block        uint64
+		expectedResult      uint64
+		lastSentCertificate *types.CertificateInfo
 	}{
 		{
 			name:           "fromBlock is 0, return startL2Block",
@@ -684,6 +685,17 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 			startL2Block:   1,
 			expectedResult: 9,
 		},
+		{
+			name:         "lastSentCertificate settled on PP",
+			fromBlock:    10,
+			startL2Block: 50,
+			lastSentCertificate: &types.CertificateInfo{
+				FromBlock: 10,
+				ToBlock:   20,
+				Status:    agglayertypes.Settled,
+			},
+			expectedResult: 50,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -697,7 +709,7 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 				},
 			}
 
-			result := flow.getLastProvenBlock(tc.fromBlock)
+			result := flow.getLastProvenBlock(tc.fromBlock, tc.lastSentCertificate)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -453,6 +453,10 @@ func (f *baseFlow) getLastSentBlockAndRetryCount(lastSentCertificateInfo *types.
 		}
 
 		retryCount = lastSentCertificateInfo.RetryCount + 1
+	} else if lastSentCertificateInfo.ToBlock < f.startL2Block {
+		// if the last sent block is less than the start L2 block read from the rollup contract
+		// we need to start from the start L2 block
+		lastSentBlock = f.startL2Block
 	}
 
 	return lastSentBlock, retryCount

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -1176,6 +1176,17 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 			expectedBlock:      10,
 			expectedRetryCount: 2,
 		},
+		{
+			name: "Last sent certificate settled on PP, building a new one on FEP with gap",
+			lastSentCertificateInfo: &types.CertificateInfo{
+				FromBlock: 0,
+				ToBlock:   10,
+				Status:    agglayertypes.Settled,
+			},
+			startL2Block:       20,
+			expectedBlock:      20,
+			expectedRetryCount: 0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

This PR fixes the case where in `PP` to `FEP` upgrade we have a gap between the last settled block in `PP` and the start block for `FEP` that is defined in the `FEP` rollup contract (this start block defines a block from which spans are created).

Fixes # (issue)
