### PR TITLE
feat: introduce on-demand Docker image building workflow

### DIFF
--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -84,11 +84,11 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: true
+          push: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ steps.image_builder.outputs.IMAGE }},push-by-digest=true
+          outputs: type=image,name=${{ steps.image_builder.outputs.IMAGE }},push-by-digest=true,push=true
 
       - name: Export digest
         run: |
@@ -100,9 +100,11 @@ jobs:
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
   merge:
-    runs-on: amd-runner-2204
+    runs-on: arm-runner-2204
     needs: build
     steps:
       - name: Download digests

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -1,0 +1,61 @@
+name: Build and push intermediary Docker image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set image tag components
+        id: vars
+        run: |
+          BRANCH=$(echo "${GITHUB_REF##*/}" | tr '/' '-')
+          TIMESTAMP=$(date -u +'%d_%m_%Y_%H_%M')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG="${BRANCH}_${TIMESTAMP}_${SHORT_SHA}"
+          FULL_IMAGE="ghcr.io/${GITHUB_REPOSITORY}:$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.vars.outputs.FULL_IMAGE }}
+
+      - name: Output pushed image
+        run: |
+           echo "Image pushed: ${{ steps.vars.outputs.FULL_IMAGE }}"

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -25,18 +25,16 @@ jobs:
           - linux/amd64
           - linux/arm64
     outputs:
-      IMAGE_NAME: ${{ steps.image_builder.outputs.IMAGE }}
-      TAGS: ${{ steps.meta.outputs.tags }}
-      VERSION: ${{ steps.meta.outputs.version }}
+      IMAGE_NAME: ${{ steps.vars.outputs.FULL_IMAGE }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare platform safe variable
+      - name: Prepare platform-safe variable
+        id: platform_vars
         run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${{ matrix.platform }}" | tr '/' '-' >> $GITHUB_ENV
 
       - name: Set image tag components
         id: vars
@@ -49,21 +47,6 @@ jobs:
           FULL_IMAGE="${{ env.REGISTRY_IMAGE }}:${IMAGE_TAG}"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_OUTPUT
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            ${IMAGE_TAG}
-
-      - name: Image name builder
-        id: image_builder
-        run: |
-          # We override default jq usage to pick our custom IMAGE_TAG
-          IMAGE="${{ env.REGISTRY_IMAGE }}:${{ steps.vars.outputs.IMAGE_TAG }}"
-          echo "IMAGE=$IMAGE" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -84,22 +67,21 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: false
-          labels: ${{ steps.meta.outputs.labels }}
+          push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ steps.image_builder.outputs.IMAGE }},push-by-digest=true,push=true
+          outputs: type=image,name=${{ steps.vars.outputs.FULL_IMAGE }},push-by-digest=true
 
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${PLATFORM_PAIR}.txt"
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ env.PLATFORM_PAIR }}.txt"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
+          path: /tmp/digests/${{ env.PLATFORM_PAIR }}.txt
           if-no-files-found: error
           retention-days: 1
 
@@ -127,9 +109,8 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          # Compose manifest create arguments from digest files
           DIGEST_ARGS=""
-          for file in digests-*.txt; do
+          for file in *.txt; do
             digest=$(cat "$file")
             DIGEST_ARGS+=" ${{ needs.build.outputs.IMAGE_NAME }}@$digest"
           done

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -1,11 +1,14 @@
 name: Build and Push Intermediary Docker Image
 
 on:
-  push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 env:
@@ -22,13 +25,20 @@ jobs:
           - linux/amd64
           - linux/arm64
     outputs:
-      IMAGE_NAME: ${{ steps.vars.outputs.IMAGE_NAME }}
-      IMAGE_TAG: ${{ steps.vars.outputs.IMAGE_TAG }}
+      IMAGE_NAME: ${{ steps.image_builder.outputs.IMAGE }}
+      TAGS: ${{ steps.meta.outputs.tags }}
+      VERSION: ${{ steps.meta.outputs.version }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image tag
+      - name: Prepare platform safe variable
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Set image tag components
         id: vars
         run: |
           BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
@@ -36,9 +46,24 @@ jobs:
           TIMESTAMP=$(date -u +'%d_%m_%Y_%H_%M')
           SHORT_SHA=$(git rev-parse --short HEAD)
           IMAGE_TAG="${BRANCH}_${TIMESTAMP}_${SHORT_SHA}"
-          IMAGE_NAME="${{ env.REGISTRY_IMAGE }}:${IMAGE_TAG}"
+          FULL_IMAGE="${{ env.REGISTRY_IMAGE }}:${IMAGE_TAG}"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            ${IMAGE_TAG}
+
+      - name: Image name builder
+        id: image_builder
+        run: |
+          # We override default jq usage to pick our custom IMAGE_TAG
+          IMAGE="${{ env.REGISTRY_IMAGE }}:${{ steps.vars.outputs.IMAGE_TAG }}"
+          echo "IMAGE=$IMAGE" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -46,7 +71,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -58,34 +83,26 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
           platforms: ${{ matrix.platform }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ steps.vars.outputs.IMAGE_NAME }},push-by-digest=true,push=true
+          outputs: type=image,name=${{ steps.image_builder.outputs.IMAGE }},push-by-digest=true
 
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Set digest file name
-        id: digest_vars
-        run: |
-          PLATFORM_SAFE=$(echo "${{ matrix.platform }}" | tr '/' '-')
-          echo "PLATFORM_SAFE=$PLATFORM_SAFE" >> $GITHUB_OUTPUT
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${PLATFORM_PAIR}.txt"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ steps.digest_vars.outputs.PLATFORM_SAFE }}
+          name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
 
   merge:
-    runs-on: arm-runner-2204
+    runs-on: amd-runner-2204
     needs: build
     steps:
       - name: Download digests
@@ -98,19 +115,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push manifest list
+      - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          IMAGE="${{ needs.build.outputs.IMAGE_NAME }}"
-          docker buildx imagetools create -t "$IMAGE" $(printf "${IMAGE}@sha256:%s " *)
+          # Compose manifest create arguments from digest files
+          DIGEST_ARGS=""
+          for file in digests-*.txt; do
+            digest=$(cat "$file")
+            DIGEST_ARGS+=" ${{ needs.build.outputs.IMAGE_NAME }}@$digest"
+          done
+          docker buildx imagetools create -t ${{ needs.build.outputs.IMAGE_NAME }} $DIGEST_ARGS
 
-      - name: Inspect image
+      - name: Inspect final image
         run: |
           docker buildx imagetools inspect ${{ needs.build.outputs.IMAGE_NAME }}

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -70,10 +70,16 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
+      - name: Set digest file name
+        id: digest_vars
+        run: |
+          PLATFORM_SAFE=$(echo "${{ matrix.platform }}" | tr '/' '-')
+          echo "PLATFORM_SAFE=$PLATFORM_SAFE" >> $GITHUB_OUTPUT
+
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform // '/' '-'}}
+          name: digests-${{ steps.digest_vars.outputs.PLATFORM_SAFE }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -1,7 +1,7 @@
 name: Build and push intermediary Docker image
 
 on:
-  pull_request:
+  push:
   workflow_dispatch:
 
 permissions:
@@ -13,7 +13,7 @@ env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-and-push:
+  build:
     runs-on: amd-runner-2204
     strategy:
       fail-fast: false
@@ -21,6 +21,8 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
+    outputs:
+      full_image: ${{ steps.vars.outputs.FULL_IMAGE }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -51,13 +53,60 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.vars.outputs.FULL_IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ steps.vars.outputs.FULL_IMAGE }},push-by-digest=true
 
-      - name: Output pushed image
+      - name: Save digest as artifact
         run: |
