### PR TITLE
feat: save settled cert on startup from scratch

### DIFF
--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -73,6 +73,8 @@ type AggSenderStorage interface {
 	GetNonAcceptedCertificate() (*NonAcceptedCertificate, error)
 	// SaveOrUpdateCertificate saves or updates a certificate in the storage
 	SaveOrUpdateCertificate(ctx context.Context, certificate types.Certificate) error
+	// GetLastSettledCertificate returns the last settled certificate from the storage
+	GetLastSettledCertificate() (*types.CertificateHeader, error)
 }
 
 var _ AggSenderStorage = (*AggSenderSQLStorage)(nil)
@@ -192,6 +194,20 @@ func (a *AggSenderSQLStorage) GetLastSentCertificateHeader() (*types.Certificate
 	if err := meddler.QueryRow(a.db, &certificateHeader,
 		fmt.Sprintf("%s ORDER BY height DESC LIMIT 1;", selectQueryCertificateHeader)); err != nil {
 		return nil, getSelectQueryError(0, err)
+	}
+	return &certificateHeader, nil
+}
+
+// GetLastSettledCertificate returns the last settled certificate from the storage
+func (a *AggSenderSQLStorage) GetLastSettledCertificate() (*types.CertificateHeader, error) {
+	var certificateHeader types.CertificateHeader
+	if err := meddler.QueryRow(a.db, &certificateHeader,
+		fmt.Sprintf("%s WHERE status = $1 ORDER BY height DESC LIMIT 1;", selectQueryCertificateHeader),
+		agglayertypes.Settled); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, fmt.Errorf("error getting last settled certificate: %w", err)
 	}
 	return &certificateHeader, nil
 }

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -71,6 +71,8 @@ type AggSenderStorage interface {
 	SaveNonAcceptedCertificate(ctx context.Context, nonAcceptedCert *NonAcceptedCertificate) error
 	// GetNonAcceptedCertificate returns the last non-accepted certificate
 	GetNonAcceptedCertificate() (*NonAcceptedCertificate, error)
+	// SaveOrUpdateCertificate saves or updates a certificate in the storage
+	SaveOrUpdateCertificate(ctx context.Context, certificate types.Certificate) error
 }
 
 var _ AggSenderStorage = (*AggSenderSQLStorage)(nil)
@@ -194,6 +196,57 @@ func (a *AggSenderSQLStorage) GetLastSentCertificateHeader() (*types.Certificate
 	return &certificateHeader, nil
 }
 
+// SaveOrUpdateCertificate saves the certificate in the storage
+// It will insert a new certificate or update the existing one if it has the same height and certificate ID
+func (a *AggSenderSQLStorage) SaveOrUpdateCertificate(ctx context.Context, certificate types.Certificate) error {
+	tx, err := newTxer(ctx, a.db)
+	if err != nil {
+		return fmt.Errorf("saveOrUpdateCertificate NewTx. Err: %w", err)
+	}
+	shouldRollback := true
+	defer func() {
+		if shouldRollback {
+			if errRllbck := tx.Rollback(); errRllbck != nil {
+				a.logger.Errorf(errWhileRollbackFormat, errRllbck)
+			}
+		}
+	}()
+
+	certInfo, err := convertCertificateToCertificateInfo(&certificate)
+	if err != nil {
+		return fmt.Errorf("error converting certificate to certificate info: %w", err)
+	}
+
+	var count int
+	err = tx.QueryRow(`SELECT COUNT(*) FROM certificate_info WHERE height = $1;`, certInfo.Height).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("error checking if certificate exists: %w", err)
+	}
+
+	// meddler does not support upsert, so we need to do this manually by checking if the certificate exists
+	if count == 0 {
+		// insert new certificate if it does not exist
+		if err = meddler.Insert(tx, "certificate_info", certInfo); err != nil {
+			return fmt.Errorf("error inserting certificate info: %w", err)
+		}
+	} else {
+		// if the certificate exists, we need to update it
+		if err = updateCertStatus(tx, certInfo.CertificateID, certInfo.Status, certInfo.UpdatedAt); err != nil {
+			return fmt.Errorf("error updating certificate status: %w", err)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("saveOrUpdateCertificate commit. Err: %w", err)
+	}
+	shouldRollback = false
+
+	a.logger.Debugf("inserted certificate - Height: %d. Hash: %s",
+		certInfo.Height, certInfo.CertificateID)
+
+	return nil
+}
+
 // SaveLastSentCertificate saves the last certificate sent to the aggLayer
 func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certificate types.Certificate) error {
 	tx, err := db.NewTx(ctx, a.db)
@@ -315,16 +368,28 @@ func (a *AggSenderSQLStorage) UpdateCertificateStatus(
 		}
 	}()
 
-	if _, err = tx.Exec(`UPDATE certificate_info SET status = $1, updated_at = $2 WHERE certificate_id = $3;`,
-		newStatus, updatedAt, certificateID.String()); err != nil {
-		return fmt.Errorf("error updating certificate info: %w", err)
+	if err = updateCertStatus(tx, certificateID, newStatus, updatedAt); err != nil {
+		return fmt.Errorf("error updating certificate status: %w", err)
 	}
+
 	if err = tx.Commit(); err != nil {
 		return err
 	}
 	shouldRollback = false
 
 	a.logger.Debugf("updated certificate status - CertificateID: %s", certificateID)
+
+	return nil
+}
+
+func updateCertStatus(tx dbtypes.Querier,
+	certificateID common.Hash,
+	newStatus agglayertypes.CertificateStatus,
+	updatedAt uint32) error {
+	if _, err := tx.Exec(`UPDATE certificate_info SET status = $1, updated_at = $2 WHERE certificate_id = $3;`,
+		newStatus, updatedAt, certificateID.String()); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -257,8 +257,13 @@ func (a *AggSenderSQLStorage) SaveOrUpdateCertificate(ctx context.Context, certi
 	}
 	shouldRollback = false
 
-	a.logger.Debugf("inserted certificate - Height: %d. Hash: %s",
-		certInfo.Height, certInfo.CertificateID)
+	action := "inserted"
+	if count > 0 {
+		action = "updated"
+	}
+
+	a.logger.Debugf("%s certificate - Height: %d. Hash: %s",
+		action, certInfo.Height, certInfo.CertificateID)
 
 	return nil
 }

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -992,3 +992,46 @@ func Test_GetNonAcceptedCert(t *testing.T) {
 	}
 	require.Equal(t, *certificate, certificateFromDB, "retrieved certificate should match the saved certificate")
 }
+
+func TestSaveOrUpdateCertificate(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "Test_GetNonAcceptedCert.sqlite")
+	cfg := AggSenderSQLStorageConfig{
+		DBPath: dbPath,
+	}
+
+	newTxer = db.NewTx
+
+	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
+	require.NoError(t, err)
+
+	signedCert := "signed-cert"
+
+	// Save new certificate
+	certificate := &types.Certificate{
+		Header: &types.CertificateHeader{
+			Height:           1,
+			CertificateID:    common.HexToHash("0x1"),
+			NewLocalExitRoot: common.HexToHash("0x2"),
+			FromBlock:        1,
+			ToBlock:          2,
+			Status:           agglayertypes.Pending,
+			CreatedAt:        uint32(time.Now().UTC().UnixMilli()),
+		},
+		SignedCertificate: &signedCert,
+		ExtraData:         "extra data",
+	}
+
+	require.NoError(t, storage.SaveOrUpdateCertificate(t.Context(), *certificate))
+	certificateFromDB, err := storage.GetCertificateByHeight(certificate.Header.Height)
+	require.NoError(t, err)
+	require.Equal(t, certificate, certificateFromDB)
+
+	// Update existing certificate
+	certificate.Header.Status = agglayertypes.Settled
+	certificate.Header.UpdatedAt = uint32(time.Now().UTC().UnixMilli())
+	require.NoError(t, storage.SaveOrUpdateCertificate(t.Context(), *certificate))
+
+	certificateFromDB, err = storage.GetCertificateByHeight(certificate.Header.Height)
+	require.NoError(t, err)
+	require.Equal(t, certificate, certificateFromDB, "equal status")
+}

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -1035,3 +1035,119 @@ func TestSaveOrUpdateCertificate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, certificate, certificateFromDB, "equal status")
 }
+
+func Test_GetLastSettledCertificate(t *testing.T) {
+	ctx := context.Background()
+	dbPath := path.Join(t.TempDir(), "Test_GetLastSettledCertificate.sqlite")
+	cfg := AggSenderSQLStorageConfig{
+		DBPath:                  dbPath,
+		KeepCertificatesHistory: true,
+	}
+	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, storage)
+
+	updateTime := uint32(time.Now().UTC().UnixMilli())
+
+	t.Run("NoSettledCertificates", func(t *testing.T) {
+		header, err := storage.GetLastSettledCertificate()
+		require.ErrorIs(t, err, db.ErrNotFound)
+		require.Nil(t, header)
+	})
+
+	t.Run("SingleSettledCertificate", func(t *testing.T) {
+		cert := types.Certificate{
+			Header: &types.CertificateHeader{
+				Height:           1,
+				CertificateID:    common.HexToHash("0x1"),
+				NewLocalExitRoot: common.HexToHash("0x2"),
+				FromBlock:        1,
+				ToBlock:          2,
+				Status:           agglayertypes.Settled,
+				CreatedAt:        updateTime,
+				UpdatedAt:        updateTime,
+			},
+		}
+		require.NoError(t, storage.SaveLastSentCertificate(ctx, cert))
+
+		header, err := storage.GetLastSettledCertificate()
+		require.NoError(t, err)
+		require.NotNil(t, header)
+		require.Equal(t, cert.Header, header)
+
+		require.NoError(t, storage.clean())
+	})
+
+	t.Run("MultipleCertificatesWithDifferentStatuses", func(t *testing.T) {
+		certs := []*types.Certificate{
+			{
+				Header: &types.CertificateHeader{
+					Height:           2,
+					CertificateID:    common.HexToHash("0x2"),
+					NewLocalExitRoot: common.HexToHash("0x3"),
+					FromBlock:        2,
+					ToBlock:          3,
+					Status:           agglayertypes.Pending,
+					CreatedAt:        updateTime,
+					UpdatedAt:        updateTime,
+				},
+			},
+			{
+				Header: &types.CertificateHeader{
+					Height:           3,
+					CertificateID:    common.HexToHash("0x3"),
+					NewLocalExitRoot: common.HexToHash("0x4"),
+					FromBlock:        3,
+					ToBlock:          4,
+					Status:           agglayertypes.Settled,
+					CreatedAt:        updateTime,
+					UpdatedAt:        updateTime,
+				},
+			},
+			{
+				Header: &types.CertificateHeader{
+					Height:           4,
+					CertificateID:    common.HexToHash("0x4"),
+					NewLocalExitRoot: common.HexToHash("0x5"),
+					FromBlock:        4,
+					ToBlock:          5,
+					Status:           agglayertypes.InError,
+					CreatedAt:        updateTime,
+					UpdatedAt:        updateTime,
+				},
+			},
+			{
+				Header: &types.CertificateHeader{
+					Height:           5,
+					CertificateID:    common.HexToHash("0x5"),
+					NewLocalExitRoot: common.HexToHash("0x6"),
+					FromBlock:        5,
+					ToBlock:          6,
+					Status:           agglayertypes.Settled,
+					CreatedAt:        updateTime,
+					UpdatedAt:        updateTime,
+				},
+			},
+		}
+
+		for _, cert := range certs {
+			require.NoError(t, storage.SaveLastSentCertificate(ctx, *cert))
+		}
+
+		header, err := storage.GetLastSettledCertificate()
+		require.NoError(t, err)
+		require.NotNil(t, header)
+		// Should return the one with the highest height and Settled status
+		require.Equal(t, certs[len(certs)-1].Header, header)
+
+		require.NoError(t, storage.clean())
+	})
+
+	t.Run("ErrorFromDB", func(t *testing.T) {
+		// Close DB to force an error
+		require.NoError(t, storage.db.Close())
+		header, err := storage.GetLastSettledCertificate()
+		require.Error(t, err)
+		require.Nil(t, header)
+	})
+}

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -430,6 +430,63 @@ func (_c *AggSenderStorage_GetLastSentCertificateHeaderWithProofIfInError_Call) 
 	return _c
 }
 
