### PR TITLE
fix: optimize check for pending certificates

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -281,20 +281,22 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 	jsonCert := string(raw)
 	prevLER := common.BytesToHash(certificate.PrevLocalExitRoot[:])
 
-	certInfo := types.CertificateInfo{
-		Height:                  certificate.Height,
-		RetryCount:              certificateParams.RetryCount,
-		CertificateID:           certificateHash,
-		NewLocalExitRoot:        certificate.NewLocalExitRoot,
-		PreviousLocalExitRoot:   &prevLER,
-		FromBlock:               certificateParams.FromBlock,
-		ToBlock:                 certificateParams.ToBlock,
-		CreatedAt:               certificateParams.CreatedAt,
-		UpdatedAt:               certificateParams.CreatedAt,
-		AggchainProof:           certificateParams.AggchainProof,
-		FinalizedL1InfoTreeRoot: &certificateParams.L1InfoTreeRootFromWhichToProve,
-		L1InfoTreeLeafCount:     certificateParams.L1InfoTreeLeafCount,
-		SignedCertificate:       &jsonCert,
+	certInfo := types.Certificate{
+		Header: &types.CertificateHeader{
+			Height:                  certificate.Height,
+			RetryCount:              certificateParams.RetryCount,
+			CertificateID:           certificateHash,
+			NewLocalExitRoot:        certificate.NewLocalExitRoot,
+			PreviousLocalExitRoot:   &prevLER,
+			FromBlock:               certificateParams.FromBlock,
+			ToBlock:                 certificateParams.ToBlock,
+			CreatedAt:               certificateParams.CreatedAt,
+			UpdatedAt:               certificateParams.CreatedAt,
+			FinalizedL1InfoTreeRoot: &certificateParams.L1InfoTreeRootFromWhichToProve,
+			L1InfoTreeLeafCount:     certificateParams.L1InfoTreeLeafCount,
+		},
+		SignedCertificate: &jsonCert,
+		AggchainProof:     certificateParams.AggchainProof,
 	}
 	// TODO: Improve this case, if a cert is not save in the storage, we are going to settle a unknown certificate
 	err = a.saveCertificateToStorage(ctx, certInfo, a.cfg.MaxRetriesStoreCertificate)
@@ -304,19 +306,18 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 	}
 
 	a.log.Infof("certificate: %s sent successfully for range of l2 blocks (from block: %d, to block: %d) cert:%s",
-		certInfo.ID(), certificateParams.FromBlock, certificateParams.ToBlock, certificate.Brief())
+		certInfo.Header.ID(), certificateParams.FromBlock, certificateParams.ToBlock, certificate.Brief())
 
 	return certificate, nil
 }
 
 // saveCertificateToStorage saves the certificate to the storage
 // it retries if it fails. if param retries == 0 it retries indefinitely
