### PR TITLE
fix: error when running `l1infotreesync` component in standalone mode

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -754,6 +754,7 @@ func createRollupDataQuerier(ctx context.Context,
 		aggkitcommon.AGGSENDER,
 		aggkitcommon.AGGSENDERVALIDATOR,
 		aggkitcommon.BRIDGE,
+		aggkitcommon.L1INFOTREESYNC,
 	}, components) {
 		return &etherman.RollupDataQuerier{}, nil
 	}


### PR DESCRIPTION
## 🔄 Changes Summary
- Fixes a panic in standalone `l1infotreesync` caused by an uninitialized `rollupDataQuerier`

Error:
```
panic: runtime error: invalid memory address or nil pointer dereference
```

