### PR TITLE
fix: some code still heck block range gaps PP to FEP without using the new flag RequireNoFEPBlockGap

### DIFF
--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -90,22 +90,20 @@ func (a *AggchainProverFlow) CheckInitialStatus(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("aggchainProverFlow - error getting last sent certificate: %w", err)
 	}
-	if err = a.sanityCheckNoBlockGaps(lastSentCertificate); err != nil {
-		if a.requireNoFEPBlockGap {
-			return fmt.Errorf("aggchainProverFlow -CheckInitialStatus fails. Err: %w", err)
-		}
-		// The sanity check is disabled
-		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
-	}
-	return nil
+	return a.sanityCheckNoBlockGaps(lastSentCertificate)
 }
 
 // sanityCheckNoBlockGaps checks that there are no gaps in the block range for next certificate
 // #436. Don't allow gaps updating from PP to FEP
 func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.CertificateInfo) error {
 	if lastSentCertificate != nil && lastSentCertificate.ToBlock+1 < a.startL2Block {
-		return fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
+		err := fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
 			lastSentCertificate.ToBlock, a.startL2Block)
+		if a.requireNoFEPBlockGap {
+			return err
+		}
+		// The sanity check is disabled
+		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

The PR #483 was not a full fix for issue #482. 

```
2025-05-16T14:00:02.120Z        INFO    aggsender/aggsender.go:255      Epoch received: EpochEvent: epoch=896 extra=ExtraInfoEventEpoch: pendingBlocks=5        {"pid": 833667, "version": "v0.3.0-beta3", "module": "aggsender"}
2025-05-16T14:00:02.120Z        INFO    aggsender/aggsender.go:282      trying to send a new certificate... EpochStatus: [896, 66.67%]  {"pid": 833667, "version": "v0.3.0-beta3", "module": "aggsender"}
2025-05-16T14:00:02.120Z        ERROR   aggsender/aggsender.go:261      error getting certificate build params: aggchainProverFlow - error checking for block gaps: gap of blocks detected: lastSentCertificate.ToBlock: 11619, startL2Block: 23741   {"pid": 833667, "version": "v0.3.0-beta3", "module": "aggsender"}
github.com/agglayer/aggkit/aggsender.(*AggSender).sendCertificates
        /home/opstack/upgrade/repos/aggkit/aggsender/aggsender.go:261
github.com/agglayer/aggkit/aggsender.(*AggSender).Start
        /home/opstack/upgrade/repos/aggkit/aggsender/aggsender.go:179
```
