### PR TITLE
chore: bump golang to 1.24.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.language == 'go' }}
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.24.4
 
       - name: Verify Go version
         if: ${{ matrix.language == 'go' }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,5 +14,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.24.2
+           go-version-input: 1.24.4
            go-package: ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.24.4
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   build-aggkit-image:
     uses: ./.github/workflows/build-aggkit-image.yml
     with:
-      go-version: 1.24.x
+      go-version: 1.24.4
       docker-image-name: aggkit
 
   read-aggkit-args:
@@ -117,7 +117,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.24.4
 
       - name: Build Aggsender Find Imported Bridge
         run: make build-tools

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.2]
+        go-version: [1.24.4]
         goarch: ["amd64"]
     runs-on: amd-runner-2204
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CONTAINER FOR BUILDING BINARY
-FROM --platform=${BUILDPLATFORM} golang:1.24.2 AS build
+FROM --platform=${BUILDPLATFORM} golang:1.24.4 AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agglayer/aggkit
 
-go 1.24.2
+go 1.24.4
 
 require (
 	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250520190516-57743a879f16.2


### PR DESCRIPTION
## Description

Golang vulnerability [check](https://github.com/agglayer/aggkit/actions/runs/15607872045/job/43961581720) started to fail. Based on the output, it is suggesting to bump the golang version to 1.24.4, and this PR is changing it.

Fixes #635
