### PR TITLE
fix: return error when limiting cert size to empty certificate

### DIFF
--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -100,9 +100,9 @@ func (f *baseFlow) limitCertSize(
 
 	for {
 		if currentCert.NumberOfBridges() == 0 && !allowEmptyCert {
-			f.log.Warnf("Minimum certificate size reached. Estimated size: %d > max size: %d",
-				currentCert.EstimatedSize(), f.maxCertSize)
-			return currentCert, nil
+			return nil, fmt.Errorf("error on reducing the certificate size. "+
+				"No bridge exits found in range from: %d, to: %d and empty certificate is not allowed",
+				currentCert.FromBlock, currentCert.ToBlock)
 		}
 
 		if f.maxCertSize == 0 || currentCert.EstimatedSize() <= f.maxCertSize {

--- a/aggsender/flows/flow_base_test.go
+++ b/aggsender/flows/flow_base_test.go
@@ -40,7 +40,23 @@ func Test_baseFlow_limitCertSize(t *testing.T) {
 			},
 		},
 		{
-			name:        "certificate size exceeds limit",
+			name:        "certificate size exceeds limit - reducing with some bridges",
+			maxCertSize: 500,
+			fullCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   10,
+				Bridges:   []bridgesync.Bridge{{BlockNum: 9}, {BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}},
+			},
+			allowEmptyCert: false,
+			expectedCert: &types.CertificateBuildParams{
+				FromBlock: 1,
+				ToBlock:   9,
+				Bridges:   []bridgesync.Bridge{{BlockNum: 9}},
+				Claims:    []bridgesync.Claim{},
+			},
+		},
+		{
+			name:        "certificate size exceeds limit - reducing to no bridges",
 			maxCertSize: 500,
 			fullCert: &types.CertificateBuildParams{
 				FromBlock: 1,
@@ -48,12 +64,7 @@ func Test_baseFlow_limitCertSize(t *testing.T) {
 				Bridges:   []bridgesync.Bridge{{BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}, {BlockNum: 10}},
 			},
 			allowEmptyCert: false,
-			expectedCert: &types.CertificateBuildParams{
-				FromBlock: 1,
-				ToBlock:   9,
-				Bridges:   []bridgesync.Bridge{},
-				Claims:    []bridgesync.Claim{},
-			},
+			expectedError:  "error on reducing the certificate size. No bridge exits found",
 		},
 		{
 			name:        "certificate size exceeds limit with minimum blocks",
@@ -94,11 +105,7 @@ func Test_baseFlow_limitCertSize(t *testing.T) {
 				Bridges:   []bridgesync.Bridge{},
 			},
 			allowEmptyCert: false,
-			expectedCert: &types.CertificateBuildParams{
-				FromBlock: 1,
-				ToBlock:   10,
-				Bridges:   []bridgesync.Bridge{},
-			},
+			expectedError:  "error on reducing the certificate size. No bridge exits found in range from: 1, to: 10 and empty certificate is not allowed",
 		},
 		{
 			name:        "maxCertSize is 0 with bridges and claims",

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -204,7 +204,7 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 
 func (d *EVMDownloader) reportBlocks(downloadedCh chan EVMBlock, blocks EVMBlocks, lastFinalizedBlock uint64) {
 	for _, block := range blocks {
-		d.log.Infof("sending block %d to the driver (with events)", block.Num)
+		d.log.Debugf("sending block %d to the driver (with events)", block.Num)
 		block.IsFinalizedBlock = d.finalizedBlockType.IsFinalized() && block.Num <= lastFinalizedBlock
 		downloadedCh <- *block
 	}


### PR DESCRIPTION
## Description

This PR is a fix of an audit report, where if we do not allow an empty certificate (no bridge exits), and we limit cert size all the way to a block where we do not have any bridge exits, we need to return an error.

Fixes # (issue)
