### PR TITLE
feat: add `signature` to `aggchain data` in `certificate`

### DIFF
--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -83,6 +83,9 @@ func (a *AgglayerGRPCClient) SendCertificate(ctx context.Context,
 						Value: ad.AggchainParams.Bytes(),
 					},
 					Context: ad.Context,
+					Signature: &v1types.FixedBytes65{
+						Value: ad.Signature,
+					},
 				},
 			},
 		}

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -196,6 +196,7 @@ type AggchainDataProof struct {
 	Vkey           []byte            `json:"vkey"`
 	AggchainParams common.Hash       `json:"aggchain_params"`
 	Context        map[string][]byte `json:"context"`
+	Signature      []byte            `json:"signature"`
 }
 
 // MarshalJSON is the implementation of the json.Marshaler interface
@@ -206,12 +207,14 @@ func (a *AggchainDataProof) MarshalJSON() ([]byte, error) {
 		Context        map[string][]byte `json:"context"`
 		Version        string            `json:"version"`
 		VKey           string            `json:"vkey"`
+		Signature      string            `json:"signature"`
 	}{
 		Proof:          common.Bytes2Hex(a.Proof),
 		AggchainParams: a.AggchainParams.String(),
 		Context:        a.Context,
 		Version:        a.Version,
 		VKey:           common.Bytes2Hex(a.Vkey),
+		Signature:      common.Bytes2Hex(a.Signature),
 	})
 }
 
@@ -223,6 +226,7 @@ func (a *AggchainDataProof) UnmarshalJSON(data []byte) error {
 		Context        map[string][]byte `json:"context"`
 		Version        string            `json:"version"`
 		VKey           string            `json:"vkey"`
+		Signature      string            `json:"signature"`
 	}{}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -233,6 +237,7 @@ func (a *AggchainDataProof) UnmarshalJSON(data []byte) error {
 	a.Context = aux.Context
 	a.Version = aux.Version
 	a.Vkey = common.Hex2Bytes(aux.VKey)
+	a.Signature = common.Hex2Bytes(aux.Signature)
 
 	return nil
 }

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1126,19 +1126,21 @@ func TestAggchainDataProof_MarshalUnmarshalJSON(t *testing.T) {
 				Context:        map[string][]byte{},
 				Version:        "0.1",
 				Vkey:           common.FromHex("0x123456"),
+				Signature:      []byte{0x01, 0x02, 0x03},
 			},
-			expected: `{"proof":"123456","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000abcdef","context":{},"version":"0.1","vkey":"123456"}`,
+			expected: `{"aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000abcdef", "context":{}, "proof":"123456", "signature":"010203", "version":"0.1", "vkey":"123456"}`,
 		},
 		{
-			name: "Empty AggchainDataProof",
+			name: "Empty AggchainDataProof, Context and Signature",
 			input: &AggchainDataProof{
 				Proof:          []byte{},
 				AggchainParams: common.Hash{},
 				Context:        map[string][]byte{},
+				Signature:      []byte{},
 				Version:        "",
 				Vkey:           []byte{},
 			},
-			expected: `{"proof":"","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000000000","context":{},"version":"","vkey":""}`,
+			expected: `{"proof":"","aggchain_params":"0x0000000000000000000000000000000000000000000000000000000000000000","context":{},"version":"","vkey":"","signature":""}`,
 		},
 	}
 

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -41,9 +41,20 @@ func TestNewFlow(t *testing.T) {
 			expectedError: "error signer.Initialize",
 		},
 		{
-			name: "error missing AggchainProofURL in AggchainProofMode",
+			name: "error creating signer in AggchainProofMode",
 			cfg: config.Config{
 				Mode: string(types.AggchainProofMode),
+				AggsenderPrivateKey: signertypes.SignerConfig{
+					Method: signertypes.MethodLocal,
+				},
+			},
+			expectedError: "error signer.Initialize",
+		},
+		{
+			name: "error missing AggchainProofURL in AggchainProofMode",
+			cfg: config.Config{
+				Mode:                string(types.AggchainProofMode),
+				AggsenderPrivateKey: signertypes.SignerConfig{Method: signertypes.MethodNone},
 			},
 			expectedError: "aggchain prover mode requires AggchainProofURL",
 		},

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -242,6 +242,7 @@ func (a *AggchainProverFlow) BuildCertificate(ctx context.Context,
 		Vkey:           buildParams.AggchainProof.SP1StarkProof.Vkey,
 		AggchainParams: buildParams.AggchainProof.AggchainParams,
 		Context:        buildParams.AggchainProof.Context,
+		Signature:      buildParams.AggchainProof.Signature,
 	}
 
 	cert.CustomChainData = buildParams.AggchainProof.CustomChainData

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -480,6 +480,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockGERQuerier,
 				nil,
 				false,