+// GetLastSettledCertificate provides a mock function with no fields
+func (_m *AggSenderStorage) GetLastSettledCertificate() (*types.CertificateHeader, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastSettledCertificate")
+	}
+
+	var r0 *types.CertificateHeader
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*types.CertificateHeader, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *types.CertificateHeader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.CertificateHeader)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggSenderStorage_GetLastSettledCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastSettledCertificate'
+type AggSenderStorage_GetLastSettledCertificate_Call struct {
+	*mock.Call
+}
+
+// GetLastSettledCertificate is a helper method to define mock.On call
+func (_e *AggSenderStorage_Expecter) GetLastSettledCertificate() *AggSenderStorage_GetLastSettledCertificate_Call {
+	return &AggSenderStorage_GetLastSettledCertificate_Call{Call: _e.mock.On("GetLastSettledCertificate")}
+}
+
+func (_c *AggSenderStorage_GetLastSettledCertificate_Call) Run(run func()) *AggSenderStorage_GetLastSettledCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_GetLastSettledCertificate_Call) Return(_a0 *types.CertificateHeader, _a1 error) *AggSenderStorage_GetLastSettledCertificate_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AggSenderStorage_GetLastSettledCertificate_Call) RunAndReturn(run func() (*types.CertificateHeader, error)) *AggSenderStorage_GetLastSettledCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNonAcceptedCertificate provides a mock function with no fields
 func (_m *AggSenderStorage) GetNonAcceptedCertificate() (*db.NonAcceptedCertificate, error) {
 	ret := _m.Called()

--- a/aggsender/mocks/mock_agg_sender_storage.go
+++ b/aggsender/mocks/mock_agg_sender_storage.go
@@ -581,6 +581,53 @@ func (_c *AggSenderStorage_SaveNonAcceptedCertificate_Call) RunAndReturn(run fun
 	return _c
 }
 
+// SaveOrUpdateCertificate provides a mock function with given fields: ctx, certificate
+func (_m *AggSenderStorage) SaveOrUpdateCertificate(ctx context.Context, certificate types.Certificate) error {
+	ret := _m.Called(ctx, certificate)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SaveOrUpdateCertificate")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.Certificate) error); ok {
+		r0 = rf(ctx, certificate)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// AggSenderStorage_SaveOrUpdateCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveOrUpdateCertificate'
+type AggSenderStorage_SaveOrUpdateCertificate_Call struct {
+	*mock.Call
+}
+
+// SaveOrUpdateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - certificate types.Certificate
+func (_e *AggSenderStorage_Expecter) SaveOrUpdateCertificate(ctx interface{}, certificate interface{}) *AggSenderStorage_SaveOrUpdateCertificate_Call {
+	return &AggSenderStorage_SaveOrUpdateCertificate_Call{Call: _e.mock.On("SaveOrUpdateCertificate", ctx, certificate)}
+}
+
+func (_c *AggSenderStorage_SaveOrUpdateCertificate_Call) Run(run func(ctx context.Context, certificate types.Certificate)) *AggSenderStorage_SaveOrUpdateCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.Certificate))
+	})
+	return _c
+}
+
+func (_c *AggSenderStorage_SaveOrUpdateCertificate_Call) Return(_a0 error) *AggSenderStorage_SaveOrUpdateCertificate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *AggSenderStorage_SaveOrUpdateCertificate_Call) RunAndReturn(run func(context.Context, types.Certificate) error) *AggSenderStorage_SaveOrUpdateCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateCertificateStatus provides a mock function with given fields: ctx, certificateID, newStatus, updatedAt
 func (_m *AggSenderStorage) UpdateCertificateStatus(ctx context.Context, certificateID common.Hash, newStatus agglayertypes.CertificateStatus, updatedAt uint32) error {
 	ret := _m.Called(ctx, certificateID, newStatus, updatedAt)

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -208,6 +208,12 @@ func (c *certStatusChecker) executeInitialStatusAction(ctx context.Context,
 		if _, err := c.updateLocalStorageWithAggLayerCert(ctx, action.cert); err != nil {
 			return fmt.Errorf("recovery: error new local storage with agglayer certificate: %w", err)
 		}
+
+		if action.settledCert != nil && action.settledCert.CertificateID != action.cert.CertificateID {
+			if _, err := c.updateLocalStorageWithAggLayerCert(ctx, action.settledCert); err != nil {
+				return fmt.Errorf("recovery: error inserting settled cert to local storage: %w", err)
+			}
+		}
 	default:
 		return fmt.Errorf("recovery: unknown action: %s", action.action)
 	}

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -193,7 +193,7 @@ func (c *certStatusChecker) checkLastCertificateFromAgglayer(ctx context.Context
 	}
 
 	for _, action := range actions {
-		if err := c.executeInitialStatusAction(ctx, action, initialStatus.LocalCert); err != nil {
+		if err := c.executeInitialStatusAction(ctx, action, initialStatus.LocalLastCert); err != nil {
 			return fmt.Errorf("recovery: error executing initial status action: %w", err)
 		}
 	}

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -187,11 +187,20 @@ func (c *certStatusChecker) checkLastCertificateFromAgglayer(ctx context.Context
 		return fmt.Errorf("recovery: error retrieving initial status: %w", err)
 	}
 	initialStatus.logData()
-	action, err := initialStatus.process()
+	actions, err := initialStatus.process()
 	if err != nil {
 		return fmt.Errorf("recovery: error processing initial status: %w", err)
 	}
-	return c.executeInitialStatusAction(ctx, action, initialStatus.LocalCert)
+
+	for _, action := range actions {
+		if err := c.executeInitialStatusAction(ctx, action, initialStatus.LocalCert); err != nil {
+			return fmt.Errorf("recovery: error executing initial status action: %w", err)
+		}
+	}
+
+	c.log.Info("recovery: initial status actions executed successfully")
+
+	return nil
 }
 
 func (c *certStatusChecker) executeInitialStatusAction(ctx context.Context,
@@ -207,12 +216,6 @@ func (c *certStatusChecker) executeInitialStatusAction(ctx context.Context,
 	case InitialStatusActionInsertNewCert:
 		if _, err := c.updateLocalStorageWithAggLayerCert(ctx, action.cert); err != nil {
 			return fmt.Errorf("recovery: error new local storage with agglayer certificate: %w", err)
-		}
-
-		if action.settledCert != nil && action.settledCert.CertificateID != action.cert.CertificateID {
-			if _, err := c.updateLocalStorageWithAggLayerCert(ctx, action.settledCert); err != nil {
-				return fmt.Errorf("recovery: error inserting settled cert to local storage: %w", err)
-			}
 		}
 	default:
 		return fmt.Errorf("recovery: unknown action: %s", action.action)
@@ -232,7 +235,7 @@ func (c *certStatusChecker) updateLocalStorageWithAggLayerCert(ctx context.Conte
 	}
 
 	c.log.Infof("setting initial certificate from AggLayer: %s", cert.String())
-	return cert, c.storage.SaveLastSentCertificate(ctx, *cert)
+	return cert, c.storage.SaveOrUpdateCertificate(ctx, *cert)
 }
 
 func newCertificateInfoFromAgglayerCertHeader(c *agglayertypes.CertificateHeader) (*types.Certificate, error) {

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -208,7 +208,7 @@ func (c *certStatusChecker) executeInitialStatusAction(ctx context.Context,
 	c.log.Infof("recovery: action: %s", action.String())
 	switch action.action {
 	case InitialStatusActionNone:
-		c.log.Info("recovery: No certificates in local storage and agglayer: initial state")
+		c.log.Info("recovery: no action needed")
 	case InitialStatusActionUpdateCurrentCert:
 		if err := c.updateCertificateStatus(ctx, localCert, action.cert); err != nil {
 			return fmt.Errorf("recovery: error updating local storage with agglayer certificate: %w", err)

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -456,9 +456,9 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			}
 
 			mockInitialStatus := &initialStatus{
-				log:         mockLogger,
-				LocalCert:   tt.localCert,
-				SettledCert: tt.agglayerCert,
+				log:                     mockLogger,
+				LocalLastCert:           tt.localCert,
+				AgglayerLastSettledCert: tt.agglayerCert,
 			}
 
 			newInitialStatusFn = func(_ context.Context,

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -2,7 +2,6 @@ package statuschecker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -269,7 +268,7 @@ func TestUpdateLocalStorageWithAggLayerCert(t *testing.T) {
 			mockLogger := log.WithFields("test", "unittest")
 
 			if tt.inputCert != nil {
-				mockStorage.EXPECT().SaveLastSentCertificate(mock.Anything, mock.MatchedBy(func(cert types.Certificate) bool {
+				mockStorage.EXPECT().SaveOrUpdateCertificate(mock.Anything, mock.MatchedBy(func(cert types.Certificate) bool {
 					return cert.Header.CertificateID == tt.expectedResult.Header.CertificateID
 				})).Return(tt.saveError)
 			}
@@ -348,37 +347,7 @@ func TestExecuteInitialStatusAction(t *testing.T) {
 				cert:   &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
 			},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().SaveLastSentCertificate(ctx, mock.Anything).Return(nil)
-			},
-		},
-		{
-			name: "Action InsertNewCert with settled cert as well - success",
-			action: &initialStatusResult{
-				action:      InitialStatusActionInsertNewCert,
-				cert:        &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
-				settledCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")},
-			},
-			mockFn: func(m *mocks.AggSenderStorage) {
-				cert, err := newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")})
-				require.NoError(t, err)
-				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
-
-				cert, err = newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")})
-				require.NoError(t, err)
-				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
-			},
-		},
-		{
-			name: "Action InsertNewCert - settled cert equal to cert",
-			action: &initialStatusResult{
-				action:      InitialStatusActionInsertNewCert,
-				cert:        &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
-				settledCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
-			},
-			mockFn: func(m *mocks.AggSenderStorage) {
-				cert, err := newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")})
-				require.NoError(t, err)
-				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
+				m.EXPECT().SaveOrUpdateCertificate(ctx, mock.Anything).Return(nil)
 			},
 		},
 		{
@@ -388,27 +357,9 @@ func TestExecuteInitialStatusAction(t *testing.T) {
 				cert:   &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
 			},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().SaveLastSentCertificate(ctx, mock.Anything).Return(fmt.Errorf("insert error"))
+				m.EXPECT().SaveOrUpdateCertificate(ctx, mock.Anything).Return(fmt.Errorf("insert error"))
 			},
 			expectedError: "recovery: error new local storage with agglayer certificate",
-		},
-		{
-			name: "Action InsertNewCert with settled cert as well - error",
-			action: &initialStatusResult{
-				action:      InitialStatusActionInsertNewCert,
-				cert:        &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
-				settledCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")},
-			},
-			mockFn: func(m *mocks.AggSenderStorage) {
-				cert, err := newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")})
-				require.NoError(t, err)
-				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
-
-				cert, err = newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")})
-				require.NoError(t, err)
-				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(errors.New("some error")).Once()
-			},
-			expectedError: "recovery: error inserting settled cert to local storage: some error",
 		},
 		{
 			name: "Unknown Action",

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -2,6 +2,7 @@ package statuschecker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -351,6 +352,36 @@ func TestExecuteInitialStatusAction(t *testing.T) {
 			},
 		},
 		{
+			name: "Action InsertNewCert with settled cert as well - success",
+			action: &initialStatusResult{
+				action:      InitialStatusActionInsertNewCert,
+				cert:        &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
+				settledCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")},
+			},
+			mockFn: func(m *mocks.AggSenderStorage) {
+				cert, err := newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")})
+				require.NoError(t, err)
+				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
+
+				cert, err = newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")})
+				require.NoError(t, err)
+				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
+			},
+		},
+		{
+			name: "Action InsertNewCert - settled cert equal to cert",
+			action: &initialStatusResult{
+				action:      InitialStatusActionInsertNewCert,
+				cert:        &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
+				settledCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
+			},
+			mockFn: func(m *mocks.AggSenderStorage) {
+				cert, err := newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")})
+				require.NoError(t, err)
+				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
+			},
+		},
+		{
 			name: "Action InsertNewCert - error",
 			action: &initialStatusResult{
 				action: InitialStatusActionInsertNewCert,
@@ -360,6 +391,24 @@ func TestExecuteInitialStatusAction(t *testing.T) {
 				m.EXPECT().SaveLastSentCertificate(ctx, mock.Anything).Return(fmt.Errorf("insert error"))
 			},
 			expectedError: "recovery: error new local storage with agglayer certificate",
+		},
+		{
+			name: "Action InsertNewCert with settled cert as well - error",
+			action: &initialStatusResult{
+				action:      InitialStatusActionInsertNewCert,
+				cert:        &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")},
+				settledCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")},
+			},
+			mockFn: func(m *mocks.AggSenderStorage) {
+				cert, err := newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x2")})
+				require.NoError(t, err)
+				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(nil).Once()
+
+				cert, err = newCertificateInfoFromAgglayerCertHeader(&agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x3")})
+				require.NoError(t, err)
+				m.EXPECT().SaveLastSentCertificate(ctx, *cert).Return(errors.New("some error")).Once()
+			},
+			expectedError: "recovery: error inserting settled cert to local storage: some error",
 		},
 		{
 			name: "Unknown Action",

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -427,7 +427,7 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			localCert:    &types.CertificateHeader{CertificateID: common.HexToHash("0x1")},
 			agglayerCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x1"), Status: agglayertypes.Settled},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.Settled, mock.Anything).Return(nil)
+				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.Settled, mock.Anything).Return(nil).Once()
 			},
 		},
 		{
@@ -439,7 +439,7 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			localCert:    &types.CertificateHeader{CertificateID: common.HexToHash("0x1")},
 			agglayerCert: &agglayertypes.CertificateHeader{CertificateID: common.HexToHash("0x1"), Status: agglayertypes.InError},
 			mockFn: func(m *mocks.AggSenderStorage) {
-				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.InError, mock.Anything).Return(fmt.Errorf("update error"))
+				m.EXPECT().UpdateCertificateStatus(ctx, common.HexToHash("0x1"), agglayertypes.InError, mock.Anything).Return(fmt.Errorf("update error")).Once()
 			},
 			expectedError: "recovery: error updating local storage with agglayer certificate",
 		},

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -37,9 +37,10 @@ func (i initialStatusAction) String() string {
 }
 
 type initialStatusResult struct {
-	action  initialStatusAction
-	message string
-	cert    *agglayertypes.CertificateHeader
+	action      initialStatusAction
+	message     string
+	cert        *agglayertypes.CertificateHeader
+	settledCert *agglayertypes.CertificateHeader
 }
 
 func (i *initialStatusResult) String() string {
@@ -133,8 +134,10 @@ func (i *initialStatus) process() (*initialStatusResult, error) {
 	// CASE 2: No certificates in local storage but agglayer has one
 	if localLastCert == nil && aggLayerLastCert != nil {
 		return &initialStatusResult{action: InitialStatusActionInsertNewCert,
-			message: "no certificates in local storage but agglayer have one (no InError)",
-			cert:    aggLayerLastCert}, nil
+			message:     "no certificates in local storage but agglayer have one (no InError)",
+			cert:        aggLayerLastCert,
+			settledCert: i.SettledCert,
+		}, nil
 	}
 	// CASE 2.1: certificate in storage but not in agglayer
 	// this is a non-sense, so throw an error

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -37,10 +37,20 @@ func (i initialStatusAction) String() string {
 }
 
 type initialStatusResult struct {
-	action      initialStatusAction
-	message     string
-	cert        *agglayertypes.CertificateHeader
-	settledCert *agglayertypes.CertificateHeader
+	action  initialStatusAction
+	message string
+	cert    *agglayertypes.CertificateHeader
+}
+
+func newInitialStatusResult(
+	action initialStatusAction,
+	message string,
+	cert *agglayertypes.CertificateHeader) *initialStatusResult {
+	return &initialStatusResult{
+		action:  action,
+		message: message,
+		cert:    cert,
+	}
 }
 
 func (i *initialStatusResult) String() string {
@@ -96,7 +106,7 @@ func (i *initialStatus) logData() {
 }
 
 // process checks the last certificates from agglayer vs local certificates and returns the action to take
-func (i *initialStatus) process() (*initialStatusResult, error) {
+func (i *initialStatus) process() ([]*initialStatusResult, error) {
 	// Check that agglayer data is consistent.
 	i.logData()
 	if err := i.checkAgglayerConsistenceCerts(); err != nil {
@@ -104,9 +114,13 @@ func (i *initialStatus) process() (*initialStatusResult, error) {
 	}
 	if i.LocalCert == nil && i.SettledCert == nil && i.PendingCert != nil {
 		if i.PendingCert.Height == 0 {
-			return &initialStatusResult{action: InitialStatusActionInsertNewCert,
-				message: "no settled cert yet, and the pending cert have the correct height (0) so we use it",
-				cert:    i.PendingCert}, nil
+			return []*initialStatusResult{
+				newInitialStatusResult(
+					InitialStatusActionInsertNewCert,
+					"no settled cert yet, and the pending cert have the correct height (0) so we use it",
+					i.PendingCert,
+				),
+			}, nil
 		}
 
 		// We don't known if pendingCert is going to be Settled or InError.
@@ -116,9 +130,13 @@ func (i *initialStatus) process() (*initialStatusResult, error) {
 				i.PendingCert.ID(), i.PendingCert.StatusString())
 		}
 		if i.PendingCert.Status.IsInError() && i.PendingCert.Height > 0 {
-			return &initialStatusResult{action: InitialStatusActionNone,
-				message: "the pending cert have wrong height and it's InError. We ignore it",
-				cert:    nil}, nil
+			return []*initialStatusResult{
+				newInitialStatusResult(
+					InitialStatusActionNone,
+					"the pending cert have wrong height and it's InError. We ignore it",
+					nil,
+				),
+			}, nil
 		}
 	}
 	aggLayerLastCert := i.getLatestAggLayerCert()
@@ -127,17 +145,25 @@ func (i *initialStatus) process() (*initialStatusResult, error) {
 
 	// CASE 1: No certificates in local storage and agglayer
 	if localLastCert == nil && aggLayerLastCert == nil {
-		return &initialStatusResult{action: InitialStatusActionNone,
-			message: "no certificates in local storage and agglayer: initial state",
-			cert:    nil}, nil
+		return []*initialStatusResult{
+			newInitialStatusResult(
+				InitialStatusActionNone,
+				"no certificates in local storage and agglayer: initial state",
+				nil,
+			),
+		}, nil
 	}
 	// CASE 2: No certificates in local storage but agglayer has one
 	if localLastCert == nil && aggLayerLastCert != nil {
-		return &initialStatusResult{action: InitialStatusActionInsertNewCert,
-			message:     "no certificates in local storage but agglayer have one (no InError)",
-			cert:        aggLayerLastCert,
-			settledCert: i.SettledCert,
-		}, nil
+		results := []*initialStatusResult{
+			newInitialStatusResult(
+				InitialStatusActionInsertNewCert,
+				"no certificates in local storage but agglayer have one (no InError)",
+				aggLayerLastCert,
+			),
+		}
+
+		return i.addLastSettledCertInsertToResults(results), nil
 	}
 	// CASE 2.1: certificate in storage but not in agglayer
 	// this is a non-sense, so throw an error
@@ -152,10 +178,14 @@ func (i *initialStatus) process() (*initialStatusResult, error) {
 	// CASE 3.2: aggsender stopped between sending to agglayer and storing to the local storage
 	if aggLayerLastCert.Height == localLastCert.Height+1 {
 		// we need to store the certificate in the local storage.
-		return &initialStatusResult{action: InitialStatusActionInsertNewCert,
-			message: fmt.Sprintf("agglayer have next cert, storing cert: %s",
-				aggLayerLastCert.ID()),
-			cert: aggLayerLastCert}, nil
+		return []*initialStatusResult{
+			newInitialStatusResult(
+				InitialStatusActionInsertNewCert,
+				fmt.Sprintf("agglayer have next cert, storing cert: %s",
+					aggLayerLastCert.ID()),
+				aggLayerLastCert,
+			),
+		}, nil
 	}
 	// CASE 4: AggSender and AggLayer are not on the same page
 	// note: we don't need to check individual fields of the certificate
@@ -166,10 +196,16 @@ func (i *initialStatus) process() (*initialStatusResult, error) {
 	}
 	// CASE 5: AggSender and AggLayer are at same page
 	// just update status
-	return &initialStatusResult{action: InitialStatusActionUpdateCurrentCert,
-		message: fmt.Sprintf("aggsender same cert, updating state: %s",
-			aggLayerLastCert.ID()),
-		cert: aggLayerLastCert}, nil
+	results := []*initialStatusResult{
+		newInitialStatusResult(
+			InitialStatusActionUpdateCurrentCert,
+			fmt.Sprintf("aggsender same cert, updating state: %s",
+				aggLayerLastCert.ID()),
+			aggLayerLastCert,
+		),
+	}
+
+	return i.addLastSettledCertInsertToResults(results), nil
 }
 
 func (i *initialStatus) checkAgglayerConsistenceCerts() error {
@@ -209,4 +245,20 @@ func (i *initialStatus) getLatestAggLayerCert() *agglayertypes.CertificateHeader
 		return i.SettledCert
 	}
 	return i.PendingCert
+}
+
+func (i *initialStatus) addLastSettledCertInsertToResults(results []*initialStatusResult) []*initialStatusResult {
+	if i.SettledCert == nil || i.PendingCert == nil {
+		return results
+	}
+
+	if i.SettledCert.CertificateID != i.PendingCert.CertificateID {
+		results = append(results, newInitialStatusResult(
+			InitialStatusActionInsertNewCert,
+			"inserting/updating last settled cert in storage",
+			i.SettledCert,
+		))
+	}
+
+	return results
 }

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -12,17 +12,20 @@ import (
 	"github.com/agglayer/aggkit/common"
 )
 
-var newInitialStatusFn = newInitialStatus
-
 const (
-	initialStatusResultsCapacity = 2
-
 	InitialStatusActionNone initialStatusAction = iota
 	InitialStatusActionUpdateCurrentCert
 	InitialStatusActionInsertNewCert
 )
 
-var ErrAgglayerInconsistence = errors.New("recovery: agglayer inconsistence")
+var (
+	newInitialStatusFn = newInitialStatus
+
+	resultTypes                  = []agglayertypes.CertificateStatus{agglayertypes.Pending, agglayertypes.Settled}
+	initialStatusResultsCapacity = len(resultTypes)
+
+	ErrAgglayerInconsistence = errors.New("recovery: agglayer inconsistence")
+)
 
 type initialStatus struct {
 	SettledCert      *agglayertypes.CertificateHeader

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -15,6 +15,8 @@ import (
 var newInitialStatusFn = newInitialStatus
 
 const (
+	initialStatusResultsCapacity = 2
+
 	InitialStatusActionNone initialStatusAction = iota
 	InitialStatusActionUpdateCurrentCert
 	InitialStatusActionInsertNewCert
@@ -23,10 +25,11 @@ const (
 var ErrAgglayerInconsistence = errors.New("recovery: agglayer inconsistence")
 
 type initialStatus struct {
-	SettledCert *agglayertypes.CertificateHeader
-	PendingCert *agglayertypes.CertificateHeader
-	LocalCert   *types.CertificateHeader
-	log         common.Logger
+	SettledCert      *agglayertypes.CertificateHeader
+	PendingCert      *agglayertypes.CertificateHeader
+	LocalCert        *types.CertificateHeader
+	LocalSettledCert *types.CertificateHeader
+	log              common.Logger
 }
 
 type initialStatusAction int
@@ -88,11 +91,18 @@ func newInitialStatus(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("recovery: error getting last sent certificate from local storage: %w", err)
 	}
+
+	localSettledCert, err := storage.GetLastSettledCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("recovery: error getting last settled certificate from local storage: %w", err)
+	}
+
 	return &initialStatus{
-		SettledCert: aggLayerLastSettledCert, // from Agglayer
-		PendingCert: aggLayerLastPendingCert, // from Agglayer
-		LocalCert:   localLastCert,
-		log:         log,
+		SettledCert:      aggLayerLastSettledCert, // from Agglayer
+		PendingCert:      aggLayerLastPendingCert, // from Agglayer
+		LocalSettledCert: localSettledCert,        // from local storage
+		LocalCert:        localLastCert,           // from local storage
+		log:              log,
 	}, nil
 }
 
@@ -105,22 +115,50 @@ func (i *initialStatus) logData() {
 		i.LocalCert.ID(), i.LocalCert.StatusString())
 }
 
-// process checks the last certificates from agglayer vs local certificates and returns the action to take
+// process processes the initial status and returns the actions to take
+// It checks the consistency of the agglayer data, processes the pending certificate,
+// and processes the settled certificate. It returns a slice of initialStatusResult
+// which contains the action to take, a message, and the certificate if applicable.
 func (i *initialStatus) process() ([]*initialStatusResult, error) {
-	// Check that agglayer data is consistent.
 	i.logData()
+
+	// Check that agglayer data is consistent.
 	if err := i.checkAgglayerConsistenceCerts(); err != nil {
 		return nil, err
 	}
+
+	results := make([]*initialStatusResult, 0, initialStatusResultsCapacity)
+
+	pendingCertAction, err := i.processLastLocalCert()
+	if err != nil {
+		return nil, fmt.Errorf("recovery: failed processing pending certificate: %w", err)
+	}
+
+	if pendingCertAction != nil {
+		results = append(results, pendingCertAction)
+	}
+
+	settledCertAction, err := i.processSettledCert()
+	if err != nil {
+		return nil, fmt.Errorf("recovery: failed processing settled certificate: %w", err)
+	}
+
+	if settledCertAction != nil {
+		results = append(results, settledCertAction)
+	}
+
+	return results, nil
+}
+
+// processLastLocalCert checks the last certificates from agglayer vs local certificates and returns the action to take
+func (i *initialStatus) processLastLocalCert() (*initialStatusResult, error) {
 	if i.LocalCert == nil && i.SettledCert == nil && i.PendingCert != nil {
 		if i.PendingCert.Height == 0 {
-			return []*initialStatusResult{
-				newInitialStatusResult(
-					InitialStatusActionInsertNewCert,
-					"no settled cert yet, and the pending cert have the correct height (0) so we use it",
-					i.PendingCert,
-				),
-			}, nil
+			return newInitialStatusResult(
+				InitialStatusActionInsertNewCert,
+				"no settled cert yet, and the pending cert have the correct height (0) so we use it",
+				i.PendingCert,
+			), nil
 		}
 
 		// We don't known if pendingCert is going to be Settled or InError.
@@ -130,13 +168,11 @@ func (i *initialStatus) process() ([]*initialStatusResult, error) {
 				i.PendingCert.ID(), i.PendingCert.StatusString())
 		}
 		if i.PendingCert.Status.IsInError() && i.PendingCert.Height > 0 {
-			return []*initialStatusResult{
-				newInitialStatusResult(
-					InitialStatusActionNone,
-					"the pending cert have wrong height and it's InError. We ignore it",
-					nil,
-				),
-			}, nil
+			return newInitialStatusResult(
+				InitialStatusActionNone,
+				"the pending cert have wrong height and it's InError. We ignore it",
+				nil,
+			), nil
 		}
 	}
 	aggLayerLastCert := i.getLatestAggLayerCert()
@@ -145,26 +181,21 @@ func (i *initialStatus) process() ([]*initialStatusResult, error) {
 
 	// CASE 1: No certificates in local storage and agglayer
 	if localLastCert == nil && aggLayerLastCert == nil {
-		return []*initialStatusResult{
-			newInitialStatusResult(
-				InitialStatusActionNone,
-				"no certificates in local storage and agglayer: initial state",
-				nil,
-			),
-		}, nil
+		return newInitialStatusResult(
+			InitialStatusActionNone,
+			"no certificates in local storage and agglayer: initial state",
+			nil,
+		), nil
 	}
 	// CASE 2: No certificates in local storage but agglayer has one
 	if localLastCert == nil && aggLayerLastCert != nil {
-		results := []*initialStatusResult{
-			newInitialStatusResult(
-				InitialStatusActionInsertNewCert,
-				"no certificates in local storage but agglayer have one (no InError)",
-				aggLayerLastCert,
-			),
-		}
-
-		return i.addLastSettledCertInsertToResults(results), nil
+		return newInitialStatusResult(
+			InitialStatusActionInsertNewCert,
+			"no certificates in local storage but agglayer have one (no InError)",
+			aggLayerLastCert,
+		), nil
 	}
+
 	// CASE 2.1: certificate in storage but not in agglayer
 	// this is a non-sense, so throw an error
 	if localLastCert != nil && aggLayerLastCert == nil {
@@ -178,14 +209,12 @@ func (i *initialStatus) process() ([]*initialStatusResult, error) {
 	// CASE 3.2: aggsender stopped between sending to agglayer and storing to the local storage
 	if aggLayerLastCert.Height == localLastCert.Height+1 {
 		// we need to store the certificate in the local storage.
-		return []*initialStatusResult{
-			newInitialStatusResult(
-				InitialStatusActionInsertNewCert,
-				fmt.Sprintf("agglayer have next cert, storing cert: %s",
-					aggLayerLastCert.ID()),
-				aggLayerLastCert,
-			),
-		}, nil
+		return newInitialStatusResult(
+			InitialStatusActionInsertNewCert,
+			fmt.Sprintf("agglayer have next cert, storing cert: %s",
+				aggLayerLastCert.ID()),
+			aggLayerLastCert,
+		), nil
 	}
 	// CASE 4: AggSender and AggLayer are not on the same page
 	// note: we don't need to check individual fields of the certificate
@@ -196,16 +225,12 @@ func (i *initialStatus) process() ([]*initialStatusResult, error) {
 	}
 	// CASE 5: AggSender and AggLayer are at same page
 	// just update status
-	results := []*initialStatusResult{
-		newInitialStatusResult(
-			InitialStatusActionUpdateCurrentCert,
-			fmt.Sprintf("aggsender same cert, updating state: %s",
-				aggLayerLastCert.ID()),
-			aggLayerLastCert,
-		),
-	}
-
-	return i.addLastSettledCertInsertToResults(results), nil
+	return newInitialStatusResult(
+		InitialStatusActionUpdateCurrentCert,
+		fmt.Sprintf("aggsender same cert, updating state: %s",
+			aggLayerLastCert.ID()),
+		aggLayerLastCert,
+	), nil
 }
 
 func (i *initialStatus) checkAgglayerConsistenceCerts() error {
@@ -230,7 +255,8 @@ func (i *initialStatus) checkAgglayerConsistenceCerts() error {
 			i.SettledCert.ID(), i.PendingCert.ID(),
 			ErrAgglayerInconsistence)
 	}
-	//
+
+	// Settled certificate has higher height than pending certificate and it is not InError. This should not happen
 	if i.SettledCert.Height > i.PendingCert.Height && !i.SettledCert.Status.IsInError() {
 		return fmt.Errorf("settled cert height %s is higher than pending cert height %s that is inNoError. Err: %w",
 			i.SettledCert.ID(), i.PendingCert.ID(),
@@ -247,18 +273,74 @@ func (i *initialStatus) getLatestAggLayerCert() *agglayertypes.CertificateHeader
 	return i.PendingCert
 }
 
-func (i *initialStatus) addLastSettledCertInsertToResults(results []*initialStatusResult) []*initialStatusResult {
-	if i.SettledCert == nil || i.PendingCert == nil {
-		return results
+// processSettledCert checks the last settled certificate from agglayer vs local storage
+func (i *initialStatus) processSettledCert() (*initialStatusResult, error) {
+	if i.PendingCert == nil {
+		// if pending cert is nil, this will be processed in the processLastLocal function
+		return nil, nil
 	}
 
-	if i.SettledCert.CertificateID != i.PendingCert.CertificateID {
-		results = append(results, newInitialStatusResult(
-			InitialStatusActionInsertNewCert,
-			"inserting/updating last settled cert in storage",
+	if i.SettledCert == nil {
+		// CASE 1: Local storage have settled certificate, but agglayer doesn't have one
+		// This is an invalid situation
+		if i.LocalSettledCert != nil {
+			return nil, fmt.Errorf("recovery: local settled certificate exists (%s)"+
+				"but agglayer has no settled certificate", i.LocalSettledCert.ID())
+		}
+
+		// CASE 2: Both local and agglayer have no settled certificate
+		return newInitialStatusResult(
+			InitialStatusActionNone,
+			"agglayer and local storage have no settled certificate",
 			i.SettledCert,
-		))
+		), nil
 	}
 
-	return results
+	if i.LocalSettledCert == nil {
+		// CASE 3: We have no settled certificate in local storage
+		return newInitialStatusResult(
+			InitialStatusActionInsertNewCert,
+			"no local settled certificate,inserting agglayer settled certificate into local storage",
+			i.SettledCert,
+		), nil
+	}
+
+	// CASE 4: We have a settled certificate in local storage
+	// but its height is higher than the one in the agglayer
+	if i.LocalSettledCert.Height > i.SettledCert.Height {
+		return nil, fmt.Errorf("recovery: local settled certificate (%s) has higher height (%d) "+
+			"than agglayer settled certificate (%s) with height (%d)",
+			i.LocalSettledCert.ID(), i.LocalSettledCert.Height,
+			i.SettledCert.ID(), i.SettledCert.Height)
+	}
+
+	// CASE 5: We have a settled certificate in local storage with same height
+	if i.LocalSettledCert.Height == i.SettledCert.Height {
+		// CASE 5.1: We have a settled certificate in local storage
+		// the height is the same but the certificate ID is different
+		// this is a problem, because it means that the local storage has a different certificate
+		// than the one in the agglayer for the same height
+		if i.LocalSettledCert.CertificateID != i.SettledCert.CertificateID {
+			return nil, fmt.Errorf("recovery: local settled certificate (%s) has same height (%d) "+
+				"but different certificate ID (%s) than agglayer settled certificate (%s)",
+				i.LocalSettledCert.ID(), i.LocalSettledCert.Height,
+				i.LocalSettledCert.CertificateID,
+				i.SettledCert.ID())
+		}
+
+		// CASE 5.2: the local settled certificate matches the agglayer settled certificate
+		return newInitialStatusResult(
+			InitialStatusActionNone,
+			"last settled certificate already in local storage with same height and ID",
+			i.SettledCert,
+		), nil
+	}
+
+	// CASE 5: We have a settled certificate in local storage that is lower than the one in the agglayer
+	// this means that we need to update the local storage with the agglayer settled
+	return newInitialStatusResult(
+		InitialStatusActionInsertNewCert,
+		"updating local storage with agglayer settled certificate",
+		i.SettledCert,
+	), nil
 }

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/db"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/common"
+	aggkitdb "github.com/agglayer/aggkit/db"
 )
 
 const (
@@ -96,7 +97,7 @@ func newInitialStatus(ctx context.Context,
 	}
 
 	localSettledCert, err := storage.GetLastSettledCertificate()
-	if err != nil {
+	if err != nil && !errors.Is(err, aggkitdb.ErrNotFound) {
 		return nil, fmt.Errorf("recovery: error getting last settled certificate from local storage: %w", err)
 	}
 

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -142,7 +142,7 @@ func (i *initialStatus) process() ([]*initialStatusResult, error) {
 		results = append(results, pendingCertAction)
 	}
 
-	settledCertAction, err := i.processSettledCert()
+	settledCertAction, err := i.processLastSettledCert()
 	if err != nil {
 		return nil, fmt.Errorf("recovery: failed processing settled certificate: %w", err)
 	}
@@ -278,8 +278,8 @@ func (i *initialStatus) getLatestAggLayerCert() *agglayertypes.CertificateHeader
 	return i.AgglayerLastPendingCert
 }
 
-// processSettledCert checks the last settled certificate from agglayer vs local storage
-func (i *initialStatus) processSettledCert() (*initialStatusResult, error) {
+// processLastSettledCert checks the last settled certificate from agglayer vs local storage
+func (i *initialStatus) processLastSettledCert() (*initialStatusResult, error) {
 	if i.AgglayerLastPendingCert == nil {
 		// if pending cert is nil, this will be processed in the processLastLocal function
 		return nil, nil
@@ -341,7 +341,7 @@ func (i *initialStatus) processSettledCert() (*initialStatusResult, error) {
 		), nil
 	}
 
-	// CASE 5: We have a settled certificate in local storage that is lower than the one in the agglayer
+	// CASE 6: We have a settled certificate in local storage that is lower than the one in the agglayer
 	// this means that we need to update the local storage with the agglayer settled
 	return newInitialStatusResult(
 		InitialStatusActionInsertNewCert,

--- a/aggsender/statuschecker/initial_state.go
+++ b/aggsender/statuschecker/initial_state.go
@@ -29,11 +29,11 @@ var (
 )
 
 type initialStatus struct {
-	SettledCert      *agglayertypes.CertificateHeader
-	PendingCert      *agglayertypes.CertificateHeader
-	LocalCert        *types.CertificateHeader
-	LocalSettledCert *types.CertificateHeader
-	log              common.Logger
+	AgglayerLastSettledCert *agglayertypes.CertificateHeader
+	AgglayerLastPendingCert *agglayertypes.CertificateHeader
+	LocalLastCert           *types.CertificateHeader
+	LocalLastSettledCert    *types.CertificateHeader
+	log                     common.Logger
 }
 
 type initialStatusAction int
@@ -102,21 +102,21 @@ func newInitialStatus(ctx context.Context,
 	}
 
 	return &initialStatus{
-		SettledCert:      aggLayerLastSettledCert, // from Agglayer
-		PendingCert:      aggLayerLastPendingCert, // from Agglayer
-		LocalSettledCert: localSettledCert,        // from local storage
-		LocalCert:        localLastCert,           // from local storage
-		log:              log,
+		AgglayerLastSettledCert: aggLayerLastSettledCert, // from Agglayer
+		AgglayerLastPendingCert: aggLayerLastPendingCert, // from Agglayer
+		LocalLastSettledCert:    localSettledCert,        // from local storage
+		LocalLastCert:           localLastCert,           // from local storage
+		log:                     log,
 	}, nil
 }
 
 // logData logs the data from the initialStatus object
 func (i *initialStatus) logData() {
-	i.log.Infof("recovery: settled certificate from AggLayer: %s", i.SettledCert.ID())
+	i.log.Infof("recovery: settled certificate from AggLayer: %s", i.AgglayerLastSettledCert.ID())
 	i.log.Infof("recovery: pending certificate from AggLayer: %s / status: %s",
-		i.PendingCert.ID(), i.PendingCert.StatusString())
+		i.AgglayerLastPendingCert.ID(), i.AgglayerLastPendingCert.StatusString())
 	i.log.Infof("recovery: certificate from Local           : %s / status: %s",
-		i.LocalCert.ID(), i.LocalCert.StatusString())
+		i.LocalLastCert.ID(), i.LocalLastCert.StatusString())
 }
 
 // process processes the initial status and returns the actions to take
@@ -156,22 +156,22 @@ func (i *initialStatus) process() ([]*initialStatusResult, error) {
 
 // processLastLocalCert checks the last certificates from agglayer vs local certificates and returns the action to take
 func (i *initialStatus) processLastLocalCert() (*initialStatusResult, error) {
-	if i.LocalCert == nil && i.SettledCert == nil && i.PendingCert != nil {
-		if i.PendingCert.Height == 0 {
+	if i.LocalLastCert == nil && i.AgglayerLastSettledCert == nil && i.AgglayerLastPendingCert != nil {
+		if i.AgglayerLastPendingCert.Height == 0 {
 			return newInitialStatusResult(
 				InitialStatusActionInsertNewCert,
 				"no settled cert yet, and the pending cert have the correct height (0) so we use it",
-				i.PendingCert,
+				i.AgglayerLastPendingCert,
 			), nil
 		}
 
 		// We don't known if pendingCert is going to be Settled or InError.
 		// We can't use it because maybe is error wrong height
-		if !i.PendingCert.Status.IsInError() && i.PendingCert.Height > 0 {
+		if !i.AgglayerLastPendingCert.Status.IsInError() && i.AgglayerLastPendingCert.Height > 0 {
 			return nil, fmt.Errorf("recovery: pendingCert %s is in state %s but have a suspicious height, so we wait to finish",
-				i.PendingCert.ID(), i.PendingCert.StatusString())
+				i.AgglayerLastPendingCert.ID(), i.AgglayerLastPendingCert.StatusString())
 		}
-		if i.PendingCert.Status.IsInError() && i.PendingCert.Height > 0 {
+		if i.AgglayerLastPendingCert.Status.IsInError() && i.AgglayerLastPendingCert.Height > 0 {
 			return newInitialStatusResult(
 				InitialStatusActionNone,
 				"the pending cert have wrong height and it's InError. We ignore it",
@@ -181,7 +181,7 @@ func (i *initialStatus) processLastLocalCert() (*initialStatusResult, error) {
 	}
 	aggLayerLastCert := i.getLatestAggLayerCert()
 	i.log.Infof("recovery: last certificate from AggLayer: %s", aggLayerLastCert.String())
-	localLastCert := i.LocalCert
+	localLastCert := i.LocalLastCert
 
 	// CASE 1: No certificates in local storage and agglayer
 	if localLastCert == nil && aggLayerLastCert == nil {
@@ -238,32 +238,33 @@ func (i *initialStatus) processLastLocalCert() (*initialStatusResult, error) {
 }
 
 func (i *initialStatus) checkAgglayerConsistenceCerts() error {
-	if i.PendingCert == nil {
+	if i.AgglayerLastPendingCert == nil {
 		return nil
 	}
 
-	if i.SettledCert == nil {
+	if i.AgglayerLastSettledCert == nil {
 		// If Height>0 and not inError, we have a problem. We should have a settled cert
-		if !i.PendingCert.Status.IsInError() && i.PendingCert.Height != 0 {
+		if !i.AgglayerLastPendingCert.Status.IsInError() && i.AgglayerLastPendingCert.Height != 0 {
 			return fmt.Errorf("consistence: no settled cert, and pending one is height %d and not in error. Err: %w",
-				i.PendingCert.Height, ErrAgglayerInconsistence)
+				i.AgglayerLastPendingCert.Height, ErrAgglayerInconsistence)
 		}
 		return nil
 	}
 
 	// Both settled and pending cert != nil, that is the potential inconsistency
 	// This is there is a settled cert for a height but also a pending cert for the same height
-	if i.PendingCert.Height == i.SettledCert.Height &&
-		!i.SettledCert.Status.IsInError() {
+	if i.AgglayerLastPendingCert.Height == i.AgglayerLastSettledCert.Height &&
+		!i.AgglayerLastSettledCert.Status.IsInError() {
 		return fmt.Errorf("consistence: settled (%s) and pending (%s) certs are different for same height. Err: %w",
-			i.SettledCert.ID(), i.PendingCert.ID(),
+			i.AgglayerLastSettledCert.ID(), i.AgglayerLastPendingCert.ID(),
 			ErrAgglayerInconsistence)
 	}
 
 	// Settled certificate has higher height than pending certificate and it is not InError. This should not happen
-	if i.SettledCert.Height > i.PendingCert.Height && !i.SettledCert.Status.IsInError() {
+	if i.AgglayerLastSettledCert.Height > i.AgglayerLastPendingCert.Height &&
+		!i.AgglayerLastSettledCert.Status.IsInError() {
 		return fmt.Errorf("settled cert height %s is higher than pending cert height %s that is inNoError. Err: %w",
-			i.SettledCert.ID(), i.PendingCert.ID(),
+			i.AgglayerLastSettledCert.ID(), i.AgglayerLastPendingCert.ID(),
 			ErrAgglayerInconsistence)
 	}
 
@@ -271,72 +272,72 @@ func (i *initialStatus) checkAgglayerConsistenceCerts() error {
 }
 
 func (i *initialStatus) getLatestAggLayerCert() *agglayertypes.CertificateHeader {
-	if i.PendingCert == nil {
-		return i.SettledCert
+	if i.AgglayerLastPendingCert == nil {
+		return i.AgglayerLastSettledCert
 	}
-	return i.PendingCert
+	return i.AgglayerLastPendingCert
 }
 
 // processSettledCert checks the last settled certificate from agglayer vs local storage
 func (i *initialStatus) processSettledCert() (*initialStatusResult, error) {
-	if i.PendingCert == nil {
+	if i.AgglayerLastPendingCert == nil {
 		// if pending cert is nil, this will be processed in the processLastLocal function
 		return nil, nil
 	}
 
-	if i.SettledCert == nil {
+	if i.AgglayerLastSettledCert == nil {
 		// CASE 1: Local storage have settled certificate, but agglayer doesn't have one
 		// This is an invalid situation
-		if i.LocalSettledCert != nil {
+		if i.LocalLastSettledCert != nil {
 			return nil, fmt.Errorf("recovery: local settled certificate exists (%s)"+
-				"but agglayer has no settled certificate", i.LocalSettledCert.ID())
+				"but agglayer has no settled certificate", i.LocalLastSettledCert.ID())
 		}
 
 		// CASE 2: Both local and agglayer have no settled certificate
 		return newInitialStatusResult(
 			InitialStatusActionNone,
 			"agglayer and local storage have no settled certificate",
-			i.SettledCert,
+			i.AgglayerLastSettledCert,
 		), nil
 	}
 
-	if i.LocalSettledCert == nil {
+	if i.LocalLastSettledCert == nil {
 		// CASE 3: We have no settled certificate in local storage
 		return newInitialStatusResult(
 			InitialStatusActionInsertNewCert,
 			"no local settled certificate,inserting agglayer settled certificate into local storage",
-			i.SettledCert,
+			i.AgglayerLastSettledCert,
 		), nil
 	}
 
 	// CASE 4: We have a settled certificate in local storage
 	// but its height is higher than the one in the agglayer
-	if i.LocalSettledCert.Height > i.SettledCert.Height {
+	if i.LocalLastSettledCert.Height > i.AgglayerLastSettledCert.Height {
 		return nil, fmt.Errorf("recovery: local settled certificate (%s) has higher height (%d) "+
 			"than agglayer settled certificate (%s) with height (%d)",
-			i.LocalSettledCert.ID(), i.LocalSettledCert.Height,
-			i.SettledCert.ID(), i.SettledCert.Height)
+			i.LocalLastSettledCert.ID(), i.LocalLastSettledCert.Height,
+			i.AgglayerLastSettledCert.ID(), i.AgglayerLastSettledCert.Height)
 	}
 
 	// CASE 5: We have a settled certificate in local storage with same height
-	if i.LocalSettledCert.Height == i.SettledCert.Height {
+	if i.LocalLastSettledCert.Height == i.AgglayerLastSettledCert.Height {
 		// CASE 5.1: We have a settled certificate in local storage
 		// the height is the same but the certificate ID is different
 		// this is a problem, because it means that the local storage has a different certificate
 		// than the one in the agglayer for the same height
-		if i.LocalSettledCert.CertificateID != i.SettledCert.CertificateID {
+		if i.LocalLastSettledCert.CertificateID != i.AgglayerLastSettledCert.CertificateID {
 			return nil, fmt.Errorf("recovery: local settled certificate (%s) has same height (%d) "+
 				"but different certificate ID (%s) than agglayer settled certificate (%s)",
-				i.LocalSettledCert.ID(), i.LocalSettledCert.Height,
-				i.LocalSettledCert.CertificateID,
-				i.SettledCert.ID())
+				i.LocalLastSettledCert.ID(), i.LocalLastSettledCert.Height,
+				i.LocalLastSettledCert.CertificateID,
+				i.AgglayerLastSettledCert.ID())
 		}
 
 		// CASE 5.2: the local settled certificate matches the agglayer settled certificate
 		return newInitialStatusResult(
 			InitialStatusActionNone,
 			"last settled certificate already in local storage with same height and ID",
-			i.SettledCert,
+			i.AgglayerLastSettledCert,
 		), nil
 	}
 
@@ -345,6 +346,6 @@ func (i *initialStatus) processSettledCert() (*initialStatusResult, error) {
 	return newInitialStatusResult(
 		InitialStatusActionInsertNewCert,
 		"updating local storage with agglayer settled certificate",
-		i.SettledCert,
+		i.AgglayerLastSettledCert,
 	), nil
 }

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -287,7 +287,7 @@ func TestRegularCases(t *testing.T) {
 			resultError:      true,
 		},
 		{
-			name:             "14| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h1   | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)",
+			name:             "14| LocalCert: ID3, h1, pending | LocalSettled: ID2, h1 | AgglayerSettled: ID2, h1 | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)",
 			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
 			localSettledCert: &certTestData{hash2, 2, agglayertypes.Settled},
 			agglayerSettled:  &certTestData{hash2, 2, agglayertypes.Settled},

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -18,9 +18,10 @@ type certTestData struct {
 }
 
 type initialStateResultTest struct {
-	action initialStatusAction
-	subMsg string
-	cert   *certTestData
+	action      initialStatusAction
+	subMsg      string
+	cert        *certTestData
+	settledCert *certTestData
 }
 
 type testCaseData struct {
@@ -155,28 +156,28 @@ func TestRegularCases(t *testing.T) {
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: nil,
-			resultActions:   &initialStateResultTest{InitialStatusActionNone, "", nil},
+			resultActions:   &initialStateResultTest{InitialStatusActionNone, "", nil, nil},
 		},
 		{
 			name:            "02| nil 				| nil 					| ID1, h0  , inError		|store(PENDING) h0 so is next cert",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 0, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.InError}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.InError}, nil},
 		},
 		{
 			name:            "03| nil 				| nil 					| ID1, h1  , inError   			|none",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 1, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionNone, "", nil},
+			resultActions:   &initialStateResultTest{InitialStatusActionNone, "", nil, nil},
 		},
 		{
 			name:            "04| nil 				| nil 					| ID1, h0  , !=inError  		| store(PENDING) h0 so is next cert",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 0, agglayertypes.Proven},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.Proven}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.Proven}, nil},
 		},
 		{
 			name:            "05| nil 				| nil 					| ID1, h1  , !=inError  		| wait, h1 is not next cert but we wait until pass to inError",
@@ -190,57 +191,56 @@ func TestRegularCases(t *testing.T) {
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerPending: nil,
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}, &certTestData{hash1, 1, agglayertypes.Proven}},
 		},
 		{
 			name:            "07| nil 				| ID1, h1 , NA	 		| ID2, h2  , inError  			| store(PENDING)",
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.InError}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.InError}, &certTestData{hash1, 1, agglayertypes.Proven}},
 		},
 		{
 			name:            "08| nil 				| ID1, h1 , NA	 		| ID2, h2  , !=inError  		| store(PENDING) h2 is next to h1",
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.Pending},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.Pending}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.Pending}, &certTestData{hash1, 1, agglayertypes.Settled}},
 		},
 		{
 			name:            "09|ID1, h1 , NA		    | nil 					| ID1, h1  , inError  			| update(PENDING)",
 			localCert:       &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 1, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 1, agglayertypes.InError}},
+			resultActions:   &initialStateResultTest{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 1, agglayertypes.InError}, nil},
 		},
-
 		{
 			name:            "10|ID2, h2 , NA			| ID1, h1 , N/A			| ID2, h2  , N/A		  		| update(PENDING)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash2, 2, agglayertypes.InError}},
+			resultActions:   &initialStateResultTest{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash2, 2, agglayertypes.InError}, nil},
 		},
 		{
 			name:            "11|ID2, h2 , NA		| ID1, h3 , N/A			| nil               			|  store(SETTLED)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 3, agglayertypes.Proven},
 			agglayerPending: nil,
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}, nil},
 		},
 		{
 			name:            "12|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , !=inError           |  store(PENDING)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash1, 3, agglayertypes.Proven},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}, nil},
 		},
 		{
 			name:            "13|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , inError             | store(PENDING)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash1, 3, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.InError}},
+			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.InError}, nil},
 		},
 	}
 	runTestCases(t, tests)
@@ -290,6 +290,13 @@ func runTestCases(t *testing.T, tests []testCaseData) {
 						require.Equal(t, tt.resultActions.cert.CertificateID, action.cert.CertificateID)
 						require.Equal(t, tt.resultActions.cert.Height, action.cert.Height)
 						require.Equal(t, tt.resultActions.cert.Status, action.cert.Status)
+					}
+
+					if tt.resultActions.settledCert != nil {
+						require.NotNil(t, action.settledCert)
+						require.Equal(t, tt.resultActions.settledCert.CertificateID, action.settledCert.CertificateID)
+						require.Equal(t, tt.resultActions.settledCert.Height, action.settledCert.Height)
+						require.Equal(t, tt.resultActions.settledCert.Status, action.settledCert.Status)
 					}
 				}
 			}

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -298,7 +298,7 @@ func TestRegularCases(t *testing.T) {
 			},
 		},
 		{
-			name:             "15| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h2   | AgglayerPending: ID3, h1 | settled cert ID missmatch",
+			name:             "15| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h2   | AgglayerPending: ID3, h1 | settled cert ID mismatch",
 			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
 			localSettledCert: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerSettled:  &certTestData{hash2, 2, agglayertypes.Settled},

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -24,12 +24,13 @@ type initialStateResultTest struct {
 }
 
 type testCaseData struct {
-	name            string
-	localCert       *certTestData
-	agglayerSettled *certTestData
-	agglayerPending *certTestData
-	resultError     bool
-	resultActions   []*initialStateResultTest
+	name             string
+	localCert        *certTestData
+	localSettledCert *certTestData
+	agglayerSettled  *certTestData
+	agglayerPending  *certTestData
+	resultError      bool
+	resultActions    []*initialStateResultTest
 }
 
 // ID|LOCAL			    | AGGLAYER SETTLED		| AGGLAYER PENDING			    | ACTION
@@ -145,9 +146,13 @@ func TestInitialStateInconsistence(t *testing.T) {
 //	 11|ID2, h2 , NA		| ID1, h3 , N/A			| nil               			|  store(SETTLED)
 //	 12|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , !=inError           |  store(PENDING)
 //	 13|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , inError             | store(PENDING)
+//	 14| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID1, h2   | AgglayerPending: ID3, h1 | agglayer doesn't have settled cert
+//	 15| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h1   | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)
+//	 16| LocalCert: ID3, h1, pending	| LocalSettled: ID1, h2	| AgglayerSettled: ID2, h3   | AgglayerPending: ID3, h1 | store(PENDING) & store(SETTLED)
 func TestRegularCases(t *testing.T) {
 	hash1 := common.HexToHash("0xdead")
 	hash2 := common.HexToHash("0xbeef")
+	hash3 := common.HexToHash("0xcafe")
 
 	tests := []testCaseData{
 		{
@@ -155,28 +160,39 @@ func TestRegularCases(t *testing.T) {
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: nil,
-			resultActions:   []*initialStateResultTest{{InitialStatusActionNone, "", nil}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionNone, "", nil}, // for pending cert
+			},
 		},
 		{
 			name:            "02| nil 				| nil 					| ID1, h0  , inError		|store(PENDING) h0 so is next cert",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 0, agglayertypes.InError},
-			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.InError}}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.InError}}, // for pending cert
+				{InitialStatusActionNone, "", nil}, // for settled cert
+			},
 		},
 		{
 			name:            "03| nil 				| nil 					| ID1, h1  , inError   			|none",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 1, agglayertypes.InError},
-			resultActions:   []*initialStateResultTest{{InitialStatusActionNone, "", nil}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionNone, "", nil}, // for pending cert
+				{InitialStatusActionNone, "", nil}, // for settled cert
+			},
 		},
 		{
 			name:            "04| nil 				| nil 					| ID1, h0  , !=inError  		| store(PENDING) h0 so is next cert",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 0, agglayertypes.Proven},
-			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.Proven}}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.Proven}}, // for pending cert
+				{InitialStatusActionNone, "", nil}, // for settled cert
+			},
 		},
 		{
 			name:            "05| nil 				| nil 					| ID1, h1  , !=inError  		| wait, h1 is not next cert but we wait until pass to inError",
@@ -190,10 +206,12 @@ func TestRegularCases(t *testing.T) {
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerPending: nil,
-			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}},
+			},
 		},
 		{
-			name:            "07| nil 				| ID1, h1 , NA	 		| ID2, h2  , inError  			| store(PENDING)",
+			name:            "07| nil 				| ID1, h1 , NA	 		| ID2, h2  , inError  			| store(PENDING)&store(SETTLED)",
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.InError},
@@ -203,7 +221,7 @@ func TestRegularCases(t *testing.T) {
 			},
 		},
 		{
-			name:            "08| nil 				| ID1, h1 , NA	 		| ID2, h2  , !=inError  		| store(PENDING) h2 is next to h1",
+			name:            "08| nil 				| ID1, h1 , NA	 		| ID2, h2  , !=inError  		| store(PENDING) h2 is next to h1 & store(SETTLED)",
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.Pending},
@@ -217,10 +235,13 @@ func TestRegularCases(t *testing.T) {
 			localCert:       &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 1, agglayertypes.InError},
