### PR TITLE
feat: support for use AWS KMS

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,5 +14,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.24.2
+           go-version-input: 1.24.4
            go-package: ./...

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.2]
+        go-version: [1.24.4]
         goarch: ["amd64"]
     runs-on: amd-runner-2204
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CONTAINER FOR BUILDING BINARY
-FROM --platform=${BUILDPLATFORM} golang:1.24.2 AS build
+FROM --platform=${BUILDPLATFORM} golang:1.24.4 AS build
 
 WORKDIR /app
 

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -202,7 +202,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 	mockAggLayerClient := agglayer.NewAgglayerClientMock(t)
 	mockEpochNotifier := mocks.NewEpochNotifier(t)
 	logger := log.WithFields("aggsender-test", "no claims test")
-	signer := signer.NewLocalSignFromPrivateKey("ut", log.WithFields("aggsender", 1), privateKey)
+	signer := signer.NewLocalSignFromPrivateKey("ut", log.WithFields("aggsender", 1), privateKey, 0)
 	aggSender := &AggSender{
 		log:             logger,
 		storage:         mockStorage,
@@ -660,7 +660,7 @@ func newAggsenderTestData(t *testing.T, creationFlags testDataFlags) *aggsenderT
 	}
 	privKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	require.NoError(t, err)
