### PR TITLE
fix: null exception on `aggsender`

### DIFF
--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -285,8 +285,8 @@ func (f *baseFlow) getImportedBridgeExits(
 			claim.GlobalExitRoot, rootFromWhichToProve)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"error getting L1 Info tree merkle proof for leaf index: %d and root: %s. Error: %w",
-				l1Info.L1InfoTreeIndex, rootFromWhichToProve, err,
+				"error getting L1 Info tree merkle proof for GER: %s and root: %s. Error: %w",
+				claim.GlobalExitRoot, rootFromWhichToProve, err,
 			)
 		}
 


### PR DESCRIPTION
## Description

This PR fixes an issue of a `nil` exception on logging which was detected while testing on kurtosis:

```
2025-06-03T22:33:26.633Z        INFO    flows/flow_base.go:157  building certificate for FromBlock: 1, ToBlock: 15632401, numBridges: 6822, numClaims: 7763, createdAt: 1748990006 estimatedSize=66225046       {"pid": 1, "version": "v0.3.0-beta6", "module": "aggsender"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x11d3f79]

goroutine 154 [running]:
github.com/agglayer/aggkit/aggsender/flows.(*baseFlow).getImportedBridgeExits(0xc00047c9c0, {0x1b26750, 0x26df3c0}, {0xc0048c0000, 0x1e53, 0x1e53?}, {0xa9, 0x13, 0x41, 0x41, ...})
        /app/aggsender/flows/flow_base.go:323 +0xb19
github.com/agglayer/aggkit/aggsender/flows.(*baseFlow).buildCertificate(0xc00047c9c0, {0x1b26750, 0x26df3c0}, 0xc0003b4000, 0x0, 0x0)
        /app/aggsender/flows/flow_base.go:164 +0x23f
github.com/agglayer/aggkit/aggsender/flows.(*PPFlow).BuildCertificate(0xc00088e840, {0x1b26750, 0x26df3c0}, 0xc000a82780?)
        /app/aggsender/flows/flow_pp.go:89 +0x30
github.com/agglayer/aggkit/aggsender.(*AggSender).sendCertificate(0xc00023cd20, {0x1b26750, 0x26df3c0})
        /app/aggsender/aggsender.go:295 +0x24b
github.com/agglayer/aggkit/aggsender.(*AggSender).sendCertificates(0xc00023cd20, {0x1b26750, 0x26df3c0}, 0x0)
        /app/aggsender/aggsender.go:258 +0x455
github.com/agglayer/aggkit/aggsender.(*AggSender).Start(0xc00023cd20, {0x1b26750, 0x26df3c0})
        /app/aggsender/aggsender.go:179 +0x1d9
created by main.start in goroutine 1
        /app/cmd/run.go:118 +0xd35
```

Fixes # (issue)
