### PR TITLE
chore: attend PR comments from PR #773

### DIFF
--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -845,8 +845,8 @@ func (c *ClaimFromMainnnet) Validate() error {
 	if c.ProofLeafMER == nil || c.ProofGERToL1Root == nil {
 		return errors.New("ClaimFromMainnnet has nil proofs")
 	}
-	if c.L1Leaf == nil {
-		return errors.New("ClaimFromMainnnet has nil L1Leaf")
+	if err := c.L1Leaf.Validate(); err != nil {
+		return fmt.Errorf("ClaimFromMainnnet L1Leaf error: %w", err)
 	}
 	return nil
 }

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -531,6 +531,9 @@ func (b *BridgeExit) Validate() error {
 	if b.LeafType.Uint8() > LeafTypeMessage.Uint8() {
 		return fmt.Errorf("bridgeExit leaf type %d is invalid", b.LeafType.Uint8())
 	}
+	if b.Amount != nil && b.Amount.Sign() < 0 {
+		return fmt.Errorf("bridgeExit amount %s is negative", b.Amount.String())
+	}
 	if err := b.TokenInfo.Validate(); err != nil {
 		return fmt.Errorf("bridgeExit token info is invalid: %w", err)
 	}

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -44,6 +44,34 @@ func TestBridgeExit_Hash(t *testing.T) {
 		bridge.Hash().String(), "metadata is nil and it's empty,use it")
 }
 
+func TestBridgeExit_Validate(t *testing.T) {
+	t.Run("bridgeExit bad leaftype", func(t *testing.T) {
+		bridgeExit := &BridgeExit{
+			LeafType: 5,
+			TokenInfo: &TokenInfo{
+				OriginNetwork:      0,
+				OriginTokenAddress: common.HexToAddress("0x1234"),
+			},
+			DestinationNetwork: 1,
+			DestinationAddress: common.HexToAddress("0x1234"),
+		}
+		require.ErrorContains(t, bridgeExit.Validate(), "bridgeExit leaf type 5 is invalid")
+	})
+	t.Run("bridgeExit amount negative", func(t *testing.T) {
+		bridgeExit := &BridgeExit{
+			LeafType: 1,
+			TokenInfo: &TokenInfo{
+				OriginNetwork:      0,
+				OriginTokenAddress: common.HexToAddress("0x1234"),
+			},
+			DestinationNetwork: 1,
+			DestinationAddress: common.HexToAddress("0x1234"),
+			Amount:             big.NewInt(-100),
+		}
+		require.ErrorContains(t, bridgeExit.Validate(), "bridgeExit amount -100 is negative")
+	})
+}
+
 func TestGenericError_Error(t *testing.T) {
 	t.Parallel()
 
@@ -624,6 +652,16 @@ func TestBridgeExit_String(t *testing.T) {
 				Metadata:           []byte{0xff, 0xee, 0xdd},
 			},
 			expectedOutput: "LeafType: Message, DestinationNetwork: 200, DestinationAddress: 0x0000000000000000000000000000000000000001, Amount: 5000, Metadata: ffeedd, TokenInfo: nil",
+		},
+		{
+			name: "Without Amount",
+			bridgeExit: &BridgeExit{
+				LeafType:           LeafTypeMessage,
+				DestinationNetwork: 200,
+				DestinationAddress: common.HexToAddress("0x1"),
+				Metadata:           []byte{0xff, 0xee, 0xdd},
+			},
+			expectedOutput: "LeafType: Message, DestinationNetwork: 200, DestinationAddress: 0x0000000000000000000000000000000000000001, Amount: <nil>, Metadata: ffeedd, TokenInfo: nil",
 		},
 	}
 
@@ -1291,19 +1329,6 @@ func TestCertificate_Validate(t *testing.T) {
 			},
 		}
 		require.ErrorContains(t, cert.Validate(), "globalIndex is nil")