-func (a *AggSender) saveCertificateToStorage(ctx context.Context, certInfo types.CertificateInfo, maxRetries int) error {
+func (a *AggSender) saveCertificateToStorage(ctx context.Context, cert types.Certificate, maxRetries int) error {
 	retries := 1
 	err := fmt.Errorf("initial_error")
-	cert := certInfo.ToCertificate()
 	for err != nil {
-		if err = a.storage.SaveLastSentCertificate(ctx, *cert); err != nil {
+		if err = a.storage.SaveLastSentCertificate(ctx, cert); err != nil {
 			// If this happens we can't work as normal, because local DB is outdated, we have to retry
 			a.log.Errorf("error saving last sent certificate %s in db: %w", cert.String(), err)
 			if retries == maxRetries {

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -213,7 +213,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 		rateLimiter:     aggkitcommon.NewRateLimit(aggkitcommon.RateLimitConfig{}),
 	}
 
-	mockStorage.EXPECT().GetLastSentCertificate().Return(&aggsendertypes.CertificateInfo{
+	mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&aggsendertypes.CertificateHeader{
 		NewLocalExitRoot: common.HexToHash("0x123"),
 		Height:           1,
 		FromBlock:        0,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -594,7 +594,6 @@ type aggsenderTestData struct {
 	compatibilityChekerMock *mocksdb.CompatibilityChecker
 	certStatusCheckerMock   *mocks.CertificateStatusChecker
 	sut                     *AggSender
-	testCerts               []aggsendertypes.CertificateInfo
 }
 
 func NewBridgesData(t *testing.T, num int, blockNum []uint64) []bridgesync.Bridge {
@@ -688,21 +687,6 @@ func newAggsenderTestData(t *testing.T, creationFlags testDataFlags) *aggsenderT
 		sut.certStatusChecker = statusCheckerMock
 	}
 
-	testCerts := []aggsendertypes.CertificateInfo{
-		{
-			Height:           0,
-			CertificateID:    common.HexToHash("0x1"),
-			NewLocalExitRoot: common.HexToHash("0x2"),
-			Status:           agglayertypes.Pending,
-		},
-		{
-			Height:           1,
-			CertificateID:    common.HexToHash("0x1a111"),
-			NewLocalExitRoot: common.HexToHash("0x2a2"),
-			Status:           agglayertypes.Pending,
-		},
-	}
-
 	return &aggsenderTestData{
 		ctx:                     ctx,
 		agglayerClientMock:      agglayerClientMock,
@@ -714,6 +698,5 @@ func newAggsenderTestData(t *testing.T, creationFlags testDataFlags) *aggsenderT
 		compatibilityChekerMock: compatibilityCheckerMock,
 		certStatusCheckerMock:   statusCheckerMock,
 		sut:                     sut,
-		testCerts:               testCerts,
 	}
 }

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -97,7 +97,7 @@ func NewAggSenderSQLStorage(logger *log.Logger, cfg AggSenderSQLStorageConfig) (
 // GetCertificateHeadersByStatus returns a list of certificate headers by their status
 func (a *AggSenderSQLStorage) GetCertificateHeadersByStatus(
 	statuses []agglayertypes.CertificateStatus) ([]*types.CertificateHeader, error) {
-	query := "SELECT * FROM certificate_info"
+	query := selectQueryCertificateHeader
 
 	args := make([]any, len(statuses))
 
@@ -142,7 +142,7 @@ func (a *AggSenderSQLStorage) GetCertificateByHeight(height uint64) (*types.Cert
 func (a *AggSenderSQLStorage) GetCertificateHeaderByHeight(height uint64) (*types.CertificateHeader, error) {
 	var certificateHeader types.CertificateHeader
 	if err := meddler.QueryRow(a.db, &certificateHeader,
-		"SELECT * FROM certificate_info WHERE height = $1;", height); err != nil {
+		fmt.Sprintf("%s WHERE height = $1;", selectQueryCertificateHeader), height); err != nil {
 		return nil, getSelectQueryError(height, err)
 	}
 	return &certificateHeader, nil
@@ -175,7 +175,7 @@ func (a *AggSenderSQLStorage) GetLastSentCertificate() (*types.Certificate, erro
 func (a *AggSenderSQLStorage) GetLastSentCertificateHeader() (*types.CertificateHeader, error) {
 	var certificateHeader types.CertificateHeader
 	if err := meddler.QueryRow(a.db, &certificateHeader,
-		"SELECT * FROM certificate_info ORDER BY height DESC LIMIT 1;"); err != nil {
+		fmt.Sprintf("%s ORDER BY height DESC LIMIT 1;", selectQueryCertificateHeader)); err != nil {
 		return nil, getSelectQueryError(0, err)
 	}
 	return &certificateHeader, nil

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -259,7 +259,7 @@ func Test_Storage(t *testing.T) {
 		// Update the status of the certificate
 		certificate.Status = agglayertypes.Settled
 		certificate.UpdatedAt = updateTime + 1
-		require.NoError(t, storage.UpdateCertificateStatus(ctx, certificate))
+		require.NoError(t, storage.UpdateCertificateStatus(ctx, certificate.CertificateID, certificate.Status, certificate.UpdatedAt))
 
 		// Fetch the certificate and verify the status has been updated
 		certificateFromDB, err := storage.GetCertificateByHeight(certificate.Height)

--- a/aggsender/db/helpers.go
+++ b/aggsender/db/helpers.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/agglayer/aggkit/aggsender/types"
+)
+
+var selectQueryCertificateHeader string
+
+func init() {
+	selectQueryCertificateHeader = SelectQuery("certificate_info")
+}
+
+// SelectQuery generates a SELECT query string for the CertificateHeader fields using reflection
+func SelectQuery(tableName string) string {
+	fields := getCertificateHeaderDBFieldNames()
+
+	query := fmt.Sprintf("SELECT %s FROM %s",
+		strings.Join(fields, ", "),
+		tableName,
+	)
+	return query
+}
+
+// getCertificateHeaderDBFieldNames retrieves a list of database field names
+// for the CertificateHeader struct based on the "meddler" struct tags.
+// It inspects the struct type using reflection, extracts the "meddler" tag
+// values, and collects the field names before any comma in the tag.
+// Returns a slice of strings containing the database field names.
+func getCertificateHeaderDBFieldNames() []string {
+	t := reflect.TypeOf(types.CertificateHeader{})
+	fields := []string{}
+
+	for i := range t.NumField() {
+		field := t.Field(i)
+		meddlerTag := field.Tag.Get("meddler")
+		if meddlerTag != "" {
+			// Extract the actual field name before any comma
+			fieldName := strings.Split(meddlerTag, ",")[0]
+			fields = append(fields, fieldName)
+		}
+	}
+
+	return fields
+}

--- a/aggsender/db/helpers.go
+++ b/aggsender/db/helpers.go
@@ -8,7 +8,10 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 )
 
-var selectQueryCertificateHeader string
+var (
+	selectQueryCertificateHeader string
+	errNoCertificateHeader       = fmt.Errorf("missing certificate header")
+)
 
 func init() {
 	selectQueryCertificateHeader = SelectQuery("certificate_info")
@@ -45,4 +48,36 @@ func getCertificateHeaderDBFieldNames() []string {
 	}
 
 	return fields
+}
+
+// convertCertificateToCertificateInfo converts a Certificate object from the types package
+// into a certificateInfo object. It extracts relevant fields from the Certificate's Header
+// and other properties to populate the certificateInfo structure.
+// Returns:
+//   - A pointer to a certificateInfo object containing the extracted data.
+//   - An error if the Certificate's Header is nil.
+//
+// Errors:
+//   - Returns errNoCertificateHeader if the provided Certificate has a nil Header.
+func convertCertificateToCertificateInfo(c *types.Certificate) (*certificateInfo, error) {
+	if c.Header == nil {
+		return nil, errNoCertificateHeader
+	}
+
+	return &certificateInfo{
+		CertificateID:           c.Header.CertificateID,
+		Height:                  c.Header.Height,
+		RetryCount:              c.Header.RetryCount,
+		PreviousLocalExitRoot:   c.Header.PreviousLocalExitRoot,
+		NewLocalExitRoot:        c.Header.NewLocalExitRoot,
+		FromBlock:               c.Header.FromBlock,
+		ToBlock:                 c.Header.ToBlock,
+		Status:                  c.Header.Status,
+		CreatedAt:               c.Header.CreatedAt,
+		UpdatedAt:               c.Header.UpdatedAt,
+		FinalizedL1InfoTreeRoot: c.Header.FinalizedL1InfoTreeRoot,
+		L1InfoTreeLeafCount:     c.Header.L1InfoTreeLeafCount,
+		SignedCertificate:       c.SignedCertificate,
+		AggchainProof:           c.AggchainProof,
+	}, nil
 }

--- a/aggsender/db/helpers_test.go
+++ b/aggsender/db/helpers_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectQuery(t *testing.T) {
+	query := SelectQuery("certificate_info")
+	require.NotEmpty(t, query)
+
+	certHeaderDBFields := getCertificateHeaderDBFieldNames()
+	selectQueryFields := getFieldNamesFromQuery(t, query)
+
+	// Check if the fields in the SELECT query match the expected fields
+	require.Equal(t, certHeaderDBFields, selectQueryFields)
+}
+
+func getFieldNamesFromQuery(t *testing.T, query string) []string {
+	t.Helper()
+
+	// Assuming the query is of the form "SELECT field1, field2 FROM table_name"
+	start := len("SELECT ")
+	end := len(query) - len(" FROM certificate_info")
+	fieldPart := query[start:end]
+	fields := strings.Split(fieldPart, ", ")
+	for i := range fields {
+		fields[i] = strings.TrimSpace(fields[i])
+	}
+	return fields
+}

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"fmt"
+
+	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggsender/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// certificateInfo is a struct that holds the information of a certificate in the database
+// It is used to store the information of a certificate in the database
+// and to retrieve it when needed.
+type certificateInfo struct {
+	Height        uint64      `meddler:"height"`
+	RetryCount    int         `meddler:"retry_count"`
+	CertificateID common.Hash `meddler:"certificate_id,hash"`
+	// PreviousLocalExitRoot if it's nil means no reported
+	PreviousLocalExitRoot   *common.Hash                    `meddler:"previous_local_exit_root,hash"`
+	NewLocalExitRoot        common.Hash                     `meddler:"new_local_exit_root,hash"`
+	FromBlock               uint64                          `meddler:"from_block"`
+	ToBlock                 uint64                          `meddler:"to_block"`
+	Status                  agglayertypes.CertificateStatus `meddler:"status"`
+	CreatedAt               uint32                          `meddler:"created_at"`
+	UpdatedAt               uint32                          `meddler:"updated_at"`
+	SignedCertificate       *string                         `meddler:"signed_certificate"`
+	AggchainProof           *types.AggchainProof            `meddler:"aggchain_proof,aggchainproof"`
+	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
+	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
+}
+
+// toCertificate converts the certificateInfo struct to a Certificate struct
+func (c *certificateInfo) toCertificate() *types.Certificate {
+	return &types.Certificate{
+		Header: &types.CertificateHeader{
+			Height:                  c.Height,
+			RetryCount:              c.RetryCount,
+			CertificateID:           c.CertificateID,
+			PreviousLocalExitRoot:   c.PreviousLocalExitRoot,
+			NewLocalExitRoot:        c.NewLocalExitRoot,
+			FromBlock:               c.FromBlock,
+			ToBlock:                 c.ToBlock,
+			Status:                  c.Status,
+			CreatedAt:               c.CreatedAt,
+			UpdatedAt:               c.UpdatedAt,
+			FinalizedL1InfoTreeRoot: c.FinalizedL1InfoTreeRoot,
+			L1InfoTreeLeafCount:     c.L1InfoTreeLeafCount,
+		},
+		SignedCertificate: c.SignedCertificate,
+		AggchainProof:     c.AggchainProof,
+	}
+}
+
+// ID returns a string with the unique identifier of the cerificate (height+certificateID)
+func (c *certificateInfo) ID() string {
+	if c == nil {
+		return types.NilStr
+	}
+	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
+}

--- a/aggsender/db/types_test.go
+++ b/aggsender/db/types_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/agglayer/aggkit/aggsender/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertificateFieldsMatchCertificateInfo(t *testing.T) {
+	// Check that all fields in CertificateInfo are present in Certificate
+	certificateInfoType := reflect.TypeOf(certificateInfo{})
+
+	for i := range certificateInfoType.NumField() {
+		field := certificateInfoType.Field(i)
+		_, found := reflect.TypeOf(types.CertificateHeader{}).FieldByName(field.Name)
+		if !found {
+			_, found = reflect.TypeOf(types.Certificate{}).FieldByName(field.Name)
+		}
+		require.True(t, found, "Field %s is missing in Certificate", field.Name)
+	}
+
+	// Check that all fields in Certificate are present in CertificateInfo
+	certificateHeaderType := reflect.TypeOf(types.CertificateHeader{})
+
+	// Check that all fields in CertificateHeader are present in CertificateInfo
+	for i := range certificateHeaderType.NumField() {
+		field := certificateHeaderType.Field(i)
+		_, found := certificateInfoType.FieldByName(field.Name)
+		require.True(t, found, "Field %s from CertificateHeader is missing in CertificateInfo", field.Name)
+	}
+
+	// Check that all fields in Certificate are present in CertificateInfo
+	certificateType := reflect.TypeOf(types.Certificate{})
+
+	for i := range certificateType.NumField() {
+		field := certificateType.Field(i)
+		if field.Name == "Header" {
+			continue
+		}
+		_, found := certificateInfoType.FieldByName(field.Name)
+		require.True(t, found, "Field %s from Certificate is missing in CertificateInfo", field.Name)
+	}
+}

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -64,13 +64,25 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 		expectedError  string
 	}{
 		{
-			name: "error getting last sent certificate",
+			name: "error checking if last sent certificate in error",
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockProverClient *mocks.AggchainProofClientInterface,
 				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
 				mockGERQuerier *mocks.GERQuerier) {
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, errors.New("some error"))
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(false, errors.New("some error"))
+			},
+			expectedError: "some error",
+		},
+		{
+			name: "error getting last sent certificate when in error",
+			mockFn: func(mockStorage *mocks.AggSenderStorage,
+				mockL2BridgeQuerier *mocks.BridgeQuerier,
+				mockProverClient *mocks.AggchainProofClientInterface,
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
+				mockGERQuerier *mocks.GERQuerier) {
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(true, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificate().Return(nil, errors.New("some error"))
 			},
 			expectedError: "some error",
 		},
@@ -84,19 +96,22 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{
-					Height:                  0,
-					FromBlock:               1,
-					ToBlock:                 10,
-					Status:                  agglayertypes.InError,
-					FinalizedL1InfoTreeRoot: &finalizedL1Root,
-					CertificateID:           common.HexToHash("0x1"),
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(true, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.Certificate{
+					Header: &types.CertificateHeader{
+						Height:                  0,
+						FromBlock:               1,
+						ToBlock:                 10,
+						Status:                  agglayertypes.InError,
+						FinalizedL1InfoTreeRoot: &finalizedL1Root,
+						CertificateID:           common.HexToHash("0x1"),
+					},
+					AggchainProof: &types.AggchainProof{
+						SP1StarkProof:   &types.SP1StarkProof{Proof: []byte("some-proof")},
+						LastProvenBlock: 1,
+						EndBlock:        10,
+					},
 				}, nil).Once()
-				mockStorage.EXPECT().GetCertificateAggchainProof(uint64(0), common.HexToHash("0x1")).Return(&types.AggchainProof{
-					SP1StarkProof:   &types.SP1StarkProof{Proof: []byte("some-proof")},
-					LastProvenBlock: 1,
-					EndBlock:        10,
-				}, nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), true).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
@@ -142,14 +157,16 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{
-					Height:        0,
-					FromBlock:     1,
-					ToBlock:       10,
-					Status:        agglayertypes.InError,
-					CertificateID: common.HexToHash("0x1"),
-				}, nil)
-				mockStorage.EXPECT().GetCertificateAggchainProof(uint64(0), common.HexToHash("0x1")).Return(nil, nil)
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(true, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.Certificate{
+					Header: &types.CertificateHeader{
+						Height:        0,
+						FromBlock:     1,
+						ToBlock:       10,
+						Status:        agglayertypes.InError,
+						CertificateID: common.HexToHash("0x1"),
+					},
+				}, nil).Once()
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), true).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
@@ -223,7 +240,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, nil).Twice()
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(false, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, nil).Once()
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), true).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
@@ -270,7 +288,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
 				mockGERQuerier *mocks.GERQuerier) {
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, nil).Twice()
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(false, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, nil).Once()
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), true).Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
 				mockL1InfoDataQuery.EXPECT().GetFinalizedL1InfoTreeData(ctx).Return(
@@ -315,7 +334,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil).Twice()
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(false, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil).Once()
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{{
 					GlobalIndex:     big.NewInt(1),
@@ -387,7 +407,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				l1Header := &gethtypes.Header{Number: big.NewInt(10)}
-				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil).Twice()
+				mockStorage.EXPECT().IsLastSentCertificateInError().Return(false, nil).Once()
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil).Once()
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return(
 					[]bridgesync.Bridge{{BlockNum: 6}, {BlockNum: 10}},

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -43,12 +43,12 @@ func (f *baseFlow) getCertificateBuildParamsInternal(
 		return nil, fmt.Errorf("error getting last processed block from l2: %w", err)
 	}
 
-	lastSentCertificateInfo, err := f.storage.GetLastSentCertificate()
+	lastSentCertificate, err := f.storage.GetLastSentCertificateHeader()
 	if err != nil {
 		return nil, err
 	}
 
-	previousToBlock, retryCount := f.getLastSentBlockAndRetryCount(lastSentCertificateInfo)
+	previousToBlock, retryCount := f.getLastSentBlockAndRetryCount(lastSentCertificate)
 
 	if previousToBlock >= lastL2BlockSynced {
 		f.log.Warnf("no new blocks to send a certificate, last certificate block: %d, last L2 block: %d",
@@ -68,7 +68,7 @@ func (f *baseFlow) getCertificateBuildParamsInternal(
 		FromBlock:           fromBlock,
 		ToBlock:             toBlock,
 		RetryCount:          retryCount,
-		LastSentCertificate: lastSentCertificateInfo,
+		LastSentCertificate: lastSentCertificate,
 		Bridges:             bridges,
 		Claims:              claims,
 		CreatedAt:           uint32(time.Now().UTC().Unix()),
@@ -121,7 +121,7 @@ func (f *baseFlow) limitCertSize(
 
 func (f *baseFlow) buildCertificate(ctx context.Context,
 	certParams *types.CertificateBuildParams,
-	lastSentCertificateInfo *types.CertificateInfo,
+	lastSentCertificate *types.CertificateHeader,
 	allowEmptyCert bool) (*agglayertypes.Certificate, error) {
 	f.log.Infof("building certificate for %s estimatedSize=%d", certParams.String(), certParams.EstimatedSize())
 
@@ -135,7 +135,7 @@ func (f *baseFlow) buildCertificate(ctx context.Context,
 		return nil, fmt.Errorf("error getting imported bridge exits: %w", err)
 	}
 
-	height, previousLER, err := f.getNextHeightAndPreviousLER(lastSentCertificateInfo)
+	height, previousLER, err := f.getNextHeightAndPreviousLER(lastSentCertificate)
 	if err != nil {
 		return nil, fmt.Errorf("error getting next height and previous LER: %w", err)
 	}
@@ -341,7 +341,7 @@ func (f *baseFlow) getImportedBridgeExits(
 
 // getNextHeightAndPreviousLER returns the height and previous LER for the new certificate
 func (f *baseFlow) getNextHeightAndPreviousLER(
-	lastSentCertificateInfo *types.CertificateInfo) (uint64, common.Hash, error) {
+	lastSentCertificateInfo *types.CertificateHeader) (uint64, common.Hash, error) {
 	if lastSentCertificateInfo == nil {
 		return 0, zeroLER, nil
 	}
@@ -365,7 +365,7 @@ func (f *baseFlow) getNextHeightAndPreviousLER(
 		// We get previous certificate that must be settled
 		f.log.Debugf("last certificate %s is in error, getting previous settled certificate height:%d",
 			lastSentCertificateInfo.Height-1)
-		lastSettleCert, err := f.storage.GetCertificateByHeight(lastSentCertificateInfo.Height - 1)
+		lastSettleCert, err := f.storage.GetCertificateHeaderByHeight(lastSentCertificateInfo.Height - 1)
 		if err != nil {
 			return 0, common.Hash{}, fmt.Errorf("error getting last settled certificate: %w", err)
 		}
@@ -398,7 +398,7 @@ func (f *baseFlow) verifyClaimGERs(claims []bridgesync.Claim) error {
 
 // getLastSentBlockAndRetryCount returns the last sent block of the last sent certificate
 // if there is no previosly sent certificate, it returns startL2Block and 0
-func (f *baseFlow) getLastSentBlockAndRetryCount(lastSentCertificateInfo *types.CertificateInfo) (uint64, int) {
+func (f *baseFlow) getLastSentBlockAndRetryCount(lastSentCertificateInfo *types.CertificateHeader) (uint64, int) {
 	if lastSentCertificateInfo == nil {
 		// this is the first certificate so we start from what we have set in start L2 block
 		return f.startL2Block, 0

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -477,15 +477,15 @@ func TestBuildCertificate(t *testing.T) {
 	mockProof := generateTestProof(t)
 
 	tests := []struct {
-		name                    string
-		bridges                 []bridgesync.Bridge
-		claims                  []bridgesync.Claim
-		lastSentCertificateInfo types.CertificateInfo
-		fromBlock               uint64
-		toBlock                 uint64
-		mockFn                  func()
-		expectedCert            *agglayertypes.Certificate
-		expectedError           bool
+		name                string
+		bridges             []bridgesync.Bridge
+		claims              []bridgesync.Claim
+		lastSentCertificate types.CertificateHeader
+		fromBlock           uint64
+		toBlock             uint64
+		mockFn              func()
+		expectedCert        *agglayertypes.Certificate
+		expectedError       bool
 	}{
 		{
 			name: "Valid certificate with bridges and claims",
@@ -518,7 +518,7 @@ func TestBuildCertificate(t *testing.T) {
 					ProofRollupExitRoot: mockProof,
 				},
 			},
-			lastSentCertificateInfo: types.CertificateInfo{
+			lastSentCertificate: types.CertificateHeader{
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Height:           1,
 				Status:           agglayertypes.Settled,
@@ -605,7 +605,7 @@ func TestBuildCertificate(t *testing.T) {
 			name:    "No bridges or claims",
 			bridges: []bridgesync.Bridge{},
 			claims:  []bridgesync.Claim{},
-			lastSentCertificateInfo: types.CertificateInfo{
+			lastSentCertificate: types.CertificateHeader{
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Height:           1,
 			},
@@ -642,7 +642,7 @@ func TestBuildCertificate(t *testing.T) {
 					ProofLocalExitRoot: mockProof,
 				},
 			},
-			lastSentCertificateInfo: types.CertificateInfo{
+			lastSentCertificate: types.CertificateHeader{
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Height:           1,
 			},
@@ -682,7 +682,7 @@ func TestBuildCertificate(t *testing.T) {
 				Claims:                         tt.claims,
 				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x7891"),
 			}
-			cert, err := flow.buildCertificate(context.Background(), certParam, &tt.lastSentCertificateInfo, false)
+			cert, err := flow.buildCertificate(context.Background(), certParam, &tt.lastSentCertificate, false)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -711,18 +711,18 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                           string
-		lastSentCertificateInfo        *types.CertificateInfo
-		lastSettleCertificateInfoCall  bool
-		lastSettleCertificateInfo      *types.CertificateInfo
-		lastSettleCertificateInfoError error
-		expectedHeight                 uint64
-		expectedPreviousLER            common.Hash
-		expectedError                  bool
+		name                       string
+		lastSentCertificate        *types.CertificateHeader
+		lastSettleCertificateCall  bool
+		lastSettledCertificate     *types.CertificateHeader
+		lastSettleCertificateError error
+		expectedHeight             uint64
+		expectedPreviousLER        common.Hash
+		expectedError              bool
 	}{
 		{
 			name: "Normal case",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:           10,
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Status:           agglayertypes.Settled,
@@ -731,14 +731,14 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 			expectedPreviousLER: common.HexToHash("0x123"),
 		},
 		{
-			name:                    "First certificate",
-			lastSentCertificateInfo: nil,
-			expectedHeight:          0,
-			expectedPreviousLER:     zeroLER,
+			name:                "First certificate",
+			lastSentCertificate: nil,
+			expectedHeight:      0,
+			expectedPreviousLER: zeroLER,
 		},
 		{
 			name: "First certificate error, with prevLER",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:                0,
 				NewLocalExitRoot:      common.HexToHash("0x123"),
 				Status:                agglayertypes.InError,
@@ -749,7 +749,7 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 		},
 		{
 			name: "First certificate error, no prevLER",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:           0,
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Status:           agglayertypes.InError,
@@ -759,7 +759,7 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 		},
 		{
 			name: "n certificate error, prevLER",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:                10,
 				NewLocalExitRoot:      common.HexToHash("0x123"),
 				PreviousLocalExitRoot: &ler1,
@@ -770,7 +770,7 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 		},
 		{
 			name: "last cert not closed, error",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:                10,
 				NewLocalExitRoot:      common.HexToHash("0x123"),
 				PreviousLocalExitRoot: &ler1,
@@ -782,12 +782,12 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 		},
 		{
 			name: "Previous certificate in error, no prevLER",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:           10,
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Status:           agglayertypes.InError,
 			},
-			lastSettleCertificateInfo: &types.CertificateInfo{
+			lastSettledCertificate: &types.CertificateHeader{
 				Height:           9,
 				NewLocalExitRoot: common.HexToHash("0x3456"),
 				Status:           agglayertypes.Settled,
@@ -797,41 +797,41 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 		},
 		{
 			name: "Previous certificate in error, no prevLER. Error getting previous cert",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:           10,
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Status:           agglayertypes.InError,
 			},
-			lastSettleCertificateInfo:      nil,
-			lastSettleCertificateInfoError: errors.New("error getting last settle certificate"),
-			expectedError:                  true,
+			lastSettledCertificate:     nil,
+			lastSettleCertificateError: errors.New("error getting last settle certificate"),
+			expectedError:              true,
 		},
 		{
 			name: "Previous certificate in error, no prevLER. prev cert not available on storage",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:           10,
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Status:           agglayertypes.InError,
 			},
-			lastSettleCertificateInfoCall:  true,
-			lastSettleCertificateInfo:      nil,
-			lastSettleCertificateInfoError: nil,
-			expectedError:                  true,
+			lastSettleCertificateCall:  true,
+			lastSettledCertificate:     nil,
+			lastSettleCertificateError: nil,
+			expectedError:              true,
 		},
 		{
 			name: "Previous certificate in error, no prevLER. prev cert not available on storage",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				Height:           10,
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Status:           agglayertypes.InError,
 			},
-			lastSettleCertificateInfo: &types.CertificateInfo{
+			lastSettledCertificate: &types.CertificateHeader{
 				Height:           9,
 				NewLocalExitRoot: common.HexToHash("0x3456"),
 				Status:           agglayertypes.InError,
 			},
-			lastSettleCertificateInfoError: nil,
-			expectedError:                  true,
+			lastSettleCertificateError: nil,
+			expectedError:              true,
 		},
 	}
 
@@ -842,11 +842,11 @@ func TestGetNextHeightAndPreviousLER(t *testing.T) {
 			t.Parallel()
 			storageMock := mocks.NewAggSenderStorage(t)
 			flow := &baseFlow{log: log.WithFields("aggsender-test", "getNextHeightAndPreviousLER"), storage: storageMock}
-			if tt.lastSettleCertificateInfoCall || tt.lastSettleCertificateInfo != nil || tt.lastSettleCertificateInfoError != nil {
-				storageMock.EXPECT().GetCertificateByHeight(mock.Anything).Return(tt.lastSettleCertificateInfo, tt.lastSettleCertificateInfoError).Once()
+			if tt.lastSettleCertificateCall || tt.lastSettledCertificate != nil || tt.lastSettleCertificateError != nil {
+				storageMock.EXPECT().GetCertificateHeaderByHeight(mock.Anything).Return(tt.lastSettledCertificate, tt.lastSettleCertificateError).Once()
 			}
 
-			height, previousLER, err := flow.getNextHeightAndPreviousLER(tt.lastSentCertificateInfo)
+			height, previousLER, err := flow.getNextHeightAndPreviousLER(tt.lastSentCertificate)
 			if tt.expectedError {
 				require.Error(t, err)
 			} else {
@@ -884,7 +884,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockL1InfoTreeQuerier *mocks.L1InfoTreeDataQuerier) {
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
-				mockStorage.EXPECT().GetLastSentCertificate().Return(nil, errors.New("some error"))
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, errors.New("some error"))
 			},
 			expectedError: "some error",
 		},
@@ -894,7 +894,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockL1InfoTreeQuerier *mocks.L1InfoTreeDataQuerier) {
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
-				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 10}, nil)
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 10}, nil)
 			},
 			expectedParams: nil,
 		},
@@ -904,7 +904,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockL1InfoTreeQuerier *mocks.L1InfoTreeDataQuerier) {
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
-				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 5}, nil)
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return(nil, nil, errors.New("some error"))
 			},
 			expectedError: "some error",
@@ -915,8 +915,9 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockL1InfoTreeQuerier *mocks.L1InfoTreeDataQuerier) {
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
-				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1")}}, nil)
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return(
+					[]bridgesync.Bridge{{}}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1")}}, nil)
 			},
 			expectedError: "GER mismatch",
 		},
@@ -929,7 +930,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
-				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 5}, nil)
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalExitRoot:  ger,
@@ -949,7 +950,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
-				mockStorage.EXPECT().GetLastSentCertificate().Return(&types.CertificateInfo{ToBlock: 5}, nil)
+				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
 				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalExitRoot:  ger,
@@ -964,7 +965,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				ToBlock:             10,
 				RetryCount:          0,
 				L1InfoTreeLeafCount: 1,
-				LastSentCertificate: &types.CertificateInfo{ToBlock: 5},
+				LastSentCertificate: &types.CertificateHeader{ToBlock: 5},
 				Bridges:             []bridgesync.Bridge{{}},
 				Claims: []bridgesync.Claim{
 					{
@@ -1017,29 +1018,29 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                    string
-		lastSentCertificateInfo *types.CertificateInfo
-		expectedBlock           uint64
-		startL2Block            uint64
-		expectedRetryCount      int
+		name                string
+		lastSentCertificate *types.CertificateHeader
+		expectedBlock       uint64
+		startL2Block        uint64
+		expectedRetryCount  int
 	}{
 		{
-			name:                    "No last sent certificate, start block is 0",
-			lastSentCertificateInfo: nil,
-			expectedBlock:           0,
-			startL2Block:            0,
-			expectedRetryCount:      0,
+			name:                "No last sent certificate, start block is 0",
+			lastSentCertificate: nil,
+			expectedBlock:       0,
+			startL2Block:        0,
+			expectedRetryCount:  0,
 		},
 		{
-			name:                    "No last sent certificate, start block is 1000",
-			lastSentCertificateInfo: nil,
-			expectedBlock:           1000,
-			startL2Block:            1000,
-			expectedRetryCount:      0,
+			name:                "No last sent certificate, start block is 1000",
+			lastSentCertificate: nil,
+			expectedBlock:       1000,
+			startL2Block:        1000,
+			expectedRetryCount:  0,
 		},
 		{
 			name: "Last sent certificate with no error",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				ToBlock: 10,
 				Status:  agglayertypes.Settled,
 			},
@@ -1048,7 +1049,7 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 		},
 		{
 			name: "Last sent certificate with error and non-zero FromBlock",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				FromBlock:  5,
 				ToBlock:    10,
 				Status:     agglayertypes.InError,
@@ -1059,7 +1060,7 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 		},
 		{
 			name: "Last sent certificate with error and zero FromBlock",
-			lastSentCertificateInfo: &types.CertificateInfo{
+			lastSentCertificate: &types.CertificateHeader{
 				FromBlock:  0,
 				ToBlock:    10,
 				Status:     agglayertypes.InError,
@@ -1078,7 +1079,7 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 
 			baseFlow := &baseFlow{startL2Block: tt.startL2Block}
 
-			block, retryCount := baseFlow.getLastSentBlockAndRetryCount(tt.lastSentCertificateInfo)
+			block, retryCount := baseFlow.getLastSentBlockAndRetryCount(tt.lastSentCertificate)
 
 			require.Equal(t, tt.expectedBlock, block)
 			require.Equal(t, tt.expectedRetryCount, retryCount)

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -131,9 +131,9 @@ func (_c *AggSenderStorage_GetCertificateByHeight_Call) RunAndReturn(run func(ui
 	return _c
 }
 
-// GetCertificatesByStatus provides a mock function with given fields: status
-func (_m *AggSenderStorage) GetCertificatesByStatus(status []agglayertypes.CertificateStatus) ([]*types.CertificateInfo, error) {
-	ret := _m.Called(status)
+// GetCertificatesByStatus provides a mock function with given fields: status, lightQuery
+func (_m *AggSenderStorage) GetCertificatesByStatus(status []agglayertypes.CertificateStatus, lightQuery bool) ([]*types.CertificateInfo, error) {
+	ret := _m.Called(status, lightQuery)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificatesByStatus")
@@ -141,19 +141,19 @@ func (_m *AggSenderStorage) GetCertificatesByStatus(status []agglayertypes.Certi
 
 	var r0 []*types.CertificateInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus) ([]*types.CertificateInfo, error)); ok {
-		return rf(status)
+	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus, bool) ([]*types.CertificateInfo, error)); ok {
+		return rf(status, lightQuery)
 	}
-	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus) []*types.CertificateInfo); ok {
-		r0 = rf(status)
+	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus, bool) []*types.CertificateInfo); ok {
+		r0 = rf(status, lightQuery)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*types.CertificateInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]agglayertypes.CertificateStatus) error); ok {
-		r1 = rf(status)
+	if rf, ok := ret.Get(1).(func([]agglayertypes.CertificateStatus, bool) error); ok {
+		r1 = rf(status, lightQuery)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -168,13 +168,14 @@ type AggSenderStorage_GetCertificatesByStatus_Call struct {
 
 // GetCertificatesByStatus is a helper method to define mock.On call
 //   - status []agglayertypes.CertificateStatus
-func (_e *AggSenderStorage_Expecter) GetCertificatesByStatus(status interface{}) *AggSenderStorage_GetCertificatesByStatus_Call {
-	return &AggSenderStorage_GetCertificatesByStatus_Call{Call: _e.mock.On("GetCertificatesByStatus", status)}
+//   - lightQuery bool
+func (_e *AggSenderStorage_Expecter) GetCertificatesByStatus(status interface{}, lightQuery interface{}) *AggSenderStorage_GetCertificatesByStatus_Call {
+	return &AggSenderStorage_GetCertificatesByStatus_Call{Call: _e.mock.On("GetCertificatesByStatus", status, lightQuery)}
 }
 
-func (_c *AggSenderStorage_GetCertificatesByStatus_Call) Run(run func(status []agglayertypes.CertificateStatus)) *AggSenderStorage_GetCertificatesByStatus_Call {
+func (_c *AggSenderStorage_GetCertificatesByStatus_Call) Run(run func(status []agglayertypes.CertificateStatus, lightQuery bool)) *AggSenderStorage_GetCertificatesByStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]agglayertypes.CertificateStatus))
+		run(args[0].([]agglayertypes.CertificateStatus), args[1].(bool))
 	})
 	return _c
 }
@@ -184,7 +185,7 @@ func (_c *AggSenderStorage_GetCertificatesByStatus_Call) Return(_a0 []*types.Cer
 	return _c
 }
 
-func (_c *AggSenderStorage_GetCertificatesByStatus_Call) RunAndReturn(run func([]agglayertypes.CertificateStatus) ([]*types.CertificateInfo, error)) *AggSenderStorage_GetCertificatesByStatus_Call {
+func (_c *AggSenderStorage_GetCertificatesByStatus_Call) RunAndReturn(run func([]agglayertypes.CertificateStatus, bool) ([]*types.CertificateInfo, error)) *AggSenderStorage_GetCertificatesByStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -293,12 +294,12 @@ func (_c *AggSenderStorage_SaveLastSentCertificate_Call) RunAndReturn(run func(c
 	return _c
 }
 
-// UpdateCertificate provides a mock function with given fields: ctx, certificate
-func (_m *AggSenderStorage) UpdateCertificate(ctx context.Context, certificate types.CertificateInfo) error {
+// UpdateCertificateStatus provides a mock function with given fields: ctx, certificate
+func (_m *AggSenderStorage) UpdateCertificateStatus(ctx context.Context, certificate types.CertificateInfo) error {
 	ret := _m.Called(ctx, certificate)
 
 	if len(ret) == 0 {
-		panic("no return value specified for UpdateCertificate")
+		panic("no return value specified for UpdateCertificateStatus")
 	}
 
 	var r0 error
@@ -311,31 +312,31 @@ func (_m *AggSenderStorage) UpdateCertificate(ctx context.Context, certificate t
 	return r0
 }
 
-// AggSenderStorage_UpdateCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCertificate'
-type AggSenderStorage_UpdateCertificate_Call struct {
+// AggSenderStorage_UpdateCertificateStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCertificateStatus'
+type AggSenderStorage_UpdateCertificateStatus_Call struct {
 	*mock.Call
 }
 
-// UpdateCertificate is a helper method to define mock.On call
+// UpdateCertificateStatus is a helper method to define mock.On call
 //   - ctx context.Context
 //   - certificate types.CertificateInfo
-func (_e *AggSenderStorage_Expecter) UpdateCertificate(ctx interface{}, certificate interface{}) *AggSenderStorage_UpdateCertificate_Call {
-	return &AggSenderStorage_UpdateCertificate_Call{Call: _e.mock.On("UpdateCertificate", ctx, certificate)}
+func (_e *AggSenderStorage_Expecter) UpdateCertificateStatus(ctx interface{}, certificate interface{}) *AggSenderStorage_UpdateCertificateStatus_Call {
+	return &AggSenderStorage_UpdateCertificateStatus_Call{Call: _e.mock.On("UpdateCertificateStatus", ctx, certificate)}
 }
 
-func (_c *AggSenderStorage_UpdateCertificate_Call) Run(run func(ctx context.Context, certificate types.CertificateInfo)) *AggSenderStorage_UpdateCertificate_Call {
+func (_c *AggSenderStorage_UpdateCertificateStatus_Call) Run(run func(ctx context.Context, certificate types.CertificateInfo)) *AggSenderStorage_UpdateCertificateStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(types.CertificateInfo))
 	})
 	return _c
 }
 
-func (_c *AggSenderStorage_UpdateCertificate_Call) Return(_a0 error) *AggSenderStorage_UpdateCertificate_Call {
+func (_c *AggSenderStorage_UpdateCertificateStatus_Call) Return(_a0 error) *AggSenderStorage_UpdateCertificateStatus_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *AggSenderStorage_UpdateCertificate_Call) RunAndReturn(run func(context.Context, types.CertificateInfo) error) *AggSenderStorage_UpdateCertificate_Call {
+func (_c *AggSenderStorage_UpdateCertificateStatus_Call) RunAndReturn(run func(context.Context, types.CertificateInfo) error) *AggSenderStorage_UpdateCertificateStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -294,17 +294,17 @@ func (_c *AggSenderStorage_SaveLastSentCertificate_Call) RunAndReturn(run func(c
 	return _c
 }
 
-// UpdateCertificateStatus provides a mock function with given fields: ctx, certificate
-func (_m *AggSenderStorage) UpdateCertificateStatus(ctx context.Context, certificate types.CertificateInfo) error {
-	ret := _m.Called(ctx, certificate)
+// UpdateCertificateStatus provides a mock function with given fields: ctx, certificateID, newStatus, updatedAt
+func (_m *AggSenderStorage) UpdateCertificateStatus(ctx context.Context, certificateID common.Hash, newStatus agglayertypes.CertificateStatus, updatedAt uint32) error {
+	ret := _m.Called(ctx, certificateID, newStatus, updatedAt)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateStatus")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.CertificateInfo) error); ok {
-		r0 = rf(ctx, certificate)
+	if rf, ok := ret.Get(0).(func(context.Context, common.Hash, agglayertypes.CertificateStatus, uint32) error); ok {
+		r0 = rf(ctx, certificateID, newStatus, updatedAt)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -319,14 +319,16 @@ type AggSenderStorage_UpdateCertificateStatus_Call struct {
 
 // UpdateCertificateStatus is a helper method to define mock.On call
 //   - ctx context.Context
-//   - certificate types.CertificateInfo
-func (_e *AggSenderStorage_Expecter) UpdateCertificateStatus(ctx interface{}, certificate interface{}) *AggSenderStorage_UpdateCertificateStatus_Call {
-	return &AggSenderStorage_UpdateCertificateStatus_Call{Call: _e.mock.On("UpdateCertificateStatus", ctx, certificate)}
+//   - certificateID common.Hash
+//   - newStatus agglayertypes.CertificateStatus
+//   - updatedAt uint32
+func (_e *AggSenderStorage_Expecter) UpdateCertificateStatus(ctx interface{}, certificateID interface{}, newStatus interface{}, updatedAt interface{}) *AggSenderStorage_UpdateCertificateStatus_Call {
+	return &AggSenderStorage_UpdateCertificateStatus_Call{Call: _e.mock.On("UpdateCertificateStatus", ctx, certificateID, newStatus, updatedAt)}
 }
 
-func (_c *AggSenderStorage_UpdateCertificateStatus_Call) Run(run func(ctx context.Context, certificate types.CertificateInfo)) *AggSenderStorage_UpdateCertificateStatus_Call {
+func (_c *AggSenderStorage_UpdateCertificateStatus_Call) Run(run func(ctx context.Context, certificateID common.Hash, newStatus agglayertypes.CertificateStatus, updatedAt uint32)) *AggSenderStorage_UpdateCertificateStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.CertificateInfo))
+		run(args[0].(context.Context), args[1].(common.Hash), args[2].(agglayertypes.CertificateStatus), args[3].(uint32))
 	})
 	return _c
 }
@@ -336,7 +338,7 @@ func (_c *AggSenderStorage_UpdateCertificateStatus_Call) Return(_a0 error) *AggS
 	return _c
 }
 
-func (_c *AggSenderStorage_UpdateCertificateStatus_Call) RunAndReturn(run func(context.Context, types.CertificateInfo) error) *AggSenderStorage_UpdateCertificateStatus_Call {
+func (_c *AggSenderStorage_UpdateCertificateStatus_Call) RunAndReturn(run func(context.Context, common.Hash, agglayertypes.CertificateStatus, uint32) error) *AggSenderStorage_UpdateCertificateStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -73,65 +73,6 @@ func (_c *AggSenderStorage_DeleteCertificate_Call) RunAndReturn(run func(context
 	return _c
 }
 
-// GetCertificateAggchainProof provides a mock function with given fields: height, certificateID
-func (_m *AggSenderStorage) GetCertificateAggchainProof(height uint64, certificateID common.Hash) (*types.AggchainProof, error) {
-	ret := _m.Called(height, certificateID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetCertificateAggchainProof")
-	}
-
-	var r0 *types.AggchainProof
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64, common.Hash) (*types.AggchainProof, error)); ok {
-		return rf(height, certificateID)
-	}
-	if rf, ok := ret.Get(0).(func(uint64, common.Hash) *types.AggchainProof); ok {
-		r0 = rf(height, certificateID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.AggchainProof)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(uint64, common.Hash) error); ok {
-		r1 = rf(height, certificateID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// AggSenderStorage_GetCertificateAggchainProof_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateAggchainProof'
-type AggSenderStorage_GetCertificateAggchainProof_Call struct {
-	*mock.Call
-}
-
-// GetCertificateAggchainProof is a helper method to define mock.On call
-//   - height uint64
-//   - certificateID common.Hash
-func (_e *AggSenderStorage_Expecter) GetCertificateAggchainProof(height interface{}, certificateID interface{}) *AggSenderStorage_GetCertificateAggchainProof_Call {
-	return &AggSenderStorage_GetCertificateAggchainProof_Call{Call: _e.mock.On("GetCertificateAggchainProof", height, certificateID)}
-}
-
-func (_c *AggSenderStorage_GetCertificateAggchainProof_Call) Run(run func(height uint64, certificateID common.Hash)) *AggSenderStorage_GetCertificateAggchainProof_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(uint64), args[1].(common.Hash))
-	})
-	return _c
-}
-
-func (_c *AggSenderStorage_GetCertificateAggchainProof_Call) Return(_a0 *types.AggchainProof, _a1 error) *AggSenderStorage_GetCertificateAggchainProof_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *AggSenderStorage_GetCertificateAggchainProof_Call) RunAndReturn(run func(uint64, common.Hash) (*types.AggchainProof, error)) *AggSenderStorage_GetCertificateAggchainProof_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCertificateByHeight provides a mock function with given fields: height
 func (_m *AggSenderStorage) GetCertificateByHeight(height uint64) (*types.Certificate, error) {
 	ret := _m.Called(height)
@@ -416,6 +357,61 @@ func (_c *AggSenderStorage_GetLastSentCertificateHeader_Call) Return(_a0 *types.
 }
 
 func (_c *AggSenderStorage_GetLastSentCertificateHeader_Call) RunAndReturn(run func() (*types.CertificateHeader, error)) *AggSenderStorage_GetLastSentCertificateHeader_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsLastSentCertificateInError provides a mock function with no fields
+func (_m *AggSenderStorage) IsLastSentCertificateInError() (bool, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsLastSentCertificateInError")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (bool, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggSenderStorage_IsLastSentCertificateInError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLastSentCertificateInError'
+type AggSenderStorage_IsLastSentCertificateInError_Call struct {
+	*mock.Call
+}
+
+// IsLastSentCertificateInError is a helper method to define mock.On call
+func (_e *AggSenderStorage_Expecter) IsLastSentCertificateInError() *AggSenderStorage_IsLastSentCertificateInError_Call {
+	return &AggSenderStorage_IsLastSentCertificateInError_Call{Call: _e.mock.On("IsLastSentCertificateInError")}
+}
+
+func (_c *AggSenderStorage_IsLastSentCertificateInError_Call) Run(run func()) *AggSenderStorage_IsLastSentCertificateInError_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_IsLastSentCertificateInError_Call) Return(_a0 bool, _a1 error) *AggSenderStorage_IsLastSentCertificateInError_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggSenderStorage_IsLastSentCertificateInError_Call) RunAndReturn(run func() (bool, error)) *AggSenderStorage_IsLastSentCertificateInError_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -361,57 +361,69 @@ func (_c *AggSenderStorage_GetLastSentCertificateHeader_Call) RunAndReturn(run f
 	return _c
 }
 
-// IsLastSentCertificateInError provides a mock function with no fields
-func (_m *AggSenderStorage) IsLastSentCertificateInError() (bool, error) {
-	ret := _m.Called()
+// GetLastSentCertificateHeaderWithProofIfInError provides a mock function with given fields: ctx
+func (_m *AggSenderStorage) GetLastSentCertificateHeaderWithProofIfInError(ctx context.Context) (*types.CertificateHeader, *types.AggchainProof, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
-		panic("no return value specified for IsLastSentCertificateInError")
+		panic("no return value specified for GetLastSentCertificateHeaderWithProofIfInError")
 	}
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (bool, error)); ok {
-		return rf()
+	var r0 *types.CertificateHeader
+	var r1 *types.AggchainProof
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*types.CertificateHeader, *types.AggchainProof, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) *types.CertificateHeader); ok {
+		r0 = rf(ctx)
 	} else {
-		r0 = ret.Get(0).(bool)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.CertificateHeader)
+		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) *types.AggchainProof); ok {
+		r1 = rf(ctx)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*types.AggchainProof)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
-// AggSenderStorage_IsLastSentCertificateInError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLastSentCertificateInError'
-type AggSenderStorage_IsLastSentCertificateInError_Call struct {
+// AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastSentCertificateHeaderWithProofIfInError'
+type AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call struct {
 	*mock.Call
 }
 
-// IsLastSentCertificateInError is a helper method to define mock.On call
-func (_e *AggSenderStorage_Expecter) IsLastSentCertificateInError() *AggSenderStorage_IsLastSentCertificateInError_Call {
-	return &AggSenderStorage_IsLastSentCertificateInError_Call{Call: _e.mock.On("IsLastSentCertificateInError")}
+// GetLastSentCertificateHeaderWithProofIfInError is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *AggSenderStorage_Expecter) GetLastSentCertificateHeaderWithProofIfInError(ctx interface{}) *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call {
+	return &AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call{Call: _e.mock.On("GetLastSentCertificateHeaderWithProofIfInError", ctx)}
 }
 
-func (_c *AggSenderStorage_IsLastSentCertificateInError_Call) Run(run func()) *AggSenderStorage_IsLastSentCertificateInError_Call {
+func (_c *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call) Run(run func(ctx context.Context)) *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
 
-func (_c *AggSenderStorage_IsLastSentCertificateInError_Call) Return(_a0 bool, _a1 error) *AggSenderStorage_IsLastSentCertificateInError_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call) Return(_a0 *types.CertificateHeader, _a1 *types.AggchainProof, _a2 error) *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *AggSenderStorage_IsLastSentCertificateInError_Call) RunAndReturn(run func() (bool, error)) *AggSenderStorage_IsLastSentCertificateInError_Call {
+func (_c *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call) RunAndReturn(run func(context.Context) (*types.CertificateHeader, *types.AggchainProof, error)) *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -73,24 +73,83 @@ func (_c *AggSenderStorage_DeleteCertificate_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// GetCertificateAggchainProof provides a mock function with given fields: height, certificateID
+func (_m *AggSenderStorage) GetCertificateAggchainProof(height uint64, certificateID common.Hash) (*types.AggchainProof, error) {
+	ret := _m.Called(height, certificateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCertificateAggchainProof")
+	}
+
+	var r0 *types.AggchainProof
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64, common.Hash) (*types.AggchainProof, error)); ok {
+		return rf(height, certificateID)
+	}
+	if rf, ok := ret.Get(0).(func(uint64, common.Hash) *types.AggchainProof); ok {
+		r0 = rf(height, certificateID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.AggchainProof)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(uint64, common.Hash) error); ok {
+		r1 = rf(height, certificateID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggSenderStorage_GetCertificateAggchainProof_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateAggchainProof'
+type AggSenderStorage_GetCertificateAggchainProof_Call struct {
+	*mock.Call
+}
+
+// GetCertificateAggchainProof is a helper method to define mock.On call
+//   - height uint64
+//   - certificateID common.Hash
+func (_e *AggSenderStorage_Expecter) GetCertificateAggchainProof(height interface{}, certificateID interface{}) *AggSenderStorage_GetCertificateAggchainProof_Call {
+	return &AggSenderStorage_GetCertificateAggchainProof_Call{Call: _e.mock.On("GetCertificateAggchainProof", height, certificateID)}
+}
+
+func (_c *AggSenderStorage_GetCertificateAggchainProof_Call) Run(run func(height uint64, certificateID common.Hash)) *AggSenderStorage_GetCertificateAggchainProof_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint64), args[1].(common.Hash))
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_GetCertificateAggchainProof_Call) Return(_a0 *types.AggchainProof, _a1 error) *AggSenderStorage_GetCertificateAggchainProof_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggSenderStorage_GetCertificateAggchainProof_Call) RunAndReturn(run func(uint64, common.Hash) (*types.AggchainProof, error)) *AggSenderStorage_GetCertificateAggchainProof_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCertificateByHeight provides a mock function with given fields: height
-func (_m *AggSenderStorage) GetCertificateByHeight(height uint64) (*types.CertificateInfo, error) {
+func (_m *AggSenderStorage) GetCertificateByHeight(height uint64) (*types.Certificate, error) {
 	ret := _m.Called(height)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByHeight")
 	}
 
-	var r0 *types.CertificateInfo
+	var r0 *types.Certificate
 	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64) (*types.CertificateInfo, error)); ok {
+	if rf, ok := ret.Get(0).(func(uint64) (*types.Certificate, error)); ok {
 		return rf(height)
 	}
-	if rf, ok := ret.Get(0).(func(uint64) *types.CertificateInfo); ok {
+	if rf, ok := ret.Get(0).(func(uint64) *types.Certificate); ok {
 		r0 = rf(height)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.CertificateInfo)
+			r0 = ret.Get(0).(*types.Certificate)
 		}
 	}
 
@@ -121,39 +180,39 @@ func (_c *AggSenderStorage_GetCertificateByHeight_Call) Run(run func(height uint
 	return _c
 }
 
-func (_c *AggSenderStorage_GetCertificateByHeight_Call) Return(_a0 *types.CertificateInfo, _a1 error) *AggSenderStorage_GetCertificateByHeight_Call {
+func (_c *AggSenderStorage_GetCertificateByHeight_Call) Return(_a0 *types.Certificate, _a1 error) *AggSenderStorage_GetCertificateByHeight_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AggSenderStorage_GetCertificateByHeight_Call) RunAndReturn(run func(uint64) (*types.CertificateInfo, error)) *AggSenderStorage_GetCertificateByHeight_Call {
+func (_c *AggSenderStorage_GetCertificateByHeight_Call) RunAndReturn(run func(uint64) (*types.Certificate, error)) *AggSenderStorage_GetCertificateByHeight_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetCertificatesByStatus provides a mock function with given fields: status, lightQuery
-func (_m *AggSenderStorage) GetCertificatesByStatus(status []agglayertypes.CertificateStatus, lightQuery bool) ([]*types.CertificateInfo, error) {
-	ret := _m.Called(status, lightQuery)
+// GetCertificateHeaderByHeight provides a mock function with given fields: height
+func (_m *AggSenderStorage) GetCertificateHeaderByHeight(height uint64) (*types.CertificateHeader, error) {
+	ret := _m.Called(height)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCertificatesByStatus")
+		panic("no return value specified for GetCertificateHeaderByHeight")
 	}
 
-	var r0 []*types.CertificateInfo
+	var r0 *types.CertificateHeader
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus, bool) ([]*types.CertificateInfo, error)); ok {
-		return rf(status, lightQuery)
+	if rf, ok := ret.Get(0).(func(uint64) (*types.CertificateHeader, error)); ok {
+		return rf(height)
 	}
-	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus, bool) []*types.CertificateInfo); ok {
-		r0 = rf(status, lightQuery)
+	if rf, ok := ret.Get(0).(func(uint64) *types.CertificateHeader); ok {
+		r0 = rf(height)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*types.CertificateInfo)
+			r0 = ret.Get(0).(*types.CertificateHeader)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]agglayertypes.CertificateStatus, bool) error); ok {
-		r1 = rf(status, lightQuery)
+	if rf, ok := ret.Get(1).(func(uint64) error); ok {
+		r1 = rf(height)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -161,53 +220,110 @@ func (_m *AggSenderStorage) GetCertificatesByStatus(status []agglayertypes.Certi
 	return r0, r1
 }
 
-// AggSenderStorage_GetCertificatesByStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificatesByStatus'
-type AggSenderStorage_GetCertificatesByStatus_Call struct {
+// AggSenderStorage_GetCertificateHeaderByHeight_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateHeaderByHeight'
+type AggSenderStorage_GetCertificateHeaderByHeight_Call struct {
 	*mock.Call
 }
 
-// GetCertificatesByStatus is a helper method to define mock.On call
-//   - status []agglayertypes.CertificateStatus
-//   - lightQuery bool
-func (_e *AggSenderStorage_Expecter) GetCertificatesByStatus(status interface{}, lightQuery interface{}) *AggSenderStorage_GetCertificatesByStatus_Call {
-	return &AggSenderStorage_GetCertificatesByStatus_Call{Call: _e.mock.On("GetCertificatesByStatus", status, lightQuery)}
+// GetCertificateHeaderByHeight is a helper method to define mock.On call
+//   - height uint64
+func (_e *AggSenderStorage_Expecter) GetCertificateHeaderByHeight(height interface{}) *AggSenderStorage_GetCertificateHeaderByHeight_Call {
+	return &AggSenderStorage_GetCertificateHeaderByHeight_Call{Call: _e.mock.On("GetCertificateHeaderByHeight", height)}
 }
 
-func (_c *AggSenderStorage_GetCertificatesByStatus_Call) Run(run func(status []agglayertypes.CertificateStatus, lightQuery bool)) *AggSenderStorage_GetCertificatesByStatus_Call {
+func (_c *AggSenderStorage_GetCertificateHeaderByHeight_Call) Run(run func(height uint64)) *AggSenderStorage_GetCertificateHeaderByHeight_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]agglayertypes.CertificateStatus), args[1].(bool))
+		run(args[0].(uint64))
 	})
 	return _c
 }
 
-func (_c *AggSenderStorage_GetCertificatesByStatus_Call) Return(_a0 []*types.CertificateInfo, _a1 error) *AggSenderStorage_GetCertificatesByStatus_Call {
+func (_c *AggSenderStorage_GetCertificateHeaderByHeight_Call) Return(_a0 *types.CertificateHeader, _a1 error) *AggSenderStorage_GetCertificateHeaderByHeight_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AggSenderStorage_GetCertificatesByStatus_Call) RunAndReturn(run func([]agglayertypes.CertificateStatus, bool) ([]*types.CertificateInfo, error)) *AggSenderStorage_GetCertificatesByStatus_Call {
+func (_c *AggSenderStorage_GetCertificateHeaderByHeight_Call) RunAndReturn(run func(uint64) (*types.CertificateHeader, error)) *AggSenderStorage_GetCertificateHeaderByHeight_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCertificateHeadersByStatus provides a mock function with given fields: status
+func (_m *AggSenderStorage) GetCertificateHeadersByStatus(status []agglayertypes.CertificateStatus) ([]*types.CertificateHeader, error) {
+	ret := _m.Called(status)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCertificateHeadersByStatus")
+	}
+
+	var r0 []*types.CertificateHeader
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus) ([]*types.CertificateHeader, error)); ok {
+		return rf(status)
+	}
+	if rf, ok := ret.Get(0).(func([]agglayertypes.CertificateStatus) []*types.CertificateHeader); ok {
+		r0 = rf(status)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*types.CertificateHeader)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]agglayertypes.CertificateStatus) error); ok {
+		r1 = rf(status)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggSenderStorage_GetCertificateHeadersByStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateHeadersByStatus'
+type AggSenderStorage_GetCertificateHeadersByStatus_Call struct {
+	*mock.Call
+}
+
+// GetCertificateHeadersByStatus is a helper method to define mock.On call
+//   - status []agglayertypes.CertificateStatus
+func (_e *AggSenderStorage_Expecter) GetCertificateHeadersByStatus(status interface{}) *AggSenderStorage_GetCertificateHeadersByStatus_Call {
+	return &AggSenderStorage_GetCertificateHeadersByStatus_Call{Call: _e.mock.On("GetCertificateHeadersByStatus", status)}
+}
+
+func (_c *AggSenderStorage_GetCertificateHeadersByStatus_Call) Run(run func(status []agglayertypes.CertificateStatus)) *AggSenderStorage_GetCertificateHeadersByStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]agglayertypes.CertificateStatus))
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_GetCertificateHeadersByStatus_Call) Return(_a0 []*types.CertificateHeader, _a1 error) *AggSenderStorage_GetCertificateHeadersByStatus_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggSenderStorage_GetCertificateHeadersByStatus_Call) RunAndReturn(run func([]agglayertypes.CertificateStatus) ([]*types.CertificateHeader, error)) *AggSenderStorage_GetCertificateHeadersByStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetLastSentCertificate provides a mock function with no fields
-func (_m *AggSenderStorage) GetLastSentCertificate() (*types.CertificateInfo, error) {
+func (_m *AggSenderStorage) GetLastSentCertificate() (*types.Certificate, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLastSentCertificate")
 	}
 
-	var r0 *types.CertificateInfo
+	var r0 *types.Certificate
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*types.CertificateInfo, error)); ok {
+	if rf, ok := ret.Get(0).(func() (*types.Certificate, error)); ok {
 		return rf()
 	}
-	if rf, ok := ret.Get(0).(func() *types.CertificateInfo); ok {
+	if rf, ok := ret.Get(0).(func() *types.Certificate); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.CertificateInfo)
+			r0 = ret.Get(0).(*types.Certificate)
 		}
 	}
 
