### PR TITLE
feat: bump e2e tests (remove l2 fund logic)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,11 +52,11 @@ jobs:
     needs:
       - build-aggkit-image
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@f4f28438053507bf0a612982ff23f859ec81f48b
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: f4f28438053507bf0a612982ff23f859ec81f48b
+      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
       test-name: "test-single-l2-network-fork12-pessimistic"
@@ -76,11 +76,11 @@ jobs:
     needs:
       - build-aggkit-image
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@f4f28438053507bf0a612982ff23f859ec81f48b
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: f4f28438053507bf0a612982ff23f859ec81f48b
+      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
       test-name: "test-single-l2-network-fork12-op-succinct"
@@ -124,11 +124,11 @@ jobs:
       - build-aggkit-image
       - build-tools
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@f4f28438053507bf0a612982ff23f859ec81f48b
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: f4f28438053507bf0a612982ff23f859ec81f48b
+      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -150,11 +150,11 @@ jobs:
       - build-aggkit-image
       - build-tools
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@f4f28438053507bf0a612982ff23f859ec81f48b
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: f4f28438053507bf0a612982ff23f859ec81f48b
+      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,11 +52,11 @@ jobs:
     needs:
       - build-aggkit-image
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@44083e2c2d2a5e84164edbbda0128253f56a6f55
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
+      agglayer-e2e-ref: 44083e2c2d2a5e84164edbbda0128253f56a6f55
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
       test-name: "test-single-l2-network-fork12-pessimistic"
@@ -76,11 +76,11 @@ jobs:
     needs:
       - build-aggkit-image
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@44083e2c2d2a5e84164edbbda0128253f56a6f55
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
+      agglayer-e2e-ref: 44083e2c2d2a5e84164edbbda0128253f56a6f55
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
       test-name: "test-single-l2-network-fork12-op-succinct"
@@ -124,11 +124,11 @@ jobs:
       - build-aggkit-image
       - build-tools
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@44083e2c2d2a5e84164edbbda0128253f56a6f55
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
+      agglayer-e2e-ref: 44083e2c2d2a5e84164edbbda0128253f56a6f55
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -150,11 +150,11 @@ jobs:
       - build-aggkit-image
       - build-tools
       - read-aggkit-args
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@30c97a87c643a4c67e87518dfaca52cde27cd23d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@44083e2c2d2a5e84164edbbda0128253f56a6f55
     secrets: inherit
     with:
       kurtosis-cdk-ref: 5a27f467008ebe9ad97fc2b2ca315d6c48efc17a
-      agglayer-e2e-ref: 30c97a87c643a4c67e87518dfaca52cde27cd23d
+      agglayer-e2e-ref: 44083e2c2d2a5e84164edbbda0128253f56a6f55
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -109,19 +109,15 @@ if [ -n "$E2E_FOLDER" ]; then
     log_info "Running BATS E2E tests..."
     case "$TEST_TYPE" in
     single-l2-network-fork12-op-succinct)
-        export DISABLE_L2_FUND="false"
         bats ./tests/aggkit/bridge-e2e.bats ./tests/aggkit/e2e-pp.bats ./tests/aggkit/bridge-sovereign-chain-e2e.bats
         ;;
     single-l2-network-fork12-pessimistic)
-        export DISABLE_L2_FUND="true"
         bats ./tests/aggkit/bridge-e2e-custom-gas.bats ./tests/aggkit/bridge-e2e.bats ./tests/aggkit/e2e-pp.bats
         ;;
     multi-l2-networks-2-chains)
-        export DISABLE_L2_FUND="true"
         bats ./tests/aggkit/bridge-e2e-2-l2s.bats
         ;;
     multi-l2-networks-3-chains)
-        export DISABLE_L2_FUND="true"
         bats ./tests/aggkit/bridge-e2e-2-l2s.bats
         ;;
     esac


### PR DESCRIPTION
## Description

This PR bumps the E2E ref which removes `DISABLE_L2_FUND`, since the L2 accounts are pre-funded in the kurtosis cdk.

Fixes #562 
