### PR TITLE
feat: cherry picks #483, 486, 489 - block gap sanity checks

### DIFF
--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -66,7 +66,8 @@ func TestConfigString(t *testing.T) {
 		"GenerateAggchainProofTimeout: 1s\n" +
 		"SovereignRollupAddr: 0x0000000000000000000000000000000000000001\n" +
 		"UseAgglayerTLS: false\n" +
-		"UseAggkitProverTLS: false\n"
+		"UseAggkitProverTLS: false\n" +
+		"RequireNoFEPBlockGap: false\n"
 
 	require.Equal(t, expected, config.String())
 }

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	UseAgglayerTLS bool `mapstructure:"UseAgglayerTLS"`
 	// UseAggkitProverTLS is a flag to enable the AggkitProver TLS handshake in the AggSender-AggkitProver gRPC connection
 	UseAggkitProverTLS bool `mapstructure:"UseAggkitProverTLS"`
+	// RequireNoFEPBlockGap is true if the AggSender should not accept a gap between
+	// lastBlock from lastCertificate and first block of FEP
+	RequireNoFEPBlockGap bool `mapstructure:"RequireNoFEPBlockGap"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {
@@ -90,5 +93,6 @@ func (c Config) String() string {
 		"GenerateAggchainProofTimeout: " + c.GenerateAggchainProofTimeout.String() + "\n" +
 		"SovereignRollupAddr: " + c.SovereignRollupAddr.Hex() + "\n" +
 		"UseAgglayerTLS: " + fmt.Sprintf("%t", c.UseAgglayerTLS) + "\n" +
-		"UseAggkitProverTLS: " + fmt.Sprintf("%t", c.UseAggkitProverTLS) + "\n"
+		"UseAggkitProverTLS: " + fmt.Sprintf("%t", c.UseAggkitProverTLS) + "\n" +
+		"RequireNoFEPBlockGap: " + fmt.Sprintf("%t", c.RequireNoFEPBlockGap) + "\n"
 }

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -78,6 +78,7 @@ func NewFlow(
 			query.NewBridgeDataQuerier(l2Syncer),
 			query.NewGERDataQuerier(l1InfoTreeQuerier, gerReader),
 			l1Client,
+			cfg.RequireNoFEPBlockGap,
 		), nil
 
 	default:

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -83,22 +83,20 @@ func (a *AggchainProverFlow) CheckInitialStatus(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("aggchainProverFlow - error getting last sent certificate: %w", err)
 	}
-	if err = a.sanityCheckNoBlockGaps(lastSentCertificate); err != nil {
-		if a.requireNoFEPBlockGap {
-			return fmt.Errorf("aggchainProverFlow -CheckInitialStatus fails. Err: %w", err)
-		}
-		// The sanity check is disabled
-		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
-	}
-	return nil
+	return a.sanityCheckNoBlockGaps(lastSentCertificate)
 }
 
 // sanityCheckNoBlockGaps checks that there are no gaps in the block range for next certificate
 // #436. Don't allow gaps updating from PP to FEP
 func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.CertificateHeader) error {
 	if lastSentCertificate != nil && lastSentCertificate.ToBlock+1 < a.startL2Block {
-		return fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
+		err := fmt.Errorf("gap of blocks detected: lastSentCertificate.ToBlock: %d, startL2Block: %d",
 			lastSentCertificate.ToBlock, a.startL2Block)
+		if a.requireNoFEPBlockGap {
+			return err
+		}
+		// The sanity check is disabled
+		a.log.Warnf("aggchainProverFlow - ignoring block gaps due to RequireNoFEPBlockGap. Err: %w", err)
 	}
 	return nil
 }

--- a/aggsender/prover/proof_generation_tool.go
+++ b/aggsender/prover/proof_generation_tool.go
@@ -93,6 +93,7 @@ func NewAggchainProofGenerationTool(
 		query.NewBridgeDataQuerier(l2Syncer),
 		query.NewGERDataQuerier(l1InfoTreeQuerier, chainGERReader),
 		l1Client,
+		false,
 	)
 
 	return &AggchainProofGenerationTool{

--- a/aggsender/prover/proof_generation_tool_test.go
+++ b/aggsender/prover/proof_generation_tool_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/log"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,4 +135,17 @@ func TestGetRPCServices(t *testing.T) {
 	require.Len(t, services, 1)
 	require.Equal(t, "aggkit", services[0].Name)
 	require.NotNil(t, services[0].Service)
+}
+
+func TestNewAggchainProofGenerationTool(t *testing.T) {
+	mockL2Syncer := mocks.NewL2BridgeSyncer(t)
+	mockL1Client := mocks.NewEthClient(t)
+	mockL2Client := mocks.NewEthClient(t)
+	mockL1Client.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	mockL1Client.EXPECT().CodeAt(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	mockL2Client.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	mockL2Client.EXPECT().CodeAt(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	_, err := NewAggchainProofGenerationTool(context.TODO(), log.WithFields("module", "test"),
+		Config{}, mockL2Syncer, nil, mockL1Client, mockL2Client)
+	require.Error(t, err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 	require.Equal(t, cfg.Profiling.ProfilingEnabled, false)
 	require.Equal(t, cfg.Profiling.ProfilingHost, "localhost")
 	require.Equal(t, cfg.Profiling.ProfilingPort, 6060)
+	require.Equal(t, cfg.AggSender.RequireNoFEPBlockGap, true)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -238,6 +238,7 @@ SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
 UseAgglayerTLS = false
 UseAggkitProverTLS = false
+RequireNoFEPBlockGap = true
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1h"


### PR DESCRIPTION
## Description

This PR cherry picks PRs for block gap sanity checks for PP -> FEP upgrade:
- PR #483 
- PR #486 
- PR #489 

### PR #483 
Add flag `RequireNoFEPBlockGap` to say if it's mandatory this sanity check

## Default value
```
[AggSender]
(...)
RequireNoFEPBlockGap = true
```

### PR #486 

The PR #483 was not a full fix for issue #482. 

```
2025-05-16T14:00:02.120Z        INFO    aggsender/aggsender.go:255      Epoch received: EpochEvent: epoch=896 extra=ExtraInfoEventEpoch: pendingBlocks=5        {"pid": 833667, "version": "v0.3.0-beta3", "module": "aggsender"}
2025-05-16T14:00:02.120Z        INFO    aggsender/aggsender.go:282      trying to send a new certificate... EpochStatus: [896, 66.67%]  {"pid": 833667, "version": "v0.3.0-beta3", "module": "aggsender"}
2025-05-16T14:00:02.120Z        ERROR   aggsender/aggsender.go:261      error getting certificate build params: aggchainProverFlow - error checking for block gaps: gap of blocks detected: lastSentCertificate.ToBlock: 11619, startL2Block: 23741   {"pid": 833667, "version": "v0.3.0-beta3", "module": "aggsender"}
github.com/agglayer/aggkit/aggsender.(*AggSender).sendCertificates
        /home/opstack/upgrade/repos/aggkit/aggsender/aggsender.go:261
github.com/agglayer/aggkit/aggsender.(*AggSender).Start
        /home/opstack/upgrade/repos/aggkit/aggsender/aggsender.go:179
```

### PR #489 

In some case of upgrade from PP to FEP with a gap  the system choose the wrong starting block for requesting a certificate. 
This is a intermediate fix: it already have some pending fixes: 
- The range of blocks could no respect the `startL2Block` (#502)
- There are no check that after a upgrade from PP to FEP it's forbidden that the last cert is InError (#499)
- Missing some sanity checks in the block gap to avoid missing relevant information (#498)

Fixes # (issue)