+				nil,
 			)
 
 			tc.mockFn(mockStorage, mockL2BridgeQuerier, mockAggchainProofClient, mockL1InfoTreeDataQuerier, mockGERQuerier)
@@ -721,14 +722,14 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		mockFn         func(*mocks.BridgeQuerier)
+		mockFn         func(*mocks.BridgeQuerier, *mocks.Signer)
 		buildParams    *types.CertificateBuildParams
 		expectedError  string
 		expectedResult *agglayertypes.Certificate
 	}{
 		{
 			name: "error building certificate",
-			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
+			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier, mockSigner *mocks.Signer) {
 				mockL2BridgeQuerier.EXPECT().GetExitRootByIndex(mock.Anything, uint32(0)).Return(common.Hash{}, errors.New("some error"))
 			},
 			buildParams: &types.CertificateBuildParams{
@@ -742,8 +743,10 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 		},
 		{
 			name: "success building certificate",
-			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
+			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier, mockSigner *mocks.Signer) {
 				mockL2BridgeQuerier.EXPECT().OriginNetwork().Return(uint32(1))
+				mockSigner.EXPECT().PublicAddress().Return(common.HexToAddress("0x123"))
+				mockSigner.EXPECT().SignHash(mock.Anything, mock.Anything).Return([]byte("signature"), nil)
 			},
 			buildParams: &types.CertificateBuildParams{
 				FromBlock:                      1,
@@ -787,6 +790,7 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 					Context: map[string][]byte{
 						"key1": []byte("value1"),
 					},
+					Signature: []byte("signature"),
 				},
 			},
 		},
@@ -797,15 +801,17 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			mockSigner := mocks.NewSigner(t)
 			mockL2BridgeQuerier := mocks.NewBridgeQuerier(t)
 			if tc.mockFn != nil {
-				tc.mockFn(mockL2BridgeQuerier)
+				tc.mockFn(mockL2BridgeQuerier, mockSigner)
 			}
 
 			aggchainFlow := &AggchainProverFlow{
 				baseFlow: &baseFlow{
 					log:             log.WithFields("flowManager", "Test_AggchainProverFlow_BuildCertificate"),
 					l2BridgeQuerier: mockL2BridgeQuerier,
+					signer:          mockSigner,
 				},
 			}
 

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/tree"
+	signertypes "github.com/agglayer/go_signer/signer/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/crypto/sha3"
@@ -33,6 +34,7 @@ type baseFlow struct {
 
 	maxCertSize  uint
 	startL2Block uint64
+	signer       signertypes.Signer
 }
 
 // getCertificateBuildParamsInternal returns the parameters to build a certificate