-	signer := signer.NewLocalSignFromPrivateKey("ut", logger, privKey)
+	signer := signer.NewLocalSignFromPrivateKey("ut", logger, privKey, 0)
 	ctx := context.TODO()
 
 	sut := &AggSender{

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -24,11 +24,7 @@ import (
 func TestNewFlow(t *testing.T) {
 	t.Parallel()
 	keyConfig := signertypes.SignerConfig{
-		Method: signertypes.MethodLocal,
-		Config: map[string]any{
-			"password": "password",
-			"path":     "../../test/config/key_trusted_sequencer.keystore",
-		},
+		Method: signertypes.MethodMock,
 	}
 	testCases := []struct {
 		name          string

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,3 +9,4 @@
 - [Etherman](./etherman.md)
 - [Release lifecycle](./release_lifecycle.md)
 - [End-to-end tests](./e2e_tests.md)
+- [Common config artifacts](./common_config.md)

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -149,31 +149,26 @@ The certificate is the data submitted to `Agglayer`. Must be signed to be accept
 
 ## Configuration
 
-| Name                              | Type                      | Description                                                                                                     |
-|-----------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------------------|
-| StoragePath                       | string                    | Full file path (with file name) where to store Aggsender DB                                                     |
-| AgglayerClient                    | *aggkitgrpc.ClientConfig  | Agglayer gRPC client configuration                                                                              |
-| AggsenderPrivateKey               | SignerConfig              | Configuration of the signer used to sign the certificate on the Aggsender before sending it to the Agglayer. It can be a local private key, or an external one. |
-| URLRPCL2                          | string                    | L2 RPC                                                                                                          |
-| BlockFinality                     | string                    | Indicates which finality the AggLayer follows (FinalizedBlock, SafeBlock, LatestBlock, PendingBlock, EarliestBlock) |
-| EpochNotificationPercentage       | uint                      | Indicates the percentage of the epoch on which the AggSender should send the certificate. 0 = begin, 50 = middle |
-| MaxRetriesStoreCertificate        | int                       | Number of retries if Aggsender fails to store certificates on DB. 0 = infinite retries                           |
-| DelayBeetweenRetries              | Duration                  | Delay between retries for storing certificate and initial status check                                           |
-| KeepCertificatesHistory           | bool                      | If true, discarded certificates are moved to the `certificate_info_history` table instead of being deleted       |
-| MaxCertSize                       | uint                      | The maximum size of the certificate. 0 means infinite size                                                      |
-| DryRun                            | bool                      | If true, AggSender will not send certificates to Agglayer (for debugging)                                       |
-| EnableRPC                         | bool                      | Enable the Aggsender's RPC layer                                                                                |
-| AggkitProverClient                | *aggkitgrpc.ClientConfig  | Configuration for the AggkitProver gRPC client                                                                  |
-| Mode                              | string                    | Defines the mode of the AggSender (PessimisticProof or AggchainProof)                                           |
-| CheckStatusCertificateInterval    | Duration                  | Interval at which the AggSender will check the certificate status in Agglayer                                   |
-| RetryCertAfterInError             | bool                      | If true, Aggsender will re-send InError certificates immediately after status change                            |
-| MaxSubmitCertificateRate          | RateLimitConfig           | Maximum allowed rate of submission of certificates in a given time                                              |
-| GlobalExitRootL2Addr              | Address                   | Address of the GlobalExitRootManager contract on L2 sovereign chain (needed for AggchainProof mode)             |
-| SovereignRollupAddr               | Address                   | Address of the sovereign rollup contract on L1                                                                  |
-| RequireStorageContentCompatibility| bool                      | If true, data stored in the database must be compatible with the running environment                            |
-| RequireNoFEPBlockGap              | bool                      | If true, AggSender should not accept a gap between lastBlock from lastCertificate and first block of FEP        |
-| OptimisticModeConfig              | optimistic.Config         | Configuration for optimistic mode (required by FEP mode)                                                        |
-| RequireOneBridgeInPPCertificate   | bool                      | If true, AggSender requires at least one bridge exit for Pessimistic Proof certificates                         |
+| Name                          | Type               | Description                                                                                                     |
+|-------------------------------|--------------------|-----------------------------------------------------------------------------------------------------------------|
+| StoragePath                   | string             | Full file path (with file name) where to store Aggsender DB                                          |
+| AggLayerURL                   | string             | URL to Agglayer                                                                                      |
+| AggsenderPrivateKey           | [SignerConfig](./common_config.md#signerconfig)       | Configuration of the signer used to sign the certificate on the Aggsender before sending it to the Agglayer.It can be a local private key, or a an external one.                                                                                                        |
+| URLRPCL2                      | string             | L2 RPC                                                                                               |
+| BlockFinality                 | string             | Indicates which finality the AggLayer follows (FinalizedBlock, SafeBlock, LatestBlock, PendingBlock, EarliestBlock)                                                                                                                                              |
+| EpochNotificationPercentage   | uint               | Indicates the percentage of the epoch on which the AggSender should send the certificate. `0` -> at beginning of epoch <br> `100` -> at end of the epoch <br> *(default: 50)*                                                                                   |
+| MaxRetriesStoreCertificate    | int                | Number of retries if Aggsender fails to store certificates on DB. <br> *(default: 0 - infinite number of retries)*                                                                                                                                                   |
+| DelayBeetweenRetries          | Duration           | Initial status check delay between retries <br> Store certificate on DB delay between retries        |
+| KeepCertificatesHistory       | bool               | Instead of deleting them, discarded certificates are moved to the `certificate_info_history` table   |
+| MaxCertSize                   | uint               | The maximum size of the certificate. <br> `0` means infinite size.                                   |
+| DryRun                        | bool               | Flag to enable the dry-run mode. <br> In this mode, the AggSender will not send certificates to the Agglayer. Useful when debugging the certficates build process on Aggsender.                                                                                 |
+| EnableRPC                     | bool               | Flag to enable the Aggsender's RPC layer                                                             |
+| AggchainProofURL              | string             | URL to the Aggchain Prover                                                                           |
+| Mode                          | string             | Defines the mode of the AggSender (regular PessimisticProof mode or the AggchainProof mode)          |
+| CheckStatusCertificateInterval| Duration           | Interval at which the AggSender will check the certificate status in Agglayer                        |
+| RetryCertAfterInError         | bool               | Indicates if Aggsender should re-send InError certificates immediatelly after it notices their status change                                                                                                                                                      |
+| MaxSubmitCertificateRate      | RateLimitConfig    | Maximum allowed rate of submission of certificates in a given time                                   |
+| GlobalExitRootL2Addr          | Address            | Address of the GlobalExitRootManager contract on l2 sovereign chain. This address is needed for the AggchainProof mode of the AggSender                                                                                                                         |
 
 ## Use Cases
 

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -149,26 +149,32 @@ The certificate is the data submitted to `Agglayer`. Must be signed to be accept
 
 ## Configuration
 
-| Name                          | Type               | Description                                                                                                     |
-|-------------------------------|--------------------|-----------------------------------------------------------------------------------------------------------------|
-| StoragePath                   | string             | Full file path (with file name) where to store Aggsender DB                                          |
-| AggLayerURL                   | string             | URL to Agglayer                                                                                      |
-| AggsenderPrivateKey           | [SignerConfig](./common_config.md#signerconfig)       | Configuration of the signer used to sign the certificate on the Aggsender before sending it to the Agglayer.It can be a local private key, or a an external one.                                                                                                        |
-| URLRPCL2                      | string             | L2 RPC                                                                                               |
-| BlockFinality                 | string             | Indicates which finality the AggLayer follows (FinalizedBlock, SafeBlock, LatestBlock, PendingBlock, EarliestBlock)                                                                                                                                              |
-| EpochNotificationPercentage   | uint               | Indicates the percentage of the epoch on which the AggSender should send the certificate. `0` -> at beginning of epoch <br> `100` -> at end of the epoch <br> *(default: 50)*                                                                                   |
-| MaxRetriesStoreCertificate    | int                | Number of retries if Aggsender fails to store certificates on DB. <br> *(default: 0 - infinite number of retries)*                                                                                                                                                   |
-| DelayBeetweenRetries          | Duration           | Initial status check delay between retries <br> Store certificate on DB delay between retries        |
-| KeepCertificatesHistory       | bool               | Instead of deleting them, discarded certificates are moved to the `certificate_info_history` table   |
-| MaxCertSize                   | uint               | The maximum size of the certificate. <br> `0` means infinite size.                                   |
-| DryRun                        | bool               | Flag to enable the dry-run mode. <br> In this mode, the AggSender will not send certificates to the Agglayer. Useful when debugging the certficates build process on Aggsender.                                                                                 |
-| EnableRPC                     | bool               | Flag to enable the Aggsender's RPC layer                                                             |
-| AggchainProofURL              | string             | URL to the Aggchain Prover                                                                           |
-| Mode                          | string             | Defines the mode of the AggSender (regular PessimisticProof mode or the AggchainProof mode)          |
-| CheckStatusCertificateInterval| Duration           | Interval at which the AggSender will check the certificate status in Agglayer                        |
-| RetryCertAfterInError         | bool               | Indicates if Aggsender should re-send InError certificates immediatelly after it notices their status change                                                                                                                                                      |
-| MaxSubmitCertificateRate      | RateLimitConfig    | Maximum allowed rate of submission of certificates in a given time                                   |
-| GlobalExitRootL2Addr          | Address            | Address of the GlobalExitRootManager contract on l2 sovereign chain. This address is needed for the AggchainProof mode of the AggSender                                                                                                                         |
+| Name                              | Type                      | Description                                                                                                     |
+|-----------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------------------|
+| StoragePath                       | string                    | Full file path (with file name) where to store Aggsender DB                                                     |
+| AgglayerClient                    | *aggkitgrpc.ClientConfig  | Agglayer gRPC client configuration                                                                              |
+| AggsenderPrivateKey               | [SignerConfig](./common_config.md#signerconfig)             | Configuration of the signer used to sign the certificate on the Aggsender before sending it to the Agglayer. It can be a local private key, or an external one. |
+| URLRPCL2                          | string                    | L2 RPC                                                                                                          |
+| BlockFinality                     | string                    | Indicates which finality the AggLayer follows (FinalizedBlock, SafeBlock, LatestBlock, PendingBlock, EarliestBlock) |
+| EpochNotificationPercentage       | uint                      | Indicates the percentage of the epoch on which the AggSender should send the certificate. 0 = begin, 50 = middle |
+| MaxRetriesStoreCertificate        | int                       | Number of retries if Aggsender fails to store certificates on DB. 0 = infinite retries                           |
+| DelayBeetweenRetries              | Duration                  | Delay between retries for storing certificate and initial status check                                           |
+| KeepCertificatesHistory           | bool                      | If true, discarded certificates are moved to the `certificate_info_history` table instead of being deleted       |
+| MaxCertSize                       | uint                      | The maximum size of the certificate. 0 means infinite size                                                      |
+| DryRun                            | bool                      | If true, AggSender will not send certificates to Agglayer (for debugging)                                       |
+| EnableRPC                         | bool                      | Enable the Aggsender's RPC layer                                                                                |
+| AggkitProverClient                | *aggkitgrpc.ClientConfig  | Configuration for the AggkitProver gRPC client                                                                  |
+| Mode                              | string                    | Defines the mode of the AggSender (PessimisticProof or AggchainProof)                                           |
+| CheckStatusCertificateInterval    | Duration                  | Interval at which the AggSender will check the certificate status in Agglayer                                   |
+| RetryCertAfterInError             | bool                      | If true, Aggsender will re-send InError certificates immediately after status change                            |
+| MaxSubmitCertificateRate          | RateLimitConfig           | Maximum allowed rate of submission of certificates in a given time                                              |
+| GlobalExitRootL2Addr              | Address                   | Address of the GlobalExitRootManager contract on L2 sovereign chain (needed for AggchainProof mode)             |
+| SovereignRollupAddr               | Address                   | Address of the sovereign rollup contract on L1                                                                  |
+| RequireStorageContentCompatibility| bool                      | If true, data stored in the database must be compatible with the running environment                            |
+| RequireNoFEPBlockGap              | bool                      | If true, AggSender should not accept a gap between lastBlock from lastCertificate and first block of FEP        |
+| OptimisticModeConfig              | optimistic.Config         | Configuration for optimistic mode (required by FEP mode)                                                        |
+| RequireOneBridgeInPPCertificate   | bool                      | If true, AggSender requires at least one bridge exit for Pessimistic Proof certificates                         |
+                                                                                              |
 
 ## Use Cases
 

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -4,7 +4,7 @@
 ## SignerConfig
 The `SignerConfig` struct is the primary configuration object used to initialize a signer. It's defined in the [go_signer](https://github.com/agglayer/go_signer) library and specifies how and where cryptographic signing operations are performed.
 
-It supports several type of signers. You must specify the desired method in the  `Method` field, the remaining parameters will depend on this selection.
+The configuration supports multiple signer types. To use it, set the desired signer type in the `Method` field. The remaining configuration parameters will vary depending on the selected method.
 
 The main methods are: 
 

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -1,0 +1,55 @@
+# Common configuration 
+
+
+## SignerConfig
+The `SignerConfig` struct is the  configuration object used to initialize a signer. It's defined in [go_signer](https://github.com/agglayer/go_signer) library. It defines how and where the cryptographic signing will be performed.
+
+It supports several type of signers. You must specify the desired method in the  `Method` field, the remaining parameters will depend on this selection.
+
+The main methods are: 
+
+### Keystore (local)
+Use this method to sign with a local keystore file.
+
+| Name | Type | Example | Description |
+| -----|------|---------|-------------|
+| Method | string | `local` | Must be `local` |
+| Path | string | `/opt/private_key.kestore`| full path to the keystore |
+| Password | string | `xdP6G8gV9PYs`| password to unlock the keystore |
+
+Example: 
+```
+[AggSender]
+AggsenderPrivateKey = { Method="local", Path="/opt/private_key.kestore", Password="xdP6G8gV9PYs" }
+```
+
+### Google Cloud KMS (GCP)
+Use this method to sign using the Google Cloud KMS infrastructure.
+
+| Name | Type | Example | Description |
+| -----|------|---------|-------------|
+| Method | string | `GCP` | Must be `GCP` |
+| KeyName | string |  | id of the key in Google Cloud |
+
+Example: 
+```
+[AggSender]
+AggsenderPrivateKey = { Method="GCP", KeyName="projects/your-prj-name/locations/your_location/keyRings/name_of_your_keyring/cryptoKeys/key-name/cryptoKeyVersions/version"}
+```
+
+### Amazon Web Services KMS (AWS)
+Use this method to sign using the AWS KMS infrastructure. The key type must be `ECC_SECG_P256K1` to ensure compatibility.
+
+| Name | Type | Example | Description |
+| -----|------|---------|-------------|
+| Method | string | `AWS` | Must be `AWS` |
+| KeyName | string | `a47c263b-6575-4835-8721-af0bbb97XXXX` | id of the key in AWS |
+
+Example: 
+```
+[AggSender]
+AggsenderPrivateKey = { Method="AWS", KeyName="a47c263b-6575-4835-8721-af0bbb97XXXX"}
+```
+## Others
+Additional signing methods are available.
+For a complete list and detailed configuration options, please refer to the [go_signer library documentation (v0.0.7)](https://github.com/agglayer/go_signer/blob/v0.0.7/README.md)  

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -2,7 +2,7 @@
 
 
 ## SignerConfig
-The `SignerConfig` struct is the  configuration object used to initialize a signer. It's defined in [go_signer](https://github.com/agglayer/go_signer) library. It defines how and where the cryptographic signing will be performed.
+The `SignerConfig` struct is the primary configuration object used to initialize a signer. It's defined in the [go_signer](https://github.com/agglayer/go_signer) library and specifies how and where cryptographic signing operations are performed.
 
 It supports several type of signers. You must specify the desired method in the  `Method` field, the remaining parameters will depend on this selection.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agglayer/aggkit
 
-go 1.24.2
+go 1.24.4
 
 require (
 	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250520190516-57743a879f16.2

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250520163122-7efa0a2f81a8.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.4
 	github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229
-	github.com/0xPolygon/zkevm-ethtx-manager v0.2.13
-	github.com/agglayer/go_signer v0.0.6
+	github.com/0xPolygon/zkevm-ethtx-manager v0.2.14
+	github.com/agglayer/go_signer v0.0.7
 	github.com/ethereum/go-ethereum v1.15.5
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/0xPolygon/cdk-contracts-tooling v0.0.4 h1:nQGwmS30bZovCKGGuF9zWcoVZFk
 github.com/0xPolygon/cdk-contracts-tooling v0.0.4/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229 h1:6YhqNQVcXkoxqs5zQVg1bREuoeKvwpffpfoL8QQT+u4=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.13 h1:LzLf0jjuPcAlhKh0FDYSp+Xe+6h7cglHgb+YfOowl4U=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.13/go.mod h1:mRdWtyuzQQOiQWvo1nNuj44H0UNqK/8FOF44bjOCKYs=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.14 h1:mC06JfotRTxRYea9zEnHbNMhB76pXmD23Axl0/HjNBw=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.14/go.mod h1:AmLGLIk9qrf1EGqZrgjBc3YGn+0Dc7Ee2KVLuiTBY7g=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7 h1:KJM1QlNZdZjNRS+ajPauD4uG+uaYgItaL+96Om3f8aI=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7/go.mod h1:exl+KHnTN6Y8HG4nSUXni4qKbAug0HjJqpebMSgl72k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -42,8 +42,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
-github.com/agglayer/go_signer v0.0.6 h1:IKeh4JMvWAXZX/0lGEF0W/UatmUc7LEo5Nm0L+yCcqc=
-github.com/agglayer/go_signer v0.0.6/go.mod h1:YIoQNqvA10L/qV9vlAV8rXjejnyPpnYA0A/zU1uxXeY=
+github.com/agglayer/go_signer v0.0.7 h1:V+4wFWjGKdL1GgXSzx2RLgglJWyce95Dy/4+9xx52hs=
+github.com/agglayer/go_signer v0.0.7/go.mod h1:PiDQugvxAgTYDD9bbWcqBMl/LuOOG/B9Hx1N1lIPq0s=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
 github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=


### PR DESCRIPTION
- support for use AWS KMS : update go_singer library to v0.0.7 and ethx-manager to v0.2.14
- Update to go `1.24.4` to fix vulnerabilities (govulncheck)

Fixes #592, #635