### PR TITLE
feat: allow `CreatedAt` and `UpdatedAt` to be zero

### DIFF
--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -9,7 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const NilStr = "nil"
+const (
+	NilStr = "nil"
+	NAStr  = "N/A"
+)
 
 type AggsenderMode string
 
@@ -200,6 +203,16 @@ func (c *CertificateHeader) String() string {
 		finalizedL1InfoTreeRoot = c.FinalizedL1InfoTreeRoot.String()
 	}
 
+	createdAt := NAStr
+	if c.CreatedAt != 0 {
+		createdAt = time.Unix(int64(c.CreatedAt), 0).Format(time.RFC1123) // For a more human-readable format
+	}
+
+	updatedAt := NAStr
+	if c.UpdatedAt != 0 {
+		updatedAt = time.Unix(int64(c.UpdatedAt), 0).Format(time.RFC1123) // For a more human-readable format
+	}
+
 	return fmt.Sprintf("aggsender.CertificateHeader: \n"+
 		"Type: %s \n"+
 		"Height: %d \n"+
@@ -223,8 +236,8 @@ func (c *CertificateHeader) String() string {
 		c.Status.String(),
 		c.FromBlock,
 		c.ToBlock,
-		time.Unix(int64(c.CreatedAt), 0),
-		time.Unix(int64(c.UpdatedAt), 0),
+		createdAt,
+		updatedAt,
 		finalizedL1InfoTreeRoot,
 		c.CertSource.String(),
 	)
@@ -256,11 +269,11 @@ func (c *CertificateHeader) IsClosed() bool {
 }
 
 // ElapsedTimeSinceCreation returns the time elapsed since the certificate was created
-func (c *CertificateHeader) ElapsedTimeSinceCreation() time.Duration {
-	if c == nil {
-		return 0
+func (c *CertificateHeader) ElapsedTimeSinceCreation() string {
+	if c == nil || c.CreatedAt == 0 {
+		return NAStr
 	}
-	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0))
+	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0)).String()
 }
 
 type Certificate struct {

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -60,7 +60,22 @@ func TestCertificate_String(t *testing.T) {
 
 		require.Equal(t, expected, cert.String())
 	})
+
+	t.Run("CreatedAt and UpdatedAt are 0", func(t *testing.T) {
+		cert := &Certificate{
+			Header: &CertificateHeader{
+				CreatedAt: 0,
+				UpdatedAt: 0,
+			},
+		}
+
+		certStr := cert.String()
+
+		require.Containsf(t, certStr, "CreatedAt: N/A", "Expected CreatedAt to be N/A")
+		require.Containsf(t, certStr, "UpdatedAt: N/A", "Expected UpdatedAt to be N/A")
+	})
 }
+
 func TestCertificateType_String(t *testing.T) {
 	tests := []struct {
 		input    CertificateType
@@ -203,4 +218,34 @@ func TestCertificateSource_String(t *testing.T) {
 			require.Equal(t, tt.expected, tt.input.String())
 		})
 	}
+}
+
+func TestCertificateHeader_ElapsedTimeSinceCreation(t *testing.T) {
+	t.Run("NilCertificateHeader", func(t *testing.T) {
+		var ch *CertificateHeader
+		require.Equal(t, NAStr, ch.ElapsedTimeSinceCreation())
+	})
+
+	t.Run("CreatedAtIsZero", func(t *testing.T) {
+		ch := &CertificateHeader{CreatedAt: 0}
+		require.Equal(t, NAStr, ch.ElapsedTimeSinceCreation())
+	})
+
+	t.Run("CreatedAtIsNow", func(t *testing.T) {
+		now := uint32(time.Now().Unix())
+		ch := &CertificateHeader{CreatedAt: now}
+		result := ch.ElapsedTimeSinceCreation()
+		// Should be a duration string, e.g., "0s"
+		require.Contains(t, result, "s")
+	})
+
+	t.Run("CreatedAtIsPast", func(t *testing.T) {
+		past := uint32(time.Now().Add(-10 * time.Second).Unix())
+		ch := &CertificateHeader{CreatedAt: past}
+		result := ch.ElapsedTimeSinceCreation()
+		// Should be at least 10s
+		dur, err := time.ParseDuration(result)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, int64(dur.Seconds()), int64(10))
+	})
 }


### PR DESCRIPTION
## 🔄 Changes Summary
Fields `CreatedAt` and `UpdatedAt` on certificates are purely `aggsender` constructs used for debugging purposes and for logging.

`CreatedAt` field is a part of the certificate `Metadata` field, which will be removed in Phase III of `aggsender multi sig` feature. Because of this, only `aggsender proposer` `db` will save `CreatedAt` and `UpdatedAt` fields, but when resyncing its state with `agglayer` (when starting from scratch), it will not have this field, since `Metadata` will be removed, so we need to support these fields to be 0 in this case.

The PR changed the functions that print and log these fields, so that when they are 0, we print `N/A` string.

## ⚠️ Breaking Changes
- NA

## 📋 Config Updates
- NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI tests are enough to test this

## 🐞 Issues
- Closes #801
