### PR TITLE
feat: save non-accepted certificates to `db`

### DIFF
--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -149,10 +149,10 @@ func (a *AggchainDataSelector) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var ok bool
-	if _, ok = obj["signature"]; ok {
-		a.obj = &AggchainDataSignature{}
-	} else if _, ok = obj["proof"]; ok {
+	if _, ok = obj["proof"]; ok {
 		a.obj = &AggchainDataProof{}
+	} else if _, ok = obj["signature"]; ok {
+		a.obj = &AggchainDataSignature{}
 	} else {
 		return errors.New("invalid aggchain_data type")
 	}

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -261,10 +261,8 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayertypes.Certifi
 	}
 	certificateHash, err := a.aggLayerClient.SendCertificate(ctx, certificate)
 	if err != nil {
-		raw, marshalErr := json.Marshal(certificate)
-		if marshalErr == nil {
-			// we ignore the marshal error, since marshaled certificate is only needed for logging
-			a.log.Errorf("error sending certificate. Err: %w. Certificate: %s", err, string(raw))
+		if err := a.storage.SaveNonAcceptedCertificate(ctx, certificate, certificateParams.CreatedAt); err != nil {
+			a.log.Errorf("error saving non accepted certificate %s in db: %w", certificate.Brief(), err)
 		}
 
 		return nil, fmt.Errorf("error sending certificate: %w", err)

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -314,7 +314,7 @@ func TestSendCertificate(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(nil, errors.New("some error")).Once()
+				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(nil, errors.New("some error")).Once()
 			},
 			expectedError: "error getting certificate build params",
 		},
@@ -323,7 +323,7 @@ func TestSendCertificate(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(nil, nil).Once()
+				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(nil, nil).Once()
 			},
 		},
 		{
@@ -331,10 +331,10 @@ func TestSendCertificate(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
+				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
-				mockFlow.On("BuildCertificate", mock.Anything, mock.Anything).Return(nil, errors.New("some error")).Once()
+				mockFlow.EXPECT().BuildCertificate(mock.Anything, mock.Anything).Return(nil, errors.New("some error")).Once()
 			},
 			expectedError: "error building certificate",
 		},
