### PR TITLE
feat: `hermez` to `pp` upgrade patch (DO NOT MERGE)

### DIFF
--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -70,6 +70,8 @@ type Config struct {
 	// RequireNoFEPBlockGap is true if the AggSender should not accept a gap between
 	// lastBlock from lastCertificate and first block of FEP
 	RequireNoFEPBlockGap bool `mapstructure:"RequireNoFEPBlockGap"`
+	// UpgradeEndBlock is the block number at which the upgrade ends
+	UpgradeEndBlock uint64 `mapstructure:"UpgradeEndBlock"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -115,6 +115,12 @@ func (a *AggchainProverFlow) sanityCheckNoBlockGaps(lastSentCertificate *types.C
 	return nil
 }
 
+func (a *AggchainProverFlow) GetCertificateBuildParamsWithEndBlock(
+	ctx context.Context, endBlock uint64) (*types.CertificateBuildParams, error) {
+	return nil, fmt.Errorf(
+		"aggchainProverFlow - GetCertificateBuildParamsWithEndBlock is not implemented for AggchainProverFlow")
+}
+
 // GetCertificateBuildParams returns the parameters to build a certificate
 // this function is the implementation of the FlowManager interface
 // What differentiates this function from the regular PP flow is that,

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -54,7 +54,7 @@ func (f *baseFlow) getCertificateBuildParamsWithEndBlock(
 		return nil, err
 	}
 
-	if lastSentCertificate.ToBlock >= endBlock {
+	if lastSentCertificate != nil && lastSentCertificate.ToBlock >= endBlock {
 		return nil, fmt.Errorf("last sent certificate block %d is greater than or equal to end block %d",
 			lastSentCertificate.ToBlock, endBlock)
 	}

--- a/aggsender/mocks/mock_aggsender_flow.go
+++ b/aggsender/mocks/mock_aggsender_flow.go
@@ -188,6 +188,65 @@ func (_c *AggsenderFlow_GetCertificateBuildParams_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// GetCertificateBuildParamsWithEndBlock provides a mock function with given fields: ctx, endBlock
+func (_m *AggsenderFlow) GetCertificateBuildParamsWithEndBlock(ctx context.Context, endBlock uint64) (*types.CertificateBuildParams, error) {
+	ret := _m.Called(ctx, endBlock)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCertificateBuildParamsWithEndBlock")
+	}
+
+	var r0 *types.CertificateBuildParams
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) (*types.CertificateBuildParams, error)); ok {
+		return rf(ctx, endBlock)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) *types.CertificateBuildParams); ok {
+		r0 = rf(ctx, endBlock)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.CertificateBuildParams)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
+		r1 = rf(ctx, endBlock)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateBuildParamsWithEndBlock'
+type AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call struct {
+	*mock.Call
+}
+
+// GetCertificateBuildParamsWithEndBlock is a helper method to define mock.On call
+//   - ctx context.Context
+//   - endBlock uint64
+func (_e *AggsenderFlow_Expecter) GetCertificateBuildParamsWithEndBlock(ctx interface{}, endBlock interface{}) *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call {
+	return &AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call{Call: _e.mock.On("GetCertificateBuildParamsWithEndBlock", ctx, endBlock)}
+}
+
+func (_c *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call) Run(run func(ctx context.Context, endBlock uint64)) *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64))
+	})
+	return _c
+}
+
+func (_c *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call) Return(_a0 *types.CertificateBuildParams, _a1 error) *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call) RunAndReturn(run func(context.Context, uint64) (*types.CertificateBuildParams, error)) *AggsenderFlow_GetCertificateBuildParamsWithEndBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewAggsenderFlow creates a new instance of AggsenderFlow. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewAggsenderFlow(t interface {

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -25,6 +25,9 @@ type AggsenderFlow interface {
 	// BuildCertificate builds a certificate based on the buildParams
 	BuildCertificate(ctx context.Context,
 		buildParams *CertificateBuildParams) (*agglayertypes.Certificate, error)
+
+	GetCertificateBuildParamsWithEndBlock(
+		ctx context.Context, endBlock uint64) (*CertificateBuildParams, error)
 }
 
 // L1InfoTreeSyncer is an interface defining functions that an L1InfoTreeSyncer should implement

--- a/config/default.go
+++ b/config/default.go
@@ -238,6 +238,7 @@ SovereignRollupAddr = "{{L1Config.polygonZkEVMAddress}}"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
 UseAgglayerTLS = false
 UseAggkitProverTLS = false
+UpgradeEndBlock = 0
 RequireNoFEPBlockGap = true
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20


### PR DESCRIPTION
## Description

This PR is just a quick patch for `Hermez` to `PP` upgrade, where `aggsender` will be provided with an end block until which it will create one large certificate needed for the upgrade, and after that certificate gets settled on `agglayer`, the `aggsender` will halt.

After this `upgrade` certificate is settled and this patched `aggsender` is halted, the regular image for `aggsender` will be started, and the PP network begins.

**IMPORTANT NOTE**: DO NOT MERGE THIS. THIS IS JUST A TEMPORARY SOLUTION FOR UPGRADE. THIS WILL NOT BE MERGED, BUT DISCARDED AFTER WE HAVE A FINAL SOLUTION.

Fixes # (issue)