-			resultActions:   []*initialStateResultTest{{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 1, agglayertypes.InError}}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 1, agglayertypes.InError}}, // for pending cert
+				{InitialStatusActionNone, "", nil}, // for settled cert
+			},
 		},
 		{
-			name:            "10|ID2, h2 , NA			| ID1, h1 , N/A			| ID2, h2  , N/A		  		| update(PENDING)",
+			name:            "10|ID2, h2 , NA			| ID1, h1 , N/A			| ID2, h2  , N/A		  		| update(PENDING)&store(SETTLED)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.InError},
@@ -237,18 +258,63 @@ func TestRegularCases(t *testing.T) {
 			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}}},
 		},
 		{
-			name:            "12|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , !=inError           |  store(PENDING)",
+			name:            "12|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , !=inError           |  store(PENDING)&store(SETTLED)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash1, 3, agglayertypes.Proven},
-			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}},
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 2, agglayertypes.Settled}},
+			},
 		},
 		{
-			name:            "13|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , inError             | store(PENDING)",
-			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
-			agglayerSettled: &certTestData{hash1, 2, agglayertypes.Settled},
-			agglayerPending: &certTestData{hash1, 3, agglayertypes.InError},
-			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.InError}}},
+			name:             "13|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , inError             | store(PENDING)&store(SETTLED)",
+			localCert:        &certTestData{hash2, 2, agglayertypes.Proven},
+			localSettledCert: nil,
+			agglayerSettled:  &certTestData{hash1, 2, agglayertypes.Settled},
+			agglayerPending:  &certTestData{hash1, 3, agglayertypes.InError},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.InError}},
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 2, agglayertypes.Settled}},
+			},
+		},
+		{
+			name:             "14| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID1, h2   | AgglayerPending: ID3, h1 | agglayer doesn't have settled cert",
+			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
+			localSettledCert: &certTestData{hash1, 2, agglayertypes.Settled},
+			agglayerSettled:  &certTestData{hash2, 1, agglayertypes.Settled},
+			agglayerPending:  &certTestData{hash1, 3, agglayertypes.Pending},
+			resultError:      true,
+		},
+		{
+			name:             "14| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h1   | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)",
+			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
+			localSettledCert: &certTestData{hash2, 2, agglayertypes.Settled},
+			agglayerSettled:  &certTestData{hash2, 2, agglayertypes.Settled},
+			agglayerPending:  &certTestData{hash1, 3, agglayertypes.Pending},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 3, agglayertypes.Pending}}, // for pending cert
+				{InitialStatusActionNone, "", nil}, // for settled cert
+			},
+		},
+		{
+			name:             "15| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h2   | AgglayerPending: ID3, h1 | settled cert ID missmatch",
+			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
+			localSettledCert: &certTestData{hash1, 2, agglayertypes.Settled},
+			agglayerSettled:  &certTestData{hash2, 2, agglayertypes.Settled},
+			agglayerPending:  &certTestData{hash1, 3, agglayertypes.Pending},
+			resultError:      true,
+		},
+		{
+			name:             "16| LocalCert: ID3, h1, pending	| LocalSettled: ID1, h2	| AgglayerSettled: ID2, h3   | AgglayerPending: ID3, h1 | store(PENDING) & store(SETTLED)",
+			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
+			localSettledCert: &certTestData{hash2, 1, agglayertypes.Settled},
+			agglayerSettled:  &certTestData{hash3, 2, agglayertypes.Settled},
+			agglayerPending:  &certTestData{hash1, 3, agglayertypes.Pending},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 3, agglayertypes.Pending}}, // for pending cert
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash3, 2, agglayertypes.Settled}},     // for settled cert
+			},
 		},
 	}
 	runTestCases(t, tests)
