### PR TITLE
feat: store in DB the type of certificate (PP/FEP)

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -294,6 +294,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 			UpdatedAt:               certificateParams.CreatedAt,
 			FinalizedL1InfoTreeRoot: &certificateParams.L1InfoTreeRootFromWhichToProve,
 			L1InfoTreeLeafCount:     certificateParams.L1InfoTreeLeafCount,
+			CertType:                certificateParams.CertificateType,
 		},
 		SignedCertificate: &jsonCert,
 		AggchainProof:     certificateParams.AggchainProof,

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -295,6 +295,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 			FinalizedL1InfoTreeRoot: &certificateParams.L1InfoTreeRootFromWhichToProve,
 			L1InfoTreeLeafCount:     certificateParams.L1InfoTreeLeafCount,
 			CertType:                certificateParams.CertificateType,
+			CertSource:              types.CertificateSourceLocal,
 		},
 		SignedCertificate: &jsonCert,
 		AggchainProof:     certificateParams.AggchainProof,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -291,8 +291,9 @@ func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := *aggsendertypes.NewCertificateMetadataFromHash(tt.metadata)
-			require.Equal(t, tt.expected, result)
+			result, err := aggsendertypes.NewCertificateMetadataFromHash(tt.metadata)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, *result)
 		})
 	}
 }

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -263,22 +263,24 @@ func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 	}{
 		{
 			name:     "Valid metadata",
-			metadata: aggsendertypes.NewCertificateMetadata(0, 1000, 123567890).ToHash(),
+			metadata: aggsendertypes.NewCertificateMetadata(0, 1000, 123567890, 123).ToHash(),
 			expected: aggsendertypes.CertificateMetadata{
-				Version:   1,
+				Version:   aggsendertypes.CertificateMetadataV2,
 				FromBlock: 0,
 				Offset:    1000,
 				CreatedAt: 123567890,
+				CertType:  123,
 			},
 		},
 		{
 			name:     "Zero metadata",
-			metadata: aggsendertypes.NewCertificateMetadata(0, 0, 0).ToHash(),
+			metadata: aggsendertypes.NewCertificateMetadata(0, 0, 0, 0).ToHash(),
 			expected: aggsendertypes.CertificateMetadata{
-				Version:   1,
+				Version:   aggsendertypes.CertificateMetadataV2,
 				FromBlock: 0,
 				Offset:    0,
 				CreatedAt: 0,
+				CertType:  0,
 			},
 		},
 	}

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -44,6 +44,7 @@ func Test_Storage(t *testing.T) {
 				CreatedAt:        updateTime,
 				UpdatedAt:        updateTime,
 				CertType:         types.CertificateTypeFEP,
+				CertSource:       types.CertificateSourceAggLayer,
 			},
 			AggchainProof: &types.AggchainProof{
 				LastProvenBlock: 0,
@@ -67,6 +68,7 @@ func Test_Storage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, certificate, *certificateFromDB)
 		require.Equal(t, certificate.Header.CertType, certificateFromDB.Header.CertType, "equal cert type")
