### PR TITLE
feat: validator: new hash for validator

### DIFF
--- a/agglayer/grpc/conversion_to_agglayer_test.go
+++ b/agglayer/grpc/conversion_to_agglayer_test.go
@@ -179,7 +179,7 @@ func TestConvertProtoCertToAgglayer(t *testing.T) {
 		require.NoError(t, err)
 		result, err := ConvertProtoCertToAgglayer(protoCert)
 		require.NotNil(t, result)
-		require.Equal(t, exampleTestAgglayerCert.Hash(), result.Hash())
+		require.Equal(t, exampleTestAgglayerCert.CertificateID(), result.CertificateID())
 		require.NoError(t, err)
 	})
 
@@ -195,7 +195,7 @@ func TestConvertProtoCertToAgglayer(t *testing.T) {
 		}
 		result, err := ConvertProtoCertToAgglayer(protoCert)
 		require.NotNil(t, result)
-		require.Equal(t, exampleTestAgglayerCert.Hash(), result.Hash())
+		require.Equal(t, exampleTestAgglayerCert.CertificateID(), result.CertificateID())
 		require.NoError(t, err)
 	})
 

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -259,6 +259,24 @@ type Certificate struct {
 	L1InfoTreeLeafCount uint32                `json:"l1_info_tree_leaf_count,omitempty"`
 }
 