@@ -279,6 +345,13 @@ func runTestCases(t *testing.T, tests []testCaseData) {
 					CertificateID: tt.agglayerPending.CertificateID,
 					Height:        tt.agglayerPending.Height,
 					Status:        tt.agglayerPending.Status,
+				}
+			}
+			if tt.localSettledCert != nil {
+				sut.LocalSettledCert = &types.CertificateHeader{
+					CertificateID: tt.localSettledCert.CertificateID,
+					Height:        tt.localSettledCert.Height,
+					Status:        tt.localSettledCert.Status,
 				}
 			}
 

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -18,10 +18,9 @@ type certTestData struct {
 }
 
 type initialStateResultTest struct {
-	action      initialStatusAction
-	subMsg      string
-	cert        *certTestData
-	settledCert *certTestData
+	action initialStatusAction
+	subMsg string
+	cert   *certTestData
 }
 
 type testCaseData struct {
@@ -30,7 +29,7 @@ type testCaseData struct {
 	agglayerSettled *certTestData
 	agglayerPending *certTestData
 	resultError     bool
-	resultActions   *initialStateResultTest
+	resultActions   []*initialStateResultTest
 }
 
 // ID|LOCAL			    | AGGLAYER SETTLED		| AGGLAYER PENDING			    | ACTION
@@ -156,28 +155,28 @@ func TestRegularCases(t *testing.T) {
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: nil,
-			resultActions:   &initialStateResultTest{InitialStatusActionNone, "", nil, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionNone, "", nil}},
 		},
 		{
 			name:            "02| nil 				| nil 					| ID1, h0  , inError		|store(PENDING) h0 so is next cert",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 0, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.InError}, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.InError}}},
 		},
 		{
 			name:            "03| nil 				| nil 					| ID1, h1  , inError   			|none",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 1, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionNone, "", nil, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionNone, "", nil}},
 		},
 		{
 			name:            "04| nil 				| nil 					| ID1, h0  , !=inError  		| store(PENDING) h0 so is next cert",
 			localCert:       nil,
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 0, agglayertypes.Proven},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.Proven}, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 0, agglayertypes.Proven}}},
 		},
 		{
 			name:            "05| nil 				| nil 					| ID1, h1  , !=inError  		| wait, h1 is not next cert but we wait until pass to inError",
@@ -191,56 +190,65 @@ func TestRegularCases(t *testing.T) {
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerPending: nil,
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}, &certTestData{hash1, 1, agglayertypes.Proven}},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}}},
 		},
 		{
 			name:            "07| nil 				| ID1, h1 , NA	 		| ID2, h2  , inError  			| store(PENDING)",
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.InError}, &certTestData{hash1, 1, agglayertypes.Proven}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.InError}},
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Proven}},
+			},
 		},
 		{
 			name:            "08| nil 				| ID1, h1 , NA	 		| ID2, h2  , !=inError  		| store(PENDING) h2 is next to h1",
 			localCert:       nil,
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.Pending},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.Pending}, &certTestData{hash1, 1, agglayertypes.Settled}},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash2, 2, agglayertypes.Pending}},
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Settled}},
+			},
 		},
 		{
 			name:            "09|ID1, h1 , NA		    | nil 					| ID1, h1  , inError  			| update(PENDING)",
 			localCert:       &certTestData{hash1, 1, agglayertypes.Proven},
 			agglayerSettled: nil,
 			agglayerPending: &certTestData{hash1, 1, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 1, agglayertypes.InError}, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash1, 1, agglayertypes.InError}}},
 		},
 		{
 			name:            "10|ID2, h2 , NA			| ID1, h1 , N/A			| ID2, h2  , N/A		  		| update(PENDING)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 1, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash2, 2, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash2, 2, agglayertypes.InError}, nil},
+			resultActions: []*initialStateResultTest{
+				{InitialStatusActionUpdateCurrentCert, "", &certTestData{hash2, 2, agglayertypes.InError}},
+				{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 1, agglayertypes.Settled}},
+			},
 		},
 		{
 			name:            "11|ID2, h2 , NA		| ID1, h3 , N/A			| nil               			|  store(SETTLED)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 3, agglayertypes.Proven},
 			agglayerPending: nil,
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}}},
 		},
 		{
 			name:            "12|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , !=inError           |  store(PENDING)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash1, 3, agglayertypes.Proven},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.Proven}}},
 		},
 		{
 			name:            "13|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , inError             | store(PENDING)",
 			localCert:       &certTestData{hash2, 2, agglayertypes.Proven},
 			agglayerSettled: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerPending: &certTestData{hash1, 3, agglayertypes.InError},
-			resultActions:   &initialStateResultTest{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.InError}, nil},
+			resultActions:   []*initialStateResultTest{{InitialStatusActionInsertNewCert, "", &certTestData{hash1, 3, agglayertypes.InError}}},
 		},
 	}
 	runTestCases(t, tests)
