### PR TITLE
feat: provide gin mode based on environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build: build-aggkit build-tools
 
 .PHONY: build-aggkit
 build-aggkit:
-	$(GOENVVARS) go build -ldflags "all=$(LDFLAGS)" -o $(GOBIN)/$(GOBINARY) $(GOCMD)
+	GIN_MODE=release $(GOENVVARS) go build -ldflags "all=$(LDFLAGS)" -o $(GOBIN)/$(GOBINARY) $(GOCMD)
 
 .PHONY: build-tools
 build-tools: ## Builds the tools

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/agglayer/aggkit/bridgeservice/types"
@@ -84,6 +85,14 @@ func New(
 ) *BridgeService {
 	meter := otel.Meter(meterName)
 	cfg.Logger.Infof("starting bridge service (network id=%d)", cfg.NetworkID)
+
+	ginMode := os.Getenv("GIN_MODE")
+	switch ginMode {
+	case gin.DebugMode, gin.ReleaseMode, gin.TestMode:
+		gin.SetMode(ginMode)
+	default:
+		gin.SetMode(gin.ReleaseMode) // fallback to release mode
+	}
 
 	b := &BridgeService{
 		logger:       cfg.Logger,

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -94,6 +94,8 @@ func New(
 	case gin.DebugMode, gin.ReleaseMode, gin.TestMode:
 		gin.SetMode(ginMode)
 	default:
+		cfg.Logger.Infof("invalid or missing GIN_MODE value ('%s') provided, defaulting to '%s' mode",
+			ginMode, gin.ReleaseMode)
 		gin.SetMode(gin.ReleaseMode) // fallback to release mode
 	}
 

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -86,6 +86,9 @@ func New(
 	meter := otel.Meter(meterName)
 	cfg.Logger.Infof("starting bridge service (network id=%d)", cfg.NetworkID)
 
+	// The GIN_MODE environment variable controls the mode of the Gin framework.
+	// Valid values are "debug", "release", and "test". If an invalid value is provided,
+	// the mode defaults to "release" for safety and performance.
 	ginMode := os.Getenv("GIN_MODE")
 	switch ginMode {
 	case gin.DebugMode, gin.ReleaseMode, gin.TestMode:


### PR DESCRIPTION
## Description

The gin library has multiple modes, since it is recommended to use the release mode in production, this PR allows to provide the gin mode, by specifying the `GIN_MODE` env variable (if the variable is missing or invalid, it fallbacks to release mode).

Fixes #470