@@ -237,18 +353,75 @@ func (_c *AggSenderStorage_GetLastSentCertificate_Call) Run(run func()) *AggSend
 	return _c
 }
 
-func (_c *AggSenderStorage_GetLastSentCertificate_Call) Return(_a0 *types.CertificateInfo, _a1 error) *AggSenderStorage_GetLastSentCertificate_Call {
+func (_c *AggSenderStorage_GetLastSentCertificate_Call) Return(_a0 *types.Certificate, _a1 error) *AggSenderStorage_GetLastSentCertificate_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AggSenderStorage_GetLastSentCertificate_Call) RunAndReturn(run func() (*types.CertificateInfo, error)) *AggSenderStorage_GetLastSentCertificate_Call {
+func (_c *AggSenderStorage_GetLastSentCertificate_Call) RunAndReturn(run func() (*types.Certificate, error)) *AggSenderStorage_GetLastSentCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLastSentCertificateHeader provides a mock function with no fields
+func (_m *AggSenderStorage) GetLastSentCertificateHeader() (*types.CertificateHeader, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastSentCertificateHeader")
+	}
+
+	var r0 *types.CertificateHeader
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*types.CertificateHeader, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *types.CertificateHeader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.CertificateHeader)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggSenderStorage_GetLastSentCertificateHeader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastSentCertificateHeader'
+type AggSenderStorage_GetLastSentCertificateHeader_Call struct {
+	*mock.Call
+}
+
+// GetLastSentCertificateHeader is a helper method to define mock.On call
+func (_e *AggSenderStorage_Expecter) GetLastSentCertificateHeader() *AggSenderStorage_GetLastSentCertificateHeader_Call {
+	return &AggSenderStorage_GetLastSentCertificateHeader_Call{Call: _e.mock.On("GetLastSentCertificateHeader")}
+}
+
+func (_c *AggSenderStorage_GetLastSentCertificateHeader_Call) Run(run func()) *AggSenderStorage_GetLastSentCertificateHeader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_GetLastSentCertificateHeader_Call) Return(_a0 *types.CertificateHeader, _a1 error) *AggSenderStorage_GetLastSentCertificateHeader_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggSenderStorage_GetLastSentCertificateHeader_Call) RunAndReturn(run func() (*types.CertificateHeader, error)) *AggSenderStorage_GetLastSentCertificateHeader_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // SaveLastSentCertificate provides a mock function with given fields: ctx, certificate
-func (_m *AggSenderStorage) SaveLastSentCertificate(ctx context.Context, certificate types.CertificateInfo) error {
+func (_m *AggSenderStorage) SaveLastSentCertificate(ctx context.Context, certificate types.Certificate) error {
 	ret := _m.Called(ctx, certificate)
 
 	if len(ret) == 0 {
@@ -256,7 +429,7 @@ func (_m *AggSenderStorage) SaveLastSentCertificate(ctx context.Context, certifi
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.CertificateInfo) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.Certificate) error); ok {
 		r0 = rf(ctx, certificate)
 	} else {
 		r0 = ret.Error(0)
@@ -272,14 +445,14 @@ type AggSenderStorage_SaveLastSentCertificate_Call struct {
 
 // SaveLastSentCertificate is a helper method to define mock.On call
 //   - ctx context.Context
-//   - certificate types.CertificateInfo
+//   - certificate types.Certificate
 func (_e *AggSenderStorage_Expecter) SaveLastSentCertificate(ctx interface{}, certificate interface{}) *AggSenderStorage_SaveLastSentCertificate_Call {
 	return &AggSenderStorage_SaveLastSentCertificate_Call{Call: _e.mock.On("SaveLastSentCertificate", ctx, certificate)}
 }
 
-func (_c *AggSenderStorage_SaveLastSentCertificate_Call) Run(run func(ctx context.Context, certificate types.CertificateInfo)) *AggSenderStorage_SaveLastSentCertificate_Call {
+func (_c *AggSenderStorage_SaveLastSentCertificate_Call) Run(run func(ctx context.Context, certificate types.Certificate)) *AggSenderStorage_SaveLastSentCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.CertificateInfo))
+		run(args[0].(context.Context), args[1].(types.Certificate))
 	})
 	return _c
 }
