### PR TITLE
refactor: include certificate height in signed cert file name

### DIFF
--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -277,13 +277,14 @@ func (a *AggSenderSQLStorage) SaveOrUpdateCertificate(ctx context.Context, certi
 // saveSignedCertificateToFile saves the signed certificate content to a file in the same directory as the database
 // and returns the file path
 func (a *AggSenderSQLStorage) saveSignedCertificateToFile(
+	certificateHeight uint64,
 	certificateID common.Hash,
 	signedCertContent string) (string, error) {
 	// Get the directory where the database is stored
 	dbDir := filepath.Dir(a.cfg.DBPath)
 
 	// Create a filename using the certificate ID
-	fileName := fmt.Sprintf("signed_cert_%s.json", certificateID)
+	fileName := fmt.Sprintf("signed_cert_%d_%s.json", certificateHeight, certificateID)
 	filePath := filepath.Join(dbDir, fileName)
 
 	// Write the signed certificate content to the file
@@ -565,7 +566,11 @@ func (a *AggSenderSQLStorage) GetNonAcceptedCertificate() (*NonAcceptedCertifica
 // handleCertificateFile Handle signed certificate file storage before database operations
 func (a *AggSenderSQLStorage) handleCertificateFile(certificate *types.Certificate) error {
 	if certificate.SignedCertificate != nil && *certificate.SignedCertificate != "" {
-		filePath, err := a.saveSignedCertificateToFile(certificate.Header.CertificateID, *certificate.SignedCertificate)
+		filePath, err := a.saveSignedCertificateToFile(
+			certificate.Header.Height,
+			certificate.Header.CertificateID,
+			*certificate.SignedCertificate,
+		)
 		if err != nil {
 			return fmt.Errorf("error saving signed certificate to file: %w", err)
 		}


### PR DESCRIPTION
## 🔄 Changes Summary

This pull request updates the logic for saving signed certificate files to improve file naming and ensure certificate height is included in the filename. The main changes are in the `AggSenderSQLStorage` implementation and affect how certificate files are stored and referenced.