@@ -343,16 +343,17 @@ func TestSendCertificate(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
+				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
-				mockFlow.On("BuildCertificate", mock.Anything, mock.Anything).Return(&agglayertypes.Certificate{
+				mockFlow.EXPECT().BuildCertificate(mock.Anything, mock.Anything).Return(&agglayertypes.Certificate{
 					NetworkID:        1,
 					Height:           0,
 					NewLocalExitRoot: common.HexToHash("0x1"),
 					BridgeExits:      []*agglayertypes.BridgeExit{{}},
 				}, nil).Once()
-				mockAgglayerClient.On("SendCertificate", mock.Anything, mock.Anything).Return(common.Hash{}, errors.New("some error")).Once()
+				mockAgglayerClient.EXPECT().SendCertificate(mock.Anything, mock.Anything).Return(common.Hash{}, errors.New("some error")).Once()
+				mockStorage.EXPECT().SaveNonAcceptedCertificate(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 			},
 			expectedError: "error sending certificate",
 		},
@@ -361,17 +362,17 @@ func TestSendCertificate(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
+				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
-				mockFlow.On("BuildCertificate", mock.Anything, mock.Anything).Return(&agglayertypes.Certificate{
+				mockFlow.EXPECT().BuildCertificate(mock.Anything, mock.Anything).Return(&agglayertypes.Certificate{
 					NetworkID:        11,
 					Height:           0,
 					NewLocalExitRoot: common.HexToHash("0x11"),
 					BridgeExits:      []*agglayertypes.BridgeExit{{}},
 				}, nil).Once()
-				mockAgglayerClient.On("SendCertificate", mock.Anything, mock.Anything).Return(common.HexToHash("0x22"), nil).Once()
-				mockStorage.On("SaveLastSentCertificate", mock.Anything, mock.Anything).Return(errors.New("some error")).Once()
+				mockAgglayerClient.EXPECT().SendCertificate(mock.Anything, mock.Anything).Return(common.HexToHash("0x22"), nil).Once()
+				mockStorage.EXPECT().SaveLastSentCertificate(mock.Anything, mock.Anything).Return(errors.New("some error")).Once()
 			},
 			expectedError: "error saving last sent certificate",
 		},
@@ -380,17 +381,17 @@ func TestSendCertificate(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockFlow *mocks.AggsenderFlow,
 				mockAgglayerClient *agglayer.AgglayerClientMock) {
-				mockFlow.On("GetCertificateBuildParams", mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
+				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(&aggsendertypes.CertificateBuildParams{
 					Bridges: []bridgesync.Bridge{{}},
 				}, nil).Once()
-				mockFlow.On("BuildCertificate", mock.Anything, mock.Anything).Return(&agglayertypes.Certificate{
+				mockFlow.EXPECT().BuildCertificate(mock.Anything, mock.Anything).Return(&agglayertypes.Certificate{
 					NetworkID:        11,
 					Height:           0,
 					NewLocalExitRoot: common.HexToHash("0x11"),
 					BridgeExits:      []*agglayertypes.BridgeExit{{}},
 				}, nil).Once()
-				mockAgglayerClient.On("SendCertificate", mock.Anything, mock.Anything).Return(common.HexToHash("0x22"), nil).Once()
-				mockStorage.On("SaveLastSentCertificate", mock.Anything, mock.Anything).Return(nil).Once()
+				mockAgglayerClient.EXPECT().SendCertificate(mock.Anything, mock.Anything).Return(common.HexToHash("0x22"), nil).Once()
+				mockStorage.EXPECT().SaveLastSentCertificate(mock.Anything, mock.Anything).Return(nil).Once()
 			},
 		},
 	}

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -386,9 +386,7 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 		}
 	}()
 
-	var raw []byte
-
-	raw, err = json.Marshal(certificate)
+	raw, err := json.Marshal(certificate)
 	if err != nil {
 		return fmt.Errorf("failed to marshal non-accepted certificate: %w", err)
 	}

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -3,9 +3,11 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggsender/db/migrations"
@@ -60,6 +62,11 @@ type AggSenderStorage interface {
 	// and the aggchain proof if the certificate is in error
 	GetLastSentCertificateHeaderWithProofIfInError(
 		ctx context.Context) (*types.CertificateHeader, *types.AggchainProof, error)
+	// SaveNonAcceptedCertificate saves a non-accepted certificate in the storage
+	SaveNonAcceptedCertificate(
+		ctx context.Context, certificate *agglayertypes.Certificate, createdAt uint32) error
+	// GetNonAcceptedCertificates returns a list of non-accepted certificates
+	GetNonAcceptedCertificates() ([]*agglayertypes.Certificate, error)
 }
 
 var _ AggSenderStorage = (*AggSenderSQLStorage)(nil)
@@ -344,13 +351,85 @@ func (a *AggSenderSQLStorage) GetLastSentCertificateHeaderWithProofIfInError(
 		if err := meddler.QueryRow(tx, &certWithOnlyProof,
 			"SELECT aggchain_proof FROM certificate_info WHERE height = $1;",
 			certificateHeader.Height); err != nil {
-			return nil, nil, getSelectQueryError(certificateHeader.Height, err)
+			// this has to exist since we where getting the certificate header
+			// for the same height from the same table
+			return nil, nil, err
 		}
 
 		return &certificateHeader, certWithOnlyProof.AggchainProof, nil
 	}
 
 	return &certificateHeader, nil, nil
+}
+
+// SaveNonAcceptedCertificate saves a non-accepted certificate in the storage
+// non-accepted certificates are certificates that were not accepted by the aggLayer
+// and are not saved in the main certificate_info table, rather in the nonaccepted_certificates table
+// This is used to keep track of non-accepted certificates
+// and to allow for debugging and analysis of why they were not accepted.
+func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
+	ctx context.Context, certificate *agglayertypes.Certificate, createdAt uint32) error {
+	if !a.cfg.KeepCertificatesHistory {
+		return nil // non-accepted certificates are not saved in history
+	}
+
+	tx, err := db.NewTx(ctx, a.db)
+	if err != nil {
+		return fmt.Errorf("SaveNonAcceptedCertificate NewTx. Err: %w", err)
+	}
+	shouldRollback := true
+	defer func() {
+		if shouldRollback {
+			if errRllbck := tx.Rollback(); errRllbck != nil {
+				a.logger.Errorf(errWhileRollbackFormat, errRllbck)
+			}
+		}
+	}()
+
+	raw, err := json.Marshal(certificate)
+	if err != nil {
+		return fmt.Errorf("error marshalling non-accepted certificate: %w", err)
+	}
+
+	nonAcceptedCert := &nonAcceptedCertificate{
+		Height:            certificate.Height,
+		SignedCertificate: string(raw),
+		CreatedAt:         createdAt,
+	}
+
+	if err = meddler.Insert(tx, "nonaccepted_certificates", nonAcceptedCert); err != nil {
+		return fmt.Errorf("error inserting non-accepted certificate: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("SaveNonAcceptedCertificate commit. Err: %w", err)
+	}
+	shouldRollback = false
+
+	a.logger.Debugf("inserted non-accepted certificate - Height: %d. CreatedAt: %s",
+		nonAcceptedCert.Height, time.Unix(int64(nonAcceptedCert.CreatedAt), 0))
+
+	return nil
+}
+
+// GetNonAcceptedCertificates returns a list of non-accepted certificates
+func (a *AggSenderSQLStorage) GetNonAcceptedCertificates() ([]*agglayertypes.Certificate, error) {
+	var nonAcceptedCerts []*nonAcceptedCertificate
+	if err := meddler.QueryAll(a.db, &nonAcceptedCerts,
+		"SELECT * FROM nonaccepted_certificates;"); err != nil {
+		return nil, fmt.Errorf("error getting non-accepted certificates: %w", err)
+	}
+
+	certificates := make([]*agglayertypes.Certificate, len(nonAcceptedCerts))
+	for i, cert := range nonAcceptedCerts {
+		var certificate agglayertypes.Certificate
+		if err := json.Unmarshal([]byte(cert.SignedCertificate), &certificate); err != nil {
+			return nil, fmt.Errorf("error unmarshalling non-accepted certificate: %w", err)
+		}
+		certificates[i] = &certificate
+	}
+
+	return certificates, nil
 }
 
 func getSelectQueryError(height uint64, err error) error {

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -205,17 +205,12 @@ func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certi
 		}
 	}()
 