-	})
-
-	t.Run("bridgeExit bad leaftype", func(t *testing.T) {
-		bridgeExit := &BridgeExit{
-			LeafType: 5,
-			TokenInfo: &TokenInfo{
-				OriginNetwork:      0,
-				OriginTokenAddress: common.HexToAddress("0x1234"),
-			},
-			DestinationNetwork: 1,
-			DestinationAddress: common.HexToAddress("0x1234"),
-		}
-		require.ErrorContains(t, bridgeExit.Validate(), "bridgeExit leaf type 5 is invalid")
 	})
 
 	t.Run("L1InfoTreeLeaf nil", func(t *testing.T) {

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1283,7 +1283,9 @@ func TestCertificate_Validate(t *testing.T) {
 					ClaimData: &ClaimFromMainnnet{
 						ProofLeafMER:     &MerkleProof{},
 						ProofGERToL1Root: &MerkleProof{},
-						L1Leaf:           &L1InfoTreeLeaf{},
+						L1Leaf: &L1InfoTreeLeaf{
+							Inner: &L1InfoTreeLeafInner{},
+						},
 					},
 				},
 			},

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -1315,7 +1315,7 @@ func TestCertificate_Validate(t *testing.T) {
 		require.NoError(t, sut.Validate())
 	})
 
-	t.Run("ClaimFromMainnnet nil", func(t *testing.T) {
+	t.Run("ClaimFromMainnnet validate", func(t *testing.T) {
 		var sut *ClaimFromMainnnet
 		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet is nil")
 		sut = &ClaimFromMainnnet{}
@@ -1324,11 +1324,13 @@ func TestCertificate_Validate(t *testing.T) {
 			ProofLeafMER:     &MerkleProof{},
 			ProofGERToL1Root: &MerkleProof{},
 		}
-		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet has nil L1Leaf")
+		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet L1Leaf error")
 		sut = &ClaimFromMainnnet{
 			ProofLeafMER:     &MerkleProof{},
 			ProofGERToL1Root: &MerkleProof{},
-			L1Leaf:           &L1InfoTreeLeaf{},
+			L1Leaf: &L1InfoTreeLeaf{
+				Inner: &L1InfoTreeLeafInner{},
+			},
 		}
 		require.NoError(t, sut.Validate())
 	})

--- a/aggsender/validator/validator_service_test.go
+++ b/aggsender/validator/validator_service_test.go
@@ -65,7 +65,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &newGRPCCertificateForTest(t),
+			Certificate: newGRPCCertificateForTest(t),
 		}
 		testData.mockValidator.EXPECT().ValidateCertificate(mock.Anything, mock.Anything).Return(nil).Once()
 		testData.mockSigner.EXPECT().SignHash(mock.Anything, mock.Anything).Return([]byte("signature"), nil).Once()
@@ -78,7 +78,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("PreviousCertificateId, fail to retrieve it", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &newGRPCCertificateForTest(t),
+			Certificate: newGRPCCertificateForTest(t),
 			PreviousCertificateId: &nodev1.CertificateId{
 				Value: &typesv1.FixedBytes32{Value: common.HexToHash("0xbeef").Bytes()},
 			},
@@ -90,7 +90,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("PreviousCertificateId, retrieved but is nil", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &newGRPCCertificateForTest(t),
+			Certificate: newGRPCCertificateForTest(t),
 			PreviousCertificateId: &nodev1.CertificateId{
 				Value: &typesv1.FixedBytes32{Value: common.HexToHash("0xbeef").Bytes()},
 			},
@@ -105,7 +105,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 		cert := newGRPCCertificateForTest(t)
 		cert.NewLocalExitRoot = nil
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &cert,
+			Certificate: cert,
 		}
 		_, err := testData.sut.ValidateCertificate(t.Context(), req)
 		require.ErrorContains(t, err, "Invalid certificate conversion")
@@ -126,7 +126,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 		testData.mockSigner.EXPECT().SignHash(mock.Anything, mock.Anything).Return([]byte("signature"), nil).Once()
 
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &cert,
+			Certificate: cert,
 		}
 		_, err := testData.sut.ValidateCertificate(t.Context(), req)
 		require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("fails validate certificate", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &newGRPCCertificateForTest(t),
+			Certificate: newGRPCCertificateForTest(t),
 		}
 		testData.mockValidator.EXPECT().ValidateCertificate(mock.Anything, mock.Anything).Return(errTestGenericError).Once()
 		_, err := testData.sut.ValidateCertificate(t.Context(), req)
@@ -165,10 +165,10 @@ func newValidatorServiceTestData(t *testing.T) *testValidatorServiceData {
 	}
 }
 