@@ -274,29 +282,26 @@ func runTestCases(t *testing.T, tests []testCaseData) {
 				}
 			}
 
-			action, err := sut.process()
+			actions, err := sut.process()
 			if tt.resultError {
 				require.Error(t, err)
-				require.Nil(t, action)
+				require.Nil(t, actions)
 			} else {
 				require.NoError(t, err)
 				if tt.resultActions != nil {
-					fmt.Print("test:", tt.name)
-					fmt.Print("result:", action.String())
-					require.Equal(t, tt.resultActions.action, action.action)
-					require.Contains(t, action.message, tt.resultActions.subMsg)
-					if tt.resultActions.cert != nil {
-						require.NotNil(t, action.cert)
-						require.Equal(t, tt.resultActions.cert.CertificateID, action.cert.CertificateID)
-						require.Equal(t, tt.resultActions.cert.Height, action.cert.Height)
-						require.Equal(t, tt.resultActions.cert.Status, action.cert.Status)
-					}
-
-					if tt.resultActions.settledCert != nil {
-						require.NotNil(t, action.settledCert)
-						require.Equal(t, tt.resultActions.settledCert.CertificateID, action.settledCert.CertificateID)
-						require.Equal(t, tt.resultActions.settledCert.Height, action.settledCert.Height)
-						require.Equal(t, tt.resultActions.settledCert.Status, action.settledCert.Status)
+					require.Len(t, actions, len(tt.resultActions))
+					for i, resultAction := range tt.resultActions {
+						action := actions[i]
+						fmt.Print("test:", tt.name)
+						fmt.Print("result:", action.String())
+						require.Equal(t, resultAction.action, action.action)
+						require.Contains(t, action.message, resultAction.subMsg)
+						if resultAction.cert != nil {
+							require.NotNil(t, action.cert)
+							require.Equal(t, resultAction.cert.CertificateID, action.cert.CertificateID)
+							require.Equal(t, resultAction.cert.Height, action.cert.Height)
+							require.Equal(t, resultAction.cert.Status, action.cert.Status)
+						}
 					}
 				}
 			}

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -147,8 +147,9 @@ func TestInitialStateInconsistence(t *testing.T) {
 //	 12|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , !=inError           |  store(PENDING)
 //	 13|ID2, h2 , NA		| ID1, h2 , settled		| ID1, h3 , inError             | store(PENDING)
 //	 14| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID1, h2   | AgglayerPending: ID3, h1 | agglayer doesn't have settled cert
-//	 15| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h1   | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)
-//	 16| LocalCert: ID3, h1, pending	| LocalSettled: ID1, h2	| AgglayerSettled: ID2, h3   | AgglayerPending: ID3, h1 | store(PENDING) & store(SETTLED)
+//	 15| LocalCert: ID3, h1, pending    | LocalSettled: ID2, h1 | AgglayerSettled: ID2, h1 | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)
+//	 16| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h2   | AgglayerPending: ID3, h1 | settled cert ID mismatch
+//	 17| LocalCert: ID3, h1, pending	| LocalSettled: ID1, h2	| AgglayerSettled: ID2, h3   | AgglayerPending: ID3, h1 | store(PENDING) & store(SETTLED)
 func TestRegularCases(t *testing.T) {
 	hash1 := common.HexToHash("0xdead")
 	hash2 := common.HexToHash("0xbeef")
@@ -287,7 +288,7 @@ func TestRegularCases(t *testing.T) {
 			resultError:      true,
 		},
 		{
-			name:             "14| LocalCert: ID3, h1, pending | LocalSettled: ID2, h1 | AgglayerSettled: ID2, h1 | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)",
+			name:             "15| LocalCert: ID3, h1, pending | LocalSettled: ID2, h1 | AgglayerSettled: ID2, h1 | AgglayerPending: ID3, h1 | store(PENDING) & none(SETTLED)",
 			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
 			localSettledCert: &certTestData{hash2, 2, agglayertypes.Settled},
 			agglayerSettled:  &certTestData{hash2, 2, agglayertypes.Settled},
@@ -298,7 +299,7 @@ func TestRegularCases(t *testing.T) {
 			},
 		},
 		{
-			name:             "15| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h2   | AgglayerPending: ID3, h1 | settled cert ID mismatch",
+			name:             "16| LocalCert: ID3, h1, pending	| LocalSettled: ID2, h1	| AgglayerSettled: ID2, h2   | AgglayerPending: ID3, h1 | settled cert ID mismatch",
 			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
 			localSettledCert: &certTestData{hash1, 2, agglayertypes.Settled},
 			agglayerSettled:  &certTestData{hash2, 2, agglayertypes.Settled},
@@ -306,7 +307,7 @@ func TestRegularCases(t *testing.T) {
 			resultError:      true,
 		},
 		{
-			name:             "16| LocalCert: ID3, h1, pending	| LocalSettled: ID1, h2	| AgglayerSettled: ID2, h3   | AgglayerPending: ID3, h1 | store(PENDING) & store(SETTLED)",
+			name:             "17| LocalCert: ID3, h1, pending	| LocalSettled: ID1, h2	| AgglayerSettled: ID2, h3   | AgglayerPending: ID3, h1 | store(PENDING) & store(SETTLED)",
 			localCert:        &certTestData{hash1, 3, agglayertypes.Pending},
 			localSettledCert: &certTestData{hash2, 1, agglayertypes.Settled},
 			agglayerSettled:  &certTestData{hash3, 2, agglayertypes.Settled},

--- a/aggsender/statuschecker/initial_state_test.go
+++ b/aggsender/statuschecker/initial_state_test.go
@@ -327,28 +327,28 @@ func runTestCases(t *testing.T, tests []testCaseData) {
 		t.Run(tt.name, func(t *testing.T) {
 			sut := initialStatus{log: logger}
 			if tt.localCert != nil {
-				sut.LocalCert = &types.CertificateHeader{
+				sut.LocalLastCert = &types.CertificateHeader{
 					CertificateID: tt.localCert.CertificateID,
 					Height:        tt.localCert.Height,
 					Status:        tt.localCert.Status,
 				}
 			}
 			if tt.agglayerSettled != nil {
-				sut.SettledCert = &agglayertypes.CertificateHeader{
+				sut.AgglayerLastSettledCert = &agglayertypes.CertificateHeader{
 					CertificateID: tt.agglayerSettled.CertificateID,
 					Height:        tt.agglayerSettled.Height,
 					Status:        tt.agglayerSettled.Status,
 				}
 			}
 			if tt.agglayerPending != nil {
-				sut.PendingCert = &agglayertypes.CertificateHeader{
+				sut.AgglayerLastPendingCert = &agglayertypes.CertificateHeader{
 					CertificateID: tt.agglayerPending.CertificateID,
 					Height:        tt.agglayerPending.Height,
 					Status:        tt.agglayerPending.Status,
 				}
 			}
 			if tt.localSettledCert != nil {
-				sut.LocalSettledCert = &types.CertificateHeader{
+				sut.LocalLastSettledCert = &types.CertificateHeader{
 					CertificateID: tt.localSettledCert.CertificateID,
 					Height:        tt.localSettledCert.Height,
 					Status:        tt.localSettledCert.Status,

--- a/aggsender/types/certificate_metadata.go
+++ b/aggsender/types/certificate_metadata.go
@@ -78,18 +78,19 @@ func NewCertificateMetadata(fromBlock uint64, offset uint32, createdAt uint32, c
 func NewCertificateMetadataFromHash(hash common.Hash) (*CertificateMetadata, error) {
 	b := hash.Bytes()
 	version := b[0]
-	if version == CertificateMetadataV0 {
+	switch version {
+	case CertificateMetadataV0:
 		return &CertificateMetadata{
 			ToBlock: hash.Big().Uint64(),
 		}, nil
-	} else if version == CertificateMetadataV1 {
+	case CertificateMetadataV1:
 		return &CertificateMetadata{
 			Version:   version,
 			FromBlock: binary.BigEndian.Uint64(b[1:9]),
 			Offset:    binary.BigEndian.Uint32(b[9:13]),
 			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
 		}, nil
-	} else if version == CertificateMetadataV2 {
+	case CertificateMetadataV2:
 		return &CertificateMetadata{
 			Version:   version,
 			FromBlock: binary.BigEndian.Uint64(b[1:9]),
@@ -97,7 +98,7 @@ func NewCertificateMetadataFromHash(hash common.Hash) (*CertificateMetadata, err
 			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
 			CertType:  b[17],
 		}, nil
-	} else {
+	default:
 		// Unsupported version
 		return nil, fmt.Errorf("newCertificateMetadataFromHash. unsupported certificate metadata version: %d", version)
 	}


### PR DESCRIPTION
## Description

Because of the new `aggsender validator` call, when starting `aggsender` from scratch, especially in situations where `aggsender` `db` was removed for some reason, we need to sync the last settled certificate as well, not just the last pending, because, to call the `aggsender validator`, regular `aggsender` needs to send the `certificate id` of the last settled certificate as well.

Fixes # (issue)