@@ -289,7 +462,7 @@ func (_c *AggSenderStorage_SaveLastSentCertificate_Call) Return(_a0 error) *AggS
 	return _c
 }
 
-func (_c *AggSenderStorage_SaveLastSentCertificate_Call) RunAndReturn(run func(context.Context, types.CertificateInfo) error) *AggSenderStorage_SaveLastSentCertificate_Call {
+func (_c *AggSenderStorage_SaveLastSentCertificate_Call) RunAndReturn(run func(context.Context, types.Certificate) error) *AggSenderStorage_SaveLastSentCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_aggsender_storer.go
+++ b/aggsender/mocks/mock_aggsender_storer.go
@@ -21,23 +21,23 @@ func (_m *AggsenderStorer) EXPECT() *AggsenderStorer_Expecter {
 }
 
 // GetCertificateByHeight provides a mock function with given fields: height
-func (_m *AggsenderStorer) GetCertificateByHeight(height uint64) (*types.CertificateInfo, error) {
+func (_m *AggsenderStorer) GetCertificateByHeight(height uint64) (*types.Certificate, error) {
 	ret := _m.Called(height)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByHeight")
 	}
 
-	var r0 *types.CertificateInfo
+	var r0 *types.Certificate
 	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64) (*types.CertificateInfo, error)); ok {
+	if rf, ok := ret.Get(0).(func(uint64) (*types.Certificate, error)); ok {
 		return rf(height)
 	}
-	if rf, ok := ret.Get(0).(func(uint64) *types.CertificateInfo); ok {
+	if rf, ok := ret.Get(0).(func(uint64) *types.Certificate); ok {
 		r0 = rf(height)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.CertificateInfo)
+			r0 = ret.Get(0).(*types.Certificate)
 		}
 	}
 
