### PR TITLE
fix: choose right initial block if there are a gap

### DIFF
--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -412,6 +412,12 @@ func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64, lastCertificat
 			lastCertificate.ToBlock, a.startL2Block)
 		return a.startL2Block
 	}
+	if fromBlock+1 < a.startL2Block {
+		// if the fromBlock is less than the starting L2 block, we need to start from the starting L2 block
+		a.log.Infof("aggchainProverFlow - getLastProvenBlock. FromBlock: %d < startL2Block: %d",
+			fromBlock, a.startL2Block)
+		return a.startL2Block
+	}
 
 	return fromBlock - 1
 }

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -378,10 +378,11 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 	return aggchainProof, root, nil
 }
 
-func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64) uint64 {
-	if fromBlock == 0 {
+func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64, lastCertificate *types.CertificateInfo) uint64 {
+	if fromBlock == 0 || (lastCertificate != nil && lastCertificate.ToBlock < a.startL2Block) {
 		// if this is the first certificate, we need to start from the starting L2 block
 		// that we got from the sovereign rollup
+		// if the last certificate is settled on PP, the last proven block is the starting L2 block
 		return a.startL2Block
 	}
 

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -100,17 +100,19 @@ func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.C
 	if lastSentCertificate != nil {
 		lastSentCertficateStr = fmt.Sprintf("cert from:%d, to:%d", lastSentCertificate.FromBlock, lastSentCertificate.ToBlock)
 	}
-	a.log.Infof("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d", lastSentCertficateStr, a.startL2Block)
+	msg := fmt.Sprintf("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d", lastSentCertficateStr, a.startL2Block)
 	if lastSentCertificate != nil && lastSentCertificate.ToBlock+1 < a.startL2Block {
 		err := fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
 			lastSentCertificate.ToBlock, a.startL2Block)
 		if a.requireNoFEPBlockGap {
+			a.log.Error("%s. Err: %s", msg+" fails!", err.Error())
 			return err
 		}
 		// The sanity check is disabled
-		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
+		a.log.Warnf("%s. Ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", msg, err)
+		return nil
 	}
-	a.log.Infof("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d pass", lastSentCertficateStr, a.startL2Block)
+	a.log.Infof("%s. pass", msg)
 
 	return nil
 }

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -113,7 +113,7 @@ func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.C
 		a.log.Warnf("%s. Ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", msg, err)
 		return nil
 	}
