### PR TITLE
feat: update hash to sign by the aggsender validators

### DIFF
--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -33,6 +33,9 @@ const (
 	EstimatedAggchainSignatureSize  = 0.07 * aggkitcommon.KB
 	EstimatedBridgeExitSize         = 0.09 * aggkitcommon.KB
 	EstimatedImportedBridgeExitSize = 2.8 * aggkitcommon.KB
+
+	// GlobalIndexBytesSize denotes the size in bytes when global index gets encoded
+	GlobalIndexBytesSize = 9
 )
 
 var (

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -331,6 +331,7 @@ func (c *Certificate) Brief() string {
 
 // CertificateID returns a certificateID that identifies the certificate
 // next fields are not included: CustomChainData, AggchainData, L1InfoTreeLeafCount
+// TODO: probably about to be changed for phase III
 func (c *Certificate) CertificateID() common.Hash {
 	bridgeExitsHashes := make([][]byte, len(c.BridgeExits))
 	for i, bridgeExit := range c.BridgeExits {

--- a/aggsender/validator/cert_hash.go
+++ b/aggsender/validator/cert_hash.go
@@ -14,7 +14,8 @@ func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error)
 		return common.Hash{}, err
 	}
 
-	claimsRawMetadata := make([]byte, 0, len(cert.ImportedBridgeExits)*2)
+	claimsRawMetadata := make([]byte, 0,
+		len(cert.ImportedBridgeExits)*(agglayertypes.GlobalIndexBytesSize+common.HashLength))
 	for _, ibe := range cert.ImportedBridgeExits {
 		claimsRawMetadata = append(claimsRawMetadata, aggkitcommon.BigIntToLittleEndianBytes(ibe.GlobalIndex.ToBigInt())...)
 		claimsRawMetadata = append(claimsRawMetadata, ibe.BridgeExit.Hash().Bytes()...)

--- a/aggsender/validator/cert_hash.go
+++ b/aggsender/validator/cert_hash.go
@@ -13,7 +13,26 @@ func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error)
 	if err := cert.Validate(); err != nil {
 		return common.Hash{}, err
 	}
+
+	claimsRawMetadata := []byte{}
+	for _, ibe := range cert.ImportedBridgeExits {
+		claimsRawMetadata = append(claimsRawMetadata, aggkitcommon.BigIntToLittleEndianBytes(ibe.GlobalIndex.ToBigInt())...)
+		claimsRawMetadata = append(claimsRawMetadata, ibe.BridgeExit.Hash().Bytes()...)
+	}
+
+	claimsHash := crypto.Keccak256(claimsRawMetadata)
+
+	var aggchainParams []byte
+	aggchainData, ok := cert.AggchainData.(*agglayertypes.AggchainDataProof)
+	if ok {
+		aggchainParams = aggchainData.AggchainParams.Bytes()
+	}
+
 	return crypto.Keccak256Hash(
+		cert.NewLocalExitRoot.Bytes(),
+		claimsHash,
+		aggkitcommon.Uint64ToLittleEndianBytes(cert.Height),
+		aggchainParams,
 		cert.CertificateID().Bytes(),
-		aggkitcommon.Uint32ToBytes(cert.L1InfoTreeLeafCount)), nil
+	), nil
 }

--- a/aggsender/validator/cert_hash.go
+++ b/aggsender/validator/cert_hash.go
@@ -14,7 +14,7 @@ func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error)
 		return common.Hash{}, err
 	}
 
