### PR TITLE
feat: cherry-pick - migration 0.2 to 0.3 issue  (#661)

### DIFF
--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/big"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -21,6 +22,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_StorageExploratory(t *testing.T) {
+	t.Skip()
+	path := os.Getenv("DB_AGGSENDER_0_2")
+	if path == "" {
+		t.Fatalf("environment variable DB_AGGSENDER_0_2 is not set")
+	}
+	cfg := AggSenderSQLStorageConfig{
+		DBPath:                  path,
+		KeepCertificatesHistory: true,
+	}
+	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
+	require.NoError(t, err)
+	cert, err := storage.GetLastSentCertificate()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+}
 func Test_Storage(t *testing.T) {
 	ctx := context.Background()
 

--- a/aggsender/db/migrations/0004.sql
+++ b/aggsender/db/migrations/0004.sql
@@ -1,0 +1,14 @@
+--- Fix migration from 0001 to 0002 that field l1_info_tree_leaf_count can't be read
+-- +migrate Down
+
+
+-- +migrate Up
+
+-- The field l1_info_tree_leaf_count is unknown for previous data stored in DB
+-- the only place where is used is to retry a FEP. So we delete all non-finalized certificates
+-- so it can't produce the error keeping as much data as possible.
+DELETE FROM certificate_info WHERE  status != 4 AND l1_info_tree_leaf_count IS NULL; -- Remove non-finalized certificates with NULL l1_info_tree_leaf_count
+DELETE FROM certificate_info_history WHERE status != 4 AND l1_info_tree_leaf_count IS NULL; -- Remove non-finalized certificates with NULL l1_info_tree_leaf_count
+--- The rest of l1info_tree_leaf_count is not used in the code, so we can safely set to 0
+UPDATE certificate_info SET l1_info_tree_leaf_count = 0 WHERE l1_info_tree_leaf_count IS NULL;
+UPDATE certificate_info_history SET l1_info_tree_leaf_count = 0 WHERE l1_info_tree_leaf_count IS NULL;

--- a/aggsender/db/migrations/0004.sql
+++ b/aggsender/db/migrations/0004.sql
@@ -7,7 +7,7 @@
 -- The field l1_info_tree_leaf_count is unknown for previous data stored in DB
 -- the only place where is used is to retry a FEP. So we delete all non-finalized certificates
 -- so it can't produce the error keeping as much data as possible.
-DELETE FROM certificate_info WHERE  status != 4 AND l1_info_tree_leaf_count IS NULL; -- Remove non-finalized certificates with NULL l1_info_tree_leaf_count
+DELETE FROM certificate_info WHERE status != 4 AND l1_info_tree_leaf_count IS NULL; -- Remove non-finalized certificates with NULL l1_info_tree_leaf_count
 DELETE FROM certificate_info_history WHERE status != 4 AND l1_info_tree_leaf_count IS NULL; -- Remove non-finalized certificates with NULL l1_info_tree_leaf_count
 --- The rest of l1info_tree_leaf_count is not used in the code, so we can safely set to 0
 UPDATE certificate_info SET l1_info_tree_leaf_count = 0 WHERE l1_info_tree_leaf_count IS NULL;

--- a/aggsender/db/migrations/migrations.go
+++ b/aggsender/db/migrations/migrations.go
@@ -18,6 +18,9 @@ var mig002 string
 //go:embed 0003.sql
 var mig003 string
 
+//go:embed 0004.sql
+var mig004 string
+
 func RunMigrations(logger *log.Logger, database *sql.DB) error {
 	migrations := []types.Migration{
 		{
@@ -31,6 +34,10 @@ func RunMigrations(logger *log.Logger, database *sql.DB) error {
 		{
 			ID:  "0003",
 			SQL: mig003,
+		},
+		{
+			ID:  "0004",
+			SQL: mig004,
 		},
 	}
 

--- a/db/meddler.go
+++ b/db/meddler.go
@@ -152,13 +152,45 @@ func (b MerkleProofMeddler) PreWrite(fieldPtr interface{}) (saveValue interface{
 type HashMeddler struct{}
 
 // PreRead is called before a Scan operation for fields that have the HashMeddler
-func (b HashMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err error) {
+func (m HashMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err error) {
 	// give a pointer to a byte buffer to grab the raw data
+	_, ok := fieldAddr.(**common.Hash)
+	if ok {
+		// This is because if not the rows.Scan fails 'converting NULL to string is unsupported'
+		return new(*string), nil
+	}
 	return new(string), nil
+}
+func (m HashMeddler) postReadDoublePtr(fieldPtr, scanTarget interface{}) error {
+	rawHashPtr, ok := scanTarget.(**string)
+	if !ok {
+		return errors.New("scanTarget is not **string")
+	}
+	// Handle the case where fieldPtr is a **common.Hash (nullable field)
+	hashPtr, ok := fieldPtr.(**common.Hash)
+	if ok {
+		if rawHashPtr == nil || *rawHashPtr == nil {
+			return nil
+		}
+		// If the string is empty, set the hash to nil
+		if len(**rawHashPtr) == 0 {
+			*hashPtr = nil
+			// Otherwise, convert the string to a common.Hash and assign it
+		} else {
+			tmp := common.HexToHash(**rawHashPtr)
+			*hashPtr = &tmp
+		}
+		return nil
+	}
+	return errors.New("fieldPtr is not **common.Hash")
 }
 
 // PostRead is called after a Scan operation for fields that have the HashMeddler
-func (b HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
+func (m HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
+	_, ok := scanTarget.(**string)
+	if ok {
+		return m.postReadDoublePtr(fieldPtr, scanTarget)
+	}
 	rawHashPtr, ok := scanTarget.(*string)
 	if !ok {
 		return errors.New("scanTarget is not *string")
@@ -170,27 +202,12 @@ func (b HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
 		*field = common.HexToHash(*rawHashPtr)
 		return nil
 	}
-
-	// Handle the case where fieldPtr is a **common.Hash (nullable field)
-	hashPtr, ok := fieldPtr.(**common.Hash)
-	if ok {
-		// If the string is empty, set the hash to nil
-		if len(*rawHashPtr) == 0 {
-			*hashPtr = nil
-			// Otherwise, convert the string to a common.Hash and assign it
-		} else {
-			tmp := common.HexToHash(*rawHashPtr)
-			*hashPtr = &tmp
-		}
-		return nil
-	}
-
-	// If fieldPtr is neither a *common.Hash nor a **common.Hash, return an error
-	return errors.New("fieldPtr is not *common.Hash or **common.Hash")
+	// If fieldPtr is neither a *common.Hash, return an error
+	return errors.New("fieldPtr is not *common.Hash")
 }
 
 // PreWrite is called before an Insert or Update operation for fields that have the HashMeddler
-func (b HashMeddler) PreWrite(fieldPtr interface{}) (saveValue interface{}, err error) {
+func (m HashMeddler) PreWrite(fieldPtr interface{}) (saveValue interface{}, err error) {
 	field, ok := fieldPtr.(common.Hash)
 	if !ok {
 		hashPtr, ok := fieldPtr.(*common.Hash)

--- a/db/meddler_test.go
+++ b/db/meddler_test.go
@@ -1,10 +1,14 @@
 package db
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/russross/meddler"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHashMeddler_PreWrite(t *testing.T) {
@@ -61,4 +65,72 @@ func TestHashMeddler_PreWrite(t *testing.T) {
 			}
 		})
 	}
+}
+
+type certificateInfo struct {
+	Height                  uint64       `meddler:"height"`
+	CertificateID           common.Hash  `meddler:"certificate_id,hash"`
+	FinalizedL1InfoTreeRoot *common.Hash `meddler:"finalized_l1_info_tree_root,hash"`
+}
+
+type certificateInfoBadType struct {
+	Height        uint64      `meddler:"height"`
+	CertificateID common.Hash `meddler:"certificate_id,hash"`
+	// The field is nullable on DB but not in struct
+	FinalizedL1InfoTreeRoot common.Hash `meddler:"finalized_l1_info_tree_root,hash"`
+}
+
+func TestMeddlerHashPointerIsNull(t *testing.T) {
+	db := createExampleDB(t)
+	var certificateInfo certificateInfo
+	err := meddler.QueryRow(db, &certificateInfo, "SELECT * FROM certificate_info where height=0;")
+	require.NoError(t, err, "null case")
+	require.Nil(t, certificateInfo.FinalizedL1InfoTreeRoot, "FinalizedL1InfoTreeRoot should be nil for height 0")
+	fmt.Print(certificateInfo)
+
+	var badCertificateInfo certificateInfoBadType
+	err = meddler.QueryRow(db, &badCertificateInfo, "SELECT * FROM certificate_info where height=0;")
+	require.Error(t, err, "bad type case")
+	require.ErrorContains(t, err, "converting NULL to string is unsupported")
+}
+
+func TestMeddlerHashPointerIsNotNull(t *testing.T) {
+	db := createExampleDB(t)
+	var certificateInfo certificateInfo
+	err := meddler.QueryRow(db, &certificateInfo, "SELECT * FROM certificate_info where height=1;")
+	require.NoError(t, err, "data case")
+	require.NotNil(t, certificateInfo.FinalizedL1InfoTreeRoot, "FinalizedL1InfoTreeRoot should not be nil for height 1")
+}
+
+func TestMeddlerHashpostReadDoublePtrBadParams(t *testing.T) {
+	h := HashMeddler{}
+	err := h.postReadDoublePtr(nil, nil)
+	require.Error(t, err)
+}
+
+func createExampleDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := ":memory:"
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE certificate_info (
+			height INTEGER PRIMARY KEY,
+			certificate_id VARCHAR NOT NULL,
+			finalized_l1_info_tree_root VARCHAR
+		);
+	`)
+	require.NoError(t, err, "failed to create table")
+	_, err = db.Exec(`
+	INSERT INTO certificate_info (height, certificate_id,finalized_l1_info_tree_root) 
+	VALUES (0,'0xbeef', NULL);
+`)
+	require.NoError(t, err, "failed to insert null data")
+	_, err = db.Exec(`
+		INSERT INTO certificate_info (height,certificate_id, finalized_l1_info_tree_root) 
+		VALUES (1, '0xbeef','0x1234567890123456789012345678901234567890');
+	`)
+	require.NoError(t, err, "failed to insert data")
+	return db
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.6-20250520163122-7efa0a2f81a8.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.4
 	github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229
-	github.com/0xPolygon/zkevm-ethtx-manager v0.2.14
+	github.com/0xPolygon/zkevm-ethtx-manager v0.2.15
 	github.com/agglayer/go_signer v0.0.7
 	github.com/ethereum/go-ethereum v1.15.5
 	github.com/gin-gonic/gin v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/0xPolygon/cdk-contracts-tooling v0.0.4 h1:nQGwmS30bZovCKGGuF9zWcoVZFk
 github.com/0xPolygon/cdk-contracts-tooling v0.0.4/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229 h1:6YhqNQVcXkoxqs5zQVg1bREuoeKvwpffpfoL8QQT+u4=
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.14 h1:mC06JfotRTxRYea9zEnHbNMhB76pXmD23Axl0/HjNBw=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.14/go.mod h1:AmLGLIk9qrf1EGqZrgjBc3YGn+0Dc7Ee2KVLuiTBY7g=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.15 h1:v9BhQkXWvg1jM3SeDRJzjwUQo0YOWFUSEtkFRfGW+dw=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.15/go.mod h1:AmLGLIk9qrf1EGqZrgjBc3YGn+0Dc7Ee2KVLuiTBY7g=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7 h1:KJM1QlNZdZjNRS+ajPauD4uG+uaYgItaL+96Om3f8aI=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7/go.mod h1:exl+KHnTN6Y8HG4nSUXni4qKbAug0HjJqpebMSgl72k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
## Description

This is a cherry pick of PR #661.

The migration from aggkit `v0.2.0` to `v0.3.0` fails if there are any certificate in database.  Procude next error: `sql: Scan error on column index 4, name "previous_local_exit_root": converting NULL to string is unsupported`

- Add support to Meddler to `*common.Hash`
- Remove no settled certificates with  `l1_info_tree_leaf_count` NULL (it could be used on code with a bad  `l1_info_tree_leaf_count` value)
- Set `l1_info_tree_leaf_count` NULL to 0 on database