-	a.log.Infof("%s. pass", msg)
+	a.log.Infof("%s. Passed check.", msg)
 
 	return nil
 }

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -134,9 +134,8 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		a.log.Infof("resending the same InError certificate: %s", lastSentCertificateInfo.String())
 		lastProvenBlock := a.getLastProvenBlock(lastSentCertificateInfo.FromBlock, lastSentCertificateInfo)
 		if lastSentCertificateInfo.FromBlock != lastProvenBlock+1 {
-			a.log.Warnf("aggchainProverFlow - last sent certificate inError fromBlock: %d doesn't match lastProvenBlock: %d."+
-				" check update process 😅",
-				lastSentCertificateInfo.FromBlock, lastProvenBlock)
+			a.log.Warnf("aggchainProverFlow - last sent certificate is InError and its fromBlock: %d doesn't match "+
+				"lastProvenBlock: %d + 1. Check update process 😅", lastSentCertificateInfo.FromBlock, lastProvenBlock)
 		}
 		bridges, claims, err := a.getBridgesAndClaims(
 			ctx, lastSentCertificateInfo.FromBlock,

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -96,6 +96,11 @@ func (a *AggchainProverFlow) CheckInitialStatus(ctx context.Context) error {
 // sanityCheckNoBlockGaps checks that there are no gaps in the block range for next certificate
 // #436. Don't allow gaps updating from PP to FEP
 func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.CertificateInfo) error {
+	lastSentCertficateStr := "nil"
+	if lastSentCertificate != nil {
+		lastSentCertficateStr = fmt.Sprintf("cert from:%d, to:%d", lastSentCertificate.FromBlock, lastSentCertificate.ToBlock)
+	}
+	a.log.Infof("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d", lastSentCertficateStr, a.startL2Block)
 	if lastSentCertificate != nil && lastSentCertificate.ToBlock+1 < a.startL2Block {
 		err := fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
 			lastSentCertificate.ToBlock, a.startL2Block)
@@ -105,6 +110,8 @@ func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.C
 		// The sanity check is disabled
 		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
 	}
+	a.log.Infof("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d pass", lastSentCertficateStr, a.startL2Block)
+
 	return nil
 }
 

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -389,10 +389,17 @@ func (a *AggchainProverFlow) GenerateAggchainProof(
 }
 
 func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64, lastCertificate *types.CertificateInfo) uint64 {
-	if fromBlock == 0 || (lastCertificate != nil && lastCertificate.ToBlock < a.startL2Block) {
+	if fromBlock == 0 {
 		// if this is the first certificate, we need to start from the starting L2 block
 		// that we got from the sovereign rollup
+		a.log.Infof("aggchainProverFlow - getLastProvenBlock - fromBlock is 0, returns startL2Block: %d",
+			a.startL2Block)
+		return a.startL2Block
+	}
+	if lastCertificate != nil && lastCertificate.ToBlock < a.startL2Block {
 		// if the last certificate is settled on PP, the last proven block is the starting L2 block
+		a.log.Infof("aggchainProverFlow - getLastProvenBlock. Last certificate block: %d < startL2Block: %d",
+			lastCertificate.ToBlock, a.startL2Block)
 		return a.startL2Block
 	}
 

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -100,7 +100,8 @@ func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.C
 	if lastSentCertificate != nil {
 		lastSentCertficateStr = fmt.Sprintf("cert from:%d, to:%d", lastSentCertificate.FromBlock, lastSentCertificate.ToBlock)
 	}
-	msg := fmt.Sprintf("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d", lastSentCertficateStr, a.startL2Block)
+	msg := fmt.Sprintf("aggchainProverFlow - sanityCheckNoBlockGaps - last sent certificate: %s, startL2Block:%d",
+		lastSentCertficateStr, a.startL2Block)
 	if lastSentCertificate != nil && lastSentCertificate.ToBlock+1 < a.startL2Block {
 		err := fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
 			lastSentCertificate.ToBlock, a.startL2Block)

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -215,8 +215,8 @@ func (a *AggchainProverFlow) verifyBuildParamsAndGenerateProof(
 	}
 
 	a.log.Infof("aggchainProverFlow - fetched auth proof for lastProvenBlock: %d, maxEndBlock: %d "+
-		"from aggchain prover. End block gotten from the prover: %d",
-		lastProvenBlock, buildParams.ToBlock, aggchainProof.EndBlock)
+		"from aggchain prover. End block gotten from the prover: %d. Proof length: %d",
+		lastProvenBlock, buildParams.ToBlock, aggchainProof.EndBlock, len(aggchainProof.SP1StarkProof.Proof))
 
 	// set the root from which to generate merkle proofs for each claim
 	// this is crucial since Aggchain Prover will use this root to generate the proofs as well

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -134,7 +134,8 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		a.log.Infof("resending the same InError certificate: %s", lastSentCertificateInfo.String())
 		lastProvenBlock := a.getLastProvenBlock(lastSentCertificateInfo.FromBlock, lastSentCertificateInfo)
 		if lastSentCertificateInfo.FromBlock != lastProvenBlock+1 {
-			a.log.Warnf("aggchainProverFlow - last sent certificate inError fromBlock: %d doesn't match lastProvenBlock: %d. check update process 😅",
+			a.log.Warnf("aggchainProverFlow - last sent certificate inError fromBlock: %d doesn't match lastProvenBlock: %d."+
+				" check update process 😅",
 				lastSentCertificateInfo.FromBlock, lastProvenBlock)
 		}
 		bridges, claims, err := a.getBridgesAndClaims(
@@ -184,7 +185,7 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 
 		return nil, err
 	}
-	lastProvenBlock := a.getLastProvenBlock(lastSentCertificateInfo.FromBlock, lastSentCertificateInfo)
+	lastProvenBlock := a.getLastProvenBlock(buildParams.FromBlock, lastSentCertificateInfo)
 	if buildParams.FromBlock != lastProvenBlock+1 {
 		a.log.Infof("aggchainProverFlow - getCertificateBuildParams - setting fromBlock to %d instead of %d",
 			lastProvenBlock+1, buildParams.FromBlock)

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -185,7 +185,7 @@ func (a *AggchainProverFlow) verifyBuildParamsAndGenerateProof(
 		return nil, fmt.Errorf("aggchainProverFlow - error checking for block gaps: %w", err)
 	}
 
-	lastProvenBlock := a.getLastProvenBlock(buildParams.FromBlock)
+	lastProvenBlock := a.getLastProvenBlock(buildParams.FromBlock, buildParams.LastSentCertificate)
 
 	aggchainProof, rootFromWhichToProveClaims, err := a.GenerateAggchainProof(
 		ctx, lastProvenBlock, buildParams.ToBlock, buildParams.Claims)

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -96,7 +96,7 @@ func (a *AggchainProverFlow) CheckInitialStatus(ctx context.Context) error {
 // sanityCheckNoBlockGaps checks that there are no gaps in the block range for next certificate
 // #436. Don't allow gaps updating from PP to FEP
 func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.CertificateInfo) error {
-	lastSentCertficateStr := "nil"
+	lastSentCertficateStr := types.NilStr
 	if lastSentCertificate != nil {
 		lastSentCertficateStr = fmt.Sprintf("cert from:%d, to:%d", lastSentCertificate.FromBlock, lastSentCertificate.ToBlock)
 	}
@@ -413,7 +413,7 @@ func (a *AggchainProverFlow) getLastProvenBlock(fromBlock uint64, lastCertificat
 			lastCertificate.ToBlock, a.startL2Block)
 		return a.startL2Block
 	}
-	if fromBlock+1 < a.startL2Block {
+	if fromBlock-1 < a.startL2Block {
 		// if the fromBlock is less than the starting L2 block, we need to start from the starting L2 block
 		a.log.Infof("aggchainProverFlow - getLastProvenBlock. FromBlock: %d < startL2Block: %d",
 			fromBlock, a.startL2Block)

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -716,6 +716,27 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 			},
 			expectedResult: 50,
 		},
+		{
+			name:                "lastSentCertificate settled on PP on the fence. Case 2",
+			fromBlock:           50,
+			startL2Block:        50,
+			lastSentCertificate: nil,
+			expectedResult:      50,
+		},
+		{
+			name:                "lastSentCertificate settled on PP on the fence. Case 3",
+			fromBlock:           51,
+			startL2Block:        50,
+			lastSentCertificate: nil,
+			expectedResult:      50,
+		},
+		{
+			name:                "lastSentCertificate settled on PP on the fence. Case 4",
+			fromBlock:           52,
+			startL2Block:        50,
+			lastSentCertificate: nil,
+			expectedResult:      51,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -670,10 +670,11 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name           string
-		fromBlock      uint64
-		startL2Block   uint64
-		expectedResult uint64
+		name                string
+		fromBlock           uint64
+		startL2Block        uint64
+		expectedResult      uint64
+		lastSentCertificate *types.CertificateInfo
 	}{
 		{
 			name:           "fromBlock is 0, return startL2Block",
@@ -693,6 +694,17 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 			startL2Block:   1,
 			expectedResult: 9,
 		},
+		{
+			name:         "lastSentCertificate settled on PP",
+			fromBlock:    10,
+			startL2Block: 50,
+			lastSentCertificate: &types.CertificateInfo{
+				FromBlock: 10,
+				ToBlock:   20,
+				Status:    agglayertypes.Settled,
+			},
+			expectedResult: 50,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -706,7 +718,7 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 				},
 			}
 
-			result := flow.getLastProvenBlock(tc.fromBlock)
+			result := flow.getLastProvenBlock(tc.fromBlock, tc.lastSentCertificate)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -725,7 +725,7 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 
 			flow := &AggchainProverFlow{
 				baseFlow: &baseFlow{
-					log:          log.WithFields("module", "ut"),
+					log:          log.WithFields("flowManager", "Test_AggchainProverFlow_GetCertificateBuildParams"),
 					startL2Block: tc.startL2Block,
 				},
 			}

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -705,6 +705,17 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 			},
 			expectedResult: 50,
 		},
+		{
+			name:         "lastSentCertificate settled on PP on the fence",
+			fromBlock:    10,
+			startL2Block: 50,
+			lastSentCertificate: &types.CertificateInfo{
+				FromBlock: 10,
+				ToBlock:   50,
+				Status:    agglayertypes.Settled,
+			},
+			expectedResult: 50,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -714,6 +725,7 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 
 			flow := &AggchainProverFlow{
 				baseFlow: &baseFlow{
+					log:          log.WithFields("module", "ut"),
 					startL2Block: tc.startL2Block,
 				},
 			}


### PR DESCRIPTION
## Description

In some case of upgrade from PP to FEP with a gap  the system choose the wrong starting block for requesting a certificate. 
This is a intermediate fix: it already have some pending fixes: 
- The range of blocks could no respect the `startL2Block` (#502)
- There are no check that after a upgrade from PP to FEP it's forbidden that the last cert is InError (#499)
- Missing some sanity checks in the block gap to avoid missing relevant information (#498)

Fixes #482
