### PR TITLE
fix: false warning log

### DIFF
--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -167,8 +167,11 @@ func (b *BlockNotifierPolling) step(ctx context.Context,
 	}
 
 	if currentBlock.Number.Uint64()-previousState.lastBlockSeen != 1 {
-		b.logger.Warnf("Missed block(s) [finality:%s]: %d -> %d",
-			b.config.BlockFinalityType, previousState.lastBlockSeen, currentBlock.Number.Uint64())
+		if !b.config.BlockFinalityType.IsSafe() && !b.config.BlockFinalityType.IsFinalized() {
+			b.logger.Warnf("Missed block(s) [finality:%s]: %d -> %d",
+				b.config.BlockFinalityType, previousState.lastBlockSeen, currentBlock.Number.Uint64())
+		}
+
 		// It start from scratch because something fails in calculation of block period
 		newState := previousState.intialBlock(currentBlock.Number.Uint64())
 		return b.nextBlockRequestDelay(nil, nil), newState, eventToEmit

--- a/aggsender/block_notifier_polling_test.go
+++ b/aggsender/block_notifier_polling_test.go
@@ -47,8 +47,8 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 		name                      string
 		previousStatus            *blockNotifierPollingInternalStatus
 		cfg                       *ConfigBlockNotifierPolling
-		HeaderByNumberError       bool
-		HeaderByNumberErrorNumber uint64
+		headerByNumberError       bool
+		headerByNumberErrorNumber uint64
 		forcedTime                time.Time
 		mockLoggerFn              func() aggkitcommon.Logger
 		expectedStatus            *blockNotifierPollingInternalStatus
@@ -58,8 +58,8 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 		{
 			name:                      "initial->receive block",
 			previousStatus:            nil,
-			HeaderByNumberError:       false,
-			HeaderByNumberErrorNumber: 100,
+			headerByNumberError:       false,
+			headerByNumberErrorNumber: 100,
 			forcedTime:                time0,
 			expectedStatus: &blockNotifierPollingInternalStatus{
 				lastBlockSeen: 100,
@@ -71,7 +71,7 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 		{
 			name:                "received block->error",
 			previousStatus:      nil,
-			HeaderByNumberError: true,
+			headerByNumberError: true,
 			forcedTime:          time0,
 			expectedStatus:      &blockNotifierPollingInternalStatus{},
 			expectedDelay:       minBlockInterval,
@@ -85,8 +85,8 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 				lastBlockTime:     time0,
 				previousBlockTime: &period0,
 			},
-			HeaderByNumberError:       false,
-			HeaderByNumberErrorNumber: 101,
+			headerByNumberError:       false,
+			headerByNumberErrorNumber: 101,
 			forcedTime:                time1,
 			expectedStatus: &blockNotifierPollingInternalStatus{
 				lastBlockSeen:     101,
@@ -110,8 +110,8 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 				mockLogger.EXPECT().Warnf("Missed block(s) [finality:%s]: %d -> %d", etherman.LatestBlock, uint64(100), uint64(105)).Once()
 				return mockLogger
 			},
-			HeaderByNumberError:       false,
-			HeaderByNumberErrorNumber: 105,
+			headerByNumberError:       false,
+			headerByNumberErrorNumber: 105,
 			forcedTime:                time1,
 			expectedStatus: &blockNotifierPollingInternalStatus{
 				lastBlockSeen: 105,
@@ -138,8 +138,8 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 				// because we didn't mock it
 				return mocks.NewLogger(t)
 			},
-			HeaderByNumberError:       false,
-			HeaderByNumberErrorNumber: 105,
+			headerByNumberError:       false,
+			headerByNumberErrorNumber: 105,
 			forcedTime:                time1,
 			expectedStatus: &blockNotifierPollingInternalStatus{
 				lastBlockSeen: 105,
@@ -160,9 +160,9 @@ func TestBlockNotifierPollingStep(t *testing.T) {
 				return tt.forcedTime
 			}
 
-			if tt.HeaderByNumberError == false {
+			if tt.headerByNumberError == false {
 				hdr1 := &types.Header{
-					Number: big.NewInt(int64(tt.HeaderByNumberErrorNumber)),
+					Number: big.NewInt(int64(tt.headerByNumberErrorNumber)),
 				}
 				testData.ethClientMock.EXPECT().HeaderByNumber(mock.Anything, mock.Anything).Return(hdr1, nil).Once()
 			} else {

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -162,6 +162,10 @@ func (b BlockNumberFinality) IsFinalized() bool {
 	return b == FinalizedBlock
 }
 
+func (b BlockNumberFinality) IsSafe() bool {
+	return b == SafeBlock
+}
+
 type BlockNumber int64
 
 const (


### PR DESCRIPTION
## Description

`block_notifier_polling` logs a false warning log when block finality is configured as Finalized or Safe for L1.

If block finality is `finalized` or `safe`, almost in all cases, the last seen finalized or safe block is behind of what is marked as the new `finalized` or `safe` block, since this is how that finality should work. Its not sequential, but if block 10 is marked as finalized, the next finalized block will be 15 for example. In this case, the warning for missed blocks can be misleading, and should not be reported.

Fixes #164 
