### PR TITLE
feat: rely on the binary startup for aggkit and remove shell

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -68,7 +68,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
+      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -92,7 +92,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
+      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -140,7 +140,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
+      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -166,7 +166,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
+      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -68,7 +68,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
+      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -92,7 +92,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
+      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -140,7 +140,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
+      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -166,7 +166,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
+      kurtosis-cdk-ref: 6b3f5c3548731f199c155bcae803d0f5b00ef450
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -68,7 +68,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
+      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -92,7 +92,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
+      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -140,7 +140,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
+      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -166,7 +166,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
+      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -68,7 +68,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 9c34c35e39143a97a8583f678cf962a6d188a8b7
+      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -92,7 +92,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 9c34c35e39143a97a8583f678cf962a6d188a8b7
+      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -140,7 +140,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 9c34c35e39143a97a8583f678cf962a6d188a8b7
+      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -166,7 +166,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 9c34c35e39143a97a8583f678cf962a6d188a8b7
+      kurtosis-cdk-ref: 0826074da47301ebf1a4a234e3e142de86e4a086
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -68,7 +68,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
+      kurtosis-cdk-ref: 2a880250c071451a1419b8ebd7b63e4cb898ea8c
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -92,7 +92,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
+      kurtosis-cdk-ref: 2a880250c071451a1419b8ebd7b63e4cb898ea8c
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -140,7 +140,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
+      kurtosis-cdk-ref: 2a880250c071451a1419b8ebd7b63e4cb898ea8c
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -166,7 +166,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: a0d23b5766c8e3f01137e3b84e6099acef542562
+      kurtosis-cdk-ref: 2a880250c071451a1419b8ebd7b63e4cb898ea8c
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -68,7 +68,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
+      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
@@ -92,7 +92,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
+      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-op-succinct }}
@@ -140,7 +140,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
+      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -166,7 +166,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
     secrets: inherit
     with:
-      kurtosis-cdk-ref: e30132fc053a0c19175dee126ff10eabfff75631
+      kurtosis-cdk-ref: f8d9b425d35aba740ab5f0f9f4ae2808a76b278e
       agglayer-e2e-ref: ed9abcea31e6d54e5ee7a7f45de6628be1ef8d1d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge


### PR DESCRIPTION
## Description

Remove bash wrapper for the aggkit startup, as we are removing the shell from the aggkit docker image (related PR #675).

Fixes #716