+// Validate certificate
+func (c *Certificate) Validate() error {
+	if c == nil {
+		return errors.New("certificate is nil")
+	}
+	for i, bridgeExit := range c.BridgeExits {
+		if err := bridgeExit.Validate(); err != nil {
+			return fmt.Errorf("bridge exit %d is invalid: %w", i, err)
+		}
+	}
+	for i, importedBridgeExit := range c.ImportedBridgeExits {
+		if err := importedBridgeExit.Validate(); err != nil {
+			return fmt.Errorf("imported bridge exit %d is invalid: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // UnmarshalJSON is the implementation of the json.Unmarshaler interface
 func (c *Certificate) UnmarshalJSON(data []byte) error {
 	aux := &struct {
@@ -311,8 +329,9 @@ func (c *Certificate) Brief() string {
 	return res
 }
 
-// Hash returns a hash that uniquely identifies the certificate
-func (c *Certificate) Hash() common.Hash {
+// CertificateID returns a certificateID that identifies the certificate
+// next fields are not included: CustomChainData, AggchainData, L1InfoTreeLeafCount
+func (c *Certificate) CertificateID() common.Hash {
 	bridgeExitsHashes := make([][]byte, len(c.BridgeExits))
 	for i, bridgeExit := range c.BridgeExits {
 		bridgeExitsHashes[i] = bridgeExit.Hash().Bytes()
@@ -432,6 +451,14 @@ type TokenInfo struct {
 	OriginTokenAddress common.Address `json:"origin_token_address"`
 }
 
+// Validate checks if the TokenInfo is valid
+func (t *TokenInfo) Validate() error {
+	if t == nil {
+		return errors.New("tokenInfo is nil")
+	}
+	return nil
+}
+
 // String returns a string representation of the TokenInfo struct
 func (t *TokenInfo) String() string {
 	return fmt.Sprintf("OriginNetwork: %d, OriginTokenAddress: %s", t.OriginNetwork, t.OriginTokenAddress.String())
@@ -442,6 +469,13 @@ type GlobalIndex struct {
 	MainnetFlag bool   `json:"mainnet_flag"`
 	RollupIndex uint32 `json:"rollup_index"`
 	LeafIndex   uint32 `json:"leaf_index"`
+}
+
+func (g *GlobalIndex) Validate() error {
+	if g == nil {
+		return errors.New("globalIndex is nil")
+	}
+	return nil
 }
 
 // String returns a string representation of the GlobalIndex struct
@@ -490,6 +524,16 @@ type BridgeExit struct {
 	Metadata           []byte         `json:"metadata"`
 }
 
+func (b *BridgeExit) Validate() error {
+	if b == nil {
+		return errors.New("bridgeExit is nil")
+	}
+	if err := b.TokenInfo.Validate(); err != nil {
+		return fmt.Errorf("bridgeExit token info is invalid: %w", err)
+	}
+	return nil
+}
+
 func (b *BridgeExit) String() string {
 	res := fmt.Sprintf("LeafType: %s, DestinationNetwork: %d, DestinationAddress: %s, Amount: %s, Metadata: %s",
 		b.LeafType.String(), b.DestinationNetwork, b.DestinationAddress.String(),
@@ -506,6 +550,9 @@ func (b *BridgeExit) String() string {
 
 // Hash returns a hash that uniquely identifies the bridge exit
 func (b *BridgeExit) Hash() common.Hash {
+	if b == nil {
+		return common.Hash{}
+	}
 	if b.Amount == nil {
 		b.Amount = big.NewInt(0)
 	}
@@ -680,6 +727,16 @@ func (l *L1InfoTreeLeaf) String() string {
 	)
 }
 
+func (l *L1InfoTreeLeaf) Validate() error {
+	if l == nil {
+		return errors.New("L1InfoTreeLeaf is nil")
+	}
+	if l.Inner == nil {
+		return errors.New("L1InfoTreeLeaf inner is nil")
+	}
+	return nil
+}
+
 type ProvenInsertedGERWithBlockNumber struct {
 	BlockNumber           uint64            `json:"block_number"`
 	ProvenInsertedGERLeaf ProvenInsertedGER `json:"inserted_ger_leaf"`
@@ -711,6 +768,7 @@ type Claim interface {
 	Hash() common.Hash
 	MarshalJSON() ([]byte, error)
 	String() string
+	Validate() error
 }
 
 // ClaimFromMainnnet represents a claim originating from the mainnet
@@ -762,6 +820,9 @@ func (c *ClaimFromMainnnet) UnmarshalJSON(data []byte) error {
 
 // Hash is the implementation of Claim interface
 func (c *ClaimFromMainnnet) Hash() common.Hash {
+	if c == nil {
+		return common.Hash{}
+	}
 	return crypto.Keccak256Hash(
 		c.ProofLeafMER.Hash().Bytes(),
 		c.ProofGERToL1Root.Hash().Bytes(),
@@ -772,6 +833,19 @@ func (c *ClaimFromMainnnet) Hash() common.Hash {
 func (c *ClaimFromMainnnet) String() string {
 	return fmt.Sprintf("ProofLeafMER: %s, ProofGERToL1Root: %s, L1Leaf: %s",
 		c.ProofLeafMER.String(), c.ProofGERToL1Root.String(), c.L1Leaf.String())
+}
+
+func (c *ClaimFromMainnnet) Validate() error {
+	if c == nil {
+		return errors.New("claim from mainnet is nil")
+	}
+	if c.ProofLeafMER == nil || c.ProofGERToL1Root == nil {
+		return errors.New("claim from mainnet has nil proofs")
+	}
+	if c.L1Leaf == nil {
+		return errors.New("claim from mainnet has nil L1Leaf")
+	}
+	return nil
 }
 
 // ClaimFromRollup represents a claim originating from a rollup
@@ -828,12 +902,28 @@ func (c *ClaimFromRollup) UnmarshalJSON(data []byte) error {
 
 // Hash is the implementation of Claim interface
 func (c *ClaimFromRollup) Hash() common.Hash {
+	if c == nil {
+		return common.Hash{}
+	}
 	return crypto.Keccak256Hash(
 		c.ProofLeafLER.Hash().Bytes(),
 		c.ProofLERToRER.Hash().Bytes(),
 		c.ProofGERToL1Root.Hash().Bytes(),
 		c.L1Leaf.Hash().Bytes(),
 	)
+}
+
+func (c *ClaimFromRollup) Validate() error {
+	if c == nil {
+		return errors.New("claim from rollup is nil")
+	}
+	if c.ProofLeafLER == nil || c.ProofLERToRER == nil || c.ProofGERToL1Root == nil {
+		return errors.New("claim from rollup has nil proofs")
+	}
+	if c.L1Leaf == nil {
+		return errors.New("claim from rollup has nil L1Leaf")
+	}
+	return nil
 }
 
 func (c *ClaimFromRollup) String() string {
@@ -922,6 +1012,22 @@ func (c *ImportedBridgeExit) Hash() common.Hash {
 		c.ClaimData.Hash().Bytes(),
 		c.GlobalIndex.Hash().Bytes(),
 	)
+}
+
+func (c *ImportedBridgeExit) Validate() error {
+	if c == nil {
+		return errors.New("importedBridge is nil")
+	}
+	if err := c.BridgeExit.Validate(); err != nil {
+		return fmt.Errorf("importedBridge.BridgeExit not valid: %w", err)
+	}
+	if err := c.ClaimData.Validate(); err != nil {
+		return fmt.Errorf("importedBridge.ClaimData exit not valid: %w", err)
+	}
+	if err := c.GlobalIndex.Validate(); err != nil {
+		return fmt.Errorf("importedBridge.GlobalIndex exit not valid: %w", err)
+	}
+	return nil
 }
 
 // GlobalIndexToLittleEndianBytes converts the global index to a byte slice in little-endian format

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -528,6 +528,9 @@ func (b *BridgeExit) Validate() error {
 	if b == nil {
 		return errors.New("bridgeExit is nil")
 	}
+	if b.LeafType.Uint8() > LeafTypeMessage.Uint8() {
+		return fmt.Errorf("bridgeExit leaf type %d is invalid", b.LeafType.Uint8())
+	}
 	if err := b.TokenInfo.Validate(); err != nil {
 		return fmt.Errorf("bridgeExit token info is invalid: %w", err)
 	}

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -553,7 +553,7 @@ func (b *BridgeExit) String() string {
 
 // Hash returns a hash that uniquely identifies the bridge exit
 func (b *BridgeExit) Hash() common.Hash {
-	if b == nil {
+	if b.Validate() != nil {
 		return common.Hash{}
 	}
 	if b.Amount == nil {
@@ -823,7 +823,7 @@ func (c *ClaimFromMainnnet) UnmarshalJSON(data []byte) error {
 
 // Hash is the implementation of Claim interface
 func (c *ClaimFromMainnnet) Hash() common.Hash {
-	if c == nil {
+	if c.Validate() != nil {
 		return common.Hash{}
 	}
 	return crypto.Keccak256Hash(
@@ -840,13 +840,13 @@ func (c *ClaimFromMainnnet) String() string {
 
 func (c *ClaimFromMainnnet) Validate() error {
 	if c == nil {
-		return errors.New("claim from mainnet is nil")
+		return errors.New("ClaimFromMainnnet is nil")
 	}
 	if c.ProofLeafMER == nil || c.ProofGERToL1Root == nil {
-		return errors.New("claim from mainnet has nil proofs")
+		return errors.New("ClaimFromMainnnet has nil proofs")
 	}
 	if c.L1Leaf == nil {
-		return errors.New("claim from mainnet has nil L1Leaf")
+		return errors.New("ClaimFromMainnnet has nil L1Leaf")
 	}
 	return nil
 }
@@ -905,7 +905,7 @@ func (c *ClaimFromRollup) UnmarshalJSON(data []byte) error {
 
 // Hash is the implementation of Claim interface
 func (c *ClaimFromRollup) Hash() common.Hash {
-	if c == nil {
+	if c.Validate() != nil {
 		return common.Hash{}
 	}
 	return crypto.Keccak256Hash(
@@ -918,13 +918,13 @@ func (c *ClaimFromRollup) Hash() common.Hash {
 
 func (c *ClaimFromRollup) Validate() error {
 	if c == nil {
-		return errors.New("claim from rollup is nil")
+		return errors.New("ClaimFromRollup is nil")
 	}
 	if c.ProofLeafLER == nil || c.ProofLERToRER == nil || c.ProofGERToL1Root == nil {
-		return errors.New("claim from rollup has nil proofs")
+		return errors.New("ClaimFromRollup has nil proofs")
 	}
 	if c.L1Leaf == nil {
-		return errors.New("claim from rollup has nil L1Leaf")
+		return errors.New("ClaimFromRollup has nil L1Leaf")
 	}
 	return nil
 }
@@ -1019,16 +1019,16 @@ func (c *ImportedBridgeExit) Hash() common.Hash {
 
 func (c *ImportedBridgeExit) Validate() error {
 	if c == nil {
-		return errors.New("importedBridge is nil")
+		return errors.New("ImportedBridgeExit is nil")
 	}
 	if err := c.BridgeExit.Validate(); err != nil {
-		return fmt.Errorf("importedBridge.BridgeExit not valid: %w", err)
+		return fmt.Errorf("ImportedBridgeExit.BridgeExit not valid: %w", err)
 	}
 	if err := c.ClaimData.Validate(); err != nil {
-		return fmt.Errorf("importedBridge.ClaimData exit not valid: %w", err)
+		return fmt.Errorf("ImportedBridgeExit.ClaimData exit not valid: %w", err)
 	}
 	if err := c.GlobalIndex.Validate(); err != nil {
-		return fmt.Errorf("importedBridge.GlobalIndex exit not valid: %w", err)
+		return fmt.Errorf("ImportedBridgeExit.GlobalIndex exit not valid: %w", err)
 	}
 	return nil
 }

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -230,7 +230,7 @@ func TestMarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedJSON, string(data))
 
-		require.Equal(t, "0x097c92944055caf6e8082fa9311cb809c29e714b97a69e7f425cd203e39fd0e4", cert.Hash().String())
+		require.Equal(t, "0x097c92944055caf6e8082fa9311cb809c29e714b97a69e7f425cd203e39fd0e4", cert.CertificateID().String())
 		require.Equal(t, "0x2f01782930cbf2bc2ab4ec16759a2288ad7df865dea387aadf55f96136269cf4", cert.BridgeExits[0].Hash().String())
 		require.Equal(t, "0xe1a594db4275e6e5ab302057e48955c7faf53a8910497590a742b3da89046320", cert.ImportedBridgeExits[0].Hash().String())
 		require.Equal(t, "0xcc9e20b86e9984d9f68b0252f224cb4bc774981c320ef375fb63706220f5af4d", cert.ImportedBridgeExits[1].Hash().String())
@@ -514,7 +514,7 @@ func TestCertificate_Hash(t *testing.T) {
 	)
 
 	// Test the certificate hash
-	calculatedHash := certificate.Hash()
+	calculatedHash := certificate.CertificateID()
 
 	require.Equal(t, calculatedHash, expectedHash)
 }

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1267,4 +1267,27 @@ func TestCertificate_Validate(t *testing.T) {
 		}
 		require.ErrorContains(t, cert.Validate(), "importedBridge is nil")
 	})
+	t.Run("fails globalIndex nil", func(t *testing.T) {
+		cert := Certificate{
+			ImportedBridgeExits: []*ImportedBridgeExit{
+				{
+					BridgeExit: &BridgeExit{
+						LeafType: LeafTypeAsset,
+						TokenInfo: &TokenInfo{
+							OriginNetwork:      0,
+							OriginTokenAddress: common.HexToAddress("0x1234"),
+						},
+						DestinationNetwork: 1,
+						DestinationAddress: common.HexToAddress("0x1234"),
+					},
+					ClaimData: &ClaimFromMainnnet{
+						ProofLeafMER:     &MerkleProof{},
+						ProofGERToL1Root: &MerkleProof{},
+						L1Leaf:           &L1InfoTreeLeaf{},
+					},
+				},
+			},
+		}
+		require.ErrorContains(t, cert.Validate(), "globalIndex is nil")
+	})
 }

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1356,7 +1356,7 @@ func TestCertificate_Validate(t *testing.T) {
 	})
 }
 
-func TestBrigeExitHash(t *testing.T) {
+func TestBridgeExitHash(t *testing.T) {
 	var sut *BridgeExit
 	require.Equal(t, common.Hash{}, sut.Hash())
 	var sut2 BridgeExit
@@ -1370,7 +1370,7 @@ func TestClaimFromMainnnetHash(t *testing.T) {
 	require.Equal(t, common.Hash{}, sut2.Hash())
 }
 
-func TestCClaimFromRolluptHash(t *testing.T) {
+func TestClaimFromRollupHash(t *testing.T) {
 	var sut *ClaimFromRollup
 	require.Equal(t, common.Hash{}, sut.Hash())
 	var sut2 ClaimFromRollup

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1290,4 +1290,90 @@ func TestCertificate_Validate(t *testing.T) {
 		}
 		require.ErrorContains(t, cert.Validate(), "globalIndex is nil")
 	})
+
+	t.Run("bridgeExit bad leaftype", func(t *testing.T) {
+		bridgeExit := &BridgeExit{
+			LeafType: 5,
+			TokenInfo: &TokenInfo{
+				OriginNetwork:      0,
+				OriginTokenAddress: common.HexToAddress("0x1234"),
+			},
+			DestinationNetwork: 1,
+			DestinationAddress: common.HexToAddress("0x1234"),
+		}
+		require.ErrorContains(t, bridgeExit.Validate(), "bridgeExit leaf type 5 is invalid")
+	})
+
+	t.Run("L1InfoTreeLeaf nil", func(t *testing.T) {
+		var sut *L1InfoTreeLeaf
+		require.ErrorContains(t, sut.Validate(), "L1InfoTreeLeaf is nil")
+		sut = &L1InfoTreeLeaf{}
+		require.ErrorContains(t, sut.Validate(), "L1InfoTreeLeaf inner is nil")
+		sut = &L1InfoTreeLeaf{
+			Inner: &L1InfoTreeLeafInner{},
+		}
+		require.NoError(t, sut.Validate())
+	})
+
+	t.Run("ClaimFromMainnnet nil", func(t *testing.T) {
+		var sut *ClaimFromMainnnet
+		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet is nil")
+		sut = &ClaimFromMainnnet{}
+		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet has nil proofs")
+		sut = &ClaimFromMainnnet{
+			ProofLeafMER:     &MerkleProof{},
+			ProofGERToL1Root: &MerkleProof{},
+		}
+		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet has nil L1Leaf")
+		sut = &ClaimFromMainnnet{
+			ProofLeafMER:     &MerkleProof{},
+			ProofGERToL1Root: &MerkleProof{},
+			L1Leaf:           &L1InfoTreeLeaf{},
+		}
+		require.NoError(t, sut.Validate())
+	})
+
+	t.Run("ClaimFromRollup nil", func(t *testing.T) {
+		var sut *ClaimFromRollup
+		require.ErrorContains(t, sut.Validate(), "ClaimFromRollup is nil")
+		sut = &ClaimFromRollup{}
+		require.ErrorContains(t, sut.Validate(), "ClaimFromRollup has nil proofs")
+		sut = &ClaimFromRollup{
+			ProofLeafLER:     &MerkleProof{},
+			ProofLERToRER:    &MerkleProof{},
+			ProofGERToL1Root: &MerkleProof{},
+		}
+		require.ErrorContains(t, sut.Validate(), "ClaimFromRollup has nil L1Leaf")
+		sut.L1Leaf = &L1InfoTreeLeaf{}
+		require.NoError(t, sut.Validate())
+	})
+
+	t.Run("ImportedBridgeExit nil", func(t *testing.T) {
+		var sut *ImportedBridgeExit
+		require.ErrorContains(t, sut.Validate(), "ImportedBridgeExit is nil")
+		sut = &ImportedBridgeExit{}
+		require.ErrorContains(t, sut.Validate(), "ImportedBridgeExit.BridgeExit not valid")
+	})
+
+}
+
+func TestBrigeExitHash(t *testing.T) {
+	var sut *BridgeExit
+	require.Equal(t, common.Hash{}, sut.Hash())
+	var sut2 BridgeExit
+	require.Equal(t, common.Hash{}, sut2.Hash())
+}
+
+func TestClaimFromMainnnetHash(t *testing.T) {
+	var sut *ClaimFromMainnnet
+	require.Equal(t, common.Hash{}, sut.Hash())
+	var sut2 ClaimFromMainnnet
+	require.Equal(t, common.Hash{}, sut2.Hash())
+}
+
+func TestCClaimFromRolluptHash(t *testing.T) {
+	var sut *ClaimFromRollup
+	require.Equal(t, common.Hash{}, sut.Hash())
+	var sut2 ClaimFromRollup
+	require.Equal(t, common.Hash{}, sut2.Hash())
 }

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1354,7 +1354,6 @@ func TestCertificate_Validate(t *testing.T) {
 		sut = &ImportedBridgeExit{}
 		require.ErrorContains(t, sut.Validate(), "ImportedBridgeExit.BridgeExit not valid")
 	})
-
 }
 
 func TestBrigeExitHash(t *testing.T) {

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1265,7 +1265,7 @@ func TestCertificate_Validate(t *testing.T) {
 		cert := Certificate{
 			ImportedBridgeExits: []*ImportedBridgeExit{nil},
 		}
-		require.ErrorContains(t, cert.Validate(), "importedBridge is nil")
+		require.ErrorContains(t, cert.Validate(), "ImportedBridgeExit is nil")
 	})
 	t.Run("fails globalIndex nil", func(t *testing.T) {
 		cert := Certificate{

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1249,3 +1249,22 @@ func TestCertificate_FEPHashToSign(t *testing.T) {
 		})
 	}
 }
+
+func TestCertificate_Validate(t *testing.T) {
+	t.Run("fails cert nil", func(t *testing.T) {
+		var cert *Certificate
+		require.Error(t, cert.Validate(), "should fail with nil certificate")
+	})
+	t.Run("fails bridgeExit nil", func(t *testing.T) {
+		cert := Certificate{
+			BridgeExits: []*BridgeExit{nil},
+		}
+		require.ErrorContains(t, cert.Validate(), "bridgeExit is nil")
+	})
+	t.Run("fails importedBridgeExit nil", func(t *testing.T) {
+		cert := Certificate{
+			ImportedBridgeExits: []*ImportedBridgeExit{nil},
+		}
+		require.ErrorContains(t, cert.Validate(), "importedBridge is nil")
+	})
+}

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -32,6 +32,9 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 
 	// override TimeNowFunc for testing
 	SetTimeNowFunc(timeNowUTCForTest)
+	t.Cleanup(func() {
+		SetTimeNowFunc(TimeNowUTC)
+	})
 
 	// Set up the test context
 	ctx := context.Background()

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -266,6 +266,9 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 
 	// override to have always the same value and not depend on real clock
 	SetTimeNowFunc(timeNowUTCForTest)
+	t.Cleanup(func() {
+		SetTimeNowFunc(TimeNowUTC)
+	})
 
 	ctx := context.Background()
 

--- a/aggsender/validator/cert_hash.go
+++ b/aggsender/validator/cert_hash.go
@@ -9,18 +9,11 @@ import (
 
 // HashCertificateToSign is the hash of the certificate that the validator will sign
 // before returning result to the aggsender
-func HashCertificateToSign(cert *agglayertypes.Certificate) common.Hash {
-	globalIndexHashes := make([][]byte, len(cert.ImportedBridgeExits))
-	for i, importedBridgeExit := range cert.ImportedBridgeExits {
-		globalIndexHashes[i] = importedBridgeExit.GlobalIndex.Hash().Bytes()
+func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error) {
+	if err := cert.Validate(); err != nil {
+		return common.Hash{}, err
 	}
-	networkID := aggkitcommon.Uint32ToBigEndianBytes(cert.NetworkID)
-	height := aggkitcommon.Uint64ToBigEndianBytes(cert.Height)
 	return crypto.Keccak256Hash(
-		cert.NewLocalExitRoot.Bytes(),
-		crypto.Keccak256Hash(globalIndexHashes...).Bytes(),
-		networkID,
-		height,
-		cert.Metadata[:],
-	)
+		cert.CertificateID().Bytes(),
+		aggkitcommon.Uint32ToBytes(cert.L1InfoTreeLeafCount)), nil
 }

--- a/aggsender/validator/cert_hash_test.go
+++ b/aggsender/validator/cert_hash_test.go
@@ -28,6 +28,21 @@ func TestHashCertificateToSign(t *testing.T) {
 		require.Equal(t, "0x7f79b617b1ee18f06b6b5104d065ef71370688bbdf22d13c756e63a2b8b24f1e", hash.String())
 	})
 
+	t.Run("error hashing invalid cert ", func(t *testing.T) {
+		cert := &agglayertypes.Certificate{
+			NetworkID:           1,
+			Height:              100,
+			NewLocalExitRoot:    common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
+			ImportedBridgeExits: nil,
+			Metadata:            [32]byte{1, 2, 3, 4, 5},
+			BridgeExits: []*agglayertypes.BridgeExit{
+				{},
+			},
+		}
+		_, err := HashCertificateToSign(cert)
+		require.Error(t, err)
+	})
+
 	t.Run("check imported fields on hash", func(t *testing.T) {
 		_, cert := getCertFromAggsenderDBForTest(t)
 		hash, err := HashCertificateToSign(cert)

--- a/aggsender/validator/cert_hash_test.go
+++ b/aggsender/validator/cert_hash_test.go
@@ -1,9 +1,14 @@
 package validator
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggsender/db"
+	"github.com/agglayer/aggkit/aggsender/types"
+	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -18,69 +23,57 @@ func TestHashCertificateToSign(t *testing.T) {
 			Metadata:            [32]byte{1, 2, 3, 4, 5},
 		}
 
-		hash := HashCertificateToSign(cert)
-		require.NotEqual(t, common.Hash{}, hash)
-	})
-
-	t.Run("should hash certificate with imported bridge exits", func(t *testing.T) {
-		cert := &agglayertypes.Certificate{
-			NetworkID:        1,
-			Height:           100,
-			NewLocalExitRoot: common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
-			ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
-				{
-					GlobalIndex: &agglayertypes.GlobalIndex{
-						MainnetFlag: true,
-						RollupIndex: 1,
-						LeafIndex:   10,
-					},
-				},
-				{
-					GlobalIndex: &agglayertypes.GlobalIndex{
-						MainnetFlag: false,
-						RollupIndex: 2,
-						LeafIndex:   20,
-					},
-				},
-			},
-			Metadata: [32]byte{1, 2, 3, 4, 5},
-		}
-
-		hash := HashCertificateToSign(cert)
-		require.NotEqual(t, common.Hash{}, hash)
-		require.Equal(t, "0x43d8f05fa6b02f43f1114ec1b73973361fa5930d15c6cc58e7614e59417ca7d0", hash.String())
+		hash, err := HashCertificateToSign(cert)
+		require.NoError(t, err)
+		require.Equal(t, "0x7f79b617b1ee18f06b6b5104d065ef71370688bbdf22d13c756e63a2b8b24f1e", hash.String())
 	})
 
 	t.Run("check imported fields on hash", func(t *testing.T) {
-		cert := &agglayertypes.Certificate{
-			NetworkID:        1,
-			Height:           100,
-			NewLocalExitRoot: common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
-			ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
-				{
-					GlobalIndex: &agglayertypes.GlobalIndex{
-						MainnetFlag: true,
-						RollupIndex: 1,
-						LeafIndex:   10,
-					},
-				},
-				{
-					GlobalIndex: &agglayertypes.GlobalIndex{
-						MainnetFlag: false,
-						RollupIndex: 2,
-						LeafIndex:   20,
-					},
-				},
-			},
-			Metadata: [32]byte{1, 2, 3, 4, 5},
-		}
-
-		require.Equal(t, "0x43d8f05fa6b02f43f1114ec1b73973361fa5930d15c6cc58e7614e59417ca7d0", HashCertificateToSign(cert).String())
+		_, cert := getCertFromAggsenderDBForTest(t)
+		hash, err := HashCertificateToSign(cert)
+		require.NoError(t, err)
+		require.Equal(t, "0xe927a8204f8f4750e4cc2c3938e43b88eaccc7ddb5f21b54ede4a69843e87b3d", hash.String())
 		cert.NetworkID += 1
-		require.Equal(t, "0x7b3a820e84307ecbaacde0af267ad50c9028aea6c43a63b6cbfe1d52474a49ad", HashCertificateToSign(cert).String())
+		hash, err = HashCertificateToSign(cert)
+		require.NoError(t, err)
+		require.Equal(t, "0x84ecc0220119803af79a5be33d9efcaea76862da70ef044151d5ae1d7b12fd4c", hash.String())
 		cert.Height += 1
-		require.Equal(t, "0xfd290b1e07867ae1f3d63619ec8a534967b52497a034b3a56de8d92b2175add6", HashCertificateToSign(cert).String())
+		hash, err = HashCertificateToSign(cert)
+		require.NoError(t, err)
+		require.Equal(t, "0x356561c0a4fe69ef6a9eb6047c99aed2d76c5ab8639b5d43e5d40ea0e4914de8", hash.String())
 		cert.Metadata = [32]byte{6, 7, 8, 9, 10}
-		require.Equal(t, "0x912dd941aadbad91de9079c8738180f0539578f8bc7c4cc18e0353d1c885ed96", HashCertificateToSign(cert).String())
+		hash, err = HashCertificateToSign(cert)
+		require.NoError(t, err)
+		require.Equal(t, "0x52bf89461f0aba19c0120e716f7f562ec508d0d77135f2869abe856e793b646c", hash.String())
 	})
+}
+
+func TestCertificateIdHash(t *testing.T) {
+	cert, unmarshalCert := getCertFromAggsenderDBForTest(t)
+	id := unmarshalCert.CertificateID()
+	require.Equal(t, cert.Header.CertificateID, id)
+	hash, err := HashCertificateToSign(unmarshalCert)
+	require.NoError(t, err)
+	require.Equal(t, "0xe927a8204f8f4750e4cc2c3938e43b88eaccc7ddb5f21b54ede4a69843e87b3d", hash.String())
+}
+
+// Returns aggsender and agglayer cert
+func getCertFromAggsenderDBForTest(t *testing.T) (*types.Certificate, *agglayertypes.Certificate) {
+	t.Helper()
+	dbPath := "testData/aggsender.sqlite"
+
+	cfg := db.AggSenderSQLStorageConfig{
+		DBPath:                  dbPath,
+		KeepCertificatesHistory: true,
+	}
+	logger := log.WithFields("test", "TestCertificateHash")
+	database, err := db.NewAggSenderSQLStorage(logger, cfg)
+	require.NoError(t, err)
+	cert, err := database.GetLastSentCertificate()
+	require.NoError(t, err)
+	var unmarshalCert *agglayertypes.Certificate
+	fmt.Println(*cert.SignedCertificate)
+	err = json.Unmarshal([]byte(*cert.SignedCertificate), &unmarshalCert)
+	require.NoError(t, err)
+	return cert, unmarshalCert
 }

--- a/aggsender/validator/cert_hash_test.go
+++ b/aggsender/validator/cert_hash_test.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
@@ -87,7 +86,6 @@ func getCertFromAggsenderDBForTest(t *testing.T) (*types.Certificate, *agglayert
 	cert, err := database.GetLastSentCertificate()
 	require.NoError(t, err)
 	var unmarshalCert *agglayertypes.Certificate
-	fmt.Println(*cert.SignedCertificate)
 	err = json.Unmarshal([]byte(*cert.SignedCertificate), &unmarshalCert)
 	require.NoError(t, err)
 	return cert, unmarshalCert

--- a/aggsender/validator/cert_hash_test.go
+++ b/aggsender/validator/cert_hash_test.go
@@ -40,11 +40,11 @@ func TestHashCertificateToSign(t *testing.T) {
 		cert.Height += 1
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x356561c0a4fe69ef6a9eb6047c99aed2d76c5ab8639b5d43e5d40ea0e4914de8", hash.String())
+		require.Equal(t, "0x88cfb3efdb3802f8a86ab1d6484ca7e2a00310da5545b4de8ae8c9011994316b", hash.String())
 		cert.Metadata = [32]byte{6, 7, 8, 9, 10}
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x52bf89461f0aba19c0120e716f7f562ec508d0d77135f2869abe856e793b646c", hash.String())
+		require.Equal(t, "0x73a8e14ed3b09cb31c27a8a833f1257cbd6507c6d5716eb55d99b7bbedabbae6", hash.String())
 	})
 }
 

--- a/aggsender/validator/validate_certificate.go
+++ b/aggsender/validator/validate_certificate.go
@@ -166,13 +166,9 @@ func (a *CertificateValidator) compareCertificates(
 	diffs := DiffsCertificate(incomingCertificate, localCertificate)
 	diffStr := strings.Join(diffs, "\n")
 	// This is redudant, but just in case
-	if incomingCertificate.Hash() != localCertificate.Hash() {
+	if incomingCertificate.CertificateID() != localCertificate.CertificateID() {
 		return fmt.Errorf("certificates hash mismatch, incoming: %s, local: %s.\n FullDiff: %s",
-			incomingCertificate.Hash().Hex(), localCertificate.Hash().Hex(), diffStr)
-	}
-	if incomingCertificate.Metadata != localCertificate.Metadata {
-		return fmt.Errorf("certificates metadata mismatch, incoming: %s, local: %s.\n FullDiff: %s",
-			incomingCertificate.Metadata.Hex(), localCertificate.Metadata.Hex(), diffStr)
+			incomingCertificate.CertificateID().Hex(), localCertificate.CertificateID().Hex(), diffStr)
 	}
 	if len(diffs) > 0 {
 		return fmt.Errorf("certificates mismatch. FullDiff: %s",

--- a/aggsender/validator/validate_certificate_test.go
+++ b/aggsender/validator/validate_certificate_test.go
@@ -249,6 +249,20 @@ func TestGetCertificatePreBuildParams(t *testing.T) {
 	})
 }
 
+func TestCompareCertificates(t *testing.T) {
+	t.Run("TestCompareCertificates not same CertificateID", func(t *testing.T) {
+		cert1 := &agglayertypes.Certificate{
+			Height: 1,
+		}
+		cert2 := &agglayertypes.Certificate{
+			Height: 2,
+		}
+		sut := &CertificateValidator{}
+		err := sut.compareCertificates(cert1, cert2)
+		require.ErrorContains(t, err, "height mismatch")
+	})
+}
+
 type testDataCertificateValidator struct {
 	ctx                   context.Context
 	logger                *log.Logger

--- a/aggsender/validator/validator_service.go
+++ b/aggsender/validator/validator_service.go
@@ -96,6 +96,13 @@ func (s *ValidatorService) ValidateCertificate(
 			Message: "Invalid certificate conversion: " + err.Error(),
 		}
 	}
+	if err = cert.Validate(); err != nil {
+		s.log.Errorf("Certificate validation failed: %v", err)
+		return nil, grpc.GRPCError{
+			Code:    codes.InvalidArgument,
+			Message: "Invalid certificate: " + err.Error(),
+		}
+	}
 	params.Certificate = cert
 	err = s.validator.ValidateCertificate(ctx, params)
 	if err != nil {
@@ -127,6 +134,12 @@ func (s *ValidatorService) signCertificate(ctx context.Context, cert *agglayerty
 			Message: "Signer is not initialized",
 		}
 	}
-	hashToSign := HashCertificateToSign(cert)
+	hashToSign, err := HashCertificateToSign(cert)
+	if err != nil {
+		return nil, grpc.GRPCError{
+			Code:    codes.Internal,
+			Message: "Error hashing certificate: " + err.Error(),
+		}
+	}
 	return s.signer.SignHash(ctx, hashToSign)
 }

--- a/aggsender/validator/validator_service.go
+++ b/aggsender/validator/validator_service.go
@@ -96,13 +96,6 @@ func (s *ValidatorService) ValidateCertificate(
 			Message: "Invalid certificate conversion: " + err.Error(),
 		}
 	}
-	if err = cert.Validate(); err != nil {
-		s.log.Errorf("Certificate validation failed: %v", err)
-		return nil, grpc.GRPCError{
-			Code:    codes.InvalidArgument,
-			Message: "Invalid certificate: " + err.Error(),
-		}
-	}
 	params.Certificate = cert
 	err = s.validator.ValidateCertificate(ctx, params)
 	if err != nil {

--- a/aggsender/validator/validator_service_test.go
+++ b/aggsender/validator/validator_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	nodev1 "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/types/v1"
 	typesv1 "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
+	v1types "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	validatormocks "github.com/agglayer/aggkit/aggsender/validator/mocks"
 	v1 "github.com/agglayer/aggkit/aggsender/validator/proto/v1"
@@ -113,6 +114,18 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		cert := testCertificate1
 		cert.NewLocalExitRoot = nil
+		req := &v1.ValidateCertificateRequest{
+			Certificate: &cert,
+		}
+		_, err := testData.sut.ValidateCertificate(t.Context(), req)
+		require.ErrorContains(t, err, "Invalid certificate conversion")
+	})
+	t.Run("converted certificate don't pass Validate()", func(t *testing.T) {
+		testData := newValidatorServiceTestData(t)
+		cert := testCertificate1
+		cert.BridgeExits = []*v1types.BridgeExit{
+			{},
+		}
 		req := &v1.ValidateCertificateRequest{
 			Certificate: &cert,
 		}

--- a/aggsender/validator/validator_service_test.go
+++ b/aggsender/validator/validator_service_test.go
@@ -10,7 +10,6 @@ import (
 
 	nodev1 "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/types/v1"
 	typesv1 "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
-	v1types "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	validatormocks "github.com/agglayer/aggkit/aggsender/validator/mocks"
 	v1 "github.com/agglayer/aggkit/aggsender/validator/proto/v1"
@@ -123,7 +122,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("converted certificate don't pass Validate()", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		cert := testCertificate1
-		cert.BridgeExits = []*v1types.BridgeExit{
+		cert.BridgeExits = []*typesv1.BridgeExit{
 			{},
 		}
 		req := &v1.ValidateCertificateRequest{

--- a/aggsender/validator/validator_service_test.go
+++ b/aggsender/validator/validator_service_test.go
@@ -119,17 +119,26 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 		_, err := testData.sut.ValidateCertificate(t.Context(), req)
 		require.ErrorContains(t, err, "Invalid certificate conversion")
 	})
-	t.Run("converted certificate don't pass Validate()", func(t *testing.T) {
+	t.Run("converted certificate with bridgeExits", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		cert := testCertificate1
 		cert.BridgeExits = []*typesv1.BridgeExit{
-			{},
+			{
+				LeafType: 1,
+				TokenInfo: &typesv1.TokenInfo{
+					OriginTokenAddress: &typesv1.FixedBytes20{},
+				},
+				DestAddress: &typesv1.FixedBytes20{},
+			},
 		}
+		testData.mockValidator.EXPECT().ValidateCertificate(mock.Anything, mock.Anything).Return(nil).Once()
+		testData.mockSigner.EXPECT().SignHash(mock.Anything, mock.Anything).Return([]byte("signature"), nil).Once()
+
 		req := &v1.ValidateCertificateRequest{
 			Certificate: &cert,
 		}
 		_, err := testData.sut.ValidateCertificate(t.Context(), req)
-		require.ErrorContains(t, err, "Invalid certificate conversion")
+		require.NoError(t, err)
 	})
 	t.Run("fails validate certificate", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)


### PR DESCRIPTION
## 🔄 Changes Summary
- It update the way of calculating hash to be signed by `validator` 
```
        let certificate_id = self.hash();

        let commitment = match self.l1_info_tree_leaf_count {
            Some(leaf_count) => keccak256_combine([
                certificate_id.as_digest().as_slice(),
                leaf_count.to_le_bytes().as_slice(),
            ]),
            None => *certificate_id,
        };
```
- Also introduce a `Validate()` function for `agglayer.Certificate`
- 
## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA


