### PR TITLE
fix: bug when bridge l1 syncer is stopped and l1 info tree syncer continues

### DIFF
--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -968,10 +968,14 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL1Bridge(ctx context.Context, 
 
 	root, err := b.bridgeL1.GetRootByLER(ctx, lastInfo.MainnetExitRoot)
 	if err != nil {
-		b.logger.Infof("failed to get root by LER for L1: %v, lastInfo MainnetExitRoot: %v, using fallback mechanism", err, lastInfo.MainnetExitRoot)
+		b.logger.Infof(
+			"failed to get root by LER for L1: %v, lastInfo MainnetExitRoot: %v, using fallback mechanism",
+			err,
+			lastInfo.MainnetExitRoot,
+		)
 		root, err = b.bridgeL1.GetLastRoot(ctx)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get last root for L1: %v", err)
+			return 0, fmt.Errorf("failed to get last root for L1: %w", err)
 		}
 	}
 	if root.Index < depositCount {
@@ -1025,10 +1029,14 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL2Bridge(ctx context.Context, 
 
 	root, err := b.bridgeL2.GetRootByLER(ctx, lastVerified.ExitRoot)
 	if err != nil {
-		b.logger.Infof("failed to get root by LER for L2: %v, lastVerified ExitRoot: %v, using fallback mechanism", err, lastVerified.ExitRoot)
+		b.logger.Infof(
+			"failed to get root by LER for L2: %v, lastVerified ExitRoot: %v, using fallback mechanism",
+			err,
+			lastVerified.ExitRoot,
+		)
 		root, err = b.bridgeL2.GetLastRoot(ctx)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get last root for L2: %v", err)
+			return 0, fmt.Errorf("failed to get last root for L2: %w", err)
 		}
 	}
 	if root.Index < depositCount {

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -968,7 +968,11 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL1Bridge(ctx context.Context, 
 
 	root, err := b.bridgeL1.GetRootByLER(ctx, lastInfo.MainnetExitRoot)
 	if err != nil {
-		return 0, err
+		b.logger.Infof("failed to get root by LER for L1: %v, lastInfo MainnetExitRoot: %v, using fallback mechanism", err, lastInfo.MainnetExitRoot)
+		root, err = b.bridgeL1.GetLastRoot(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get last root for L1: %v", err)
+		}
 	}
 	if root.Index < depositCount {
 		return 0, ErrNotOnL1Info
@@ -1021,7 +1025,11 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL2Bridge(ctx context.Context, 
 
 	root, err := b.bridgeL2.GetRootByLER(ctx, lastVerified.ExitRoot)
 	if err != nil {
-		return 0, err
+		b.logger.Infof("failed to get root by LER for L2: %v, lastVerified ExitRoot: %v, using fallback mechanism", err, lastVerified.ExitRoot)
+		root, err = b.bridgeL2.GetLastRoot(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get last root for L2: %v", err)
+		}
 	}
 	if root.Index < depositCount {
 		return 0, ErrNotOnL1Info

--- a/bridgeservice/bridge_interfaces.go
+++ b/bridgeservice/bridge_interfaces.go
@@ -13,6 +13,7 @@ import (
 type Bridger interface {
 	GetProof(ctx context.Context, depositCount uint32, localExitRoot common.Hash) (tree.Proof, error)
 	GetRootByLER(ctx context.Context, ler common.Hash) (*tree.Root, error)
+	GetLastRoot(ctx context.Context) (*tree.Root, error)
 	GetBridgesPaged(ctx context.Context, pageNumber, pageSize uint32,
 		depositCount *uint64, networkIDs []uint32, fromAddress string) ([]*bridgesync.Bridge, int, error)
 	GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*bridgesync.TokenMapping, int, error)

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -144,7 +144,7 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge(t *testing.T) {
 			},
 			depositCount:  11,
 			expectedIndex: 0,
-			expectedErr:   fooErr,
+			expectedErr:   fmt.Errorf("failed to get last root for L1: %w", fooErr),
 		},
 		{
 			description: "not included yet",
@@ -354,7 +354,7 @@ func TestGetFirstL1InfoTreeIndexForL2Bridge(t *testing.T) {
 			},
 			depositCount:  11,
 			expectedIndex: 0,
-			expectedErr:   fooErr,
+			expectedErr:   fmt.Errorf("failed to get last root for L2: %w", fooErr),
 		},
 		{
 			description: "not included yet",

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -129,13 +129,17 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge(t *testing.T) {
 			expectedErr:   fooErr,
 		},
 		{
-			description: "error on first GetRootByLER",
+			description: "error on first GetRootByLER and GetLastRoot",
 			setupMocks: func() {
 				b.l1InfoTree.EXPECT().GetLastInfo().
 					Return(lastL1Info, nil).
 					Once()
 				b.bridgeL1.EXPECT().GetRootByLER(ctx, lastL1Info.MainnetExitRoot).
 					Return(&tree.Root{}, fooErr).
+					Once()
+				// With the fallback logic, it will try GetLastRoot when GetRootByLER fails
+				b.bridgeL1.EXPECT().GetLastRoot(ctx).
+					Return(nil, fooErr).
 					Once()
 			},
 			depositCount:  11,
@@ -194,7 +198,7 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge(t *testing.T) {
 			expectedErr:   fooErr,
 		},
 		{
-			description: "error on GetRootByLER (inside binnary search)",
+			description: "error on GetRootByLER (inside binary search)",
 			setupMocks: func() {
 				b.l1InfoTree.EXPECT().GetLastInfo().
 					Return(lastL1Info, nil).
@@ -344,6 +348,9 @@ func TestGetFirstL1InfoTreeIndexForL2Bridge(t *testing.T) {
 				b.bridgeL2.EXPECT().GetRootByLER(ctx, lastVerified.ExitRoot).
 					Return(&tree.Root{}, fooErr).
 					Once()
+				b.bridgeL2.EXPECT().GetLastRoot(ctx).
+					Return(&tree.Root{}, fooErr).
+					Once()
 			},
 			depositCount:  11,
 			expectedIndex: 0,
@@ -401,7 +408,7 @@ func TestGetFirstL1InfoTreeIndexForL2Bridge(t *testing.T) {
 			expectedErr:   fooErr,
 		},
 		{
-			description: "error on GetRootByLER (inside binnary search)",
+			description: "error on GetRootByLER (inside binary search)",
 			setupMocks: func() {
 				b.l1InfoTree.EXPECT().GetLastVerifiedBatches(networkID).
 					Return(lastVerified, nil).
@@ -1369,7 +1376,7 @@ func TestL1InfoTreeIndexForBridgeHandler(t *testing.T) {
 		require.Contains(t, w.Body.String(), fooErrMsg)
 	})
 
-	t.Run("Error from GetRootByLER", func(t *testing.T) {
+	t.Run("Error from GetRootByLER and GetLastRoot", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 
 		bridgeMocks.l1InfoTree.EXPECT().
@@ -1386,13 +1393,18 @@ func TestL1InfoTreeIndexForBridgeHandler(t *testing.T) {
 			GetRootByLER(mock.Anything, mock.Anything).
 			Return(nil, fmt.Errorf(barErrMsg))
 
+		// With the fallback logic, it will try GetLastRoot when GetRootByLER fails
+		bridgeMocks.bridgeL1.EXPECT().
+			GetLastRoot(mock.Anything).
+			Return(nil, fmt.Errorf("last root error"))
+
 		queryParams := url.Values{}
 		queryParams.Set("network_id", "0")
 		queryParams.Set("deposit_count", fmt.Sprintf("%d", depositCount))
 
 		w := performRequest(t, bridgeMocks.bridge.router, http.MethodGet, fmt.Sprintf("%s/l1-info-tree-index?%s", BridgeV1Prefix, queryParams.Encode()), nil)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
-		require.Contains(t, w.Body.String(), barErrMsg)
+		require.Contains(t, w.Body.String(), "last root error")
 	})
 
 	t.Run("Invalid network ID parameter", func(t *testing.T) {
@@ -2137,4 +2149,191 @@ func TestHealthCheckHandler(t *testing.T) {
 	require.Equal(t, "ok", response.Status)
 	require.NotEmpty(t, response.Time)
 	require.NotEmpty(t, response.Version)
+}
+
+func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
+	ctx := context.Background()
+	networkID := uint32(1)
+	b := newBridgeWithMocks(t, networkID)
+
+	lastInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     1000,
+		MainnetExitRoot: common.HexToHash("0xabc"),
+		L1InfoTreeIndex: 1000,
+	}
+
+	firstInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     10,
+		MainnetExitRoot: common.HexToHash("0xdef"),
+		L1InfoTreeIndex: 10,
+	}
+
+	depositCount := uint32(500)
+	expectedIndex := uint32(500)
+
+	t.Run("GetRootByLER fails but GetLastRoot succeeds", func(t *testing.T) {
+		// Setup mocks for the fallback scenario
+		b.l1InfoTree.EXPECT().GetLastInfo().
+			Return(lastInfo, nil).
+			Once()
+
+		// First call to GetRootByLER fails
+		b.bridgeL1.EXPECT().GetRootByLER(ctx, lastInfo.MainnetExitRoot).
+			Return(nil, errors.New("LER not found")).
+			Once()
+
+		// Fallback to GetLastRoot succeeds
+		fallbackRoot := &tree.Root{
+			Index:    depositCount,
+			BlockNum: uint64(depositCount),
+		}
+		b.bridgeL1.EXPECT().GetLastRoot(ctx).
+			Return(fallbackRoot, nil).
+			Once()
+
+		// Continue with normal flow
+		b.l1InfoTree.EXPECT().GetFirstInfo().
+			Return(firstInfo, nil).
+			Once()
+
+		// Mock the binary search calls
+		targetInfo := &l1infotreesync.L1InfoTreeLeaf{
+			BlockNumber:     uint64(expectedIndex),
+			MainnetExitRoot: common.HexToHash("0x123"),
+			L1InfoTreeIndex: expectedIndex,
+		}
+		b.l1InfoTree.EXPECT().GetFirstInfoAfterBlock(mock.Anything).
+			Return(targetInfo, nil).
+			Once()
+
+		// Mock successful GetRootByLER in binary search
+		b.bridgeL1.EXPECT().GetRootByLER(ctx, targetInfo.MainnetExitRoot).
+			Return(&tree.Root{Index: depositCount}, nil).
+			Once()
+
+		// Execute the function
+		actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(ctx, depositCount)
+
+		// Verify results
+		require.NoError(t, err)
+		require.Equal(t, expectedIndex, actualIndex)
+
+		// Verify all mocks were called as expected
+		b.l1InfoTree.AssertExpectations(t)
+		b.bridgeL1.AssertExpectations(t)
+	})
+
+	t.Run("GetRootByLER fails and GetLastRoot also fails", func(t *testing.T) {
+		// Setup mocks for the double failure scenario
+		b.l1InfoTree.EXPECT().GetLastInfo().
+			Return(lastInfo, nil).
+			Once()
+
+		// First call to GetRootByLER fails
+		b.bridgeL1.EXPECT().GetRootByLER(ctx, lastInfo.MainnetExitRoot).
+			Return(nil, errors.New("LER not found")).
+			Once()
+
+		// Fallback to GetLastRoot also fails
+		b.bridgeL1.EXPECT().GetLastRoot(ctx).
+			Return(nil, errors.New("last root not available")).
+			Once()
+
+		// Execute the function
+		actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(ctx, depositCount)
+
+		// Verify results - should return error from GetLastRoot
+		require.Error(t, err)
+		require.Equal(t, uint32(0), actualIndex)
+		require.Contains(t, err.Error(), "last root not available")
+
+		// Verify all mocks were called as expected
+		b.l1InfoTree.AssertExpectations(t)
+		b.bridgeL1.AssertExpectations(t)
+	})
+
+	t.Run("GetRootByLER fails, GetLastRoot succeeds but root index is too low", func(t *testing.T) {
+		// Setup mocks for the fallback scenario with insufficient index
+		b.l1InfoTree.EXPECT().GetLastInfo().
+			Return(lastInfo, nil).
+			Once()
+
+		// First call to GetRootByLER fails
+		b.bridgeL1.EXPECT().GetRootByLER(ctx, lastInfo.MainnetExitRoot).
+			Return(nil, errors.New("LER not found")).
+			Once()
+
+		// Fallback to GetLastRoot succeeds but returns low index
+		fallbackRoot := &tree.Root{
+			Index:    depositCount - 100, // Lower than depositCount
+			BlockNum: uint64(depositCount - 100),
+		}
+		b.bridgeL1.EXPECT().GetLastRoot(ctx).
+			Return(fallbackRoot, nil).
+			Once()
+
+		// Execute the function
+		actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(ctx, depositCount)
+
+		// Verify results - should return ErrNotOnL1Info
+		require.Error(t, err)
+		require.Equal(t, uint32(0), actualIndex)
+		require.Equal(t, ErrNotOnL1Info, err)
+
+		// Verify all mocks were called as expected
+		b.l1InfoTree.AssertExpectations(t)
+		b.bridgeL1.AssertExpectations(t)
+	})
+
+	t.Run("GetRootByLER fails, GetLastRoot succeeds with higher index", func(t *testing.T) {
+		// Setup mocks for the fallback scenario with higher index
+		b.l1InfoTree.EXPECT().GetLastInfo().
+			Return(lastInfo, nil).
+			Once()
+
+		// First call to GetRootByLER fails
+		b.bridgeL1.EXPECT().GetRootByLER(ctx, lastInfo.MainnetExitRoot).
+			Return(nil, errors.New("LER not found")).
+			Once()
+
+		// Fallback to GetLastRoot succeeds with higher index
+		fallbackRoot := &tree.Root{
+			Index:    depositCount + 50, // Higher than depositCount
+			BlockNum: uint64(depositCount + 50),
+		}
+		b.bridgeL1.EXPECT().GetLastRoot(ctx).
+			Return(fallbackRoot, nil).
+			Once()
+
+		// Continue with normal flow
+		b.l1InfoTree.EXPECT().GetFirstInfo().
+			Return(firstInfo, nil).
+			Once()
+
+		// Mock the binary search calls
+		targetInfo := &l1infotreesync.L1InfoTreeLeaf{
+			BlockNumber:     uint64(expectedIndex),
+			MainnetExitRoot: common.HexToHash("0x123"),
+			L1InfoTreeIndex: expectedIndex,
+		}
+		b.l1InfoTree.EXPECT().GetFirstInfoAfterBlock(mock.Anything).
+			Return(targetInfo, nil).
+			Once()
+
+		// Mock successful GetRootByLER in binary search
+		b.bridgeL1.EXPECT().GetRootByLER(ctx, targetInfo.MainnetExitRoot).
+			Return(&tree.Root{Index: depositCount}, nil).
+			Once()
+
+		// Execute the function
+		actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(ctx, depositCount)
+
+		// Verify results
+		require.NoError(t, err)
+		require.Equal(t, expectedIndex, actualIndex)
+
+		// Verify all mocks were called as expected
+		b.l1InfoTree.AssertExpectations(t)
+		b.bridgeL1.AssertExpectations(t)
+	})
 }

--- a/bridgeservice/mocks/mock_bridger.go
+++ b/bridgeservice/mocks/mock_bridger.go
@@ -279,6 +279,64 @@ func (_c *Bridger_GetLastReorgEvent_Call) RunAndReturn(run func(context.Context)
 	return _c
 }
 
+// GetLastRoot provides a mock function with given fields: ctx
+func (_m *Bridger) GetLastRoot(ctx context.Context) (*types.Root, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastRoot")
+	}
+
+	var r0 *types.Root
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*types.Root, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *types.Root); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.Root)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Bridger_GetLastRoot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastRoot'
+type Bridger_GetLastRoot_Call struct {
+	*mock.Call
+}
+
+// GetLastRoot is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Bridger_Expecter) GetLastRoot(ctx interface{}) *Bridger_GetLastRoot_Call {
+	return &Bridger_GetLastRoot_Call{Call: _e.mock.On("GetLastRoot", ctx)}
+}
+
+func (_c *Bridger_GetLastRoot_Call) Run(run func(ctx context.Context)) *Bridger_GetLastRoot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *Bridger_GetLastRoot_Call) Return(_a0 *types.Root, _a1 error) *Bridger_GetLastRoot_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Bridger_GetLastRoot_Call) RunAndReturn(run func(context.Context) (*types.Root, error)) *Bridger_GetLastRoot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLegacyTokenMigrations provides a mock function with given fields: ctx, pageNumber, pageSize
 func (_m *Bridger) GetLegacyTokenMigrations(ctx context.Context, pageNumber uint32, pageSize uint32) ([]*bridgesync.LegacyTokenMigration, int, error) {
 	ret := _m.Called(ctx, pageNumber, pageSize)

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -398,6 +398,17 @@ func (s *BridgeSync) GetBlockByLER(ctx context.Context, ler common.Hash) (uint64
 	return root.BlockNum, nil
 }
 
+func (s *BridgeSync) GetLastRoot(ctx context.Context) (*tree.Root, error) {
+	if s.processor.isHalted() {
+		return nil, sync.ErrInconsistentState
+	}
+	root, err := s.processor.exitTree.GetLastRoot(s.processor.db)
+	if err != nil {
+		return nil, err
+	}
+	return &root, nil
+}
+
 func (s *BridgeSync) GetRootByLER(ctx context.Context, ler common.Hash) (*tree.Root, error) {
 	if s.processor.isHalted() {
 		return nil, sync.ErrInconsistentState

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -486,3 +486,169 @@ func TestBridgeSync_GetLastReorgEvent(t *testing.T) {
 		require.Nil(t, reorgEvent)
 	})
 }
+
+func TestBridgeSync_GetLastRoot(t *testing.T) {
+	const (
+		syncBlockChunkSize         = uint64(100)
+		initialBlock               = uint64(0)
+		waitForNewBlocksPeriod     = time.Second * 10
+		retryAfterErrorPeriod      = time.Second * 5
+		maxRetryAttemptsAfterError = 3
+		originNetwork              = uint32(1)
+	)
+
+	var (
+		blockFinalityType = aggkittypes.SafeBlock
+		ctx               = context.Background()
+		dbPath            = path.Join(t.TempDir(), "TestGetLastRoot.sqlite")
+		bridge            = common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	)
+
+	mockEthClient := mocksethclient.NewEthClienter(t)
+	mockEthClient.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(
+		common.FromHex("0x000000000000000000000000000000000000000000000000000000000000002a"), nil).Once()
+	mockEthClient.EXPECT().
+		CallContract(
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).
+		Return(common.LeftPadBytes(common.HexToAddress("0x3c351e10").Bytes(), 32), nil).
+		Maybe()
+	mockReorgDetector := mocksbridgesync.NewReorgDetector(t)
+
+	mockReorgDetector.EXPECT().Subscribe(mock.Anything).Return(nil, nil)
+	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
+	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
+
+	s, err := NewL2(
+		ctx,
+		dbPath,
+		bridge,
+		syncBlockChunkSize,
+		blockFinalityType,
+		mockReorgDetector,
+		mockEthClient,
+		initialBlock,
+		waitForNewBlocksPeriod,
+		retryAfterErrorPeriod,
+		maxRetryAttemptsAfterError,
+		originNetwork,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	t.Run("get last root when no roots exist", func(t *testing.T) {
+		root, err := s.GetLastRoot(ctx)
+		require.Error(t, err)
+		require.Nil(t, root)
+		// The error should be db.ErrNotFound from the tree package
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("get last root after processing bridge events", func(t *testing.T) {
+		// Create some bridge events to process
+		bridgeEvents := []interface{}{
+			Event{Bridge: &Bridge{
+				BlockNum:           1,
+				BlockPos:           0,
+				FromAddress:        common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				TxHash:             common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+				Calldata:           []byte{0x01, 0x02, 0x03},
+				BlockTimestamp:     1234567890,
+				LeafType:           1,
+				OriginNetwork:      1,
+				OriginAddress:      common.HexToAddress("0x3333333333333333333333333333333333333333"),
+				DestinationNetwork: 2,
+				DestinationAddress: common.HexToAddress("0x4444444444444444444444444444444444444444"),
+				Amount:             big.NewInt(1000000),
+				Metadata:           []byte{0x04, 0x05, 0x06},
+				DepositCount:       0,
+				IsNativeToken:      true,
+			}},
+			Event{Bridge: &Bridge{
+				BlockNum:           1,
+				BlockPos:           1,
+				FromAddress:        common.HexToAddress("0x5555555555555555555555555555555555555555"),
+				TxHash:             common.HexToHash("0x6666666666666666666666666666666666666666666666666666666666666666"),
+				Calldata:           []byte{0x07, 0x08, 0x09},
+				BlockTimestamp:     1234567890,
+				LeafType:           1,
+				OriginNetwork:      1,
+				OriginAddress:      common.HexToAddress("0x7777777777777777777777777777777777777777"),
+				DestinationNetwork: 2,
+				DestinationAddress: common.HexToAddress("0x8888888888888888888888888888888888888888"),
+				Amount:             big.NewInt(2000000),
+				Metadata:           []byte{0x0a, 0x0b, 0x0c},
+				DepositCount:       1,
+				IsNativeToken:      false,
+			}},
+		}
+
+		block := sync.Block{
+			Num:    1,
+			Events: bridgeEvents,
+		}
+
+		err = s.processor.ProcessBlock(ctx, block)
+		require.NoError(t, err)
+
+		root, err := s.GetLastRoot(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, root)
+		require.Equal(t, uint64(1), root.BlockNum)
+		require.Equal(t, uint64(1), root.BlockPosition)
+		require.Equal(t, uint32(1), root.Index)
+		require.NotEqual(t, common.Hash{}, root.Hash)
+	})
+
+	t.Run("get last root when processor is halted", func(t *testing.T) {
+		s.processor.halted = true
+		root, err := s.GetLastRoot(ctx)
+		require.ErrorIs(t, err, sync.ErrInconsistentState)
+		require.Nil(t, root)
+	})
+
+	t.Run("get last root after multiple blocks", func(t *testing.T) {
+		// Reset halted state
+		s.processor.halted = false
+
+		// Process another block with more bridge events
+		bridgeEvents := []interface{}{
+			Event{Bridge: &Bridge{
+				BlockNum:           2,
+				BlockPos:           0,
+				FromAddress:        common.HexToAddress("0x9999999999999999999999999999999999999999"),
+				TxHash:             common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+				Calldata:           []byte{0x0d, 0x0e, 0x0f},
+				BlockTimestamp:     1234567891,
+				LeafType:           1,
+				OriginNetwork:      1,
+				OriginAddress:      common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+				DestinationNetwork: 2,
+				DestinationAddress: common.HexToAddress("0xcccccccccccccccccccccccccccccccccccccccc"),
+				Amount:             big.NewInt(3000000),
+				Metadata:           []byte{0x10, 0x11, 0x12},
+				DepositCount:       2,
+				IsNativeToken:      true,
+			}},
+		}
+
+		block := sync.Block{
+			Num:    2,
+			Events: bridgeEvents,
+		}
+
+		err = s.processor.ProcessBlock(ctx, block)
+		require.NoError(t, err)
+
+		root, err := s.GetLastRoot(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, root)
+		require.Equal(t, uint64(2), root.BlockNum)
+		require.Equal(t, uint64(0), root.BlockPosition)
+		require.Equal(t, uint32(2), root.Index)
+		require.NotEqual(t, common.Hash{}, root.Hash)
+	})
+}


### PR DESCRIPTION
## 🔄 Changes Summary
- fallback mechanism where if we dont have latest l1infotree index in l1 or l2 dbs

## 🐞 Issues
- Closes #827 