@@ -68,34 +68,34 @@ func (_c *AggsenderStorer_GetCertificateByHeight_Call) Run(run func(height uint6
 	return _c
 }
 
-func (_c *AggsenderStorer_GetCertificateByHeight_Call) Return(_a0 *types.CertificateInfo, _a1 error) *AggsenderStorer_GetCertificateByHeight_Call {
+func (_c *AggsenderStorer_GetCertificateByHeight_Call) Return(_a0 *types.Certificate, _a1 error) *AggsenderStorer_GetCertificateByHeight_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AggsenderStorer_GetCertificateByHeight_Call) RunAndReturn(run func(uint64) (*types.CertificateInfo, error)) *AggsenderStorer_GetCertificateByHeight_Call {
+func (_c *AggsenderStorer_GetCertificateByHeight_Call) RunAndReturn(run func(uint64) (*types.Certificate, error)) *AggsenderStorer_GetCertificateByHeight_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetLastSentCertificate provides a mock function with no fields
-func (_m *AggsenderStorer) GetLastSentCertificate() (*types.CertificateInfo, error) {
+func (_m *AggsenderStorer) GetLastSentCertificate() (*types.Certificate, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLastSentCertificate")
 	}
 
-	var r0 *types.CertificateInfo
+	var r0 *types.Certificate
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*types.CertificateInfo, error)); ok {
+	if rf, ok := ret.Get(0).(func() (*types.Certificate, error)); ok {
 		return rf()
 	}
-	if rf, ok := ret.Get(0).(func() *types.CertificateInfo); ok {
+	if rf, ok := ret.Get(0).(func() *types.Certificate); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.CertificateInfo)
+			r0 = ret.Get(0).(*types.Certificate)
 		}
 	}
 
@@ -125,12 +125,12 @@ func (_c *AggsenderStorer_GetLastSentCertificate_Call) Run(run func()) *Aggsende
 	return _c
 }
 