-	var (
-		certInfo *certificateInfo
-		certInDB *certificateInfo
-	)
-
-	certInfo, err = convertCertificateToCertificateInfo(&certificate)
+	certInfo, err := convertCertificateToCertificateInfo(&certificate)
 	if err != nil {
 		return fmt.Errorf("error converting certificate to certificate info: %w", err)
 	}
 
-	certInDB, err = getCertificateByHeight(tx, certInfo.Height)
+	certInDB, err := getCertificateByHeight(tx, certInfo.Height)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		return fmt.Errorf("saveLastSentCertificate getCertificateByHeight. Err: %w", err)
 	}
@@ -380,7 +375,7 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 
 	tx, err := db.NewTx(ctx, a.db)
 	if err != nil {
-		return fmt.Errorf("SaveNonAcceptedCertificate NewTx. Err: %w", err)
+		return fmt.Errorf("failed to create db transaction for non-accepted certificate persistence: %w", err)
 	}
 	shouldRollback := true
 	defer func() {
@@ -395,7 +390,7 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 
 	raw, err = json.Marshal(certificate)
 	if err != nil {
-		return fmt.Errorf("error marshalling non-accepted certificate: %w", err)
+		return fmt.Errorf("failed to marshal non-accepted certificate: %w", err)
 	}
 
 	nonAcceptedCert := &nonAcceptedCertificate{
@@ -405,11 +400,11 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 	}
 
 	if err = meddler.Insert(tx, "nonaccepted_certificates", nonAcceptedCert); err != nil {
-		return fmt.Errorf("error inserting non-accepted certificate: %w", err)
+		return fmt.Errorf("failed to insert non-accepted certificate: %w", err)
 	}
 
 	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("SaveNonAcceptedCertificate commit. Err: %w", err)
+		return fmt.Errorf("failed to commit db transaction for non-accepted certificate: %w", err)
 	}
 	shouldRollback = false
 

