### PR TITLE
fix: extraparamfieldname casing

### DIFF
--- a/etherman/rpcopnode.go
+++ b/etherman/rpcopnode.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	ExtraParamFieldName = "OpNodeURL"
+	ExtraParamFieldName = "opnodeurl"
 )
 
 type OpNodeClienter interface {


### PR DESCRIPTION
## Description

- fix error when attempting to configure `L2RPC` in aggkit config.
```FATAL	cmd/run.go:370	failed to create client for L2 using URL: {http://op-el-1-op-geth-op-node-001:8545 op map[opnodeurl:http://op-cl-1-op-node-op-geth-001:8547]}. Err:field OpNodeURL not found in extra params. Err: field OpNodeURL not found in extra params of rpcclient config%!(EXTRA string=```

## Testing

Tested on custom image with this change with success.