-func (_c *AggsenderStorer_GetLastSentCertificate_Call) Return(_a0 *types.CertificateInfo, _a1 error) *AggsenderStorer_GetLastSentCertificate_Call {
+func (_c *AggsenderStorer_GetLastSentCertificate_Call) Return(_a0 *types.Certificate, _a1 error) *AggsenderStorer_GetLastSentCertificate_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AggsenderStorer_GetLastSentCertificate_Call) RunAndReturn(run func() (*types.CertificateInfo, error)) *AggsenderStorer_GetLastSentCertificate_Call {
+func (_c *AggsenderStorer_GetLastSentCertificate_Call) RunAndReturn(run func() (*types.Certificate, error)) *AggsenderStorer_GetLastSentCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/rpc/aggsender_rpc.go
+++ b/aggsender/rpc/aggsender_rpc.go
@@ -9,8 +9,8 @@ import (
 )
 
 type AggsenderStorer interface {
-	GetCertificateByHeight(height uint64) (*types.CertificateInfo, error)
-	GetLastSentCertificate() (*types.CertificateInfo, error)
+	GetCertificateByHeight(height uint64) (*types.Certificate, error)
+	GetLastSentCertificate() (*types.Certificate, error)
 }
 
 type AggsenderInterface interface {
@@ -57,19 +57,26 @@ func (b *AggsenderRPC) Status() (interface{}, rpc.Error) {
 // -d '{"method":"aggsender_getCertificateHeaderPerHeight", "params":[$height], "id":1}'
 func (b *AggsenderRPC) GetCertificateHeaderPerHeight(height *uint64) (interface{}, rpc.Error) {
 	var (
-		certInfo *types.CertificateInfo
-		err      error
+		cert *types.Certificate
+		err  error
 	)
 	if height == nil {
-		certInfo, err = b.storage.GetLastSentCertificate()
+		cert, err = b.storage.GetLastSentCertificate()
 	} else {
-		certInfo, err = b.storage.GetCertificateByHeight(*height)
+		cert, err = b.storage.GetCertificateByHeight(*height)
 	}
 	if err != nil {
 		return nil, rpc.NewRPCError(rpc.DefaultErrorCode, fmt.Sprintf("error getting certificate by height: %v", err))
 	}
-	if certInfo == nil {
+	if cert == nil {
 		return nil, rpc.NewRPCError(rpc.NotFoundErrorCode, "certificate not found")
 	}
+
+	certInfo, err := cert.ToCertificateInfo()
+	if err != nil {
+		return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
+			fmt.Sprintf("error converting certificate to CertificateInfo: %v", err))
+	}
+
 	return certInfo, nil
 }

--- a/aggsender/rpc/aggsender_rpc.go
+++ b/aggsender/rpc/aggsender_rpc.go
@@ -72,11 +72,5 @@ func (b *AggsenderRPC) GetCertificateHeaderPerHeight(height *uint64) (interface{
 		return nil, rpc.NewRPCError(rpc.NotFoundErrorCode, "certificate not found")
 	}
 
-	certInfo, err := cert.ToCertificateInfo()
-	if err != nil {
-		return nil, rpc.NewRPCError(rpc.DefaultErrorCode,
-			fmt.Sprintf("error converting certificate to CertificateInfo: %v", err))
-	}
-
-	return certInfo, nil
+	return cert, nil
 }

--- a/aggsender/rpc/aggsender_rpc_test.go
+++ b/aggsender/rpc/aggsender_rpc_test.go
@@ -23,15 +23,17 @@ func TestAggsenderRPCGetCertificateHeaderPerHeight(t *testing.T) {
 	cases := []struct {
 		name          string
 		height        *uint64
-		certResult    *types.CertificateInfo
+		certResult    *types.Certificate
 		certError     error
 		expectedError string
 		expectedNil   bool
 	}{
 		{
-			name:       "latest, no error",
-			certResult: &types.CertificateInfo{},
-			certError:  nil,
+			name: "latest, no error",
+			certResult: &types.Certificate{
+				Header: &types.CertificateHeader{},
+			},
+			certError: nil,
 		},
 		{
 			name:          "latest,no error, no cert",
@@ -41,17 +43,21 @@ func TestAggsenderRPCGetCertificateHeaderPerHeight(t *testing.T) {
 			expectedNil:   true,
 		},
 		{
-			name:          "latest,error",
-			certResult:    &types.CertificateInfo{},
+			name: "latest,error",
+			certResult: &types.Certificate{
+				Header: &types.CertificateHeader{},
+			},
 			certError:     fmt.Errorf("my_error"),
 			expectedError: "my_error",
 			expectedNil:   true,
 		},
 		{
-			name:       "hight, no error",
-			height:     &height,
-			certResult: &types.CertificateInfo{},
-			certError:  nil,
+			name:   "hight, no error",
+			height: &height,
+			certResult: &types.Certificate{
+				Header: &types.CertificateHeader{},
+			},
+			certError: nil,
 		},
 	}
 

--- a/aggsender/rpcclient/client.go
+++ b/aggsender/rpcclient/client.go
@@ -39,7 +39,7 @@ func (c *Client) GetStatus() (*types.AggsenderInfo, error) {
 	return &result, nil
 }
 
-func (c *Client) GetCertificateHeaderPerHeight(height *uint64) (*types.CertificateInfo, error) {
+func (c *Client) GetCertificateHeaderPerHeight(height *uint64) (*types.Certificate, error) {
 	response, err := jSONRPCCall(c.url, "aggsender_getCertificateHeaderPerHeight", height)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (c *Client) GetCertificateHeaderPerHeight(height *uint64) (*types.Certifica
 	if response.Error != nil {
 		return nil, fmt.Errorf("error in the response calling aggsender_getCertificateHeaderPerHeight: %v", response.Error)
 	}
-	cert := types.CertificateInfo{}
+	cert := types.Certificate{}
 	err = json.Unmarshal(response.Result, &cert)
 	if err != nil {
 		return nil, err

--- a/aggsender/rpcclient/client_test.go
+++ b/aggsender/rpcclient/client_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetCertificateHeaderPerHeight(t *testing.T) {
 	sut := NewClient("url")
 	height := uint64(1)
-	responseCert := types.CertificateInfo{}
+	responseCert := types.Certificate{Header: &types.CertificateHeader{}}
 	responseCertJSON, err := json.Marshal(responseCert)
 	require.NoError(t, err)
 	response := rpc.Response{

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -99,7 +99,7 @@ func (c *certStatusChecker) CheckInitialStatus(
 // It returns:
 // bool -> if there are pending certificates
 func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) types.CertStatus {
-	pendingCertificates, err := c.storage.GetCertificatesByStatus(agglayertypes.NonSettledStatuses)
+	pendingCertificates, err := c.storage.GetCertificatesByStatus(agglayertypes.NonSettledStatuses, true)
 	if err != nil {
 		c.log.Errorf("error getting pending certificates: %w", err)
 		return types.CertStatus{ExistPendingCerts: true, ExistNewInErrorCert: false}
@@ -166,7 +166,7 @@ func (c *certStatusChecker) updateCertificateStatus(ctx context.Context,
 
 	localCert.Status = agglayerCert.Status
 	localCert.UpdatedAt = uint32(time.Now().UTC().Unix())
-	if err := c.storage.UpdateCertificate(ctx, *localCert); err != nil {
+	if err := c.storage.UpdateCertificateStatus(ctx, *localCert); err != nil {
 		c.log.Errorf("error updating certificate %s status in storage: %w", agglayerCert.ID(), err)
 		return fmt.Errorf("error updating certificate. Err: %w", err)
 	}

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -166,7 +166,11 @@ func (c *certStatusChecker) updateCertificateStatus(ctx context.Context,
 
 	localCert.Status = agglayerCert.Status
 	localCert.UpdatedAt = uint32(time.Now().UTC().Unix())
-	if err := c.storage.UpdateCertificateStatus(ctx, *localCert); err != nil {
+	if err := c.storage.UpdateCertificateStatus(
+		ctx,
+		localCert.CertificateID,
+		localCert.Status,
+		localCert.UpdatedAt); err != nil {
 		c.log.Errorf("error updating certificate %s status in storage: %w", agglayerCert.ID(), err)
 		return fmt.Errorf("error updating certificate. Err: %w", err)
 	}

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -13,7 +13,10 @@ import (
 	"github.com/agglayer/aggkit/log"
 )
 
-var _ types.CertificateStatusChecker = (*certStatusChecker)(nil)
+var (
+	naAgglayerHeader                                = "na/agglayer header"
+	_                types.CertificateStatusChecker = (*certStatusChecker)(nil)
+)
 
 // certStatusChecker is a struct responsible for checking the status of certificates.
 // It provides functionality to interact with the storage layer, communicate with the
@@ -99,7 +102,7 @@ func (c *certStatusChecker) CheckInitialStatus(
 // It returns:
 // bool -> if there are pending certificates
 func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) types.CertStatus {
-	pendingCertificates, err := c.storage.GetCertificatesByStatus(agglayertypes.NonSettledStatuses, true)
+	pendingCertificates, err := c.storage.GetCertificateHeadersByStatus(agglayertypes.NonSettledStatuses)
 	if err != nil {
 		c.log.Errorf("error getting pending certificates: %w", err)
 		return types.CertStatus{ExistPendingCerts: true, ExistNewInErrorCert: false}
@@ -142,7 +145,7 @@ func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) 
 
 // updateCertificate updates the certificate status in the storage
 func (c *certStatusChecker) updateCertificateStatus(ctx context.Context,
-	localCert *types.CertificateInfo,
+	localCert *types.CertificateHeader,
 	agglayerCert *agglayertypes.CertificateHeader) error {
 	if localCert.Status == agglayerCert.Status {
 		return nil
@@ -192,7 +195,7 @@ func (c *certStatusChecker) checkLastCertificateFromAgglayer(ctx context.Context
 }
 
 func (c *certStatusChecker) executeInitialStatusAction(ctx context.Context,
-	action *initialStatusResult, localCert *types.CertificateInfo) error {
+	action *initialStatusResult, localCert *types.CertificateHeader) error {
 	c.log.Infof("recovery: action: %s", action.String())
 	switch action.action {
 	case InitialStatusActionNone:
@@ -213,17 +216,17 @@ func (c *certStatusChecker) executeInitialStatusAction(ctx context.Context,
 
 // updateLocalStorageWithAggLayerCert updates the local storage with the certificate from the AggLayer
 func (c *certStatusChecker) updateLocalStorageWithAggLayerCert(ctx context.Context,
-	aggLayerCert *agglayertypes.CertificateHeader) (*types.CertificateInfo, error) {
-	certInfo := newCertificateInfoFromAgglayerCertHeader(aggLayerCert)
-	if certInfo == nil {
+	aggLayerCert *agglayertypes.CertificateHeader) (*types.Certificate, error) {
+	cert := newCertificateInfoFromAgglayerCertHeader(aggLayerCert)
+	if cert == nil {
 		return nil, nil
 	}
 
-	c.log.Infof("setting initial certificate from AggLayer: %s", certInfo.String())
-	return certInfo, c.storage.SaveLastSentCertificate(ctx, *certInfo)
+	c.log.Infof("setting initial certificate from AggLayer: %s", cert.String())
+	return cert, c.storage.SaveLastSentCertificate(ctx, *cert)
 }
 
-func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader) *types.CertificateInfo {
+func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader) *types.Certificate {
 	if c == nil {
 		return nil
 	}
@@ -237,19 +240,23 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 		createdAt = now
 	}
 
-	res := &types.CertificateInfo{
-		Height:            c.Height,
-		CertificateID:     c.CertificateID,
-		NewLocalExitRoot:  c.NewLocalExitRoot,
-		FromBlock:         meta.FromBlock,
-		ToBlock:           toBlock,
-		Status:            c.Status,
-		CreatedAt:         createdAt,
-		UpdatedAt:         now,
-		SignedCertificate: "na/agglayer header",
+	res := &types.Certificate{
+		Header: &types.CertificateHeader{
+			Height:           c.Height,
+			CertificateID:    c.CertificateID,
+			NewLocalExitRoot: c.NewLocalExitRoot,
+			FromBlock:        meta.FromBlock,
+			ToBlock:          toBlock,
+			Status:           c.Status,
+			CreatedAt:        createdAt,
+			UpdatedAt:        now,
+		},
+		SignedCertificate: &naAgglayerHeader,
 	}
+
 	if c.PreviousLocalExitRoot != nil {
-		res.PreviousLocalExitRoot = c.PreviousLocalExitRoot
+		res.Header.PreviousLocalExitRoot = c.PreviousLocalExitRoot
 	}
+
 	return res
 }

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -136,7 +136,7 @@ func TestNewCertificateInfoFromAgglayerCertHeader(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputHeader    *agglayertypes.CertificateHeader
-		expectedResult *types.CertificateInfo
+		expectedResult *types.Certificate
 	}{
 		{
 			name:           "Nil input header",
@@ -153,16 +153,18 @@ func TestNewCertificateInfoFromAgglayerCertHeader(t *testing.T) {
 				Status:                agglayertypes.Settled,
 				PreviousLocalExitRoot: &previousLER,
 			},
-			expectedResult: &types.CertificateInfo{
-				Height:                100,
-				CertificateID:         common.HexToHash("0x1"),
-				NewLocalExitRoot:      common.HexToHash("0xabc"),
-				FromBlock:             10,
-				ToBlock:               15,
-				Status:                agglayertypes.Settled,
-				CreatedAt:             1234567890,
-				SignedCertificate:     &naAgglayerHeader,
-				PreviousLocalExitRoot: &previousLER,
+			expectedResult: &types.Certificate{
+				Header: &types.CertificateHeader{
+					Height:                100,
+					CertificateID:         common.HexToHash("0x1"),
+					NewLocalExitRoot:      common.HexToHash("0xabc"),
+					FromBlock:             10,
+					ToBlock:               15,
+					Status:                agglayertypes.Settled,
+					CreatedAt:             1234567890,
+					PreviousLocalExitRoot: &previousLER,
+				},
+				SignedCertificate: &naAgglayerHeader,
 			},
 		},
 		{
@@ -174,13 +176,15 @@ func TestNewCertificateInfoFromAgglayerCertHeader(t *testing.T) {
 				Metadata:         common.BigToHash(big.NewInt(25)),
 				Status:           agglayertypes.InError,
 			},
-			expectedResult: &types.CertificateInfo{
-				Height:            200,
-				CertificateID:     common.HexToHash("0x2"),
-				NewLocalExitRoot:  common.HexToHash("0x123"),
-				FromBlock:         0,
-				ToBlock:           25,
-				Status:            agglayertypes.InError,
+			expectedResult: &types.Certificate{
+				Header: &types.CertificateHeader{
+					Height:           200,
+					CertificateID:    common.HexToHash("0x2"),
+					NewLocalExitRoot: common.HexToHash("0x123"),
+					FromBlock:        0,
+					ToBlock:          25,
+					Status:           agglayertypes.InError,
+				},
 				SignedCertificate: &naAgglayerHeader,
 			},
 		},
@@ -196,14 +200,14 @@ func TestNewCertificateInfoFromAgglayerCertHeader(t *testing.T) {
 				require.Nil(t, result)
 			} else {
 				require.NotNil(t, result)
-				require.Equal(t, tt.expectedResult.Height, result.Header.Height)
-				require.Equal(t, tt.expectedResult.CertificateID, result.Header.CertificateID)
-				require.Equal(t, tt.expectedResult.NewLocalExitRoot, result.Header.NewLocalExitRoot)
-				require.Equal(t, tt.expectedResult.FromBlock, result.Header.FromBlock)
-				require.Equal(t, tt.expectedResult.ToBlock, result.Header.ToBlock)
-				require.Equal(t, tt.expectedResult.Status, result.Header.Status)
+				require.Equal(t, tt.expectedResult.Header.Height, result.Header.Height)
+				require.Equal(t, tt.expectedResult.Header.CertificateID, result.Header.CertificateID)
+				require.Equal(t, tt.expectedResult.Header.NewLocalExitRoot, result.Header.NewLocalExitRoot)
+				require.Equal(t, tt.expectedResult.Header.FromBlock, result.Header.FromBlock)
+				require.Equal(t, tt.expectedResult.Header.ToBlock, result.Header.ToBlock)
+				require.Equal(t, tt.expectedResult.Header.Status, result.Header.Status)
+				require.Equal(t, tt.expectedResult.Header.PreviousLocalExitRoot, result.Header.PreviousLocalExitRoot)
 				require.Equal(t, tt.expectedResult.SignedCertificate, result.SignedCertificate)
-				require.Equal(t, tt.expectedResult.PreviousLocalExitRoot, result.Header.PreviousLocalExitRoot)
 			}
 		})
 	}

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -112,9 +112,9 @@ func TestCheckIfCertificatesAreSettled(t *testing.T) {
 				mockAggLayerClient.EXPECT().GetCertificateHeader(mock.Anything, certID).Return(header, tt.clientError)
 			}
 			if tt.updateDBError != nil {
-				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything).Return(tt.updateDBError)
+				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.updateDBError)
 			} else if tt.clientError == nil && tt.getFromDBError == nil {
-				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything).Return(nil)
+				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			}
 
 			certStatusChecker := NewCertStatusChecker(mockLogger, mockStorage, mockAggLayerClient, 1)
@@ -327,7 +327,7 @@ func TestExecuteInitialStatusAction(t *testing.T) {
 			},
 			localCert: &types.CertificateInfo{CertificateID: common.HexToHash("0x1")},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificateStatus(ctx, mock.Anything).Return(fmt.Errorf("update error"))
+				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.InError, mock.Anything).Return(fmt.Errorf("update error"))
 			},
 			expectedError: "recovery: error updating local storage with agglayer certificate",
 		},
@@ -418,7 +418,7 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			localCert:    &types.CertificateInfo{CertificateID: common.HexToHash("0x1")},
 			agglayerCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x1"), Status: agglayertypes.Settled},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificateStatus(ctx, mock.Anything).Return(nil)
+				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.Settled, mock.Anything).Return(nil)
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			localCert:    &types.CertificateInfo{CertificateID: common.HexToHash("0x1")},
 			agglayerCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x1"), Status: agglayertypes.InError},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificateStatus(ctx, mock.Anything).Return(fmt.Errorf("update error"))
+				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.InError, mock.Anything).Return(fmt.Errorf("update error"))
 			},
 			expectedError: "recovery: error updating local storage with agglayer certificate",
 		},

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -106,15 +106,15 @@ func TestCheckIfCertificatesAreSettled(t *testing.T) {
 			mockAggLayerClient := agglayer.NewAgglayerClientMock(t)
 			mockLogger := log.WithFields("test", "unittest")
 
-			mockStorage.EXPECT().GetCertificatesByStatus(agglayertypes.NonSettledStatuses).Return(
+			mockStorage.EXPECT().GetCertificatesByStatus(agglayertypes.NonSettledStatuses, true).Return(
 				tt.pendingCertificates, tt.getFromDBError)
 			for certID, header := range tt.certificateHeaders {
 				mockAggLayerClient.EXPECT().GetCertificateHeader(mock.Anything, certID).Return(header, tt.clientError)
 			}
 			if tt.updateDBError != nil {
-				mockStorage.EXPECT().UpdateCertificate(mock.Anything, mock.Anything).Return(tt.updateDBError)
+				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything).Return(tt.updateDBError)
 			} else if tt.clientError == nil && tt.getFromDBError == nil {
-				mockStorage.EXPECT().UpdateCertificate(mock.Anything, mock.Anything).Return(nil)
+				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything).Return(nil)
 			}
 
 			certStatusChecker := NewCertStatusChecker(mockLogger, mockStorage, mockAggLayerClient, 1)
@@ -327,7 +327,7 @@ func TestExecuteInitialStatusAction(t *testing.T) {
 			},
 			localCert: &types.CertificateInfo{CertificateID: common.HexToHash("0x1")},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificate(ctx, mock.Anything).Return(fmt.Errorf("update error"))
+				m.EXPECT().UpdateCertificateStatus(ctx, mock.Anything).Return(fmt.Errorf("update error"))
 			},
 			expectedError: "recovery: error updating local storage with agglayer certificate",
 		},
@@ -418,7 +418,7 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			localCert:    &types.CertificateInfo{CertificateID: common.HexToHash("0x1")},
 			agglayerCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x1"), Status: agglayertypes.Settled},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificate(ctx, mock.Anything).Return(nil)
+				m.EXPECT().UpdateCertificateStatus(ctx, mock.Anything).Return(nil)
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			localCert:    &types.CertificateInfo{CertificateID: common.HexToHash("0x1")},
 			agglayerCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x1"), Status: agglayertypes.InError},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificate(ctx, mock.Anything).Return(fmt.Errorf("update error"))
+				m.EXPECT().UpdateCertificateStatus(ctx, mock.Anything).Return(fmt.Errorf("update error"))
 			},
 			expectedError: "recovery: error updating local storage with agglayer certificate",
 		},

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -25,7 +25,7 @@ var ErrAgglayerInconsistence = errors.New("recovery: agglayer inconsistence")
 type initialStatus struct {
 	SettledCert *agglayertypes.CertificateHeader
 	PendingCert *agglayertypes.CertificateHeader
-	LocalCert   *types.CertificateInfo
+	LocalCert   *types.CertificateHeader
 	log         common.Logger
 }
 
@@ -73,7 +73,7 @@ func newInitialStatus(ctx context.Context,
 		return nil, fmt.Errorf("recovery: error getting GetLatestPendingCertificateHeader from agglayer: %w", err)
 	}
 
-	localLastCert, err := storage.GetLastSentCertificate()
+	localLastCert, err := storage.GetLastSentCertificateHeader()
 	if err != nil {
 		return nil, fmt.Errorf("recovery: error getting last sent certificate from local storage: %w", err)
 	}

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -253,7 +253,7 @@ func runTestCases(t *testing.T, tests []testCaseData) {
 		t.Run(tt.name, func(t *testing.T) {
 			sut := initialStatus{log: logger}
 			if tt.localCert != nil {
-				sut.LocalCert = &types.CertificateInfo{
+				sut.LocalCert = &types.CertificateHeader{
 					CertificateID: tt.localCert.CertificateID,
 					Height:        tt.localCert.Height,
 					Status:        tt.localCert.Status,

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -22,7 +22,7 @@ type CertificateBuildParams struct {
 	Claims                         []bridgesync.Claim
 	CreatedAt                      uint32
 	RetryCount                     int
-	LastSentCertificate            *CertificateInfo
+	LastSentCertificate            *CertificateHeader
 	L1InfoTreeRootFromWhichToProve common.Hash
 	L1InfoTreeLeafCount            uint32
 	AggchainProof                  *AggchainProof

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -9,8 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var errNoCertificateHeader = fmt.Errorf("missing certificate header")
-
 const NilStr = "nil"
 
 type AggsenderMode string
@@ -189,76 +187,6 @@ func (c *Certificate) String() string {
 		c.Header.String(),
 		aggchainProof,
 	)
-}
-
-func (c *Certificate) ToCertificateInfo() (*CertificateInfo, error) {
-	if c.Header == nil {
-		return nil, errNoCertificateHeader
-	}
-
-	return &CertificateInfo{
-		CertificateID:           c.Header.CertificateID,
-		Height:                  c.Header.Height,
-		RetryCount:              c.Header.RetryCount,
-		PreviousLocalExitRoot:   c.Header.PreviousLocalExitRoot,
-		NewLocalExitRoot:        c.Header.NewLocalExitRoot,
-		FromBlock:               c.Header.FromBlock,
-		ToBlock:                 c.Header.ToBlock,
-		Status:                  c.Header.Status,
-		CreatedAt:               c.Header.CreatedAt,
-		UpdatedAt:               c.Header.UpdatedAt,
-		FinalizedL1InfoTreeRoot: c.Header.FinalizedL1InfoTreeRoot,
-		L1InfoTreeLeafCount:     c.Header.L1InfoTreeLeafCount,
-		SignedCertificate:       c.SignedCertificate,
-		AggchainProof:           c.AggchainProof,
-	}, nil
-}
-
-type CertificateInfo struct {
-	Height        uint64      `meddler:"height"`
-	RetryCount    int         `meddler:"retry_count"`
-	CertificateID common.Hash `meddler:"certificate_id,hash"`
-	// PreviousLocalExitRoot if it's nil means no reported
-	PreviousLocalExitRoot   *common.Hash                    `meddler:"previous_local_exit_root,hash"`
-	NewLocalExitRoot        common.Hash                     `meddler:"new_local_exit_root,hash"`
-	FromBlock               uint64                          `meddler:"from_block"`
-	ToBlock                 uint64                          `meddler:"to_block"`
-	Status                  agglayertypes.CertificateStatus `meddler:"status"`
-	CreatedAt               uint32                          `meddler:"created_at"`
-	UpdatedAt               uint32                          `meddler:"updated_at"`
-	SignedCertificate       *string                         `meddler:"signed_certificate"`
-	AggchainProof           *AggchainProof                  `meddler:"aggchain_proof,aggchainproof"`
-	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
-	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
-}
-
-func (c *CertificateInfo) ToCertificate() *Certificate {
-	return &Certificate{
-		Header: &CertificateHeader{
-			Height:                  c.Height,
-			RetryCount:              c.RetryCount,
-			CertificateID:           c.CertificateID,
-			PreviousLocalExitRoot:   c.PreviousLocalExitRoot,
-			NewLocalExitRoot:        c.NewLocalExitRoot,
-			FromBlock:               c.FromBlock,
-			ToBlock:                 c.ToBlock,
-			Status:                  c.Status,
-			CreatedAt:               c.CreatedAt,
-			UpdatedAt:               c.UpdatedAt,
-			FinalizedL1InfoTreeRoot: c.FinalizedL1InfoTreeRoot,
-			L1InfoTreeLeafCount:     c.L1InfoTreeLeafCount,
-		},
-		SignedCertificate: c.SignedCertificate,
-		AggchainProof:     c.AggchainProof,
-	}
-}
-
-// ID returns a string with the unique identifier of the cerificate (height+certificateID)
-func (c *CertificateInfo) ID() string {
-	if c == nil {
-		return NilStr
-	}
-	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
 }
 
 type CertificateMetadata struct {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+var errNoCertificateHeader = fmt.Errorf("missing certificate header")
+
 const NilStr = "nil"
 
 type AggsenderMode string
@@ -79,6 +81,139 @@ func (s *SP1StarkProof) String() string {
 	)
 }
 
+type CertificateHeader struct {
+	Height                  uint64                          `meddler:"height"`
+	RetryCount              int                             `meddler:"retry_count"`
+	CertificateID           common.Hash                     `meddler:"certificate_id,hash"`
+	PreviousLocalExitRoot   *common.Hash                    `meddler:"previous_local_exit_root,hash"`
+	NewLocalExitRoot        common.Hash                     `meddler:"new_local_exit_root,hash"`
+	FromBlock               uint64                          `meddler:"from_block"`
+	ToBlock                 uint64                          `meddler:"to_block"`
+	Status                  agglayertypes.CertificateStatus `meddler:"status"`
+	CreatedAt               uint32                          `meddler:"created_at"`
+	UpdatedAt               uint32                          `meddler:"updated_at"`
+	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
+	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
+}
+
+func (c *CertificateHeader) String() string {
+	if c == nil {
+		return NilStr
+	}
+	previousLocalExitRoot := NilStr
+	if c.PreviousLocalExitRoot != nil {
+		previousLocalExitRoot = c.PreviousLocalExitRoot.String()
+	}
+	finalizedL1InfoTreeRoot := NilStr
+	if c.FinalizedL1InfoTreeRoot != nil {
+		finalizedL1InfoTreeRoot = c.FinalizedL1InfoTreeRoot.String()
+	}
+
+	return fmt.Sprintf("aggsender.CertificateHeader: \n"+
+		"Height: %d \n"+
+		"RetryCount: %d \n"+
+		"CertificateID: %s \n"+
+		"PreviousLocalExitRoot: %s \n"+
+		"NewLocalExitRoot: %s \n"+
+		"Status: %s \n"+
+		"FromBlock: %d \n"+
+		"ToBlock: %d \n"+
+		"CreatedAt: %s \n"+
+		"UpdatedAt: %s \n"+
+		"FinalizedL1InfoTreeRoot: %s \n",
+		c.Height,
+		c.RetryCount,
+		c.CertificateID.String(),
+		previousLocalExitRoot,
+		c.NewLocalExitRoot.String(),
+		c.Status.String(),
+		c.FromBlock,
+		c.ToBlock,
+		time.Unix(int64(c.CreatedAt), 0),
+		time.Unix(int64(c.UpdatedAt), 0),
+		finalizedL1InfoTreeRoot,
+	)
+}
+
+// ID returns a string with the unique identifier of the cerificate (height+certificateID)
+func (c *CertificateHeader) ID() string {
+	if c == nil {
+		return NilStr
+	}
+	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
+}
+
+// StatusString returns the string representation of the status
+func (c *CertificateHeader) StatusString() string {
+	if c == nil {
+		return "???"
+	}
+	return c.Status.String()
+}
+
+// IsClosed returns true if the certificate is closed (settled or inError)
+func (c *CertificateHeader) IsClosed() bool {
+	if c == nil {
+		return false
+	}
+	return c.Status.IsClosed()
+}
+
+// ElapsedTimeSinceCreation returns the time elapsed since the certificate was created
+func (c *CertificateHeader) ElapsedTimeSinceCreation() time.Duration {
+	if c == nil {
+		return 0
+	}
+	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0))
+}
+
+type Certificate struct {
+	Header            *CertificateHeader
+	SignedCertificate *string        `meddler:"signed_certificate"`
+	AggchainProof     *AggchainProof `meddler:"aggchain_proof,aggchainproof"`
+}
+
+func (c *Certificate) String() string {
+	if c == nil {
+		return NilStr
+	}
+
+	aggchainProof := NilStr
+	if c.AggchainProof != nil {
+		aggchainProof = c.AggchainProof.String()
+	}
+
+	return fmt.Sprintf("aggsender.Certificate: \n"+
+		"Header: %s \n"+
+		"AggchainProof: %s \n",
+		c.Header.String(),
+		aggchainProof,
+	)
+}
+
+func (c *Certificate) ToCertificateInfo() (*CertificateInfo, error) {
+	if c.Header == nil {
+		return nil, errNoCertificateHeader
+	}
+
+	return &CertificateInfo{
+		CertificateID:           c.Header.CertificateID,
+		Height:                  c.Header.Height,
+		RetryCount:              c.Header.RetryCount,
+		PreviousLocalExitRoot:   c.Header.PreviousLocalExitRoot,
+		NewLocalExitRoot:        c.Header.NewLocalExitRoot,
+		FromBlock:               c.Header.FromBlock,
+		ToBlock:                 c.Header.ToBlock,
+		Status:                  c.Header.Status,
+		CreatedAt:               c.Header.CreatedAt,
+		UpdatedAt:               c.Header.UpdatedAt,
+		FinalizedL1InfoTreeRoot: c.Header.FinalizedL1InfoTreeRoot,
+		L1InfoTreeLeafCount:     c.Header.L1InfoTreeLeafCount,
+		SignedCertificate:       c.SignedCertificate,
+		AggchainProof:           c.AggchainProof,
+	}, nil
+}
+
 type CertificateInfo struct {
 	Height        uint64      `meddler:"height"`
 	RetryCount    int         `meddler:"retry_count"`
@@ -91,10 +226,31 @@ type CertificateInfo struct {
 	Status                  agglayertypes.CertificateStatus `meddler:"status"`
 	CreatedAt               uint32                          `meddler:"created_at"`
 	UpdatedAt               uint32                          `meddler:"updated_at"`
-	SignedCertificate       string                          `meddler:"signed_certificate"`
+	SignedCertificate       *string                         `meddler:"signed_certificate"`
 	AggchainProof           *AggchainProof                  `meddler:"aggchain_proof,aggchainproof"`
 	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
 	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
+}
+
+func (c *CertificateInfo) ToCertificate() *Certificate {
+	return &Certificate{
+		Header: &CertificateHeader{
+			Height:                  c.Height,
+			RetryCount:              c.RetryCount,
+			CertificateID:           c.CertificateID,
+			PreviousLocalExitRoot:   c.PreviousLocalExitRoot,
+			NewLocalExitRoot:        c.NewLocalExitRoot,
+			FromBlock:               c.FromBlock,
+			ToBlock:                 c.ToBlock,
+			Status:                  c.Status,
+			CreatedAt:               c.CreatedAt,
+			UpdatedAt:               c.UpdatedAt,
+			FinalizedL1InfoTreeRoot: c.FinalizedL1InfoTreeRoot,
+			L1InfoTreeLeafCount:     c.L1InfoTreeLeafCount,
+		},
+		SignedCertificate: c.SignedCertificate,
+		AggchainProof:     c.AggchainProof,
+	}
 }
 
 func (c *CertificateInfo) String() string {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -253,81 +253,12 @@ func (c *CertificateInfo) ToCertificate() *Certificate {
 	}
 }
 
-func (c *CertificateInfo) String() string {
-	if c == nil {
-		return NilStr
-	}
-	previousLocalExitRoot := NilStr
-	if c.PreviousLocalExitRoot != nil {
-		previousLocalExitRoot = c.PreviousLocalExitRoot.String()
-	}
-	finalizedL1InfoTreeRoot := NilStr
-	if c.FinalizedL1InfoTreeRoot != nil {
-		finalizedL1InfoTreeRoot = c.FinalizedL1InfoTreeRoot.String()
-	}
-	aggchainProof := NilStr
-	if c.AggchainProof != nil {
-		aggchainProof = c.AggchainProof.String()
-	}
-
-	return fmt.Sprintf("aggsender.CertificateInfo: \n"+
-		"Height: %d \n"+
-		"RetryCount: %d \n"+
-		"CertificateID: %s \n"+
-		"PreviousLocalExitRoot: %s \n"+
-		"NewLocalExitRoot: %s \n"+
-		"Status: %s \n"+
-		"FromBlock: %d \n"+
-		"ToBlock: %d \n"+
-		"CreatedAt: %s \n"+
-		"UpdatedAt: %s \n"+
-		"AggchainProof: %s \n"+
-		"FinalizedL1InfoTreeRoot: %s \n",
-		c.Height,
-		c.RetryCount,
-		c.CertificateID.String(),
-		previousLocalExitRoot,
-		c.NewLocalExitRoot.String(),
-		c.Status.String(),
-		c.FromBlock,
-		c.ToBlock,
-		time.Unix(int64(c.CreatedAt), 0),
-		time.Unix(int64(c.UpdatedAt), 0),
-		aggchainProof,
-		finalizedL1InfoTreeRoot,
-	)
-}
-
 // ID returns a string with the unique identifier of the cerificate (height+certificateID)
 func (c *CertificateInfo) ID() string {
 	if c == nil {
 		return NilStr
 	}
 	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
-}
-
-// StatusString returns the string representation of the status
-func (c *CertificateInfo) StatusString() string {
-	if c == nil {
-		return "???"
-	}
-	return c.Status.String()
-}
-
-// IsClosed returns true if the certificate is closed (settled or inError)
-func (c *CertificateInfo) IsClosed() bool {
-	if c == nil {
-		return false
-	}
-	return c.Status.IsClosed()
-}
-
-// ElapsedTimeSinceCreation returns the time elapsed since the certificate was created
-func (c *CertificateInfo) ElapsedTimeSinceCreation() time.Duration {
-	if c == nil {
-		return 0
-	}
-	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0))
 }
 
 type CertificateMetadata struct {

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 	"math/big"
-	"reflect"
 	"testing"
 	"time"
 
@@ -80,40 +79,4 @@ func TestCertificate_String(t *testing.T) {
 
 		require.Equal(t, expected, cert.String())
 	})
-}
-
-func TestCertificateFieldsMatchCertificateInfo(t *testing.T) {
-	// Check that all fields in CertificateInfo are present in Certificate
-	certificateInfoType := reflect.TypeOf(CertificateInfo{})
-
-	for i := range certificateInfoType.NumField() {
-		field := certificateInfoType.Field(i)
-		_, found := reflect.TypeOf(CertificateHeader{}).FieldByName(field.Name)
-		if !found {
-			_, found = reflect.TypeOf(Certificate{}).FieldByName(field.Name)
-		}
-		require.True(t, found, "Field %s is missing in Certificate", field.Name)
-	}
-
-	// Check that all fields in Certificate are present in CertificateInfo
-	certificateHeaderType := reflect.TypeOf(CertificateHeader{})
-
-	// Check that all fields in CertificateHeader are present in CertificateInfo
-	for i := range certificateHeaderType.NumField() {
-		field := certificateHeaderType.Field(i)
-		_, found := certificateInfoType.FieldByName(field.Name)
-		require.True(t, found, "Field %s from CertificateHeader is missing in CertificateInfo", field.Name)
-	}
-
-	// Check that all fields in Certificate are present in CertificateInfo
-	certificateType := reflect.TypeOf(Certificate{})
-
-	for i := range certificateType.NumField() {
-		field := certificateType.Field(i)
-		if field.Name == "Header" {
-			continue
-		}
-		_, found := certificateInfoType.FieldByName(field.Name)
-		require.True(t, found, "Field %s from Certificate is missing in CertificateInfo", field.Name)
-	}
 }

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -31,13 +31,13 @@ func TestMetadataConversions(t *testing.T) {
 	require.Equal(t, createdAt, extractBlock.CreatedAt)
 }
 
-func TestCertificateInfo_String(t *testing.T) {
-	t.Run("NilCertificateInfo", func(t *testing.T) {
-		var certInfo *CertificateInfo
+func TestCertificate_String(t *testing.T) {
+	t.Run("NilCertificate", func(t *testing.T) {
+		var certInfo *Certificate
 		require.Equal(t, NilStr, certInfo.String())
 	})
 
-	t.Run("CompleteCertificateInfo", func(t *testing.T) {
+	t.Run("CompleteCertificate", func(t *testing.T) {
 		previousLocalExitRoot := common.HexToHash("0xabc123")
 		finalizedL1InfoTreeRoot := common.HexToHash("0xdef456")
 		aggchainProof := &AggchainProof{
@@ -54,49 +54,31 @@ func TestCertificateInfo_String(t *testing.T) {
 			},
 		}
 
-		certInfo := &CertificateInfo{
-			Height:                  10,
-			RetryCount:              2,
-			CertificateID:           common.HexToHash("0x789abc"),
-			PreviousLocalExitRoot:   &previousLocalExitRoot,
-			NewLocalExitRoot:        common.HexToHash("0x123456"),
-			FromBlock:               1000,
-			ToBlock:                 2000,
-			Status:                  agglayertypes.CertificateStatus(1),
-			CreatedAt:               uint32(time.Now().Unix()),
-			UpdatedAt:               uint32(time.Now().Unix()),
-			AggchainProof:           aggchainProof,
-			FinalizedL1InfoTreeRoot: &finalizedL1InfoTreeRoot,
+		cert := &Certificate{
+			Header: &CertificateHeader{
+				Height:                  10,
+				RetryCount:              2,
+				CertificateID:           common.HexToHash("0x789abc"),
+				PreviousLocalExitRoot:   &previousLocalExitRoot,
+				NewLocalExitRoot:        common.HexToHash("0x123456"),
+				FromBlock:               1000,
+				ToBlock:                 2000,
+				Status:                  agglayertypes.CertificateStatus(1),
+				CreatedAt:               uint32(time.Now().Unix()),
+				UpdatedAt:               uint32(time.Now().Unix()),
+				FinalizedL1InfoTreeRoot: &finalizedL1InfoTreeRoot,
+			},
+			AggchainProof: aggchainProof,
 		}
 
-		expected := fmt.Sprintf("aggsender.CertificateInfo: \n"+
-			"Height: %d \n"+
-			"RetryCount: %d \n"+
-			"CertificateID: %s \n"+
-			"PreviousLocalExitRoot: %s \n"+
-			"NewLocalExitRoot: %s \n"+
-			"Status: %s \n"+
-			"FromBlock: %d \n"+
-			"ToBlock: %d \n"+
-			"CreatedAt: %s \n"+
-			"UpdatedAt: %s \n"+
-			"AggchainProof: %s \n"+
-			"FinalizedL1InfoTreeRoot: %s \n",
-			certInfo.Height,
-			certInfo.RetryCount,
-			certInfo.CertificateID.String(),
-			previousLocalExitRoot.String(),
-			certInfo.NewLocalExitRoot.String(),
-			certInfo.Status.String(),
-			certInfo.FromBlock,
-			certInfo.ToBlock,
-			time.Unix(int64(certInfo.CreatedAt), 0),
-			time.Unix(int64(certInfo.UpdatedAt), 0),
-			aggchainProof.String(),
-			finalizedL1InfoTreeRoot.String(),
+		expected := fmt.Sprintf("aggsender.Certificate: \n"+
+			"Header: %s \n"+
+			"AggchainProof: %s \n",
+			cert.Header.String(),
+			cert.AggchainProof.String(),
 		)
 
-		require.Equal(t, expected, certInfo.String())
+		require.Equal(t, expected, cert.String())
 	})
 }
 

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 
@@ -97,4 +98,40 @@ func TestCertificateInfo_String(t *testing.T) {
 
 		require.Equal(t, expected, certInfo.String())
 	})
+}
+
+func TestCertificateFieldsMatchCertificateInfo(t *testing.T) {
+	// Check that all fields in CertificateInfo are present in Certificate
+	certificateInfoType := reflect.TypeOf(CertificateInfo{})
+
+	for i := range certificateInfoType.NumField() {
+		field := certificateInfoType.Field(i)
+		_, found := reflect.TypeOf(CertificateHeader{}).FieldByName(field.Name)
+		if !found {
+			_, found = reflect.TypeOf(Certificate{}).FieldByName(field.Name)
+		}
+		require.True(t, found, "Field %s is missing in Certificate", field.Name)
+	}
+
+	// Check that all fields in Certificate are present in CertificateInfo
+	certificateHeaderType := reflect.TypeOf(CertificateHeader{})
+
+	// Check that all fields in CertificateHeader are present in CertificateInfo
+	for i := range certificateHeaderType.NumField() {
+		field := certificateHeaderType.Field(i)
+		_, found := certificateInfoType.FieldByName(field.Name)
+		require.True(t, found, "Field %s from CertificateHeader is missing in CertificateInfo", field.Name)
+	}
+
+	// Check that all fields in Certificate are present in CertificateInfo
+	certificateType := reflect.TypeOf(Certificate{})
+
+	for i := range certificateType.NumField() {
+		field := certificateType.Field(i)
+		if field.Name == "Header" {
+			continue
+		}
+		_, found := certificateInfoType.FieldByName(field.Name)
+		require.True(t, found, "Field %s from Certificate is missing in CertificateInfo", field.Name)
+	}
 }

--- a/tools/aggsender_find_imported_bridge/aggsender_find_imported_bridge.go
+++ b/tools/aggsender_find_imported_bridge/aggsender_find_imported_bridge.go
@@ -66,7 +66,7 @@ func certContainsGlobalIndex(cert *types.CertificateInfo, globalIndex *agglayert
 
 func tryUnmarshalCertificate(cert *types.CertificateInfo) (*agglayertypes.Certificate, error) {
 	var certSigned agglayertypes.Certificate
-	err := json.Unmarshal([]byte(cert.SignedCertificate), &certSigned)
+	err := json.Unmarshal([]byte(*cert.SignedCertificate), &certSigned)
 	if err == nil {
 		return &certSigned, nil
 	}
@@ -74,7 +74,7 @@ func tryUnmarshalCertificate(cert *types.CertificateInfo) (*agglayertypes.Certif
 	log.Warnf("Error unmarshal new certificate format: %v. It will fallback to the old one", err)
 
 	var certSignedOld agglayertypes.SignedCertificate
-	err = json.Unmarshal([]byte(cert.SignedCertificate), &certSignedOld)
+	err = json.Unmarshal([]byte(*cert.SignedCertificate), &certSignedOld)
 	if err != nil {
 		log.Errorf("Could not unmarshal certificate with old format: %v", err)
 		return nil, fmt.Errorf("error Unmarshal cert. Err: %w", err)

--- a/tools/aggsender_find_imported_bridge/aggsender_find_imported_bridge.go
+++ b/tools/aggsender_find_imported_bridge/aggsender_find_imported_bridge.go
@@ -47,7 +47,7 @@ func unmarshalGlobalIndex(globalIndex string) (*agglayertypes.GlobalIndex, error
 
 // This function find out the certificate for a deposit
 // It use the aggsender RPC
-func certContainsGlobalIndex(cert *types.CertificateInfo, globalIndex *agglayertypes.GlobalIndex) (bool, error) {
+func certContainsGlobalIndex(cert *types.Certificate, globalIndex *agglayertypes.GlobalIndex) (bool, error) {
 	if cert == nil {
 		return false, nil
 	}
@@ -64,7 +64,7 @@ func certContainsGlobalIndex(cert *types.CertificateInfo, globalIndex *agglayert
 	return false, nil
 }
 
-func tryUnmarshalCertificate(cert *types.CertificateInfo) (*agglayertypes.Certificate, error) {
+func tryUnmarshalCertificate(cert *types.Certificate) (*agglayertypes.Certificate, error) {
 	var certSigned agglayertypes.Certificate
 	err := json.Unmarshal([]byte(*cert.SignedCertificate), &certSigned)
 	if err == nil {
@@ -105,7 +105,7 @@ func main() {
 		os.Exit(errLevelComms)
 	}
 
-	currentHeight := cert.Height
+	currentHeight := cert.Header.Height
 	for cert != nil {
 		found, err := certContainsGlobalIndex(cert, decodedGlobalIndex)
 		if err != nil {
@@ -114,8 +114,8 @@ func main() {
 		}
 		if found {
 			log.Infof("Found certificate for global index: %v", globalIndex)
-			if cert.Status.IsSettled() {
-				log.Infof("Certificate is settled: %s status:%s", cert.ID(), cert.Status.String())
+			if cert.Header.Status.IsSettled() {
+				log.Infof("Certificate is settled: %s status:%s", cert.Header.ID(), cert.Header.Status.String())
 				os.Exit(0)
 			}
 			log.Errorf("Certificate is not settled")


### PR DESCRIPTION
## Description

During profiling of `aggsender` run against the new `FEP` (`op succinct`) stack, we noticed that a significant portion of `CPU` time was used to read the full certificates from the `aggsender db` while checking for changes in the certificate status.

Since `aggsender` only needs to know couple of things when checking for changes in status of pending certificates (like `certificate_id`, `height`, `retry_count`, `status`), this PR enables fetching full certificate by status, or a light version of it from the `aggsender db`, so we do not load all the data. Most of the time was spent loading `aggchain proof` data on the certificate from `db`, since proofs are quite large and heavy, and they are not needed when checking for changes in the certificate status.

### `CertificateInfo` split

This PR splits the `CertificateInfo` struct that is used in `aggsender` into two structs:

```go
type CertificateHeader struct {
	Height                  uint64                          `meddler:"height"`
	RetryCount              int                             `meddler:"retry_count"`
	CertificateID           common.Hash                     `meddler:"certificate_id,hash"`
	PreviousLocalExitRoot   *common.Hash                    `meddler:"previous_local_exit_root,hash"`
	NewLocalExitRoot        common.Hash                     `meddler:"new_local_exit_root,hash"`
	FromBlock               uint64                          `meddler:"from_block"`
	ToBlock                 uint64                          `meddler:"to_block"`
	Status                  agglayertypes.CertificateStatus `meddler:"status"`
	CreatedAt               uint32                          `meddler:"created_at"`
	UpdatedAt               uint32                          `meddler:"updated_at"`
	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
}

type Certificate struct {
	Header            *CertificateHeader
	SignedCertificate *string        `meddler:"signed_certificate"`
	AggchainProof     *AggchainProof `meddler:"aggchain_proof,aggchainproof"`
}
```

Since most of the time, `aggsender` only needs the data from `CertificateHeader`, this split is used to optimize data querying and loading from `aggsender db`, since `aggchain proof` can be quite large, and it is not optimal to load it every time, only in the cases when we need to resend it to the `agglayer`.

### DB changes

`AggSenderStorage` now contains functions to get the `CertificateHeader` instead of the full certificate that contains the `aggchain proof` as well. This way we are only loading simple data from the certificate and optimizing data loading.

Another function was added, called: `GetCertificateAggchainProof(height uint64, certificateID common.Hash) (*types.AggchainProof, error)`, that is called to load `aggchain proof` from the `db` in the cases when we actually need to load it (when resending the `InError` certificate).

Fixes # (issue)