-	claimsRawMetadata := []byte{}
+	claimsRawMetadata := make([]byte, 0, len(cert.ImportedBridgeExits)*2)
 	for _, ibe := range cert.ImportedBridgeExits {
 		claimsRawMetadata = append(claimsRawMetadata, aggkitcommon.BigIntToLittleEndianBytes(ibe.GlobalIndex.ToBigInt())...)
 		claimsRawMetadata = append(claimsRawMetadata, ibe.BridgeExit.Hash().Bytes()...)

--- a/aggsender/validator/cert_hash_test.go
+++ b/aggsender/validator/cert_hash_test.go
@@ -24,7 +24,7 @@ func TestHashCertificateToSign(t *testing.T) {
 
 		hash, err := HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x7f79b617b1ee18f06b6b5104d065ef71370688bbdf22d13c756e63a2b8b24f1e", hash.String())
+		require.Equal(t, "0xf60d40dabaa4d0a427d04a19b6cd58d57c28a5c58b76791e349fc1b5e0223c45", hash.String())
 	})
 
 	t.Run("error hashing invalid cert ", func(t *testing.T) {
@@ -46,19 +46,19 @@ func TestHashCertificateToSign(t *testing.T) {
 		_, cert := getCertFromAggsenderDBForTest(t)
 		hash, err := HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0xe927a8204f8f4750e4cc2c3938e43b88eaccc7ddb5f21b54ede4a69843e87b3d", hash.String())
+		require.Equal(t, "0x4e43189545291d5d69db51da28e7534b4fc1d501602c454111778f987a012977", hash.String())
 		cert.NetworkID += 1
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x84ecc0220119803af79a5be33d9efcaea76862da70ef044151d5ae1d7b12fd4c", hash.String())
+		require.Equal(t, "0xd19f41bf5692eefcbf8efbfeed974ac9adac836abd418504c48b1f25f9480bf5", hash.String())
 		cert.Height += 1
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x88cfb3efdb3802f8a86ab1d6484ca7e2a00310da5545b4de8ae8c9011994316b", hash.String())
+		require.Equal(t, "0x53054a4b3a9b64077e38e29726d51307303f040d9624f8399492c714ad74f268", hash.String())
 		cert.Metadata = [32]byte{6, 7, 8, 9, 10}
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x73a8e14ed3b09cb31c27a8a833f1257cbd6507c6d5716eb55d99b7bbedabbae6", hash.String())
+		require.Equal(t, "0xbb5243f1087a7e1fdb23954f20e03ac8b9b8aca0e01f2a7c38f16d1c23fbf4f1", hash.String())
 	})
 }
 
@@ -68,7 +68,7 @@ func TestCertificateIdHash(t *testing.T) {
 	require.Equal(t, cert.Header.CertificateID, id)
 	hash, err := HashCertificateToSign(unmarshalCert)
 	require.NoError(t, err)
-	require.Equal(t, "0xe927a8204f8f4750e4cc2c3938e43b88eaccc7ddb5f21b54ede4a69843e87b3d", hash.String())
+	require.Equal(t, "0x4e43189545291d5d69db51da28e7534b4fc1d501602c454111778f987a012977", hash.String())
 }
 
 // Returns aggsender and agglayer cert

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -944,9 +944,7 @@ func GenerateGlobalIndex(mainnetFlag bool, rollupIndex uint32, localExitRootInde
 	leri := new(big.Int).SetUint64(uint64(localExitRootIndex)).FillBytes(buf[:])
 	globalIndexBytes = append(globalIndexBytes, leri...)
 
-	result := new(big.Int).SetBytes(globalIndexBytes)
-
-	return result
+	return new(big.Int).SetBytes(globalIndexBytes)
 }
 
 // Decodes global index to its three parts:


### PR DESCRIPTION
## 🔄 Changes Summary
The hash for the aggsender validator is calculated based on this [comment](https://github.com/agglayer/protocol-research/issues/169#issuecomment-3136968862).

```rust
commitment = keccak256_combine([
    certificate.new_local_exit_root,
    commit_imported_bridge_exits: certificate.claim_hash(), // defined below
    certificate.height,
    certificate.aggchain_params, // nil value if no aggchain proof
    certificate_id // re-computed only on the agglayer, but free input for the PP
]);

/// keccak(ib[0].global_index # ib[0].bridge_exit_hash # .. # ib[n].global_index # ib[n].bridge_exit_hash)
fn claim_hash() -> Digest {
    keccak256_combine(self.imported_bridge_exits.iter().map(|ibe| {
        [
            ibe.global_index.as_le_slice(),
            ibe.bridge_exit_hash.as_slice(),
        ]
        .concat()
    }))
}
```

## ⚠️ Breaking Changes
- 🛠️ **Config**: N/A
- 🔌 **API/CLI**: N/A
- 🗑️ **Deprecated Features**: N/A

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: N/A

## 🐞 Issues
- Closes #804

## 🔗 Related PRs
- N/A

## 📝 Notes
- N/A