-           echo "Image pushed: ${{ steps.vars.outputs.FULL_IMAGE }}"
+          mkdir -p digests
+          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.platform }}.txt"
+        shell: bash
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-digest-${{ matrix.platform }}
+          path: digests/${{ matrix.platform }}.txt
+
+  create-manifest:
+    runs-on: amd-runner-2204
+    needs: build
+    steps:
+      - name: Download all digests
+        uses: actions/download-artifact@v4
+        with:
+          path: digests
+          pattern: image-digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-platform manifest
+        run: |
+          FULL_IMAGE="${{ needs.build.outputs.full_image }}"
+          CREATE_ARGS=""
+          for digest_file in digests/*.txt; do
+            digest=$(cat "$digest_file")
+            CREATE_ARGS="$CREATE_ARGS ${FULL_IMAGE}@${digest}"
+          done
+          docker buildx imagetools create -t $FULL_IMAGE $CREATE_ARGS
+
+      - name: Inspect final image
+        run: |
+          docker buildx imagetools inspect ${{ needs.build.outputs.full_image }}

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -56,13 +56,12 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ steps.vars.outputs.FULL_IMAGE }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ steps.vars.outputs.FULL_IMAGE }},push-by-digest=true
+         context: .
+         platforms: ${{ matrix.platform }}
+         push: true
+         cache-from: type=gha
+         cache-to: type=gha,mode=max
+         outputs: type=image,name=${{ steps.vars.outputs.FULL_IMAGE }},push-by-digest=true
 
       - name: Save digest as artifact
         run: |

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Prepare platform-safe variable
         id: platform_vars
         run: |
-          echo "PLATFORM_PAIR=${{ matrix.platform }}" | tr '/' '-' >> $GITHUB_ENV
+          PLATFORM_PAIR=$(echo "${{ matrix.platform }}" | tr '/' '-')
+          echo "PLATFORM_PAIR=$PLATFORM_PAIR" >> $GITHUB_ENV
 
       - name: Set image tag components
         id: vars
@@ -70,12 +71,12 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ steps.vars.outputs.FULL_IMAGE }},push-by-digest=true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true
 
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ env.PLATFORM_PAIR }}.txt"
+          echo "${{ env.REGISTRY_IMAGE }}@${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ env.PLATFORM_PAIR }}.txt"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -109,12 +110,13 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          TAG=${{ needs.build.outputs.IMAGE_NAME }}
           DIGEST_ARGS=""
           for file in *.txt; do
-            digest=$(cat "$file")
-            DIGEST_ARGS+=" ${{ needs.build.outputs.IMAGE_NAME }}@$digest"
+            ref=$(cat "$file")
+            DIGEST_ARGS+=" $ref"
           done
-          docker buildx imagetools create -t ${{ needs.build.outputs.IMAGE_NAME }} $DIGEST_ARGS
+          docker buildx imagetools create -t "$TAG" $DIGEST_ARGS
 
       - name: Inspect final image
         run: |

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -1,6 +1,7 @@
 name: Build and push intermediary Docker image
 
 on:
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -1,11 +1,11 @@
-name: Build and push intermediary Docker image
+name: Build and Push Intermediary Docker Image
 
 on:
   push:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 env:
@@ -22,12 +22,13 @@ jobs:
           - linux/amd64
           - linux/arm64
     outputs:
-      full_image: ${{ steps.vars.outputs.FULL_IMAGE }}
+      IMAGE_NAME: ${{ steps.vars.outputs.IMAGE_NAME }}
+      IMAGE_TAG: ${{ steps.vars.outputs.IMAGE_TAG }}
     steps:
-      - name: Checkout source
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image tag components
+      - name: Set image tag
         id: vars
         run: |
           BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
@@ -35,9 +36,9 @@ jobs:
           TIMESTAMP=$(date -u +'%d_%m_%Y_%H_%M')
           SHORT_SHA=$(git rev-parse --short HEAD)
           IMAGE_TAG="${BRANCH}_${TIMESTAMP}_${SHORT_SHA}"
-          FULL_IMAGE="ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}"
+          IMAGE_NAME="${{ env.REGISTRY_IMAGE }}:${IMAGE_TAG}"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,67 +46,65 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
-         context: .
-         platforms: ${{ matrix.platform }}
-         push: true
-         cache-from: type=gha
-         cache-to: type=gha,mode=max
-         outputs: type=image,name=ghcr.io/${{ github.repository }}/${{ matrix.platform }},push-by-digest=true
+          context: .
+          push: false
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ steps.vars.outputs.IMAGE_NAME }},push-by-digest=true,push=true
 
-      - name: Save digest as artifact
+      - name: Export digest
         run: |
-          mkdir -p digests
-          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.platform }}.txt"
-        shell: bash
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Upload digest artifact
+      - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: image-digest-${{ matrix.platform }}
-          path: digests/${{ matrix.platform }}.txt
+          name: digests-${{ matrix.platform // '/' '-'}}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-  create-manifest:
-    runs-on: amd-runner-2204
+  merge:
+    runs-on: arm-runner-2204
     needs: build
     steps:
-      - name: Download all digests
+      - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: digests
-          pattern: image-digest-*
+          path: /tmp/digests
+          pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push multi-platform manifest
+      - name: Create and push manifest list
+        working-directory: /tmp/digests
         run: |
-          FULL_IMAGE="${{ needs.build.outputs.full_image }}"
-          CREATE_ARGS=""
-          for digest_file in digests/*.txt; do
-            digest=$(cat "$digest_file")
-            CREATE_ARGS="$CREATE_ARGS ${FULL_IMAGE}@${digest}"
-          done
-          docker buildx imagetools create -t $FULL_IMAGE $CREATE_ARGS
+          IMAGE="${{ needs.build.outputs.IMAGE_NAME }}"
+          docker buildx imagetools create -t "$IMAGE" $(printf "${IMAGE}@sha256:%s " *)
 
-      - name: Inspect final image
+      - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ needs.build.outputs.full_image }}
+          docker buildx imagetools inspect ${{ needs.build.outputs.IMAGE_NAME }}

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -41,10 +41,10 @@ jobs:
         id: vars
         run: |
           BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')
-          TIMESTAMP=$(date -u +'%d_%m_%Y_%H_%M')
+          FORMATTED_BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '/_' '--')
+          TIMESTAMP=$(date -u +'%Y_%m_%d_%H_%M')
           SHORT_SHA=$(git rev-parse --short HEAD)
-          IMAGE_TAG="${BRANCH}_${TIMESTAMP}_${SHORT_SHA}"
+          IMAGE_TAG="${FORMATTED_BRANCH_NAME}_${TIMESTAMP}_${SHORT_SHA}"
           FULL_IMAGE="${{ env.REGISTRY_IMAGE }}:${IMAGE_TAG}"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: amd-runner-2204
     strategy:
       fail-fast: false
       matrix:
@@ -28,11 +28,12 @@ jobs:
       - name: Set image tag components
         id: vars
         run: |
-          BRANCH=$(echo "${GITHUB_REF##*/}" | tr '/' '-')
+          BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')
           TIMESTAMP=$(date -u +'%d_%m_%Y_%H_%M')
           SHORT_SHA=$(git rev-parse --short HEAD)
           IMAGE_TAG="${BRANCH}_${TIMESTAMP}_${SHORT_SHA}"
-          FULL_IMAGE="ghcr.io/${GITHUB_REPOSITORY}:$IMAGE_TAG"
+          FULL_IMAGE="ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-intermediary-image.yml
+++ b/.github/workflows/build-intermediary-image.yml
@@ -61,7 +61,7 @@ jobs:
          push: true
          cache-from: type=gha
          cache-to: type=gha,mode=max
-         outputs: type=image,name=${{ steps.vars.outputs.FULL_IMAGE }},push-by-digest=true
+         outputs: type=image,name=ghcr.io/${{ github.repository }}/${{ matrix.platform }},push-by-digest=true
 
       - name: Save digest as artifact
         run: |

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and Push Intermediary Docker Image
+name: Build and Push Docker Image
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description

This PR adds Build and push intermediary Docker image. This is used when we need to create an intermediary Docker image, used for integration testing, but would not like to create a semver release.

Fixes #566
