### PR TITLE
fix: agglayer client cache issues

### DIFF
--- a/agglayer/agglayer_client_cache.go
+++ b/agglayer/agglayer_client_cache.go
@@ -60,6 +60,8 @@ func NewCertificateCache(
 	c := ttlcache.New(
 		ttlcache.WithTTL[common.Hash, agglayertypes.CertificateHeader](ttl),
 		ttlcache.WithCapacity[common.Hash, agglayertypes.CertificateHeader](capacity),
+		// disable extension of the TTL on cache hits
+		ttlcache.WithDisableTouchOnHit[common.Hash, agglayertypes.CertificateHeader](),
 	)
 	return &AgglayerClientCache{
 		cache:          c,
@@ -82,6 +84,8 @@ func NewCertificateCache(
 //   - error: An error if the certificate header could not be retrieved.
 func (c *AgglayerClientCache) GetCertificateHeader(
 	ctx context.Context, certificateID common.Hash) (*agglayertypes.CertificateHeader, error) {
+	c.cache.DeleteExpired()
+
 	if c.cache.Has(certificateID) {
 		tmp := c.cache.Get(certificateID).Value()
 		return &tmp, nil

--- a/agglayer/agglayer_client_cache_test.go
+++ b/agglayer/agglayer_client_cache_test.go
@@ -75,3 +75,46 @@ func TestGetCertificateHeader(t *testing.T) {
 	require.ErrorContains(t, err, "some error")
 	require.Zero(t, certCache.cache.Len()) // Ensure the cache is empty after
 }
+
+func TestExpiration(t *testing.T) {
+	t.Parallel()
+
+	ttl := 3 * time.Second
+	capacity := uint64(1)
+	certificateID := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	certificateHeader := &agglayertypes.CertificateHeader{
+		CertificateID: certificateID,
+		Height:        1,
+		NetworkID:     1,
+		Status:        agglayertypes.Settled,
+	}
+
+	mockAgglayerClient := NewAgglayerClientMock(t)
+	certCache := NewCertificateCache(mockAgglayerClient, ttl, capacity)
+
+	timer := time.NewTimer(ttl)
+	mockAgglayerClient.EXPECT().GetCertificateHeader(t.Context(), certificateID).Return(certificateHeader, nil).Once()
+
+	ch := make(chan struct{})
+	go func() {
+		for {
+			// constantly check if the certificate is in the cache
+			// until its ttl expires so that we always touch that cache entry
+			cachedCert, err := certCache.GetCertificateHeader(t.Context(), certificateID)
+			require.NoError(t, err)
+			require.Equal(t, certificateHeader, cachedCert)
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+				continue
+			case <-timer.C:
+				close(ch)
+				return
+			}
+		}
+	}()
+
+	<-ch
+
+	require.False(t, certCache.cache.Has(certificateID)) // Ensure the cache is empty after TTL
+}

--- a/config/default.go
+++ b/config/default.go
@@ -204,7 +204,7 @@ RequireValidatorCall = false
 	[AggSender.AgglayerClient]
 		Cached = false
 		[AggSender.AgglayerClient.ConfigurationCache]
-			TTL = "15m"
+			TTL = "5m"
 			Capacity = 100
 		[AggSender.AgglayerClient.GRPC]
 			URL = "{{AggLayerURL}}"
@@ -276,7 +276,7 @@ DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
 [Validator.AgglayerClient]
 	Cached = true
 	[Validator.AgglayerClient.ConfigurationCache]
-		TTL = "15m"
+		TTL = "5m"
 		Capacity = 100
 	[Validator.AgglayerClient.GRPC]
 		URL = "{{AggSender.AgglayerClient.GRPC.URL}}"


### PR DESCRIPTION
## 🔄 Changes Summary
This PR fixes issues with the `agglayer client cache` found while testing.

The issue was that regular `aggsender` was using this cache, even though it doesn't need it, but it did found an issue, where cache items were not deleted after expiration, hence they couldn't be refreshed. That is why it saw a certificate as constantly `Pending` even though it was `Settled` on `agglayer`, because the `cache` did not refresh the item.

The `Cached` parameter should only be `true` on `aggsender-validator` because it is only getting the `settled` certificates.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
Updated the default values for:
```
[Validator.AgglayerClient.ConfigurationCache]
        TTL = "5m"

[AggSender.AgglayerClient.ConfigurationCache]
	TTL = "5m"
```

## ✅ Testing
- `aggkit` CI
- manual testing using branch on kurtosis: https://github.com/0xPolygon/kurtosis-cdk/compare/main...jhilliard/aggsender-validator-committee 

## 🐞 Issues
NA
