### PR TITLE
fix: multiline swagger descriptions

### DIFF
--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -588,7 +588,7 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 
 // @Summary Get injected L1 info tree leaf after a given L1 info tree index
 // @Description Returns the L1 info tree leaf either at the given index (for L1)
-// or the first injected global exit root after the given index (for L2).
+// @Description or the first injected global exit root after the given index (for L2).
 // @Tags l1-info-tree-leaf
 // @Param network_id query int true "Network ID"
 // @Param l1_info_tree_index query int true "L1 Info Tree Index"
@@ -669,7 +669,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 //
 // @Summary Get claim proof
 // @Description Returns the Merkle proofs (local and rollup exit root) and
-// the corresponding L1 info tree leaf needed to verify a claim.
+// @Description the corresponding L1 info tree leaf needed to verify a claim.
 // @Tags claims
 // @Param network_id query uint32 true "Target network ID"
 // @Param l1_info_tree_index query uint32 true "Index in the L1 info tree"
@@ -836,7 +836,7 @@ func (b *BridgeService) GetLastReorgEventHandler(c *gin.Context) {
 //
 // @Summary Get bridge sync status
 // @Description Returns the sync status by comparing the deposit count
-// from the bridge contract with the deposit count in the bridge sync database for both L1 and L2 networks.
+// @Description from the bridge contract with the deposit count in the bridge sync database for both L1 and L2 networks.
 // @Tags sync
 // @Produce json
 // @Success 200 {object} types.SyncStatus "Bridge sync status for both L1 and L2 networks"

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -125,7 +125,7 @@ const docTemplate = `{
         },
         "/claim-proof": {
             "get": {
-                "description": "Returns the Merkle proofs (local and rollup exit root) and",
+                "description": "Returns the Merkle proofs (local and rollup exit root) and\nthe corresponding L1 info tree leaf needed to verify a claim.",
                 "produces": [
                     "application/json"
                 ],
@@ -249,7 +249,7 @@ const docTemplate = `{
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2).",
                 "produces": [
                     "application/json"
                 ],
@@ -439,7 +439,7 @@ const docTemplate = `{
         },
         "/sync-status": {
             "get": {
-                "description": "Returns the sync status by comparing the deposit count",
+                "description": "Returns the sync status by comparing the deposit count\nfrom the bridge contract with the deposit count in the bridge sync database for both L1 and L2 networks.",
                 "produces": [
                     "application/json"
                 ],

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -118,7 +118,7 @@
         },
         "/claim-proof": {
             "get": {
-                "description": "Returns the Merkle proofs (local and rollup exit root) and",
+                "description": "Returns the Merkle proofs (local and rollup exit root) and\nthe corresponding L1 info tree leaf needed to verify a claim.",
                 "produces": [
                     "application/json"
                 ],
@@ -242,7 +242,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2).",
                 "produces": [
                     "application/json"
                 ],
@@ -432,7 +432,7 @@
         },
         "/sync-status": {
             "get": {
-                "description": "Returns the sync status by comparing the deposit count",
+                "description": "Returns the sync status by comparing the deposit count\nfrom the bridge contract with the deposit count in the bridge sync database for both L1 and L2 networks.",
                 "produces": [
                     "application/json"
                 ],

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -446,7 +446,9 @@ paths:
       - bridges
   /claim-proof:
     get:
-      description: Returns the Merkle proofs (local and rollup exit root) and
+      description: |-
+        Returns the Merkle proofs (local and rollup exit root) and
+        the corresponding L1 info tree leaf needed to verify a claim.
       parameters:
       - description: Target network ID
         in: query
@@ -529,7 +531,9 @@ paths:
       - claims
   /injected-l1-info-leaf:
     get:
-      description: Returns the L1 info tree leaf either at the given index (for L1)
+      description: |-
+        Returns the L1 info tree leaf either at the given index (for L1)
+        or the first injected global exit root after the given index (for L2).
       parameters:
       - description: Network ID
         in: query
@@ -657,7 +661,9 @@ paths:
       - legacy-token-migrations
   /sync-status:
     get:
-      description: Returns the sync status by comparing the deposit count
+      description: |-
+        Returns the sync status by comparing the deposit count
+        from the bridge contract with the deposit count in the bridge sync database for both L1 and L2 networks.
       produces:
       - application/json
       responses:

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -118,7 +118,7 @@
         },
         "/claim-proof": {
             "get": {
-                "description": "Returns the Merkle proofs (local and rollup exit root) and",
+                "description": "Returns the Merkle proofs (local and rollup exit root) and\nthe corresponding L1 info tree leaf needed to verify a claim.",
                 "produces": [
                     "application/json"
                 ],
@@ -242,7 +242,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2).",
                 "produces": [
                     "application/json"
                 ],
@@ -432,7 +432,7 @@
         },
         "/sync-status": {
             "get": {
-                "description": "Returns the sync status by comparing the deposit count",
+                "description": "Returns the sync status by comparing the deposit count\nfrom the bridge contract with the deposit count in the bridge sync database for both L1 and L2 networks.",
                 "produces": [
                     "application/json"
                 ],


### PR DESCRIPTION
## Description

Fix the multiline comments in the Swagger docs for Bridge service. In cases there were multiple lines, only first one was rendered.

Fixes #622 