+		require.Equal(t, certificate.Header.CertSource, certificateFromDB.Header.CertSource, "equal cert source")
 
 		// try to save a certificate without certificate header
 		certificateWithoutHeader := types.Certificate{

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -669,6 +669,8 @@ func Test_GetLastSentCertificateHeaderWithProofIfInError(t *testing.T) {
 				Status:           agglayertypes.Settled,
 				CreatedAt:        uint32(time.Now().UTC().UnixMilli()),
 				UpdatedAt:        uint32(time.Now().UTC().UnixMilli()),
+				CertType:         types.CertificateTypeFEP,
+				CertSource:       types.CertificateSourceLocal,
 			},
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
@@ -707,6 +709,8 @@ func Test_GetLastSentCertificateHeaderWithProofIfInError(t *testing.T) {
 				Status:           agglayertypes.InError,
 				CreatedAt:        uint32(time.Now().UTC().UnixMilli()),
 				UpdatedAt:        uint32(time.Now().UTC().UnixMilli()),
+				CertType:         types.CertificateTypeFEP,
+				CertSource:       types.CertificateSourceLocal,
 			},
 			AggchainProof: aggchainProof,
 		}

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -43,6 +43,7 @@ func Test_Storage(t *testing.T) {
 				Status:           agglayertypes.Settled,
 				CreatedAt:        updateTime,
 				UpdatedAt:        updateTime,
+				CertType:         types.CertificateTypeFEP,
 			},
 			AggchainProof: &types.AggchainProof{
 				LastProvenBlock: 0,
@@ -65,6 +66,7 @@ func Test_Storage(t *testing.T) {
 		certificateFromDB, err := storage.GetCertificateByHeight(certificate.Header.Height)
 		require.NoError(t, err)
 		require.Equal(t, certificate, *certificateFromDB)
+		require.Equal(t, certificate.Header.CertType, certificateFromDB.Header.CertType, "equal cert type")
 
 		// try to save a certificate without certificate header
 		certificateWithoutHeader := types.Certificate{

--- a/aggsender/db/helpers.go
+++ b/aggsender/db/helpers.go
@@ -78,6 +78,7 @@ func convertCertificateToCertificateInfo(c *types.Certificate) (*certificateInfo
 		FinalizedL1InfoTreeRoot: c.Header.FinalizedL1InfoTreeRoot,
 		L1InfoTreeLeafCount:     c.Header.L1InfoTreeLeafCount,
 		CertType:                c.Header.CertType,
+		CertSource:              c.Header.CertSource,
 		SignedCertificate:       c.SignedCertificate,
 		AggchainProof:           c.AggchainProof,
 	}, nil

--- a/aggsender/db/helpers.go
+++ b/aggsender/db/helpers.go
@@ -77,6 +77,7 @@ func convertCertificateToCertificateInfo(c *types.Certificate) (*certificateInfo
 		UpdatedAt:               c.Header.UpdatedAt,
 		FinalizedL1InfoTreeRoot: c.Header.FinalizedL1InfoTreeRoot,
 		L1InfoTreeLeafCount:     c.Header.L1InfoTreeLeafCount,
+		CertType:                c.Header.CertType,
 		SignedCertificate:       c.SignedCertificate,
 		AggchainProof:           c.AggchainProof,
 	}, nil

--- a/aggsender/db/migrations/0003.sql
+++ b/aggsender/db/migrations/0003.sql
@@ -1,7 +1,11 @@
 -- +migrate Down
 ALTER TABLE certificate_info DROP COLUMN cert_type;
+ALTER TABLE certificate_info DROP COLUMN cert_source;
 ALTER TABLE certificate_info_history DROP COLUMN cert_type;
+ALTER TABLE certificate_info_history DROP COLUMN cert_source;
 
 -- +migrate Up
 ALTER TABLE certificate_info ADD COLUMN cert_type VARCHAR DEFAULT "";
+ALTER TABLE certificate_info ADD COLUMN cert_source VARCHAR DEFAULT "";
 ALTER TABLE certificate_info_history ADD COLUMN cert_type VARCHAR DEFAULT "";
+ALTER TABLE certificate_info_history ADD COLUMN cert_source VARCHAR DEFAULT "";

--- a/aggsender/db/migrations/0003.sql
+++ b/aggsender/db/migrations/0003.sql
@@ -1,0 +1,7 @@
+-- +migrate Down
+ALTER TABLE certificate_info DROP COLUMN cert_type;
+ALTER TABLE certificate_info_history DROP COLUMN cert_type;
+
+-- +migrate Up
+ALTER TABLE certificate_info ADD COLUMN cert_type VARCHAR DEFAULT "";
+ALTER TABLE certificate_info_history ADD COLUMN cert_type VARCHAR DEFAULT "";

--- a/aggsender/db/migrations/migrations.go
+++ b/aggsender/db/migrations/migrations.go
@@ -15,6 +15,9 @@ var mig001 string
 //go:embed 0002.sql
 var mig002 string
 
+//go:embed 0003.sql
+var mig003 string
+
 func RunMigrations(logger *log.Logger, database *sql.DB) error {
 	migrations := []types.Migration{
 		{
@@ -24,6 +27,10 @@ func RunMigrations(logger *log.Logger, database *sql.DB) error {
 		{
 			ID:  "0002",
 			SQL: mig002,
+		},
+		{
+			ID:  "0003",
+			SQL: mig003,
 		},
 	}
 

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -27,6 +27,7 @@ type certificateInfo struct {
 	AggchainProof           *types.AggchainProof            `meddler:"aggchain_proof,aggchainproof"`
 	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
 	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
+	CertType                types.CertificateType           `meddler:"cert_type"`
 }
 
 // toCertificate converts the certificateInfo struct to a Certificate struct
@@ -45,6 +46,7 @@ func (c *certificateInfo) toCertificate() *types.Certificate {
 			UpdatedAt:               c.UpdatedAt,
 			FinalizedL1InfoTreeRoot: c.FinalizedL1InfoTreeRoot,
 			L1InfoTreeLeafCount:     c.L1InfoTreeLeafCount,
+			CertType:                c.CertType,
 		},
 		SignedCertificate: c.SignedCertificate,
 		AggchainProof:     c.AggchainProof,

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -28,6 +28,7 @@ type certificateInfo struct {
 	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
 	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
 	CertType                types.CertificateType           `meddler:"cert_type"`
+	CertSource              types.CertificateSource         `meddler:"cert_source"` // Source of the certificate, e.g., AggLayer, SP1, etc.
 }
 
 // toCertificate converts the certificateInfo struct to a Certificate struct
@@ -47,6 +48,7 @@ func (c *certificateInfo) toCertificate() *types.Certificate {
 			FinalizedL1InfoTreeRoot: c.FinalizedL1InfoTreeRoot,
 			L1InfoTreeLeafCount:     c.L1InfoTreeLeafCount,
 			CertType:                c.CertType,
+			CertSource:              c.CertSource,
 		},
 		SignedCertificate: c.SignedCertificate,
 		AggchainProof:     c.AggchainProof,

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -28,7 +28,7 @@ type certificateInfo struct {
 	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
 	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
 	CertType                types.CertificateType           `meddler:"cert_type"`
-	CertSource              types.CertificateSource         `meddler:"cert_source"` // Source of the certificate, e.g., AggLayer, SP1, etc.
+	CertSource              types.CertificateSource         `meddler:"cert_source"`
 }
 
 // toCertificate converts the certificateInfo struct to a Certificate struct

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -144,7 +144,7 @@ func (a *AggchainProverFlow) GetCertificateBuildParams(ctx context.Context) (*ty
 		return buildParams, nil
 	}
 
-	buildParams, err := a.baseFlow.getCertificateBuildParamsInternal(ctx, true)
+	buildParams, err := a.baseFlow.getCertificateBuildParamsInternal(ctx, true, types.CertificateTypeFEP)
 	if err != nil {
 		if errors.Is(err, errNoNewBlocks) {
 			// no new blocks to send a certificate

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -728,7 +728,7 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 				Height:              0,
 				NewLocalExitRoot:    zeroLER,
 				CustomChainData:     []byte("some-data"),
-				Metadata:            types.NewCertificateMetadata(1, 9, uint32(createdAt.Unix()), uint8(types.CertificateTypeFEPInt)).ToHash(),
+				Metadata:            types.NewCertificateMetadata(1, 9, uint32(createdAt.Unix()), types.CertificateTypeFEP.ToInt()).ToHash(),
 				BridgeExits:         []*agglayertypes.BridgeExit{},
 				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{},
 				PrevLocalExitRoot:   zeroLER,

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -355,9 +355,10 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					SP1StarkProof: &types.SP1StarkProof{Proof: []byte("some-proof")}, LastProvenBlock: 6, EndBlock: 10}, nil)
 			},
 			expectedParams: &types.CertificateBuildParams{
-				FromBlock:  6,
-				ToBlock:    10,
-				RetryCount: 0,
+				FromBlock:       6,
+				ToBlock:         10,
+				RetryCount:      0,
+				CertificateType: types.CertificateTypeFEP,
 				LastSentCertificate: &types.CertificateHeader{
 					ToBlock: 5,
 				},
@@ -438,7 +439,8 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				LastSentCertificate: &types.CertificateHeader{
 					ToBlock: 5,
 				},
-				Bridges: []bridgesync.Bridge{{BlockNum: 6}},
+				CertificateType: types.CertificateTypeFEP,
+				Bridges:         []bridgesync.Bridge{{BlockNum: 6}},
 				Claims: []bridgesync.Claim{{
 					BlockNum:        8,
 					GlobalIndex:     big.NewInt(1),
@@ -704,6 +706,7 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 				Claims:                         []bridgesync.Claim{},
 				CreatedAt:                      uint32(createdAt.Unix()),
 				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x1"),
+				CertificateType:                types.CertificateTypeFEP,
 				AggchainProof: &types.AggchainProof{
 					SP1StarkProof: &types.SP1StarkProof{
 						Proof:   []byte("some-proof"),

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -725,7 +725,7 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 				Height:              0,
 				NewLocalExitRoot:    zeroLER,
 				CustomChainData:     []byte("some-data"),
-				Metadata:            types.NewCertificateMetadata(1, 9, uint32(createdAt.Unix())).ToHash(),
+				Metadata:            types.NewCertificateMetadata(1, 9, uint32(createdAt.Unix()), uint8(types.CertificateTypeFEPInt)).ToHash(),
 				BridgeExits:         []*agglayertypes.BridgeExit{},
 				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{},
 				PrevLocalExitRoot:   zeroLER,

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -150,6 +150,7 @@ func (f *baseFlow) buildCertificate(ctx context.Context,
 		certParams.FromBlock,
 		uint32(certParams.ToBlock-certParams.FromBlock),
 		certParams.CreatedAt,
+		certParams.CertificateType.ToInt(),
 	)
 
 	return &agglayertypes.Certificate{

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -37,7 +37,7 @@ type baseFlow struct {
 
 // getCertificateBuildParamsInternal returns the parameters to build a certificate
 func (f *baseFlow) getCertificateBuildParamsInternal(
-	ctx context.Context, allowEmptyCert bool) (*types.CertificateBuildParams, error) {
+	ctx context.Context, allowEmptyCert bool, certType types.CertificateType) (*types.CertificateBuildParams, error) {
 	lastL2BlockSynced, err := f.l2BridgeQuerier.GetLastProcessedBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting last processed block from l2: %w", err)
@@ -72,6 +72,7 @@ func (f *baseFlow) getCertificateBuildParamsInternal(
 		Bridges:             bridges,
 		Claims:              claims,
 		CreatedAt:           uint32(time.Now().UTC().Unix()),
+		CertificateType:     certType,
 	}
 
 	buildParams, err = f.limitCertSize(buildParams, allowEmptyCert)

--- a/aggsender/flows/flow_pp.go
+++ b/aggsender/flows/flow_pp.go
@@ -48,7 +48,7 @@ func (p *PPFlow) CheckInitialStatus(ctx context.Context) error {
 // GetCertificateBuildParams returns the parameters to build a certificate
 // this function is the implementation of the FlowManager interface
 func (p *PPFlow) GetCertificateBuildParams(ctx context.Context) (*types.CertificateBuildParams, error) {
-	buildParams, err := p.getCertificateBuildParamsInternal(ctx, false)
+	buildParams, err := p.getCertificateBuildParamsInternal(ctx, false, types.CertificateTypePP)
 	if err != nil {
 		if errors.Is(err, errNoNewBlocks) || errors.Is(err, query.ErrNoBridgeExits) {
 			// no new blocks to send a certificate, or no bridge exits consumed

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -680,6 +680,7 @@ func TestBuildCertificate(t *testing.T) {
 				ToBlock:                        tt.toBlock,
 				Bridges:                        tt.bridges,
 				Claims:                         tt.claims,
+				CertificateType:                types.CertificateTypePP,
 				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x7891"),
 			}
 			cert, err := flow.buildCertificate(context.Background(), certParam, &tt.lastSentCertificate, false)
@@ -965,6 +966,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				ToBlock:             10,
 				RetryCount:          0,
 				L1InfoTreeLeafCount: 1,
+				CertificateType:     types.CertificateTypePP,
 				LastSentCertificate: &types.CertificateHeader{ToBlock: 5},
 				Bridges:             []bridgesync.Bridge{{}},
 				Claims: []bridgesync.Claim{

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -529,7 +529,7 @@ func TestBuildCertificate(t *testing.T) {
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
-				Metadata:          types.NewCertificateMetadata(0, 10, 0).ToHash(),
+				Metadata:          types.NewCertificateMetadata(0, 10, 0, uint8(types.CertificateTypePPInt)).ToHash(),
 				BridgeExits: []*agglayertypes.BridgeExit{
 					{
 						LeafType: agglayertypes.LeafTypeAsset,

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -529,7 +529,7 @@ func TestBuildCertificate(t *testing.T) {
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
-				Metadata:          types.NewCertificateMetadata(0, 10, 0, uint8(types.CertificateTypePPInt)).ToHash(),
+				Metadata:          types.NewCertificateMetadata(0, 10, 0, types.CertificateTypePP.ToInt()).ToHash(),
 				BridgeExits: []*agglayertypes.BridgeExit{
 					{
 						LeafType: agglayertypes.LeafTypeAsset,

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -235,9 +235,11 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 	}
 	now := uint32(time.Now().UTC().Unix())
 	meta := types.NewCertificateMetadataFromHash(c.Metadata)
-	var toBlock uint64
-	var createdAt uint32
-	var certType types.CertificateType
+	var (
+		toBlock   uint64
+		createdAt uint32
+		certType  types.CertificateType
+	)
 
 	switch meta.Version {
 	case types.CertificateMetadataV0:

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -235,26 +235,30 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 	toBlock := meta.FromBlock + uint64(meta.Offset)
 	createdAt := meta.CreatedAt
 
-	if meta.Version < 1 {
+	if meta.Version == types.CertificateMetadataV0 {
 		toBlock = meta.ToBlock
 		createdAt = now
 	}
-
-	res := &types.Certificate{
-		Header: &types.CertificateHeader{
-			Height:           c.Height,
-			CertificateID:    c.CertificateID,
-			NewLocalExitRoot: c.NewLocalExitRoot,
-			FromBlock:        meta.FromBlock,
-			ToBlock:          toBlock,
-			Status:           c.Status,
-			CreatedAt:        createdAt,
-			UpdatedAt:        now,
-		},
-		SignedCertificate: &naAgglayerHeader,
+	var res *types.Certificate
+	if meta.Version == types.CertificateMetadataV1 {
+		res = &types.Certificate{
+			Header: &types.CertificateHeader{
+				Height:           c.Height,
+				CertificateID:    c.CertificateID,
+				NewLocalExitRoot: c.NewLocalExitRoot,
+				FromBlock:        meta.FromBlock,
+				ToBlock:          toBlock,
+				Status:           c.Status,
+				CreatedAt:        createdAt,
+				UpdatedAt:        now,
+				CertType:         types.CertificateTypeUnknown,
+			},
+			SignedCertificate: &naAgglayerHeader,
+		}
 	}
-	// We try to guess the type of certificate
-	res.Header.CertType = res.GetCertType()
+	if meta.Version == types.CertificateMetadataV2 {
+		res.Header.CertType = types.NewCertificateTypeFromInt(meta.CertType)
+	}
 
 	if c.PreviousLocalExitRoot != nil {
 		res.Header.PreviousLocalExitRoot = c.PreviousLocalExitRoot

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -253,6 +253,8 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 		},
 		SignedCertificate: &naAgglayerHeader,
 	}
+	// We try to guess the type of certificate
+	res.Header.CertType = res.GetCertType()
 
 	if c.PreviousLocalExitRoot != nil {
 		res.Header.PreviousLocalExitRoot = c.PreviousLocalExitRoot

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -234,7 +234,11 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 		return nil, nil
 	}
 	now := uint32(time.Now().UTC().Unix())
-	meta := types.NewCertificateMetadataFromHash(c.Metadata)
+	meta, err := types.NewCertificateMetadataFromHash(c.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("newCertificateInfoFromAgglayerCertHeader."+
+			" error creating certificate metadata from hash: %w", err)
+	}
 	var (
 		toBlock   uint64
 		createdAt uint32

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -240,7 +240,7 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 		createdAt = now
 	}
 	var res *types.Certificate
-	if meta.Version == types.CertificateMetadataV1 {
+	if meta.Version >= types.CertificateMetadataV1 {
 		res = &types.Certificate{
 			Header: &types.CertificateHeader{
 				Height:           c.Height,
@@ -259,7 +259,7 @@ func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader
 	if meta.Version == types.CertificateMetadataV2 {
 		res.Header.CertType = types.NewCertificateTypeFromInt(meta.CertType)
 	}
-
+	res.Header.CertSource = types.CertificateSourceAggLayer
 	if c.PreviousLocalExitRoot != nil {
 		res.Header.PreviousLocalExitRoot = c.PreviousLocalExitRoot
 	}

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -195,7 +195,8 @@ func TestNewCertificateInfoFromAgglayerCertHeader(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := newCertificateInfoFromAgglayerCertHeader(tt.inputHeader)
+			result, err := newCertificateInfoFromAgglayerCertHeader(tt.inputHeader)
+			require.NoError(t, err)
 			if tt.expectedResult == nil {
 				require.Nil(t, result)
 			} else {

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -26,11 +26,12 @@ type CertificateBuildParams struct {
 	L1InfoTreeRootFromWhichToProve common.Hash
 	L1InfoTreeLeafCount            uint32
 	AggchainProof                  *AggchainProof
+	CertificateType                CertificateType
 }
 
 func (c *CertificateBuildParams) String() string {
-	return fmt.Sprintf("FromBlock: %d, ToBlock: %d, numBridges: %d, numClaims: %d, createdAt: %d",
-		c.FromBlock, c.ToBlock, c.NumberOfBridges(), c.NumberOfClaims(), c.CreatedAt)
+	return fmt.Sprintf("Type: %s FromBlock: %d, ToBlock: %d, numBridges: %d, numClaims: %d, createdAt: %d",
+		c.CertificateType, c.FromBlock, c.ToBlock, c.NumberOfBridges(), c.NumberOfClaims(), c.CreatedAt)
 }
 
 // Range create a new CertificateBuildParams with the given range
@@ -58,6 +59,7 @@ func (c *CertificateBuildParams) Range(fromBlock, toBlock uint64) (*CertificateB
 		AggchainProof:                  c.AggchainProof,
 		L1InfoTreeRootFromWhichToProve: c.L1InfoTreeRootFromWhichToProve,
 		L1InfoTreeLeafCount:            c.L1InfoTreeLeafCount,
+		CertificateType:                c.CertificateType,
 	}
 
 	for _, bridge := range c.Bridges {

--- a/aggsender/types/certificate_metadata.go
+++ b/aggsender/types/certificate_metadata.go
@@ -11,7 +11,7 @@ import (
 const (
 	CertificateMetadataV0 = uint8(0) // Pre v1 metadata, only ToBlock is stored
 	CertificateMetadataV1 = uint8(1) // Post v1 metadata, FromBlock, Offset, CreatedAt are stored
-	CertificateMetadataV2 = uint8(2) // Same V1 + typeCert
+	CertificateMetadataV2 = uint8(2) // Same V1 + CertType
 )
 
 type CertificateMetadata struct {

--- a/aggsender/types/certificate_metadata.go
+++ b/aggsender/types/certificate_metadata.go
@@ -34,7 +34,7 @@ type CertificateMetadata struct {
 	CertType uint8 // version >= V2
 }
 
-// NewCertificateMetadataFromHash returns a new CertificateMetadata from the given hash
+// NewCertificateMetadata returns a new CertificateMetadata from the given hash
 func NewCertificateMetadata(fromBlock uint64, offset uint32, createdAt uint32, certType uint8) *CertificateMetadata {
 	return &CertificateMetadata{
 		FromBlock: fromBlock,

--- a/aggsender/types/certificate_metadata.go
+++ b/aggsender/types/certificate_metadata.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"encoding/binary"
-	"log"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -47,20 +47,20 @@ func NewCertificateMetadata(fromBlock uint64, offset uint32, createdAt uint32, c
 }
 
 // NewCertificateMetadataFromHash returns a new CertificateMetadata from the given hash
-func NewCertificateMetadataFromHash(hash common.Hash) *CertificateMetadata {
+func NewCertificateMetadataFromHash(hash common.Hash) (*CertificateMetadata, error) {
 	b := hash.Bytes()
 	version := b[0]
 	if version == CertificateMetadataV0 {
 		return &CertificateMetadata{
 			ToBlock: hash.Big().Uint64(),
-		}
+		}, nil
 	} else if version == CertificateMetadataV1 {
 		return &CertificateMetadata{
 			Version:   version,
 			FromBlock: binary.BigEndian.Uint64(b[1:9]),
 			Offset:    binary.BigEndian.Uint32(b[9:13]),
 			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
-		}
+		}, nil
 	} else if version == CertificateMetadataV2 {
 		return &CertificateMetadata{
 			Version:   version,
@@ -68,11 +68,10 @@ func NewCertificateMetadataFromHash(hash common.Hash) *CertificateMetadata {
 			Offset:    binary.BigEndian.Uint32(b[9:13]),
 			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
 			CertType:  b[17],
-		}
+		}, nil
 	} else {
-		// Unsupported version, return nil
-		log.Panicf("aggsender: unsupported certificate metadata version: %d", version)
-		return nil
+		// Unsupported version
+		return nil, fmt.Errorf("newCertificateMetadataFromHash. unsupported certificate metadata version: %d", version)
 	}
 }
 

--- a/aggsender/types/certificate_metadata.go
+++ b/aggsender/types/certificate_metadata.go
@@ -1,0 +1,104 @@
+package types
+
+import (
+	"encoding/binary"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	CertificateMetadataV0 = uint8(0) // Pre v1 metadata, only ToBlock is stored
+	CertificateMetadataV1 = uint8(1) // Post v1 metadata, FromBlock, Offset, CreatedAt are stored
+	CertificateMetadataV2 = uint8(2) // Same V1 + typeCert
+)
+
+type CertificateMetadata struct {
+	// ToBlock contains the pre v1 value stored in the metadata certificate field
+	// is not stored in the hash post v1
+	ToBlock uint64
+
+	// FromBlock is the block number from which the certificate contains data
+	FromBlock uint64
+
+	// Offset is the number of blocks from the FromBlock that the certificate contains
+	Offset uint32
+
+	// CreatedAt is the timestamp when the certificate was created
+	CreatedAt uint32
+
+	// Version is the version of the metadata
+	Version uint8
+
+	// CertType is the type of certificate
+	CertType uint8 // version >= V2
+}
+
+// NewCertificateMetadataFromHash returns a new CertificateMetadata from the given hash
+func NewCertificateMetadata(fromBlock uint64, offset uint32, createdAt uint32, certType uint8) *CertificateMetadata {
+	return &CertificateMetadata{
+		FromBlock: fromBlock,
+		Offset:    offset,
+		CreatedAt: createdAt,
+		CertType:  certType,
+		Version:   CertificateMetadataV2,
+	}
+}
+
+// NewCertificateMetadataFromHash returns a new CertificateMetadata from the given hash
+func NewCertificateMetadataFromHash(hash common.Hash) *CertificateMetadata {
+	b := hash.Bytes()
+	version := b[0]
+	if version == CertificateMetadataV0 {
+		return &CertificateMetadata{
+			ToBlock: hash.Big().Uint64(),
+		}
+	} else if version == CertificateMetadataV1 {
+		return &CertificateMetadata{
+			Version:   version,
+			FromBlock: binary.BigEndian.Uint64(b[1:9]),
+			Offset:    binary.BigEndian.Uint32(b[9:13]),
+			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
+		}
+	} else if version == CertificateMetadataV2 {
+		return &CertificateMetadata{
+			Version:   version,
+			FromBlock: binary.BigEndian.Uint64(b[1:9]),
+			Offset:    binary.BigEndian.Uint32(b[9:13]),
+			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
+			CertType:  b[17],
+		}
+	} else {
+		// Unsupported version, return nil
+		log.Panicf("aggsender: unsupported certificate metadata version: %d", version)
+		return nil
+	}
+}
+
+// ToHash returns the hash of the metadata
+func (c *CertificateMetadata) ToHash() common.Hash {
+	b := make([]byte, common.HashLength) // 32-byte hash
+
+	// Encode version
+	b[0] = c.Version
+	if c.Version == CertificateMetadataV0 {
+		// For v0, we only store ToBlock
+		binary.BigEndian.PutUint64(b[1:9], c.ToBlock)
+		return common.BytesToHash(b)
+	}
+	// CertificateMetadataV1
+	// Encode fromBlock
+	binary.BigEndian.PutUint64(b[1:9], c.FromBlock)
+
+	// Encode offset
+	binary.BigEndian.PutUint32(b[9:13], c.Offset)
+
+	// Encode createdAt
+	binary.BigEndian.PutUint32(b[13:17], c.CreatedAt)
+
+	if c.Version == CertificateMetadataV2 {
+		// Encode typeCert
+		b[17] = c.CertType
+	}
+	return common.BytesToHash(b)
+}

--- a/aggsender/types/certificate_metadata.go
+++ b/aggsender/types/certificate_metadata.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/binary"
 	"log"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -80,12 +81,11 @@ func (c *CertificateMetadata) ToHash() common.Hash {
 	b := make([]byte, common.HashLength) // 32-byte hash
 
 	// Encode version
-	b[0] = c.Version
 	if c.Version == CertificateMetadataV0 {
 		// For v0, we only store ToBlock
-		binary.BigEndian.PutUint64(b[1:9], c.ToBlock)
-		return common.BytesToHash(b)
+		return common.BigToHash(new(big.Int).SetUint64(c.ToBlock))
 	}
+	b[0] = c.Version
 	// CertificateMetadataV1
 	// Encode fromBlock
 	binary.BigEndian.PutUint64(b[1:9], c.FromBlock)

--- a/aggsender/types/certificate_metadata_test.go
+++ b/aggsender/types/certificate_metadata_test.go
@@ -11,7 +11,8 @@ import (
 func TestMetadataConversions_V0_toBlock_Only(t *testing.T) {
 	toBlock := uint64(123567890)
 	hash := common.BigToHash(new(big.Int).SetUint64(toBlock))
-	meta := NewCertificateMetadataFromHash(hash)
+	meta, err := NewCertificateMetadataFromHash(hash)
+	require.NoError(t, err)
 	require.Equal(t, toBlock, meta.ToBlock)
 	metabuild := meta.ToHash()
 	require.Equal(t, hash, metabuild)
@@ -25,7 +26,8 @@ func TestMetadataConversions_V1(t *testing.T) {
 		CreatedAt: 123,
 	}
 	hash := meta.ToHash()
-	metabuild := NewCertificateMetadataFromHash(hash)
+	metabuild, err := NewCertificateMetadataFromHash(hash)
+	require.NoError(t, err)
 	require.Equal(t, meta.FromBlock, metabuild.FromBlock)
 	require.Equal(t, meta.Offset, metabuild.Offset)
 	require.Equal(t, meta.CreatedAt, metabuild.CreatedAt)
@@ -41,7 +43,8 @@ func TestMetadataConversions_V2(t *testing.T) {
 		CertType:  32,
 	}
 	hash := meta.ToHash()
-	metabuild := NewCertificateMetadataFromHash(hash)
+	metabuild, err := NewCertificateMetadataFromHash(hash)
+	require.NoError(t, err)
 	require.Equal(t, meta.FromBlock, metabuild.FromBlock)
 	require.Equal(t, meta.Offset, metabuild.Offset)
 	require.Equal(t, meta.CreatedAt, metabuild.CreatedAt)
@@ -53,12 +56,8 @@ func TestMetadataConversions_UnknownMetadataVersion(t *testing.T) {
 	b := make([]byte, common.HashLength)
 	b[0] = 254 // Unknown version
 	hash := common.BytesToHash(b)
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("NewCertificateMetadataFromHash for unknown version did not panic")
-		}
-	}()
-	_ = NewCertificateMetadataFromHash(hash)
+	_, err := NewCertificateMetadataFromHash(hash)
+	require.Error(t, err)
 }
 
 func TestMetadataConversions(t *testing.T) {
@@ -68,7 +67,8 @@ func TestMetadataConversions(t *testing.T) {
 	certType := uint8(123)
 	meta := NewCertificateMetadata(fromBlock, offset, createdAt, certType)
 	c := meta.ToHash()
-	extractBlock := NewCertificateMetadataFromHash(c)
+	extractBlock, err := NewCertificateMetadataFromHash(c)
+	require.NoError(t, err)
 	require.Equal(t, fromBlock, extractBlock.FromBlock)
 	require.Equal(t, offset, extractBlock.Offset)
 	require.Equal(t, createdAt, extractBlock.CreatedAt)

--- a/aggsender/types/certificate_metadata_test.go
+++ b/aggsender/types/certificate_metadata_test.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataConversions_V0_toBlock_Only(t *testing.T) {
+	toBlock := uint64(123567890)
+	hash := common.BigToHash(new(big.Int).SetUint64(toBlock))
+	meta := NewCertificateMetadataFromHash(hash)
+	require.Equal(t, toBlock, meta.ToBlock)
+	metabuild := meta.ToHash()
+	require.Equal(t, hash, metabuild)
+}
+
+func TestMetadataConversions_V1(t *testing.T) {
+	meta := &CertificateMetadata{
+		Version:   CertificateMetadataV1,
+		FromBlock: 123567890,
+		Offset:    1000,
+		CreatedAt: 123,
+	}
+	hash := meta.ToHash()
+	metabuild := NewCertificateMetadataFromHash(hash)
+	require.Equal(t, meta.FromBlock, metabuild.FromBlock)
+	require.Equal(t, meta.Offset, metabuild.Offset)
+	require.Equal(t, meta.CreatedAt, metabuild.CreatedAt)
+	require.Equal(t, meta.Version, metabuild.Version)
+}
+
+func TestMetadataConversions_V2(t *testing.T) {
+	meta := &CertificateMetadata{
+		Version:   CertificateMetadataV2,
+		FromBlock: 123567890,
+		Offset:    1000,
+		CreatedAt: 123,
+		CertType:  32,
+	}
+	hash := meta.ToHash()
+	metabuild := NewCertificateMetadataFromHash(hash)
+	require.Equal(t, meta.FromBlock, metabuild.FromBlock)
+	require.Equal(t, meta.Offset, metabuild.Offset)
+	require.Equal(t, meta.CreatedAt, metabuild.CreatedAt)
+	require.Equal(t, meta.Version, metabuild.Version)
+	require.Equal(t, meta.CertType, metabuild.CertType)
+}
+
+func TestMetadataConversions_UnknownMetadataVersion(t *testing.T) {
+	b := make([]byte, common.HashLength)
+	b[0] = 254 // Unknown version
+	hash := common.BytesToHash(b)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("NewCertificateMetadataFromHash for unknown version did not panic")
+		}
+	}()
+	_ = NewCertificateMetadataFromHash(hash)
+}
+
+func TestMetadataConversions(t *testing.T) {
+	fromBlock := uint64(123567890)
+	offset := uint32(1000)
+	createdAt := uint32(0)
+	certType := uint8(123)
+	meta := NewCertificateMetadata(fromBlock, offset, createdAt, certType)
+	c := meta.ToHash()
+	extractBlock := NewCertificateMetadataFromHash(c)
+	require.Equal(t, fromBlock, extractBlock.FromBlock)
+	require.Equal(t, offset, extractBlock.Offset)
+	require.Equal(t, createdAt, extractBlock.CreatedAt)
+	require.Equal(t, certType, extractBlock.CertType)
+	require.Equal(t, CertificateMetadataV2, extractBlock.Version)
+}

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -34,8 +34,8 @@ func (c CertificateType) String() string {
 	return string(c)
 }
 
-func (ct CertificateType) ToInt() uint8 {
-	switch ct {
+func (c CertificateType) ToInt() uint8 {
+	switch c {
 	case CertificateTypeFEP:
 		return uint8(CertificateTypeFEPInt)
 	case CertificateTypePP:
@@ -196,7 +196,8 @@ func (c *CertificateHeader) ID() string {
 	if c == nil {
 		return NilStr
 	}
-	return fmt.Sprintf("%d/%s (retry: %d, type: %s)", c.Height, c.CertificateID.String(), c.RetryCount, c.CertSource.String())
+	return fmt.Sprintf("%d/%s (retry: %d, type: %s)",
+		c.Height, c.CertificateID.String(), c.RetryCount, c.CertSource.String())
 }
 
 // StatusString returns the string representation of the status

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -30,6 +30,10 @@ const (
 	CertificateTypeFEPInt     CertificateTypeInt = 2
 )
 
+func (c CertificateType) String() string {
+	return string(c)
+}
+
 func (ct CertificateType) ToInt() uint8 {
 	switch ct {
 	case CertificateTypeFEP:
@@ -49,6 +53,18 @@ func NewCertificateTypeFromInt(i uint8) CertificateType {
 	default:
 		return CertificateTypeUnknown
 	}
+}
+
+type CertificateSource string
+
+const (
+	CertificateSourceAggLayer CertificateSource = "agglayer"
+	CertificateSourceLocal    CertificateSource = "Local"
+	CertificateSourceUnknown  CertificateSource = ""
+)
+
+func (c CertificateSource) String() string {
+	return string(c)
 }
 
 // CertStatus holds the status of pending and in error certificates
@@ -128,6 +144,8 @@ type CertificateHeader struct {
 	// CertType must be private but there are a lot of code that create CertificateInfo directly
 	// so I add a GetCertType() that is not idiomatic but helps to determine the kind of certificate
 	CertType CertificateType `meddler:"cert_type"`
+	// This is the origin of this data, it can be from the AggLayer or from the local sender
+	CertSource CertificateSource `meddler:"cert_source"`
 }
 
 func (c *CertificateHeader) String() string {
@@ -144,6 +162,7 @@ func (c *CertificateHeader) String() string {
 	}
 
 	return fmt.Sprintf("aggsender.CertificateHeader: \n"+
+		"Type: %s \n"+
 		"Height: %d \n"+
 		"RetryCount: %d \n"+
 		"CertificateID: %s \n"+
@@ -154,7 +173,9 @@ func (c *CertificateHeader) String() string {
 		"ToBlock: %d \n"+
 		"CreatedAt: %s \n"+
 		"UpdatedAt: %s \n"+
-		"FinalizedL1InfoTreeRoot: %s \n",
+		"FinalizedL1InfoTreeRoot: %s \n"+
+		"Source: %s \n",
+		c.CertType.String(),
 		c.Height,
 		c.RetryCount,
 		c.CertificateID.String(),
@@ -166,6 +187,7 @@ func (c *CertificateHeader) String() string {
 		time.Unix(int64(c.CreatedAt), 0),
 		time.Unix(int64(c.UpdatedAt), 0),
 		finalizedL1InfoTreeRoot,
+		c.CertSource.String(),
 	)
 }
 
@@ -174,7 +196,7 @@ func (c *CertificateHeader) ID() string {
 	if c == nil {
 		return NilStr
 	}
-	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
+	return fmt.Sprintf("%d/%s (retry: %d, type: %s)", c.Height, c.CertificateID.String(), c.RetryCount, c.CertSource.String())
 }
 
 // StatusString returns the string representation of the status

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"time"
 
@@ -17,41 +18,66 @@ const (
 	AggchainProofMode    AggsenderMode = "AggchainProof"
 )
 
-type CertificateType string
-type CertificateTypeInt uint8
+type CertificateType uint8
 
 const (
-	CertificateTypeUnknown CertificateType = ""
-	CertificateTypePP      CertificateType = "pp"
-	CertificateTypeFEP     CertificateType = "fep"
+	CertificateTypeUnknownStr string = ""
+	CertificateTypePPStr      string = "pp"
+	CertificateTypeFEPStr     string = "fep"
 
-	CertificateTypeUnknownInt CertificateTypeInt = 0
-	CertificateTypePPInt      CertificateTypeInt = 1
-	CertificateTypeFEPInt     CertificateTypeInt = 2
+	CertificateTypeUnknown CertificateType = 0
+	CertificateTypePP      CertificateType = 1
+	CertificateTypeFEP     CertificateType = 2
 )
 
 func (c CertificateType) String() string {
-	return string(c)
+	switch c {
+	case CertificateTypeFEP:
+		return CertificateTypeFEPStr
+	case CertificateTypePP:
+		return CertificateTypePPStr
+	default:
+		return CertificateTypeUnknownStr
+	}
+}
+
+// meddler support for store as string
+func (c CertificateType) Value() (driver.Value, error) {
+	return c.String(), nil
+}
+
+// meddler support for store as string
+func (c *CertificateType) Scan(value interface{}) error {
+	str, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("CertificateType: expected string, got %T", value)
+	}
+	v, err := NewCertificateTypeFromStr(str)
+	if err != nil {
+		return fmt.Errorf("CertificateType.Scan(...): %w", err)
+	}
+	*c = v
+	return nil
 }
 
 func (c CertificateType) ToInt() uint8 {
-	switch c {
-	case CertificateTypeFEP:
-		return uint8(CertificateTypeFEPInt)
-	case CertificateTypePP:
-		return uint8(CertificateTypePPInt)
-	default:
-		return uint8(CertificateTypeUnknownInt)
-	}
+	return uint8(c)
 }
-func NewCertificateTypeFromInt(i uint8) CertificateType {
-	switch i {
-	case uint8(CertificateTypePPInt):
-		return CertificateTypePP
-	case uint8(CertificateTypeFEPInt):
-		return CertificateTypeFEP
+
+func NewCertificateTypeFromInt(v uint8) CertificateType {
+	return CertificateType(v)
+}
+
+func NewCertificateTypeFromStr(v string) (CertificateType, error) {
+	switch v {
+	case CertificateTypePPStr:
+		return CertificateTypePP, nil
+	case CertificateTypeFEPStr:
+		return CertificateTypeFEP, nil
+	case CertificateTypeUnknownStr:
+		return CertificateTypeUnknown, nil
 	default:
-		return CertificateTypeUnknown
+		return CertificateTypeUnknown, fmt.Errorf("unknown CertificateType: %s", v)
 	}
 }
 

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -18,6 +18,14 @@ const (
 	AggchainProofMode    AggsenderMode = "AggchainProof"
 )
 
+type CertificateType string
+
+const (
+	CertificateTypeUnknown CertificateType = ""
+	CertificateTypeFEP     CertificateType = "fep"
+	CertificateTypePP      CertificateType = "pp"
+)
+
 // CertStatus holds the status of pending and in error certificates
 type CertStatus struct {
 	ExistPendingCerts   bool
@@ -92,6 +100,9 @@ type CertificateHeader struct {
 	UpdatedAt               uint32                          `meddler:"updated_at"`
 	FinalizedL1InfoTreeRoot *common.Hash                    `meddler:"finalized_l1_info_tree_root,hash"`
 	L1InfoTreeLeafCount     uint32                          `meddler:"l1_info_tree_leaf_count"`
+	// CertType must be private but there are a lot of code that create CertificateInfo directly
+	// so I add a GetCertType() that is not idiomatic but helps to determine the kind of certificate
+	CertType CertificateType `meddler:"cert_type"`
 }
 
 func (c *CertificateHeader) String() string {
@@ -169,6 +180,20 @@ type Certificate struct {
 	Header            *CertificateHeader
 	SignedCertificate *string        `meddler:"signed_certificate"`
 	AggchainProof     *AggchainProof `meddler:"aggchain_proof,aggchainproof"`
+}
+
+func (c *Certificate) GetCertType() CertificateType {
+	if c == nil {
+		return CertificateTypeUnknown
+	}
+	if c.Header.CertType == CertificateTypeUnknown {
+		if c.AggchainProof != nil {
+			return CertificateTypeFEP
+		} else {
+			return CertificateTypePP
+		}
+	}
+	return c.Header.CertType
 }
 
 func (c *Certificate) String() string {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -59,7 +59,7 @@ type CertificateSource string
 
 const (
 	CertificateSourceAggLayer CertificateSource = "agglayer"
-	CertificateSourceLocal    CertificateSource = "Local"
+	CertificateSourceLocal    CertificateSource = "local"
 	CertificateSourceUnknown  CertificateSource = ""
 )
 

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"math/big"
 	"testing"
 	"time"
 
@@ -10,25 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMetadataConversions_toBlock_Only(t *testing.T) {
-	toBlock := uint64(123567890)
-	hash := common.BigToHash(new(big.Int).SetUint64(toBlock))
-	meta := NewCertificateMetadataFromHash(hash)
-	require.Equal(t, toBlock, meta.ToBlock)
-}
-
-func TestMetadataConversions(t *testing.T) {
-	fromBlock := uint64(123567890)
-	offset := uint32(1000)
-	createdAt := uint32(0)
-	meta := NewCertificateMetadata(fromBlock, offset, createdAt)
-	c := meta.ToHash()
-	extractBlock := NewCertificateMetadataFromHash(c)
-	require.Equal(t, fromBlock, extractBlock.FromBlock)
-	require.Equal(t, offset, extractBlock.Offset)
-	require.Equal(t, createdAt, extractBlock.CreatedAt)
-}
 
 func TestCertificate_String(t *testing.T) {
 	t.Run("NilCertificate", func(t *testing.T) {


### PR DESCRIPTION
## Description

Add a new field on DB:
-  `cert_type`:  PP or FEP certificate. 
- `cert_source`:  agglayer or local

The `cert_type` is stored on cert metadata, so it can be retrieved by aggsender in case that need to resync

Fixes: #499 
