### PR TITLE
fix: handle `bridge exit` `metadata` always the same

### DIFF
--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -38,8 +38,6 @@ const (
 var (
 	NonSettledStatuses = []CertificateStatus{Pending, Candidate, Proven}
 	ClosedStatuses     = []CertificateStatus{Settled, InError}
-
-	emptyBytesHash = crypto.Keccak256(nil)
 )
 
 // String representation of the enum
@@ -369,7 +367,7 @@ func (c *Certificate) FEPHashToSign() common.Hash {
 
 	importedBridgeExitsHash := crypto.Keccak256(chunks...)
 
-	aggchainParams := emptyBytesHash
+	aggchainParams := aggkitcommon.EmptyBytesHash
 	aggchainDataProof, ok := c.AggchainData.(*AggchainDataProof)
 	if ok {
 		aggchainParams = aggchainDataProof.AggchainParams.Bytes()
@@ -514,7 +512,7 @@ func (b *BridgeExit) Hash() common.Hash {
 
 	metaDataHash := b.Metadata
 	if len(metaDataHash) == 0 {
-		metaDataHash = emptyBytesHash
+		metaDataHash = aggkitcommon.EmptyBytesHash
 	}
 
 	return crypto.Keccak256Hash(

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1187,9 +1187,9 @@ func TestCertificate_FEPHashToSign(t *testing.T) {
 			certificate: &Certificate{},
 			expectedHash: crypto.Keccak256Hash(
 				common.Hash{}.Bytes(),
-				emptyBytesHash,
+				aggkitcommon.EmptyBytesHash,
 				aggkitcommon.Uint64ToLittleEndianBytes(0),
-				emptyBytesHash,
+				aggkitcommon.EmptyBytesHash,
 			),
 		},
 		{
@@ -1203,7 +1203,7 @@ func TestCertificate_FEPHashToSign(t *testing.T) {
 			},
 			expectedHash: crypto.Keccak256Hash(
 				common.HexToHash("0xdef456").Bytes(),
-				emptyBytesHash,
+				aggkitcommon.EmptyBytesHash,
 				aggkitcommon.Uint64ToLittleEndianBytes(100),
 				common.HexToHash("0x123abc").Bytes(),
 			),

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
 	treetypes "github.com/agglayer/aggkit/tree/types"
@@ -39,6 +40,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 		BridgeExit: &agglayertypes.BridgeExit{
 			LeafType:  0,
 			TokenInfo: &agglayertypes.TokenInfo{},
+			Metadata:  aggkitcommon.EmptyBytesHash,
 		},
 		GlobalIndex: &agglayertypes.GlobalIndex{
 			LeafIndex: 1,
@@ -49,6 +51,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 		BridgeExit: &agglayertypes.BridgeExit{
 			LeafType:  0,
 			TokenInfo: &agglayertypes.TokenInfo{},
+			Metadata:  aggkitcommon.EmptyBytesHash,
 		},
 		GlobalIndex: &agglayertypes.GlobalIndex{
 			LeafIndex: 2,

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -324,16 +324,10 @@ func (f *baseFlow) getNewLocalExitRoot(
 }
 
 // convertBridgeMetadata converts the bridge metadata to a hash using crypto.Keccak256.
-// If the metadata is empty, it returns nil (the zero value for a slice in Go).
-// Note: The "previous flag" is no longer returned by this function.
+// If the metadata is empty, it returns an empty array hash
+// which is basically Keccak256(nil) = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470.
 func convertBridgeMetadata(metadata []byte) []byte {
-	var metaData []byte
-
-	if len(metadata) > 0 {
-		metaData = crypto.Keccak256(metadata)
-	}
-
-	return metaData
+	return crypto.Keccak256(metadata)
 }
 
 // ConvertClaimToImportedBridgeExit converts a claim to an ImportedBridgeExit object
@@ -342,7 +336,6 @@ func (f *baseFlow) ConvertClaimToImportedBridgeExit(claim bridgesync.Claim) (*ag
 	if claim.IsMessage {
 		leafType = agglayertypes.LeafTypeMessage
 	}
-	metaData := convertBridgeMetadata(claim.Metadata)
 
 	bridgeExit := &agglayertypes.BridgeExit{
 		LeafType: leafType,
@@ -353,7 +346,7 @@ func (f *baseFlow) ConvertClaimToImportedBridgeExit(claim bridgesync.Claim) (*ag
 		DestinationNetwork: claim.DestinationNetwork,
 		DestinationAddress: claim.DestinationAddress,
 		Amount:             claim.Amount,
-		Metadata:           metaData,
+		Metadata:           convertBridgeMetadata(claim.Metadata),
 	}
 
 	mainnetFlag, rollupIndex, leafIndex, err := bridgesync.DecodeGlobalIndex(claim.GlobalIndex)
@@ -376,7 +369,6 @@ func (f *baseFlow) getBridgeExits(bridges []bridgesync.Bridge) []*agglayertypes.
 	bridgeExits := make([]*agglayertypes.BridgeExit, 0, len(bridges))
 
 	for _, bridge := range bridges {
-		metaData := convertBridgeMetadata(bridge.Metadata)
 		bridgeExits = append(bridgeExits, &agglayertypes.BridgeExit{
 			LeafType: agglayertypes.LeafType(bridge.LeafType),
 			TokenInfo: &agglayertypes.TokenInfo{
@@ -386,7 +378,7 @@ func (f *baseFlow) getBridgeExits(bridges []bridgesync.Bridge) []*agglayertypes.
 			DestinationNetwork: bridge.DestinationNetwork,
 			DestinationAddress: bridge.DestinationAddress,
 			Amount:             bridge.Amount,
-			Metadata:           metaData,
+			Metadata:           convertBridgeMetadata(bridge.Metadata),
 		})
 	}
 

--- a/common/common.go
+++ b/common/common.go
@@ -10,12 +10,14 @@ import (
 	"github.com/agglayer/aggkit/config/types"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const KB = 1 << 10 // 1024
 
 var (
-	ZeroHash = common.HexToHash("0x0")
+	ZeroHash       = common.HexToHash("0x0")
+	EmptyBytesHash = crypto.Keccak256(nil)
 )
 
 const (


### PR DESCRIPTION
## Description

This PR fixes the issue of handling `bridgeExit.Metadata` field differently. Even if metadata on a bridge exit is nil or empty, it should always be hashed using `crypto.Keccak256` to avoid confusion.

The old behavior is a legacy code where in first iterations of `agglayer` it expected that metadata is either nil, or hashed, which is no longer the case. `agglayer` now has a function that either uses hash of a nil array or if it is already provided, use what is provided. See line: https://github.com/agglayer/interop/blob/6e795b43facd26ba2bf58f87f964ce52b4532d00/crates/unified-bridge/src/bridge_exit.rs#L86.

Fixes #707 
