### PR TITLE
fix: grpc retry policies validation of request timeout

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -230,11 +230,6 @@ RequireNoFEPBlockGap = true
 		MinConnectTimeout = "5s"
 		RequestTimeout = "{{GenerateAggchainProofTimeout}}"
 		UseTLS = false
-		[AggSender.AggkitProverClient.Retry]
-			InitialBackoff = "1s"
-			MaxBackoff = "10s"
-			BackoffMultiplier = 2.0
-			MaxAttempts = 16
 	[AggSender.MaxSubmitCertificateRate]
 		NumRequests = 20
 		Interval = "1h"
@@ -258,11 +253,6 @@ GlobalExitRootL2 = "{{L2Config.GlobalExitRootAddr}}"
 		MinConnectTimeout = "5s"
 		UseTLS = false
 		RequestTimeout = "{{GenerateAggchainProofTimeout}}"
-		[AggchainProofGen.AggkitProverClient.Retry]
-			InitialBackoff = "1s"
-			MaxBackoff = "10s"
-			BackoffMultiplier = 2.0
-			MaxAttempts = 16
 
 [Profiling]
 ProfilingHost = "localhost"

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -122,13 +122,9 @@ func (c *ClientConfig) validateRequestTimeout() error {
 		backoff = time.Duration(float64(backoff) * c.Retry.BackoffMultiplier)
 	}
 
-	// Add per-attempt execution time buffer (optional)
-	avgCallBuffer := 1 * time.Second
-	expectedMinTimeout := totalBackoff + time.Duration(c.Retry.MaxAttempts)*avgCallBuffer
-
-	if c.RequestTimeout.Duration < expectedMinTimeout {
-		return fmt.Errorf("RequestTimeout (%s) is too short; expected at least %s to accommodate retries",
-			c.RequestTimeout, expectedMinTimeout)
+	if c.RequestTimeout.Duration < totalBackoff {
+		return fmt.Errorf("RequestTimeout (%s) is too short; expected at least %s to accommodate the worst case retries",
+			c.RequestTimeout, totalBackoff)
 	}
 
 	return nil

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -447,6 +447,17 @@ func TestValidateRequestTimeout(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:    "valid - just enough for backoff",
+			timeout: types.NewDuration(7 * time.Second),
+			retryConfig: &RetryConfig{
+				InitialBackoff:    types.NewDuration(1 * time.Second),
+				MaxBackoff:        types.NewDuration(10 * time.Second),
+				BackoffMultiplier: 2.0,
+				MaxAttempts:       4,
+			},
+			expectError: false,
+		},
+		{
 			name:    "invalid - timeout too short for retry backoff",
 			timeout: types.NewDuration(2 * time.Second),
 			retryConfig: &RetryConfig{

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -426,3 +426,88 @@ func TestGRPCError_Is(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRequestTimeout(t *testing.T) {
+	tests := []struct {
+		name         string
+		timeout      types.Duration
+		retryConfig  *RetryConfig
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name:    "valid - enough timeout for backoff and calls",
+			timeout: types.NewDuration(30 * time.Second),
+			retryConfig: &RetryConfig{
+				InitialBackoff:    types.NewDuration(1 * time.Second),
+				MaxBackoff:        types.NewDuration(10 * time.Second),
+				BackoffMultiplier: 2.0,
+				MaxAttempts:       5,
+			},
+			expectError: false,
+		},
+		{
+			name:    "invalid - timeout too short for retry backoff",
+			timeout: types.NewDuration(2 * time.Second),
+			retryConfig: &RetryConfig{
+				InitialBackoff:    types.NewDuration(1 * time.Second),
+				MaxBackoff:        types.NewDuration(10 * time.Second),
+				BackoffMultiplier: 2.0,
+				MaxAttempts:       4,
+			},
+			expectError:  true,
+			errorMessage: "RequestTimeout",
+		},
+		{
+			name:    "valid - single attempt, no retry",
+			timeout: types.NewDuration(1 * time.Second),
+			retryConfig: &RetryConfig{
+				InitialBackoff:    types.NewDuration(1 * time.Second),
+				MaxBackoff:        types.NewDuration(1 * time.Second),
+				BackoffMultiplier: 2.0,
+				MaxAttempts:       1,
+			},
+			expectError: false,
+		},
+		{
+			name:    "invalid - zero timeout",
+			timeout: types.NewDuration(0),
+			retryConfig: &RetryConfig{
+				InitialBackoff:    types.NewDuration(1 * time.Second),
+				MaxBackoff:        types.NewDuration(10 * time.Second),
+				BackoffMultiplier: 2.0,
+				MaxAttempts:       3,
+			},
+			expectError:  true,
+			errorMessage: "RequestTimeout",
+		},
+		{
+			name:    "valid - large timeout with high retries",
+			timeout: types.NewDuration(2 * time.Minute),
+			retryConfig: &RetryConfig{
+				InitialBackoff:    types.NewDuration(2 * time.Second),
+				MaxBackoff:        types.NewDuration(15 * time.Second),
+				BackoffMultiplier: 1.5,
+				MaxAttempts:       10,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientCfg := &ClientConfig{
+				RequestTimeout: tt.timeout,
+				Retry:          tt.retryConfig,
+			}
+			err := clientCfg.validateRequestTimeout()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the validation of minimum request timeout formula which calculates the least required request timeout to accommodate for all the retries.

Fixes #624 