-func newGRPCCertificateForTest(t *testing.T) nodev1.Certificate {
+func newGRPCCertificateForTest(t *testing.T) *nodev1.Certificate {
 	t.Helper()
-	testL1InfoTreeLeafCount = uint32(123)
-	return nodev1.Certificate{
+	testL1InfoTreeLeafCount := uint32(123)
+	return &nodev1.Certificate{
 		Height:              42,
 		NewLocalExitRoot:    &typesv1.FixedBytes32{},
 		PrevLocalExitRoot:   &typesv1.FixedBytes32{},

--- a/aggsender/validator/validator_service_test.go
+++ b/aggsender/validator/validator_service_test.go
@@ -24,15 +24,6 @@ var (
 	signature = &typesv1.AggchainData_Signature{
 		Signature: &typesv1.FixedBytes65{Value: []byte("test_signature")},
 	}
-	testL1InfoTreeLeafCount = uint32(123)
-	testCertificate1        = nodev1.Certificate{
-		Height:              42,
-		NewLocalExitRoot:    &typesv1.FixedBytes32{},
-		PrevLocalExitRoot:   &typesv1.FixedBytes32{},
-		Metadata:            &typesv1.FixedBytes32{},
-		L1InfoTreeLeafCount: &testL1InfoTreeLeafCount,
-		AggchainData:        &typesv1.AggchainData{Data: signature},
-	}
 	errTestGenericError = errors.New("generic error")
 )
 
@@ -74,7 +65,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &testCertificate1,
+			Certificate: &newGRPCCertificateForTest(t),
 		}
 		testData.mockValidator.EXPECT().ValidateCertificate(mock.Anything, mock.Anything).Return(nil).Once()
 		testData.mockSigner.EXPECT().SignHash(mock.Anything, mock.Anything).Return([]byte("signature"), nil).Once()
@@ -87,7 +78,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("PreviousCertificateId, fail to retrieve it", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &testCertificate1,
+			Certificate: &newGRPCCertificateForTest(t),
 			PreviousCertificateId: &nodev1.CertificateId{
 				Value: &typesv1.FixedBytes32{Value: common.HexToHash("0xbeef").Bytes()},
 			},
@@ -99,7 +90,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("PreviousCertificateId, retrieved but is nil", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &testCertificate1,
+			Certificate: &newGRPCCertificateForTest(t),
 			PreviousCertificateId: &nodev1.CertificateId{
 				Value: &typesv1.FixedBytes32{Value: common.HexToHash("0xbeef").Bytes()},
 			},
@@ -111,7 +102,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 
 	t.Run("fails to convert certificate", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
-		cert := testCertificate1
+		cert := newGRPCCertificateForTest(t)
 		cert.NewLocalExitRoot = nil
 		req := &v1.ValidateCertificateRequest{
 			Certificate: &cert,
@@ -121,7 +112,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	})
 	t.Run("converted certificate with bridgeExits", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
-		cert := testCertificate1
+		cert := newGRPCCertificateForTest(t)
 		cert.BridgeExits = []*typesv1.BridgeExit{
 			{
 				LeafType: 1,
@@ -143,7 +134,7 @@ func TestValidatorService_ValidateCertificate(t *testing.T) {
 	t.Run("fails validate certificate", func(t *testing.T) {
 		testData := newValidatorServiceTestData(t)
 		req := &v1.ValidateCertificateRequest{
-			Certificate: &testCertificate1,
+			Certificate: &newGRPCCertificateForTest(t),
 		}
 		testData.mockValidator.EXPECT().ValidateCertificate(mock.Anything, mock.Anything).Return(errTestGenericError).Once()
 		_, err := testData.sut.ValidateCertificate(t.Context(), req)
@@ -171,5 +162,18 @@ func newValidatorServiceTestData(t *testing.T) *testValidatorServiceData {
 		mockAgglayerClient: mockAgglayerClient,
 		mockSigner:         mockSigner,
 		sut:                sut,
+	}
+}
+
+func newGRPCCertificateForTest(t *testing.T) nodev1.Certificate {
+	t.Helper()
+	testL1InfoTreeLeafCount = uint32(123)
+	return nodev1.Certificate{
+		Height:              42,
+		NewLocalExitRoot:    &typesv1.FixedBytes32{},
+		PrevLocalExitRoot:   &typesv1.FixedBytes32{},
+		Metadata:            &typesv1.FixedBytes32{},
+		L1InfoTreeLeafCount: &testL1InfoTreeLeafCount,
+		AggchainData:        &typesv1.AggchainData{Data: signature},
 	}
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- Comments from PR #773 
- Check that bridgeExit.Amount no es negative (https://github.com/agglayer/aggkit/pull/773#discussion_r2228519923)
- Improvement in validate certificate implementation  (https://github.com/agglayer/aggkit/pull/773#discussion_r2228537651)
- Avoid warning `assignment copies lock value` in unittest execution (https://github.com/agglayer/aggkit/pull/773#discussion_r2228543043)
