### PR TITLE
feat: redirect gin output to debug logger

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -65,7 +65,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@5795e76565b0ad4dd270725a76eba7bcefd535de
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ff68ade8edd2f1608a8afe7c9d3e46943bfe0b4b
+      kurtosis-cdk-ref: 76ea67fb491333f8a7d419307f3e397cfc055f80
       agglayer-e2e-ref: 5795e76565b0ad4dd270725a76eba7bcefd535de
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -89,7 +89,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@5795e76565b0ad4dd270725a76eba7bcefd535de
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ff68ade8edd2f1608a8afe7c9d3e46943bfe0b4b
+      kurtosis-cdk-ref: 76ea67fb491333f8a7d419307f3e397cfc055f80
       agglayer-e2e-ref: 5795e76565b0ad4dd270725a76eba7bcefd535de
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -137,7 +137,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@5795e76565b0ad4dd270725a76eba7bcefd535de
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ff68ade8edd2f1608a8afe7c9d3e46943bfe0b4b
+      kurtosis-cdk-ref: 76ea67fb491333f8a7d419307f3e397cfc055f80
       agglayer-e2e-ref: 5795e76565b0ad4dd270725a76eba7bcefd535de
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -163,7 +163,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@5795e76565b0ad4dd270725a76eba7bcefd535de
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ff68ade8edd2f1608a8afe7c9d3e46943bfe0b4b
+      kurtosis-cdk-ref: 76ea67fb491333f8a7d419307f3e397cfc055f80
       agglayer-e2e-ref: 5795e76565b0ad4dd270725a76eba7bcefd535de
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -110,6 +110,10 @@ func New(
 		gin.SetMode(gin.ReleaseMode) // fallback to release mode
 	}
 
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.Use(LoggerHandler(cfg.Logger))
+
 	b := &BridgeService{
 		logger:       cfg.Logger,
 		address:      cfg.Address,
@@ -121,7 +125,7 @@ func New(
 		injectedGERs: injectedGERs,
 		bridgeL1:     bridgeL1,
 		bridgeL2:     bridgeL2,
-		router:       gin.Default(),
+		router:       router,
 	}
 
 	b.registerRoutes()
@@ -130,8 +134,8 @@ func New(
 	return b
 }
 
-// GinZapLogger returns a Gin middleware that logs HTTP requests using zap at DEBUG level.
-func GinZapLogger(logger aggkitcommon.Logger) gin.HandlerFunc {
+// LoggerHandler returns a Gin middleware that logs HTTP requests using logger at DEBUG level.
+func LoggerHandler(logger aggkitcommon.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		path := c.Request.URL.Path

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	zkevm "github.com/agglayer/aggkit"
+	"github.com/agglayer/aggkit"
 	"github.com/hermeznetwork/tracerr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -86,7 +86,7 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 	zapCfg.Level = level
 	zapCfg.OutputPaths = cfg.Outputs
 	zapCfg.InitialFields = map[string]interface{}{
-		"version": zkevm.Version,
+		"version": aggkit.Version,
 		"pid":     os.Getpid(),
 	}
 


### PR DESCRIPTION
## Description

Log the GIN requests in the debug log, as structured logs, instead of using the builtin GIN logger.

Fixes #636
