### PR TITLE
fix: run time error when running l1infotreesync only

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -673,6 +673,7 @@ func createRollupDataQuerier(cfg config.L1NetworkConfig, components []string) (*
 		aggkitcommon.AGGCHAINPROOFGEN,
 		aggkitcommon.AGGSENDER,
 		aggkitcommon.BRIDGE,
+		aggkitcommon.L1INFOTREESYNC,
 	}, components) {
 		return nil, nil
 	}


### PR DESCRIPTION
## 🔄 Changes Summary
- Cherry Pick https://github.com/agglayer/aggkit/pull/848

