### PR TITLE
fix: add where clause to the get latest info until block

### DIFF
--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -204,7 +204,8 @@ func (p *processor) GetLatestInfoUntilBlock(ctx context.Context, blockNum uint64
 	info := &L1InfoTreeLeaf{}
 	err = meddler.QueryRow(
 		tx, info,
-		`SELECT * FROM l1info_leaf ORDER BY block_num DESC, block_pos DESC LIMIT 1;`,
+		`SELECT * FROM l1info_leaf WHERE block_num <= $1 ORDER BY block_num DESC, block_pos DESC LIMIT 1;`,
+		blockNum,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
## Description

Add where clause to include filtering until provided block number in the `GetLatestInfoUntilBlock` function, so that it reflects the name.

Fixes #639 
