### PR TITLE
feat: cherry pick #471 - support `TLS` in `gRPC`

### DIFF
--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -28,11 +28,11 @@ type AgglayerGRPCClient struct {
 }
 
 // NewAggchainProofClient initializes a new AggchainProof instance
-func NewAgglayerGRPCClient(serverAddr string) (*AgglayerGRPCClient, error) {
+func NewAgglayerGRPCClient(serverAddr string, useTLS bool) (*AgglayerGRPCClient, error) {
 	// trim the http:// prefix if it exists in the URL because the go-grpc client expects it without it
 	addr := strings.TrimPrefix(serverAddr, "http://")
 
-	grpcClient, err := aggkitCommon.NewClient(addr)
+	grpcClient, err := aggkitCommon.NewClient(addr, useTLS)
 	if err != nil {
 		return nil, err
 	}

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -64,7 +64,9 @@ func TestConfigString(t *testing.T) {
 		"RetryCertAfterInError: false\n" +
 		"MaxSubmitRate: RateLimitConfig{Unlimited}\n" +
 		"GenerateAggchainProofTimeout: 1s\n" +
-		"SovereignRollupAddr: 0x0000000000000000000000000000000000000001\n"
+		"SovereignRollupAddr: 0x0000000000000000000000000000000000000001\n" +
+		"UseAgglayerTLS: false\n" +
+		"UseAggkitProverTLS: false\n"
 
 	require.Equal(t, expected, config.String())
 }

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -63,6 +63,10 @@ type Config struct {
 	// RequireStorageContentCompatibility is true it's mandatory that data stored in the database
 	// is compatible with the running environment
 	RequireStorageContentCompatibility bool `mapstructure:"RequireStorageContentCompatibility"`
+	// UseAgglayerTLS is a flag to enable the Agglayer TLS handshake in the AggSender-Agglayer gRPC connection
+	UseAgglayerTLS bool `mapstructure:"UseAgglayerTLS"`
+	// UseAggkitProverTLS is a flag to enable the AggkitProver TLS handshake in the AggSender-AggkitProver gRPC connection
+	UseAggkitProverTLS bool `mapstructure:"UseAggkitProverTLS"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {
@@ -84,5 +88,7 @@ func (c Config) String() string {
 		"RetryCertAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
 		"MaxSubmitRate: " + c.MaxSubmitCertificateRate.String() + "\n" +
 		"GenerateAggchainProofTimeout: " + c.GenerateAggchainProofTimeout.String() + "\n" +
-		"SovereignRollupAddr: " + c.SovereignRollupAddr.Hex() + "\n"
+		"SovereignRollupAddr: " + c.SovereignRollupAddr.Hex() + "\n" +
+		"UseAgglayerTLS: " + fmt.Sprintf("%t", c.UseAgglayerTLS) + "\n" +
+		"UseAggkitProverTLS: " + fmt.Sprintf("%t", c.UseAggkitProverTLS) + "\n"
 }

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -51,7 +51,7 @@ func NewFlow(
 
 		aggchainProofClient, err := grpc.NewAggchainProofClient(
 			cfg.AggchainProofURL,
-			cfg.GenerateAggchainProofTimeout.Duration)
+			cfg.GenerateAggchainProofTimeout.Duration, cfg.UseAggkitProverTLS)
 		if err != nil {
 			return nil, fmt.Errorf("error creating aggkit prover client: %w", err)
 		}

--- a/aggsender/grpc/aggchain_proof_client.go
+++ b/aggsender/grpc/aggchain_proof_client.go
@@ -42,9 +42,9 @@ type AggchainProofClient struct {
 
 // NewAggchainProofClient initializes a new AggchainProof instance
 func NewAggchainProofClient(serverAddr string,
-	generateProofTimeout time.Duration) (*AggchainProofClient, error) {
+	generateProofTimeout time.Duration, useTLS bool) (*AggchainProofClient, error) {
 	addr := strings.TrimPrefix(serverAddr, "http://")
-	grpcClient, err := aggkitcommon.NewClient(addr)
+	grpcClient, err := aggkitcommon.NewClient(addr, useTLS)
 	if err != nil {
 		return nil, err
 	}

--- a/aggsender/prover/proof_generation_tool.go
+++ b/aggsender/prover/proof_generation_tool.go
@@ -45,6 +45,9 @@ type Config struct {
 
 	// SovereignRollupAddr is the address of the sovereign rollup contract on L1
 	SovereignRollupAddr common.Address `mapstructure:"SovereignRollupAddr"`
+
+	// UseAggkitProverTLS is a flag to enable the AggkitProver TLS handshake in the AggSender-AggkitProver gRPC connection
+	UseAggkitProverTLS bool `mapstructure:"UseAggkitProverTLS"`
 }
 
 // AggchainProofGenerationTool is a tool to generate Aggchain proofs
@@ -68,7 +71,7 @@ func NewAggchainProofGenerationTool(
 	l1Client types.EthClient,
 	l2Client types.EthClient) (*AggchainProofGenerationTool, error) {
 	aggchainProofClient, err := grpc.NewAggchainProofClient(
-		cfg.AggchainProofURL, cfg.GenerateAggchainProofTimeout.Duration)
+		cfg.AggchainProofURL, cfg.GenerateAggchainProofTimeout.Duration, cfg.UseAggkitProverTLS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AggchainProofClient: %w", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -191,7 +191,7 @@ func createAggSender(
 	l2Client etherman.EthClienter) (*aggsender.AggSender, error) {
 	logger := log.WithFields("module", aggkitcommon.AGGSENDER)
 
-	agglayerClient, err := agglayer.NewAgglayerGRPCClient(cfg.AggLayerURL)
+	agglayerClient, err := agglayer.NewAgglayerGRPCClient(cfg.AggLayerURL, cfg.UseAgglayerTLS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agglayer grpc client: %w", err)
 	}

--- a/common/grpc_client.go
+++ b/common/grpc_client.go
@@ -1,12 +1,14 @@
 package common
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
@@ -17,10 +19,16 @@ type Client struct {
 }
 
 // NewClient initializes and returns a new gRPC client
-func NewClient(serverAddr string) (*Client, error) {
-	// TODO - Check if we need to use this
+func NewClient(serverAddr string, useTLS bool) (*Client, error) {
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	if useTLS {
+		creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12})
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
 	conn, err := grpc.NewClient(serverAddr, opts...)
 	if err != nil {
 		return nil, err

--- a/config/default.go
+++ b/config/default.go
@@ -236,6 +236,8 @@ GlobalExitRootL2="{{L2Config.GlobalExitRootAddr}}"
 GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
 SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
+UseAgglayerTLS = false
+UseAggkitProverTLS = false
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1h"
@@ -250,6 +252,7 @@ AggchainProofURL = "{{AggchainProofURL}}"
 SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 GlobalExitRootL2 = "{{L2Config.GlobalExitRootAddr}}"
 GenerateAggchainProofTimeout="{{GenerateAggchainProofTimeout}}"
+UseAggkitProverTLS = false
 
 [Profiling]
 ProfilingHost = "localhost"


### PR DESCRIPTION
## Description

This PR cherry picks PR #471 to `develop`.

This PR supports configuring `gRPC` clients to expect `TLS` handshakes when connecting to a `gRPC` server.

We need this in real systems, which will use TLS.

### Config change

This PR adds two new config parameters to `Aggsender` config:

- `UseAgglayerTLS` - it says to the `aggsender grpc` communication client to do TLS handshakes when opening connections.
- `UseAggkitProverTLS` -  it says to the `aggsender grpc` communication client to do TLS handshakes when opening connections.

### Kurtosis CDK
Kurtosis doesn't have TLS, everything is in local, so these parameters should be false (they are false by default).