--- a/aggsender/flows/flow_pp.go
+++ b/aggsender/flows/flow_pp.go
@@ -16,8 +16,6 @@ import (
 // PPFlow is a struct that holds the logic for the regular pessimistic proof flow
 type PPFlow struct {
 	*baseFlow
-
-	signer signertypes.Signer
 }
 
 // NewPPFlow returns a new instance of the PPFlow
@@ -28,13 +26,13 @@ func NewPPFlow(log types.Logger,
 	l2BridgeQuerier types.BridgeQuerier,
 	signer signertypes.Signer) *PPFlow {
 	return &PPFlow{
-		signer: signer,
 		baseFlow: &baseFlow{
 			log:                   log,
 			l2BridgeQuerier:       l2BridgeQuerier,
 			storage:               storage,
 			l1InfoTreeDataQuerier: l1InfoTreeQuerier,
 			maxCertSize:           maxCertSize,
+			signer:                signer,
 		},
 	}
 }
@@ -94,7 +92,7 @@ func (p *PPFlow) BuildCertificate(ctx context.Context,
 // signCertificate signs a certificate with the aggsender key
 func (p *PPFlow) signCertificate(ctx context.Context,
 	certificate *agglayertypes.Certificate) (*agglayertypes.Certificate, error) {
-	hashToSign := certificate.HashToSign()
+	hashToSign := certificate.PPHashToSign()
 	sig, err := p.signer.SignHash(ctx, hashToSign)
 	if err != nil {
 		return nil, err

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -994,12 +994,12 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 			mockL2BridgeQuerier := mocks.NewBridgeQuerier(t)
 			mockL1InfoTreeQuerier := mocks.NewL1InfoTreeDataQuerier(t)
 			ppFlow := &PPFlow{
-				signer: signer,
 				baseFlow: &baseFlow{
 					log:                   log.WithFields("test", "Test_PPFlow_GetCertificateBuildParams"),
 					storage:               mockStorage,
 					l2BridgeQuerier:       mockL2BridgeQuerier,
 					l1InfoTreeDataQuerier: mockL1InfoTreeQuerier,
+					signer:                signer,
 				},
 			}
 
@@ -1146,9 +1146,9 @@ func Test_PPFlow_SignCertificate(t *testing.T) {
 			}
 
 			ppFlow := &PPFlow{
-				signer: mockSigner,
 				baseFlow: &baseFlow{
-					log: log.WithFields("test", "Test_PPFlow_SignCertificate"),
+					log:    log.WithFields("test", "Test_PPFlow_SignCertificate"),
+					signer: mockSigner,
 				},
 			}
 

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -164,11 +164,6 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 		return nil, errProofNotSP1Stark
 	}
 
-	var signature []byte
-	if resp.AggchainProof.Signature != nil {
-		signature = resp.AggchainProof.Signature.Value
-	}
-
 	return &types.AggchainProof{
 		SP1StarkProof: &types.SP1StarkProof{
 			Proof:   proof.Sp1Stark.Proof,
@@ -181,6 +176,5 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 		CustomChainData: resp.CustomChainData,
 		AggchainParams:  common.BytesToHash(resp.AggchainProof.AggchainParams.Value),
 		Context:         resp.AggchainProof.Context,
-		Signature:       signature,
 	}, nil
 }

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -164,6 +164,11 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 		return nil, errProofNotSP1Stark
 	}
 
+	var signature []byte
+	if resp.AggchainProof.Signature != nil {
+		signature = resp.AggchainProof.Signature.Value
+	}
+
 	return &types.AggchainProof{
 		SP1StarkProof: &types.SP1StarkProof{
 			Proof:   proof.Sp1Stark.Proof,
@@ -176,5 +181,6 @@ func (c *AggchainProofClient) GenerateAggchainProof(
 		CustomChainData: resp.CustomChainData,
 		AggchainParams:  common.BytesToHash(resp.AggchainProof.AggchainParams.Value),
 		Context:         resp.AggchainProof.Context,
+		Signature:       signature,
 	}, nil
 }

--- a/aggsender/prover/proof_generation_tool.go
+++ b/aggsender/prover/proof_generation_tool.go
@@ -94,6 +94,7 @@ func NewAggchainProofGenerationTool(
 		query.NewGERDataQuerier(l1InfoTreeQuerier, chainGERReader),
 		l1Client,
 		false,
+		nil,
 	)
 
 	return &AggchainProofGenerationTool{

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -100,13 +100,14 @@ type CertStatus struct {
 }
 
 type AggchainProof struct {
-	LastProvenBlock uint64            `json:"last_proven_block"`
-	EndBlock        uint64            `json:"end_block"`
-	CustomChainData []byte            `json:"custom_chain_data,omitempty"`
-	LocalExitRoot   common.Hash       `json:"local_exit_root"`
-	AggchainParams  common.Hash       `json:"aggchain_params"`
-	Context         map[string][]byte `json:"context,omitempty"`
-	SP1StarkProof   *SP1StarkProof    `json:"sp1_stark_proof,omitempty"`
+	LastProvenBlock uint64
+	EndBlock        uint64
+	CustomChainData []byte
+	LocalExitRoot   common.Hash
+	AggchainParams  common.Hash
+	Context         map[string][]byte
+	SP1StarkProof   *SP1StarkProof
+	Signature       []byte
 }
 
 func (a *AggchainProof) String() string {
@@ -133,11 +134,11 @@ func (a *AggchainProof) String() string {
 
 type SP1StarkProof struct {
 	// SP1 Version
-	Version string `json:"version,omitempty"`
+	Version string
 	// SP1 stark proof.
-	Proof []byte `json:"proof,omitempty"`
+	Proof []byte
 	// SP1 stark proof verification key.
-	Vkey []byte `json:"vkey,omitempty"`
+	Vkey []byte
 }
 
 func (s *SP1StarkProof) String() string {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -121,7 +121,8 @@ func (a *AggchainProof) String() string {
 		"LocalExitRoot: %s \n"+
 		"AggchainParams: %s \n"+
 		"Context: %v \n"+
-		"SP1StarkProof: %v \n",
+		"SP1StarkProof: %v \n"+
+		"Signature: %s",
 		a.LastProvenBlock,
 		a.EndBlock,
 		a.CustomChainData,
@@ -129,6 +130,7 @@ func (a *AggchainProof) String() string {
 		a.AggchainParams.String(),
 		a.Context,
 		a.SP1StarkProof.String(),
+		common.Bytes2Hex(a.Signature),
 	)
 }
 

--- a/common/common.go
+++ b/common/common.go
@@ -18,12 +18,22 @@ var (
 	ZeroHash = common.HexToHash("0x0")
 )
 
-// Uint64ToBytes converts a uint64 to a byte slice
-func Uint64ToBytes(num uint64) []byte {
+// Uint64ToBigEndianBytes converts a uint64 to a byte slice in big-endian order
+func Uint64ToBigEndianBytes(num uint64) []byte {
 	const uint64ByteSize = 8
 
 	bytes := make([]byte, uint64ByteSize)
 	binary.BigEndian.PutUint64(bytes, num)
+
+	return bytes
+}
+
+// Uint64ToLittleEndianBytes converts a uint64 to a byte slice in little-endian order
+func Uint64ToLittleEndianBytes(num uint64) []byte {
+	const uint64ByteSize = 8
+
+	bytes := make([]byte, uint64ByteSize)
+	binary.LittleEndian.PutUint64(bytes, num)
 
 	return bytes
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -139,3 +139,45 @@ func TestEstimateSliceCapacity(t *testing.T) {
 		})
 	}
 }
+
+func TestUint64ToLittleEndianBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    uint64
+		expected []byte
+	}{
+		{
+			name:     "Zero value",
+			input:    0,
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "Small value",
+			input:    1,
+			expected: []byte{1, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "Max uint64 value",
+			input:    ^uint64(0),
+			expected: []byte{255, 255, 255, 255, 255, 255, 255, 255},
+		},
+		{
+			name:     "Arbitrary value",
+			input:    123456789,
+			expected: []byte{21, 205, 91, 7, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Uint64ToLittleEndianBytes(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR updates the `GenerateAggchainProofRequest` and `SubmitCertificate` APIs on `aggkit prover` and `agglayer` respectively.

The `AggchainProofFlow` on the `aggsender` now implements signing of the `FEP` certificate. The signer is the `trustedSequencer` address, configured in the `AggsenderPrivateKey` config parameter (similar to the old `PessimisticProof` flow).

The hash that needs to be signed differs from the one we are signing in the `PessimisticProof` flow, and is calculated by hashing this data from the certificate:
- new_local_exit_root
- claim_hash (the hash of all the global index + bridge exit hash from the imported bridge exits in certificate)
- Certificate's height
- aggchain_params

Fixes # (issue)
