### PR TITLE
feat: be able to disable sanity check of block range gap PP to FEP

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -96,7 +96,7 @@ func New(
 			logger, cfg.MaxCertSize, cfg.BridgeMetadataAsHash,
 			cfg.GlobalExitRootL2Addr, cfg.SovereignRollupAddr,
 			aggchainProofClient, storage,
-			l1InfoTreeSyncer, l2Syncer, l1Client, l2Client)
+			l1InfoTreeSyncer, l2Syncer, l1Client, l2Client, cfg.RequireNoFEPBlockGap)
 		if err != nil {
 			return nil, fmt.Errorf("error creating aggchain prover flow: %w", err)
 		}

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -65,6 +65,9 @@ type Config struct {
 	// RequireStorageContentCompatibility is true it's mandatory that data stored in the database
 	// is compatible with the running environment
 	RequireStorageContentCompatibility bool `mapstructure:"RequireStorageContentCompatibility"`
+	// RequireNoFEPBlockGap is true if the AggSender should not accept a gap between
+	// lastBlock from lastCertificate and first block of FEP
+	RequireNoFEPBlockGap bool `mapstructure:"RequireNoFEPBlockGap"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -55,7 +55,8 @@ func NewAggchainProverFlow(log types.Logger,
 	l1InfoTreeSyncer types.L1InfoTreeSyncer,
 	l2Syncer types.L2BridgeSyncer,
 	l1Client types.EthClient,
-	l2Client types.EthClient) (*AggchainProverFlow, error) {
+	l2Client types.EthClient,
+	requireNoFEPBlockGap bool) (*AggchainProverFlow, error) {
 	gerReader, err := funcNewEVMChainGERReader(gerL2Address, l2Client)
 	if err != nil {
 		return nil, fmt.Errorf("aggchainProverFlow - error creating EVMChainGERReader: %w", err)
@@ -67,8 +68,9 @@ func NewAggchainProverFlow(log types.Logger,
 	}
 	log.Infof("aggchainProverFlow - read from severeignRollup (L1) starting L2 block: %d", startL2Block)
 	return &AggchainProverFlow{
-		gerReader:           gerReader,
-		aggchainProofClient: aggkitProverClient,
+		gerReader:            gerReader,
+		aggchainProofClient:  aggkitProverClient,
+		requireNoFEPBlockGap: requireNoFEPBlockGap,
 		baseFlow: &baseFlow{
 			log:                   log,
 			l2Syncer:              l2Syncer,

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -90,13 +90,12 @@ func (a *AggchainProverFlow) CheckInitialStatus(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("aggchainProverFlow - error getting last sent certificate: %w", err)
 	}
-	err = a.sanityCheckNoBlockGaps(lastSentCertificate)
-	if a.requireNoFEPBlockGap {
-		return err
-	}
-	// The sanity check is disabled
-	if err != nil {
-		a.log.Warnf("aggchainProverFlow - (disabled error due RequireNoFEPBlockGap) checking for block gaps: %s", err.Error())
+	if err = a.sanityCheckNoBlockGaps(lastSentCertificate); err != nil {
+		if a.requireNoFEPBlockGap {
+			return fmt.Errorf("aggchainProverFlow -CheckInitialStatus fails. Err: %w", err)
+		}
+		// The sanity check is disabled
+		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
 	}
 	return nil
 }

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -832,46 +832,61 @@ func Test_AggchainProverFlow_CheckInitialStatus(t *testing.T) {
 	testCases := []struct {
 		name                        string
 		cert                        *types.CertificateInfo
+		requireNoFEPBlockGap        bool
 		getLastSentCertificateError error
 		expectedError               bool
 	}{
 		{
 			name:                        "error getting last sent certificate",
 			cert:                        nil,
+			requireNoFEPBlockGap:        true,
 			getLastSentCertificateError: exampleError,
 			expectedError:               true,
 		},
 		{
-			name:          "no last sent certificate on storage",
-			cert:          nil,
-			expectedError: false,
+			name:                 "no last sent certificate on storage",
+			cert:                 nil,
+			requireNoFEPBlockGap: true,
+			expectedError:        false,
 		},
 		{
 			name: "last cert after upgrade L2 block (startL2Block) that is OK",
 			cert: &types.CertificateInfo{
 				ToBlock: 4000,
 			},
-			expectedError: false,
+			requireNoFEPBlockGap: true,
+			expectedError:        false,
 		},
 		{
 			name: "last cert is immediately before upgrade L2 block (startL2Block) that is OK",
 			cert: &types.CertificateInfo{
 				ToBlock: 1233,
 			},
-			expectedError: false,
+			requireNoFEPBlockGap: true,
+			expectedError:        false,
 		},
 		{
 			name: "last cert is 2 block below upgrade L2 block (startL2Block) so it's a gap of block 1233. Error",
 			cert: &types.CertificateInfo{
 				ToBlock: 1232,
 			},
-			expectedError: true,
+			requireNoFEPBlockGap: true,
+			expectedError:        true,
+		},
+		{
+			name: "there are a gap, but bypass error because requireNoFEPBlockGap is false",
+			cert: &types.CertificateInfo{
+				ToBlock: 1232,
+			},
+			requireNoFEPBlockGap: false,
+			expectedError:        false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockStorage.EXPECT().GetLastSentCertificate().Return(tc.cert, tc.getLastSentCertificateError).Once()
+			sut.requireNoFEPBlockGap = tc.requireNoFEPBlockGap
 			err := sut.CheckInitialStatus(context.TODO())
 			if tc.expectedError {
 				require.Error(t, err)

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -1023,6 +1023,7 @@ func Test_AggchainProverFlow_NewAggchainProverFlow(t *testing.T) {
 				mockL2Syncer,
 				mockL1Client,
 				mockL2Client,
+				true,
 			)
 
 			if tc.expectedError != "" {

--- a/aggsender/prover/proof_generation_tool.go
+++ b/aggsender/prover/proof_generation_tool.go
@@ -81,6 +81,7 @@ func NewAggchainProofGenerationTool(
 		l2Syncer,
 		l1Client,
 		l2Client,
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the AggchainProverFlow: %w", err)

--- a/aggsender/prover/proof_generation_tool_test.go
+++ b/aggsender/prover/proof_generation_tool_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/log"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,4 +135,18 @@ func TestGetRPCServices(t *testing.T) {
 	require.Len(t, services, 1)
 	require.Equal(t, "aggkit", services[0].Name)
 	require.NotNil(t, services[0].Service)
+}
+
+func TestNewAggchainProofGenerationTool(t *testing.T) {
+	mockL2Syncer := mocks.NewL2BridgeSyncer(t)
+	mockL1Client := mocks.NewEthClient(t)
+	mockL2Client := mocks.NewEthClient(t)
+	mockL1Client.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	mockL1Client.EXPECT().CodeAt(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	mockL2Client.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	mockL2Client.EXPECT().CodeAt(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	_, err := NewAggchainProofGenerationTool(context.TODO(), log.WithFields("module", "test"),
+		Config{}, mockL2Syncer, nil, mockL1Client, mockL2Client)
+	require.Error(t, err)
+
 }

--- a/aggsender/prover/proof_generation_tool_test.go
+++ b/aggsender/prover/proof_generation_tool_test.go
@@ -148,5 +148,4 @@ func TestNewAggchainProofGenerationTool(t *testing.T) {
 	_, err := NewAggchainProofGenerationTool(context.TODO(), log.WithFields("module", "test"),
 		Config{}, mockL2Syncer, nil, mockL1Client, mockL2Client)
 	require.Error(t, err)
-
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 	require.Equal(t, cfg.Profiling.ProfilingEnabled, false)
 	require.Equal(t, cfg.Profiling.ProfilingHost, "localhost")
 	require.Equal(t, cfg.Profiling.ProfilingPort, 6060)
+	require.Equal(t, cfg.AggSender.RequireNoFEPBlockGap, true)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -237,6 +237,7 @@ GlobalExitRootL2="{{L2Config.GlobalExitRootAddr}}"
 GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
 SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
+RequireNoFEPBlockGap = true
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1h"


### PR DESCRIPTION
## Description

Add flag `RequireNoFEPBlockGap` to say if it's mandatory this sanity check

## Default value
```
[AggSender]
(...)
RequireNoFEPBlockGap = true
```

Fixes #482