--- a/aggsender/db/migrations/0003.sql
+++ b/aggsender/db/migrations/0003.sql
@@ -3,9 +3,17 @@ ALTER TABLE certificate_info DROP COLUMN cert_type;
 ALTER TABLE certificate_info DROP COLUMN cert_source;
 ALTER TABLE certificate_info_history DROP COLUMN cert_type;
 ALTER TABLE certificate_info_history DROP COLUMN cert_source;
+DROP TABLE IF EXISTS nonaccepted_certificates;
 
 -- +migrate Up
 ALTER TABLE certificate_info ADD COLUMN cert_type VARCHAR DEFAULT "";
 ALTER TABLE certificate_info ADD COLUMN cert_source VARCHAR DEFAULT "";
 ALTER TABLE certificate_info_history ADD COLUMN cert_type VARCHAR DEFAULT "";
 ALTER TABLE certificate_info_history ADD COLUMN cert_source VARCHAR DEFAULT "";
+
+CREATE TABLE nonaccepted_certificates (
+    height                     INTEGER NOT NULL,
+    created_at                 INTEGER NOT NULL,
+    signed_certificate         TEXT,
+    PRIMARY KEY (height, created_at)
+);

--- a/aggsender/db/migrations/migrations_test.go
+++ b/aggsender/db/migrations/migrations_test.go
@@ -1,0 +1,173 @@
+package migrations
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/agglayer/aggkit/db"
+	"github.com/agglayer/aggkit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func Test001(t *testing.T) {
+	t.Parallel()
+
+	dbPath := path.Join(t.TempDir(), "aggsenderTest001.sqlite")
+	db, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+
+	log := log.WithFields("aggsender-test", "migrations001")
+
+	require.NoError(t, RunMigrations(log, db))
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(`
+		INSERT INTO certificate_info (
+			height,
+			retry_count,
+			certificate_id,
+			status,
+			previous_local_exit_root,
+			new_local_exit_root,
+			from_block,
+			to_block,
+			created_at,
+			updated_at,
+			signed_certificate
+		) VALUES (10, 0, '0x789abc', 4, '0x123456', '0x23456', 1000, 2000, 0, 0, 'N/A');
+
+		INSERT INTO certificate_info_history (
+			height,
+			retry_count,
+			certificate_id,
+			status,
+			previous_local_exit_root,
+			new_local_exit_root,
+			from_block,
+			to_block,
+			created_at,
+			updated_at,
+			signed_certificate
+		) VALUES (3, 2, '0x789abc', 2, '0x123456', '0x23456', 310, 520, 0, 0, 'N/A');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+}
+
+func Test002(t *testing.T) {
+	t.Parallel()
+	dbPath := path.Join(t.TempDir(), "aggsenderTest002.sqlite")
+	db, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+
+	log := log.WithFields("aggsender-test", "migrations002")
+	require.NoError(t, RunMigrations(log, db))
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(`
+		INSERT INTO certificate_info (
+			height,
+			retry_count,
+			certificate_id,
+			status,
+			previous_local_exit_root,
+			new_local_exit_root,
+			from_block,
+			to_block,
+			created_at,
+			updated_at,
+			signed_certificate,
+			aggchain_proof,
+			finalized_l1_info_tree_root,
+			l1_info_tree_leaf_count
+		) VALUES (10, 0, '0x789abc', 4, '0x123456', '0x23456', 1000, 2000, 0, 0, 'N/A', 'proof_data',  'root_data', 5);
+
+		INSERT INTO certificate_info_history (
+			height,
+			retry_count,
+			certificate_id,
+			status,
+			previous_local_exit_root,
+			new_local_exit_root,
+			from_block,
+			to_block,
+			created_at,
+			updated_at,
+			signed_certificate,
+			aggchain_proof,
+			finalized_l1_info_tree_root,
+			l1_info_tree_leaf_count
+		) VALUES (3, 2, '0x789abc', 2, '0x123456', '0x23456', 310, 520, 0, 0, 'N/A', 'proof_data_2', 'root_data_2', 15);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+}
+
+func Test003(t *testing.T) {
+	t.Parallel()
+	dbPath := path.Join(t.TempDir(), "aggsenderTest002.sqlite")
+	db, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+
+	log := log.WithFields("aggsender-test", "migrations002")
+	require.NoError(t, RunMigrations(log, db))
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(`
+		INSERT INTO certificate_info (
+			height,
+			retry_count,
+			certificate_id,
+			status,
+			previous_local_exit_root,
+			new_local_exit_root,
+			from_block,
+			to_block,
+			created_at,
+			updated_at,
+			signed_certificate,
+			aggchain_proof,
+			finalized_l1_info_tree_root,
+			l1_info_tree_leaf_count,
+			cert_type,
+			cert_source
+		) VALUES (10, 0, '0x789abc', 4, '0x123456', '0x23456', 1000, 2000, 0, 0, 'N/A', 'proof_data',  'root_data', 5, 'fep', 'aggsender');
+
+		INSERT INTO certificate_info_history (
+			height,
+			retry_count,
+			certificate_id,
+			status,
+			previous_local_exit_root,
+			new_local_exit_root,
+			from_block,
+			to_block,
+			created_at,
+			updated_at,
+			signed_certificate,
+			aggchain_proof,
+			finalized_l1_info_tree_root,
+			l1_info_tree_leaf_count,
+			cert_type,
+			cert_source
+		) VALUES (3, 2, '0x789abc', 2, '0x123456', '0x23456', 310, 520, 0, 0, 'N/A', 'proof_data_2', 'root_data_2', 15, 'pp', 'agglayer');
+
+		INSERT INTO nonaccepted_certificates (
+			height,
+			created_at,
+			signed_certificate
+		) VALUES (10, 123456789, 'N/A');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+}

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -62,3 +62,9 @@ func (c *certificateInfo) ID() string {
 	}
 	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
 }
+
+type nonAcceptedCertificate struct {
+	Height            uint64 `meddler:"height"`
+	SignedCertificate string `meddler:"signed_certificate"`
+	CreatedAt         uint32 `meddler:"created_at"`
+}

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -428,6 +428,63 @@ func (_c *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call) 
 	return _c
 }
 
+// GetNonAcceptedCertificates provides a mock function with no fields
+func (_m *AggSenderStorage) GetNonAcceptedCertificates() ([]*agglayertypes.Certificate, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNonAcceptedCertificates")
+	}
+
+	var r0 []*agglayertypes.Certificate
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]*agglayertypes.Certificate, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []*agglayertypes.Certificate); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*agglayertypes.Certificate)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggSenderStorage_GetNonAcceptedCertificates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNonAcceptedCertificates'
+type AggSenderStorage_GetNonAcceptedCertificates_Call struct {
+	*mock.Call
+}
+
+// GetNonAcceptedCertificates is a helper method to define mock.On call
+func (_e *AggSenderStorage_Expecter) GetNonAcceptedCertificates() *AggSenderStorage_GetNonAcceptedCertificates_Call {
+	return &AggSenderStorage_GetNonAcceptedCertificates_Call{Call: _e.mock.On("GetNonAcceptedCertificates")}
+}
+
+func (_c *AggSenderStorage_GetNonAcceptedCertificates_Call) Run(run func()) *AggSenderStorage_GetNonAcceptedCertificates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_GetNonAcceptedCertificates_Call) Return(_a0 []*agglayertypes.Certificate, _a1 error) *AggSenderStorage_GetNonAcceptedCertificates_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggSenderStorage_GetNonAcceptedCertificates_Call) RunAndReturn(run func() ([]*agglayertypes.Certificate, error)) *AggSenderStorage_GetNonAcceptedCertificates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SaveLastSentCertificate provides a mock function with given fields: ctx, certificate
 func (_m *AggSenderStorage) SaveLastSentCertificate(ctx context.Context, certificate types.Certificate) error {
 	ret := _m.Called(ctx, certificate)
@@ -471,6 +528,54 @@ func (_c *AggSenderStorage_SaveLastSentCertificate_Call) Return(_a0 error) *AggS
 }
 
 func (_c *AggSenderStorage_SaveLastSentCertificate_Call) RunAndReturn(run func(context.Context, types.Certificate) error) *AggSenderStorage_SaveLastSentCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SaveNonAcceptedCertificate provides a mock function with given fields: ctx, certificate, createdAt
+func (_m *AggSenderStorage) SaveNonAcceptedCertificate(ctx context.Context, certificate *agglayertypes.Certificate, createdAt uint32) error {
+	ret := _m.Called(ctx, certificate, createdAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SaveNonAcceptedCertificate")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *agglayertypes.Certificate, uint32) error); ok {
+		r0 = rf(ctx, certificate, createdAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// AggSenderStorage_SaveNonAcceptedCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveNonAcceptedCertificate'
+type AggSenderStorage_SaveNonAcceptedCertificate_Call struct {
+	*mock.Call
+}
+
+// SaveNonAcceptedCertificate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - certificate *agglayertypes.Certificate
+//   - createdAt uint32
+func (_e *AggSenderStorage_Expecter) SaveNonAcceptedCertificate(ctx interface{}, certificate interface{}, createdAt interface{}) *AggSenderStorage_SaveNonAcceptedCertificate_Call {
+	return &AggSenderStorage_SaveNonAcceptedCertificate_Call{Call: _e.mock.On("SaveNonAcceptedCertificate", ctx, certificate, createdAt)}
+}
+
+func (_c *AggSenderStorage_SaveNonAcceptedCertificate_Call) Run(run func(ctx context.Context, certificate *agglayertypes.Certificate, createdAt uint32)) *AggSenderStorage_SaveNonAcceptedCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*agglayertypes.Certificate), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_SaveNonAcceptedCertificate_Call) Return(_a0 error) *AggSenderStorage_SaveNonAcceptedCertificate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *AggSenderStorage_SaveNonAcceptedCertificate_Call) RunAndReturn(run func(context.Context, *agglayertypes.Certificate, uint32) error) *AggSenderStorage_SaveNonAcceptedCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

This PR introduces saving of non-accepted certificates to a separate table in `aggsender db`: `nonaccepted_certificates`. 

This is done for easier debugging and root cause analysis when `agglayer` does not accept a certificate, but returns an error when the request for `submitCertificate` is sent.

These certificates need to be rebuild from scratch, and can not be saved in existing tables, because, they have are not resent for now. We will use them just as a way to do a root cause analysis if a given problem ocurrs.

Also, keep in mind, that they will be saved in `db` only if `KeepHistory` config parameter on `aggsender` is `true`.

Fixes #517 
