### PR TITLE
feat: use bridge db query timeout

### DIFF
--- a/aggsender/validator/validate_db_test.go
+++ b/aggsender/validator/validate_db_test.go
@@ -28,13 +28,14 @@ func TestValidateFullAggsenderDB(t *testing.T) {
 	testDataPath := getTestDataPath(t)
 	logger := log.WithFields("test", "TestValidateFullAggsenderDB")
 	ctx := context.TODO()
+	dbQueryTimeout := 30 * time.Second
 	mockL2EthClient := mocksethclient.NewEthClienter(t)
 	mockL2EthClient.EXPECT().BlockByNumber(ctx, mock.Anything).Return(&types.Block{}, nil).Maybe()
 	bridgeSyncL2, err := bridgesync.NewL2ReadOnly(
 		ctx,
 		testDataPath+"/bridgel2sync.sqlite",
 		1, // OrigNetwork
-		time.Second*30,
+		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 	lastProcessBlock, err := bridgeSyncL2.GetLastProcessedBlock(ctx)

--- a/aggsender/validator/validate_db_test.go
+++ b/aggsender/validator/validate_db_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonrollupmanager"
 	"github.com/agglayer/aggkit/aggsender/flows"
@@ -33,6 +34,7 @@ func TestValidateFullAggsenderDB(t *testing.T) {
 		ctx,
 		testDataPath+"/bridgel2sync.sqlite",
 		1, // OrigNetwork
+		time.Second*30,
 	)
 	require.NoError(t, err)
 	lastProcessBlock, err := bridgeSyncL2.GetLastProcessedBlock(ctx)

--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -103,10 +103,10 @@ func TestBridgeCallData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, originNetwork, networkID)
 
-	databaseQueryTimeout := 30 * time.Second
+	dbQueryTimeout := 30 * time.Second
 
 	bridgeSync, err := NewL1(ctx, dbPathBridgeSyncL1, bridgeProxyAddr, 1, aggkittypes.FinalizedBlock, client,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, databaseQueryTimeout)
+		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, dbQueryTimeout)
 	require.NoError(t, err)
 	go bridgeSync.Start(ctx)
 

--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -103,8 +103,10 @@ func TestBridgeCallData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, originNetwork, networkID)
 
+	databaseQueryTimeout := 30 * time.Second
+
 	bridgeSync, err := NewL1(ctx, dbPathBridgeSyncL1, bridgeProxyAddr, 1, aggkittypes.FinalizedBlock, client,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false)
+		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, databaseQueryTimeout)
 	require.NoError(t, err)
 	go bridgeSync.Start(ctx)
 

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -84,7 +84,7 @@ func NewL1(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
-	databaseQueryTimeout time.Duration,
+	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -102,7 +102,7 @@ func NewL1(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 }
 
@@ -110,11 +110,11 @@ func NewL2ReadOnly(
 	ctx context.Context,
 	dbPath string,
 	originNetwork uint32,
-	databaseQueryTimeout time.Duration,
+	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	syncerID := L2BridgeSyncer
 	logger := log.WithFields("module", syncerID.String())
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, databaseQueryTimeout)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, dbQueryTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func NewL2(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
-	databaseQueryTimeout time.Duration,
+	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -158,7 +158,7 @@ func NewL2(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 }
 
@@ -178,7 +178,7 @@ func newBridgeSync(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
-	databaseQueryTimeout time.Duration,
+	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
 
@@ -194,7 +194,7 @@ func newBridgeSync(
 		return nil, err
 	}
 
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, databaseQueryTimeout)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, dbQueryTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -366,7 +366,7 @@ func (s *BridgeSync) GetTokenMappings(ctx context.Context, pageNumber, pageSize 
 		return nil, 0, ErrInvalidPageSize
 	}
 
-	return s.processor.GetTokenMappings(pageNumber, pageSize)
+	return s.processor.GetTokenMappings(ctx, pageNumber, pageSize)
 }
 
 func (s *BridgeSync) GetLegacyTokenMigrations(

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -84,6 +84,7 @@ func NewL1(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
+	databaseQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -101,6 +102,7 @@ func NewL1(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
+		databaseQueryTimeout,
 	)
 }
 
@@ -108,10 +110,11 @@ func NewL2ReadOnly(
 	ctx context.Context,
 	dbPath string,
 	originNetwork uint32,
+	databaseQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	syncerID := L2BridgeSyncer
 	logger := log.WithFields("module", syncerID.String())
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, databaseQueryTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +140,7 @@ func NewL2(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
+	databaseQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -154,6 +158,7 @@ func NewL2(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
+		databaseQueryTimeout,
 	)
 }
 
@@ -173,6 +178,7 @@ func newBridgeSync(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
+	databaseQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
 
@@ -188,7 +194,7 @@ func newBridgeSync(
 		return nil, err
 	}
 
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, databaseQueryTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -54,7 +54,7 @@ func TestNewLx(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
-	databaseQueryTimeout := 30 * time.Second
+	dbQueryTimeout := 30 * time.Second
 
 	l1BridgeSync, err := NewL1(
 		ctx,
@@ -70,7 +70,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 	t.Log(err)
 	require.Error(t, err)
@@ -214,7 +214,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
-	databaseQueryTimeout := 30 * time.Second
+	dbQueryTimeout := 30 * time.Second
 
 	s, err := NewL2(
 		ctx,
@@ -231,7 +231,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		originNetwork,
 		false,
 		false,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 
@@ -349,7 +349,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
-	databaseQueryTimeout := 30 * time.Second
+	dbQueryTimeout := 30 * time.Second
 
 	s, err := NewL2(
 		ctx,
@@ -366,7 +366,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		originNetwork,
 		false,
 		false,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 
@@ -533,7 +533,7 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
-	databaseQueryTimeout := 30 * time.Second
+	dbQueryTimeout := 30 * time.Second
 
 	s, err := NewL2(
 		ctx,
@@ -550,7 +550,7 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 		originNetwork,
 		false,
 		false,
-		databaseQueryTimeout,
+		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -53,6 +53,9 @@ func TestNewLx(t *testing.T) {
 	mockReorgDetector.EXPECT().Subscribe(mock.Anything).Return(nil, nil)
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
+
+	databaseQueryTimeout := 30 * time.Second
+
 	l1BridgeSync, err := NewL1(
 		ctx,
 		dbPath,
@@ -67,6 +70,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
+		databaseQueryTimeout,
 	)
 
 	require.NoError(t, err)
@@ -89,6 +93,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
+		databaseQueryTimeout,
 	)
 
 	require.NoError(t, err)
@@ -115,6 +120,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
+		databaseQueryTimeout,
 	)
 	t.Log(err)
 	require.Error(t, err)
@@ -208,6 +214,8 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
+	databaseQueryTimeout := 30 * time.Second
+
 	s, err := NewL2(
 		ctx,
 		dbPath,
@@ -223,6 +231,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		originNetwork,
 		false,
 		false,
+		databaseQueryTimeout,
 	)
 	require.NoError(t, err)
 
@@ -340,6 +349,8 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
+	databaseQueryTimeout := 30 * time.Second
+
 	s, err := NewL2(
 		ctx,
 		dbPath,
@@ -355,6 +366,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		originNetwork,
 		false,
 		false,
+		databaseQueryTimeout,
 	)
 	require.NoError(t, err)
 
@@ -521,6 +533,8 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 	mockReorgDetector.EXPECT().GetFinalizedBlockType().Return(blockFinalityType)
 	mockReorgDetector.EXPECT().String().Return("mockReorgDetector")
 
+	databaseQueryTimeout := 30 * time.Second
+
 	s, err := NewL2(
 		ctx,
 		dbPath,
@@ -536,6 +550,7 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 		originNetwork,
 		false,
 		false,
+		databaseQueryTimeout,
 	)
 	require.NoError(t, err)
 

--- a/bridgesync/config.go
+++ b/bridgesync/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	// RequireStorageContentCompatibility is true it's mandatory that data stored in the database
 	// is compatible with the running environment
 	RequireStorageContentCompatibility bool `mapstructure:"RequireStorageContentCompatibility"`
-	// DatabaseQueryTimeout is the timeout for database operations (queries, transactions)
+	// DBQueryTimeout is the timeout for database operations (queries, transactions)
 	// This is separate from HTTP timeouts to allow database operations more time when needed
-	DatabaseQueryTimeout types.Duration `mapstructure:"DatabaseQueryTimeout"`
+	DBQueryTimeout types.Duration `mapstructure:"DBQueryTimeout"`
 }

--- a/bridgesync/config.go
+++ b/bridgesync/config.go
@@ -27,4 +27,7 @@ type Config struct {
 	// RequireStorageContentCompatibility is true it's mandatory that data stored in the database
 	// is compatible with the running environment
 	RequireStorageContentCompatibility bool `mapstructure:"RequireStorageContentCompatibility"`
+	// DatabaseQueryTimeout is the timeout for database operations (queries, transactions)
+	// This is separate from HTTP timeouts to allow database operations more time when needed
+	DatabaseQueryTimeout types.Duration `mapstructure:"DatabaseQueryTimeout"`
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -344,13 +344,13 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) error
 }
 
 type processor struct {
-	db                   *sql.DB
-	exitTree             *tree.AppendOnlyTree
-	log                  *log.Logger
-	mu                   mutex.RWMutex
-	halted               bool
-	haltedReason         string
-	databaseQueryTimeout time.Duration
+	db             *sql.DB
+	exitTree       *tree.AppendOnlyTree
+	log            *log.Logger
+	mu             mutex.RWMutex
+	halted         bool
+	haltedReason   string
+	dbQueryTimeout time.Duration
 	compatibility.CompatibilityDataStorager[BridgeSyncRuntimeData]
 }
 
@@ -358,7 +358,7 @@ func newProcessor(
 	dbPath string,
 	name string,
 	logger *log.Logger,
-	databaseQueryTimeout time.Duration,
+	dbQueryTimeout time.Duration,
 ) (*processor, error) {
 	err := migrations.RunMigrations(dbPath)
 	if err != nil {
@@ -372,10 +372,10 @@ func newProcessor(
 	exitTree := tree.NewAppendOnlyTree(database, "")
 
 	return &processor{
-		db:                   database,
-		exitTree:             exitTree,
-		log:                  logger,
-		databaseQueryTimeout: databaseQueryTimeout,
+		db:             database,
+		exitTree:       exitTree,
+		log:            logger,
+		dbQueryTimeout: dbQueryTimeout,
 		CompatibilityDataStorager: compatibility.NewKeyValueToCompatibilityStorage[BridgeSyncRuntimeData](
 			db.NewKeyValueStorage(database),
 			name,
@@ -1056,5 +1056,5 @@ func (p *processor) unhalt() {
 }
 
 func (p *processor) withDatabaseTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(ctx), p.databaseQueryTimeout)
+	return context.WithTimeout(context.WithoutCancel(ctx), p.dbQueryTimeout)
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -1045,5 +1045,5 @@ func (p *processor) unhalt() {
 }
 
 func (p *processor) withDatabaseTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(ctx), p.dbQueryTimeout)
+	return context.WithTimeout(ctx, p.dbQueryTimeout)
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -629,7 +629,9 @@ func (p *processor) GetLegacyTokenMigrations(
 	return tokenMigrations, legacyTokenMigrationsCount, nil
 }
 
-func (p *processor) queryBlockRange(ctx context.Context, tx dbtypes.Querier, fromBlock, toBlock uint64, table string) (*sql.Rows, error) {
+func (p *processor) queryBlockRange(
+	ctx context.Context, tx dbtypes.Querier, fromBlock, toBlock uint64, table string,
+) (*sql.Rows, error) {
 	if err := p.isBlockProcessed(ctx, tx, toBlock); err != nil {
 		return nil, err
 	}
@@ -881,7 +883,9 @@ func (p *processor) GetTotalNumberOfRecords(ctx context.Context, tableName, wher
 	defer cancel()
 
 	count := 0
-	err := p.db.QueryRowContext(dbCtx, fmt.Sprintf(`SELECT COUNT(*) AS count FROM %s%s;`, tableName, whereClause)).Scan(&count)
+	err := p.db.QueryRowContext(dbCtx, fmt.Sprintf(
+		`SELECT COUNT(*) AS count FROM %s%s;`, tableName, whereClause,
+	)).Scan(&count)
 	if err != nil {
 		return 0, err
 	}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -387,7 +387,7 @@ func newProcessor(
 func (p *processor) GetBridges(
 	ctx context.Context, fromBlock, toBlock uint64,
 ) ([]Bridge, error) {
-	rows, err := p.queryBlockRange(p.db, fromBlock, toBlock, bridgeTableName)
+	rows, err := p.queryBlockRange(ctx, p.db, fromBlock, toBlock, bridgeTableName)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no bridges were found for block range [%d..%d]", fromBlock, toBlock)
@@ -419,7 +419,7 @@ func (p *processor) GetBridges(
 
 //nolint:dupl
 func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([]Claim, error) {
-	rows, err := p.queryBlockRange(p.db, fromBlock, toBlock, claimTableName)
+	rows, err := p.queryBlockRange(ctx, p.db, fromBlock, toBlock, claimTableName)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no claims were found for block range [%d..%d]", fromBlock, toBlock)
@@ -454,7 +454,7 @@ func (p *processor) GetBridgesPaged(
 ) ([]*Bridge, int, error) {
 	whereClause := p.buildBridgesFilterClause(depositCount, networkIDs, fromAddress)
 	orderByClause := "deposit_count DESC"
-	bridgesCount, err := p.GetTotalNumberOfRecords(bridgeTableName, whereClause)
+	bridgesCount, err := p.GetTotalNumberOfRecords(ctx, bridgeTableName, whereClause)
 	if err != nil {
 		return []*Bridge{}, 0, err
 	}
@@ -521,7 +521,7 @@ func (p *processor) GetClaimsPaged(
 	ctx context.Context, pageNumber, pageSize uint32, networkIDs []uint32, fromAddress string,
 ) ([]*Claim, int, error) {
 	whereClause := p.buildClaimsFilterClause(networkIDs, fromAddress)
-	claimsCount, err := p.GetTotalNumberOfRecords(claimTableName, whereClause)
+	claimsCount, err := p.GetTotalNumberOfRecords(ctx, claimTableName, whereClause)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -585,7 +585,7 @@ func (p *processor) buildClaimsFilterClause(networkIDs []uint32, fromAddress str
 func (p *processor) GetLegacyTokenMigrations(
 	ctx context.Context, pageNumber, pageSize uint32) ([]*LegacyTokenMigration, int, error) {
 	whereClause := ""
-	legacyTokenMigrationsCount, err := p.GetTotalNumberOfRecords(legacyTokenMigrationTableName, whereClause)
+	legacyTokenMigrationsCount, err := p.GetTotalNumberOfRecords(ctx, legacyTokenMigrationTableName, whereClause)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to fetch the total number of %s entries: %w", legacyTokenMigrationTableName, err)
 	}
@@ -629,11 +629,19 @@ func (p *processor) GetLegacyTokenMigrations(
 	return tokenMigrations, legacyTokenMigrationsCount, nil
 }
 
-func (p *processor) queryBlockRange(tx dbtypes.Querier, fromBlock, toBlock uint64, table string) (*sql.Rows, error) {
-	if err := p.isBlockProcessed(tx, toBlock); err != nil {
+func (p *processor) queryBlockRange(ctx context.Context, tx dbtypes.Querier, fromBlock, toBlock uint64, table string) (*sql.Rows, error) {
+	if err := p.isBlockProcessed(ctx, tx, toBlock); err != nil {
 		return nil, err
 	}
-	rows, err := tx.Query(fmt.Sprintf(`
+
+	sqlDB, ok := tx.(*sql.DB)
+	if !ok {
+		return nil, fmt.Errorf("expected *sql.DB, got %T", tx)
+	}
+
+	// Create a context with database timeout
+	dbCtx, _ := p.withDatabaseTimeout(ctx)
+	rows, err := sqlDB.QueryContext(dbCtx, fmt.Sprintf(`
 		SELECT * FROM %s
 		WHERE block_num >= $1 AND block_num <= $2
 		ORDER BY block_num ASC, block_pos ASC;
@@ -657,7 +665,9 @@ func (p *processor) queryPagedWithContext(ctx context.Context, tx dbtypes.Querie
 		return nil, fmt.Errorf("expected *sql.DB, got %T", tx)
 	}
 
-	rows, err := sqlDB.QueryContext(ctx, fmt.Sprintf(`
+	// Create a context with database timeout
+	dbCtx, _ := p.withDatabaseTimeout(ctx)
+	rows, err := sqlDB.QueryContext(dbCtx, fmt.Sprintf(`
 		SELECT *
 		FROM %s
 		%s
@@ -673,8 +683,8 @@ func (p *processor) queryPagedWithContext(ctx context.Context, tx dbtypes.Querie
 	return rows, nil
 }
 
-func (p *processor) isBlockProcessed(tx dbtypes.Querier, blockNum uint64) error {
-	lpb, err := p.getLastProcessedBlockWithTx(tx)
+func (p *processor) isBlockProcessed(ctx context.Context, tx dbtypes.Querier, blockNum uint64) error {
+	lpb, err := p.getLastProcessedBlockWithTx(ctx, tx)
 	if err != nil {
 		return err
 	}
@@ -687,13 +697,22 @@ func (p *processor) isBlockProcessed(tx dbtypes.Querier, blockNum uint64) error 
 // GetLastProcessedBlock returns the last processed block by the processor, including blocks
 // that don't have events
 func (p *processor) GetLastProcessedBlock(ctx context.Context) (uint64, error) {
-	return p.getLastProcessedBlockWithTx(p.db)
+	return p.getLastProcessedBlockWithTx(ctx, p.db)
 }
 
-func (p *processor) getLastProcessedBlockWithTx(tx dbtypes.Querier) (uint64, error) {
+func (p *processor) getLastProcessedBlockWithTx(ctx context.Context, tx dbtypes.Querier) (uint64, error) {
 	var lastProcessedBlockNum uint64
 
-	row := tx.QueryRow("SELECT num FROM block ORDER BY num DESC LIMIT 1;")
+	sqlDB, ok := tx.(*sql.DB)
+	if !ok {
+		return 0, fmt.Errorf("expected *sql.DB, got %T", tx)
+	}
+
+	// Create a context with database timeout
+	dbCtx, cancel := p.withDatabaseTimeout(ctx)
+	defer cancel()
+
+	row := sqlDB.QueryRowContext(dbCtx, "SELECT num FROM block ORDER BY num DESC LIMIT 1;")
 	err := row.Scan(&lastProcessedBlockNum)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
@@ -705,7 +724,12 @@ func (p *processor) getLastProcessedBlockWithTx(tx dbtypes.Querier) (uint64, err
 // as if the last block processed was firstReorgedBlock-1
 func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 	p.log.Infof("reorg detected at %d block", firstReorgedBlock)
-	tx, err := db.NewTx(ctx, p.db)
+
+	// Create a context with database timeout for the transaction
+	dbCtx, cancel := p.withDatabaseTimeout(ctx)
+	defer cancel()
+
+	tx, err := db.NewTx(dbCtx, p.db)
 	if err != nil {
 		p.log.Errorf("failed to start transaction for reorg: %v", err)
 		return err
@@ -756,7 +780,12 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		p.log.Errorf("processor is halted due to: %s", p.haltedReason)
 		return sync.ErrInconsistentState
 	}
-	tx, err := db.NewTx(ctx, p.db)
+
+	// Create a context with database timeout for the transaction
+	dbCtx, cancel := p.withDatabaseTimeout(ctx)
+	defer cancel()
+
+	tx, err := db.NewTx(dbCtx, p.db)
 	if err != nil {
 		p.log.Errorf("failed to start transaction for block %d: %v", block.Num, err)
 		return err
@@ -842,13 +871,17 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 }
 
 // GetTotalNumberOfRecords returns the total number of records in the given table
-func (p *processor) GetTotalNumberOfRecords(tableName, whereClause string) (int, error) {
+func (p *processor) GetTotalNumberOfRecords(ctx context.Context, tableName, whereClause string) (int, error) {
 	if !tableNameRegex.MatchString(tableName) {
 		return 0, fmt.Errorf("invalid table name '%s' provided", tableName)
 	}
 
+	// Create a context with database timeout
+	dbCtx, cancel := p.withDatabaseTimeout(ctx)
+	defer cancel()
+
 	count := 0
-	err := p.db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) AS count FROM %s%s;`, tableName, whereClause)).Scan(&count)
+	err := p.db.QueryRowContext(dbCtx, fmt.Sprintf(`SELECT COUNT(*) AS count FROM %s%s;`, tableName, whereClause)).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -858,11 +891,7 @@ func (p *processor) GetTotalNumberOfRecords(tableName, whereClause string) (int,
 
 // GetTokenMappings returns the paged token mappings from the database
 func (p *processor) GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*TokenMapping, int, error) {
-	// Create a context with database timeout for the entire operation
-	dbCtx, cancel := context.WithTimeout(ctx, p.databaseQueryTimeout)
-	defer cancel()
-
-	totalTokenMappings, err := p.GetTotalNumberOfRecords(tokenMappingTableName, "")
+	totalTokenMappings, err := p.GetTotalNumberOfRecords(ctx, tokenMappingTableName, "")
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to fetch the total number of %s entries: %w", tokenMappingTableName, err)
 	}
@@ -876,7 +905,7 @@ func (p *processor) GetTokenMappings(ctx context.Context, pageNumber, pageSize u
 		return nil, 0, fmt.Errorf("failed to calculate offset for pageNumber=%d, pageSize=%d: %w", pageNumber, pageSize, err)
 	}
 
-	tokenMappings, err := p.fetchTokenMappings(dbCtx, pageSize, offset)
+	tokenMappings, err := p.fetchTokenMappings(ctx, pageSize, offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1024,4 +1053,8 @@ func (p *processor) unhalt() {
 	p.halted = false
 	p.haltedReason = ""
 	p.log.Info("processor unhalted")
+}
+
+func (p *processor) withDatabaseTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), p.databaseQueryTimeout)
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -354,7 +354,12 @@ type processor struct {
 	compatibility.CompatibilityDataStorager[BridgeSyncRuntimeData]
 }
 
-func newProcessor(dbPath string, name string, logger *log.Logger, databaseQueryTimeout time.Duration) (*processor, error) {
+func newProcessor(
+	dbPath string,
+	name string,
+	logger *log.Logger,
+	databaseQueryTimeout time.Duration,
+) (*processor, error) {
 	err := migrations.RunMigrations(dbPath)
 	if err != nil {
 		return nil, err
@@ -468,7 +473,7 @@ func (p *processor) GetBridgesPaged(
 		return nil, 0, err
 	}
 
-	rows, err := p.queryPaged(p.db, offset, pageSize, bridgeTableName, orderByClause, whereClause)
+	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, bridgeTableName, orderByClause, whereClause)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no bridges were found for provided parameters (pageNumber=%d, pageSize=%d, where clause=%s)",
@@ -537,7 +542,7 @@ func (p *processor) GetClaimsPaged(
 
 	orderByClause := "block_num DESC, block_pos DESC"
 
-	rows, err := p.queryPaged(p.db, offset, pageSize, claimTableName, orderByClause, whereClause)
+	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, claimTableName, orderByClause, whereClause)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no claims were found for provided parameters (pageNumber=%d, pageSize=%d)",
@@ -600,7 +605,7 @@ func (p *processor) GetLegacyTokenMigrations(
 	}
 
 	orderByClause := "block_num DESC, block_pos DESC"
-	rows, err := p.queryPaged(p.db, offset, pageSize, legacyTokenMigrationTableName, orderByClause, whereClause)
+	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, legacyTokenMigrationTableName, orderByClause, whereClause)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no legacy token migrations were found for provided parameters (pageNumber=%d, pageSize=%d)",
@@ -651,6 +656,33 @@ func (p *processor) queryPaged(tx dbtypes.Querier,
 	table, orderByClause, whereClause string,
 ) (*sql.Rows, error) {
 	rows, err := tx.Query(fmt.Sprintf(`
+		SELECT *
+		FROM %s
+		%s
+		ORDER BY %s
+		LIMIT $1 OFFSET $2;
+	`, table, whereClause, orderByClause), pageSize, offset)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return rows, nil
+}
+
+// queryPagedWithContext returns a paged result from the given table with context support
+func (p *processor) queryPagedWithContext(ctx context.Context, tx dbtypes.Querier,
+	offset, pageSize uint32,
+	table, orderByClause, whereClause string,
+) (*sql.Rows, error) {
+	// Use the underlying sql.DB for context-aware queries
+	sqlDB, ok := tx.(*sql.DB)
+	if !ok {
+		return nil, fmt.Errorf("expected *sql.DB, got %T", tx)
+	}
+
+	rows, err := sqlDB.QueryContext(ctx, fmt.Sprintf(`
 		SELECT *
 		FROM %s
 		%s
@@ -850,9 +882,9 @@ func (p *processor) GetTotalNumberOfRecords(tableName, whereClause string) (int,
 }
 
 // GetTokenMappings returns the paged token mappings from the database
-func (p *processor) GetTokenMappings(pageNumber, pageSize uint32) ([]*TokenMapping, int, error) {
+func (p *processor) GetTokenMappings(ctx context.Context, pageNumber, pageSize uint32) ([]*TokenMapping, int, error) {
 	// Create a context with database timeout for the entire operation
-	ctx, cancel := context.WithTimeout(context.Background(), p.databaseQueryTimeout)
+	dbCtx, cancel := context.WithTimeout(ctx, p.databaseQueryTimeout)
 	defer cancel()
 
 	totalTokenMappings, err := p.GetTotalNumberOfRecords(tokenMappingTableName, "")
@@ -869,7 +901,7 @@ func (p *processor) GetTokenMappings(pageNumber, pageSize uint32) ([]*TokenMappi
 		return nil, 0, fmt.Errorf("failed to calculate offset for pageNumber=%d, pageSize=%d: %w", pageNumber, pageSize, err)
 	}
 
-	tokenMappings, err := p.fetchTokenMappings(ctx, pageSize, offset)
+	tokenMappings, err := p.fetchTokenMappings(dbCtx, pageSize, offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -881,7 +913,7 @@ func (p *processor) GetTokenMappings(pageNumber, pageSize uint32) ([]*TokenMappi
 func (p *processor) fetchTokenMappings(ctx context.Context, pageSize uint32, offset uint32) ([]*TokenMapping, error) {
 	orderByClause := "block_num DESC"
 
-	rows, err := p.queryPaged(p.db, offset, pageSize, tokenMappingTableName, orderByClause, "")
+	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, tokenMappingTableName, orderByClause, "")
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			pageNumber := (offset / pageSize) + 1

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	mutex "sync"
+	"time"
 
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync/migrations"
@@ -343,16 +344,17 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) error
 }
 
 type processor struct {
-	db           *sql.DB
-	exitTree     *tree.AppendOnlyTree
-	log          *log.Logger
-	mu           mutex.RWMutex
-	halted       bool
-	haltedReason string
+	db                   *sql.DB
+	exitTree             *tree.AppendOnlyTree
+	log                  *log.Logger
+	mu                   mutex.RWMutex
+	halted               bool
+	haltedReason         string
+	databaseQueryTimeout time.Duration
 	compatibility.CompatibilityDataStorager[BridgeSyncRuntimeData]
 }
 
-func newProcessor(dbPath string, name string, logger *log.Logger) (*processor, error) {
+func newProcessor(dbPath string, name string, logger *log.Logger, databaseQueryTimeout time.Duration) (*processor, error) {
 	err := migrations.RunMigrations(dbPath)
 	if err != nil {
 		return nil, err
@@ -363,10 +365,17 @@ func newProcessor(dbPath string, name string, logger *log.Logger) (*processor, e
 	}
 
 	exitTree := tree.NewAppendOnlyTree(database, "")
+
+	// Set default database query timeout if not configured
+	if databaseQueryTimeout <= 0 {
+		databaseQueryTimeout = 30 * time.Second
+	}
+
 	return &processor{
-		db:       database,
-		exitTree: exitTree,
-		log:      logger,
+		db:                   database,
+		exitTree:             exitTree,
+		log:                  logger,
+		databaseQueryTimeout: databaseQueryTimeout,
 		CompatibilityDataStorager: compatibility.NewKeyValueToCompatibilityStorage[BridgeSyncRuntimeData](
 			db.NewKeyValueStorage(database),
 			name,
@@ -842,6 +851,10 @@ func (p *processor) GetTotalNumberOfRecords(tableName, whereClause string) (int,
 
 // GetTokenMappings returns the paged token mappings from the database
 func (p *processor) GetTokenMappings(pageNumber, pageSize uint32) ([]*TokenMapping, int, error) {
+	// Create a context with database timeout for the entire operation
+	ctx, cancel := context.WithTimeout(context.Background(), p.databaseQueryTimeout)
+	defer cancel()
+
 	totalTokenMappings, err := p.GetTotalNumberOfRecords(tokenMappingTableName, "")
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to fetch the total number of %s entries: %w", tokenMappingTableName, err)
@@ -856,7 +869,7 @@ func (p *processor) GetTokenMappings(pageNumber, pageSize uint32) ([]*TokenMappi
 		return nil, 0, fmt.Errorf("failed to calculate offset for pageNumber=%d, pageSize=%d: %w", pageNumber, pageSize, err)
 	}
 
-	tokenMappings, err := p.fetchTokenMappings(pageSize, offset)
+	tokenMappings, err := p.fetchTokenMappings(ctx, pageSize, offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -865,7 +878,7 @@ func (p *processor) GetTokenMappings(pageNumber, pageSize uint32) ([]*TokenMappi
 }
 
 // fetchTokenMappings fetches token mappings from the database, based on the provided pagination parameters
-func (p *processor) fetchTokenMappings(pageSize uint32, offset uint32) ([]*TokenMapping, error) {
+func (p *processor) fetchTokenMappings(ctx context.Context, pageSize uint32, offset uint32) ([]*TokenMapping, error) {
 	orderByClause := "block_num DESC"
 
 	rows, err := p.queryPaged(p.db, offset, pageSize, tokenMappingTableName, orderByClause, "")

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -600,7 +600,9 @@ func (p *processor) GetLegacyTokenMigrations(
 	}
 
 	orderByClause := "block_num DESC, block_pos DESC"
-	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, legacyTokenMigrationTableName, orderByClause, whereClause)
+	rows, err := p.queryPagedWithContext(
+		ctx, p.db, offset, pageSize, legacyTokenMigrationTableName, orderByClause, whereClause,
+	)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no legacy token migrations were found for provided parameters (pageNumber=%d, pageSize=%d)",

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -636,14 +636,9 @@ func (p *processor) queryBlockRange(
 		return nil, err
 	}
 
-	sqlDB, ok := tx.(*sql.DB)
-	if !ok {
-		return nil, fmt.Errorf("expected *sql.DB, got %T", tx)
-	}
-
 	// Create a context with database timeout
 	dbCtx, _ := p.withDatabaseTimeout(ctx)
-	rows, err := sqlDB.QueryContext(dbCtx, fmt.Sprintf(`
+	rows, err := tx.QueryContext(dbCtx, fmt.Sprintf(`
 		SELECT * FROM %s
 		WHERE block_num >= $1 AND block_num <= $2
 		ORDER BY block_num ASC, block_pos ASC;
@@ -662,14 +657,9 @@ func (p *processor) queryPaged(ctx context.Context, tx dbtypes.Querier,
 	offset, pageSize uint32,
 	table, orderByClause, whereClause string,
 ) (*sql.Rows, error) {
-	sqlDB, ok := tx.(*sql.DB)
-	if !ok {
-		return nil, fmt.Errorf("expected *sql.DB, got %T", tx)
-	}
-
 	// Create a context with database timeout
 	dbCtx, _ := p.withDatabaseTimeout(ctx)
-	rows, err := sqlDB.QueryContext(dbCtx, fmt.Sprintf(`
+	rows, err := tx.QueryContext(dbCtx, fmt.Sprintf(`
 		SELECT *
 		FROM %s
 		%s
@@ -705,16 +695,11 @@ func (p *processor) GetLastProcessedBlock(ctx context.Context) (uint64, error) {
 func (p *processor) getLastProcessedBlockWithTx(ctx context.Context, tx dbtypes.Querier) (uint64, error) {
 	var lastProcessedBlockNum uint64
 
-	sqlDB, ok := tx.(*sql.DB)
-	if !ok {
-		return 0, fmt.Errorf("expected *sql.DB, got %T", tx)
-	}
-
 	// Create a context with database timeout
 	dbCtx, cancel := p.withDatabaseTimeout(ctx)
 	defer cancel()
 
-	row := sqlDB.QueryRowContext(dbCtx, "SELECT num FROM block ORDER BY num DESC LIMIT 1;")
+	row := tx.QueryRowContext(dbCtx, "SELECT num FROM block ORDER BY num DESC LIMIT 1;")
 	err := row.Scan(&lastProcessedBlockNum)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -371,11 +371,6 @@ func newProcessor(
 
 	exitTree := tree.NewAppendOnlyTree(database, "")
 
-	// Set default database query timeout if not configured
-	if databaseQueryTimeout <= 0 {
-		databaseQueryTimeout = 30 * time.Second
-	}
-
 	return &processor{
 		db:                   database,
 		exitTree:             exitTree,
@@ -650,33 +645,11 @@ func (p *processor) queryBlockRange(tx dbtypes.Querier, fromBlock, toBlock uint6
 	return rows, nil
 }
 
-// queryPaged returns a paged result from the given table
-func (p *processor) queryPaged(tx dbtypes.Querier,
-	offset, pageSize uint32,
-	table, orderByClause, whereClause string,
-) (*sql.Rows, error) {
-	rows, err := tx.Query(fmt.Sprintf(`
-		SELECT *
-		FROM %s
-		%s
-		ORDER BY %s
-		LIMIT $1 OFFSET $2;
-	`, table, whereClause, orderByClause), pageSize, offset)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, db.ErrNotFound
-		}
-		return nil, err
-	}
-	return rows, nil
-}
-
 // queryPagedWithContext returns a paged result from the given table with context support
 func (p *processor) queryPagedWithContext(ctx context.Context, tx dbtypes.Querier,
 	offset, pageSize uint32,
 	table, orderByClause, whereClause string,
 ) (*sql.Rows, error) {
-	// Use the underlying sql.DB for context-aware queries
 	sqlDB, ok := tx.(*sql.DB)
 	if !ok {
 		return nil, fmt.Errorf("expected *sql.DB, got %T", tx)

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -468,7 +468,7 @@ func (p *processor) GetBridgesPaged(
 		return nil, 0, err
 	}
 
-	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, bridgeTableName, orderByClause, whereClause)
+	rows, err := p.queryPaged(ctx, p.db, offset, pageSize, bridgeTableName, orderByClause, whereClause)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no bridges were found for provided parameters (pageNumber=%d, pageSize=%d, where clause=%s)",
@@ -537,7 +537,7 @@ func (p *processor) GetClaimsPaged(
 
 	orderByClause := "block_num DESC, block_pos DESC"
 
-	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, claimTableName, orderByClause, whereClause)
+	rows, err := p.queryPaged(ctx, p.db, offset, pageSize, claimTableName, orderByClause, whereClause)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no claims were found for provided parameters (pageNumber=%d, pageSize=%d)",
@@ -600,7 +600,7 @@ func (p *processor) GetLegacyTokenMigrations(
 	}
 
 	orderByClause := "block_num DESC, block_pos DESC"
-	rows, err := p.queryPagedWithContext(
+	rows, err := p.queryPaged(
 		ctx, p.db, offset, pageSize, legacyTokenMigrationTableName, orderByClause, whereClause,
 	)
 	if err != nil {
@@ -655,8 +655,8 @@ func (p *processor) queryBlockRange(ctx context.Context, tx dbtypes.Querier, fro
 	return rows, nil
 }
 
-// queryPagedWithContext returns a paged result from the given table with context support
-func (p *processor) queryPagedWithContext(ctx context.Context, tx dbtypes.Querier,
+// queryPaged returns a paged result from the given table with context support
+func (p *processor) queryPaged(ctx context.Context, tx dbtypes.Querier,
 	offset, pageSize uint32,
 	table, orderByClause, whereClause string,
 ) (*sql.Rows, error) {
@@ -917,7 +917,7 @@ func (p *processor) GetTokenMappings(ctx context.Context, pageNumber, pageSize u
 func (p *processor) fetchTokenMappings(ctx context.Context, pageSize uint32, offset uint32) ([]*TokenMapping, error) {
 	orderByClause := "block_num DESC"
 
-	rows, err := p.queryPagedWithContext(ctx, p.db, offset, pageSize, tokenMappingTableName, orderByClause, "")
+	rows, err := p.queryPaged(ctx, p.db, offset, pageSize, tokenMappingTableName, orderByClause, "")
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			pageNumber := (offset / pageSize) + 1

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -662,7 +662,7 @@ func (a *getTotalRecordsAction) desc() string {
 func (a *getTotalRecordsAction) execute(t *testing.T) {
 	t.Helper()
 
-	recordsNum, err := a.p.GetTotalNumberOfRecords(a.tableName, "")
+	recordsNum, err := a.p.GetTotalNumberOfRecords(context.Background(), a.tableName, "")
 	require.NoError(t, err)
 	require.Equal(t, a.expectedRecordsNum, recordsNum)
 }
@@ -2290,7 +2290,7 @@ func TestProcessor_DatabaseConnectionErrors(t *testing.T) {
 		p := createTestProcessor(t, "DatabaseConnectionErrors")
 
 		// Test with invalid table name
-		_, err := p.GetTotalNumberOfRecords("invalid_table_name", "")
+		_, err := p.GetTotalNumberOfRecords(context.Background(), "invalid_table_name", "")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such table")
 	})

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const dbQueryTimeout = 30 * time.Second
+
 func TestBigIntString(t *testing.T) {
 	globalIndex := GenerateGlobalIndex(true, 0, 1093)
 	fmt.Println(globalIndex.String())
@@ -85,7 +87,7 @@ func TestBigIntString(t *testing.T) {
 func TestProcessor(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgeSyncerProcessor.db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 	actions := []processAction{
 		// processed: ~
@@ -818,7 +820,7 @@ func TestInsertAndGetClaim(t *testing.T) {
 	err := migrations.RunMigrations(path)
 	require.NoError(t, err)
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "foo", logger, 30*time.Second)
+	p, err := newProcessor(path, "foo", logger, dbQueryTimeout)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -903,7 +905,7 @@ func TestGetBridgesPublished(t *testing.T) {
 			path := path.Join(t.TempDir(), fmt.Sprintf("bridgesyncTestGetBridgesPublished_%s.sqlite", tc.name))
 			require.NoError(t, migrations.RunMigrations(path))
 			logger := log.WithFields("bridge-syncer", "foo")
-			p, err := newProcessor(path, "foo", logger, 30*time.Second)
+			p, err := newProcessor(path, "foo", logger, dbQueryTimeout)
 			require.NoError(t, err)
 
 			tx, err := p.db.BeginTx(context.Background(), nil)
@@ -936,7 +938,7 @@ func TestGetBridgesPublished(t *testing.T) {
 func TestProcessBlockInvalidIndex(t *testing.T) {
 	path := path.Join(t.TempDir(), "aggsenderTestProcessor.sqlite")
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "foo", logger, 30*time.Second)
+	p, err := newProcessor(path, "foo", logger, dbQueryTimeout)
 	require.NoError(t, err)
 	err = p.ProcessBlock(context.Background(), sync.Block{
 		Num: 0,
@@ -967,7 +969,7 @@ func TestGetBridgesPaged(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgesyncGetBridgesPaged.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -1206,7 +1208,7 @@ func TestGetClaimsPaged(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgesyncGetClaimsPaged.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -1334,7 +1336,7 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 
 	allTokenMappings := make([]*TokenMapping, 0, tokenMappingsCount)
@@ -1433,7 +1435,7 @@ func TestProcessor_GetLegacyTokenMigrations(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 
 	const (
@@ -1981,7 +1983,7 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 func TestQueryBlockRangeOrdering(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgeSyncerProcessorOrdering.db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 
 	// Create test data with events in different blocks and positions
@@ -2365,7 +2367,7 @@ func createTestProcessor(t *testing.T, dbName string) *processor {
 
 	path := path.Join(t.TempDir(), dbName+".db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
+	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
 	return p
 }

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1409,7 +1409,7 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, totalTokenMappings, err := p.GetTokenMappings(tt.pageNumber, tt.pageSize)
+			result, totalTokenMappings, err := p.GetTokenMappings(context.Background(), tt.pageNumber, tt.pageSize)
 			if tt.expectedErr != "" {
 				require.ErrorContains(t, err, tt.expectedErr)
 			} else {
@@ -2270,12 +2270,12 @@ func TestProcessor_ErrorPathLogging(t *testing.T) {
 		require.NoError(t, p.ProcessBlock(context.Background(), testBlock))
 
 		// Test invalid page number (page 10 with only 1 record and page size 5)
-		_, _, err := p.GetTokenMappings(10, 5)
+		_, _, err := p.GetTokenMappings(context.Background(), 10, 5)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid page number")
 
 		// Test successful case with valid page
-		mappings, count, err := p.GetTokenMappings(1, 5)
+		mappings, count, err := p.GetTokenMappings(context.Background(), 1, 5)
 		require.NoError(t, err)
 		require.Len(t, mappings, 1)
 		require.Equal(t, 1, count)
@@ -2332,7 +2332,7 @@ func TestProcessor_CalculateOffsetErrors(t *testing.T) {
 		require.NoError(t, p.ProcessBlock(context.Background(), testBlock))
 
 		// Test with page number that would result in offset >= total records
-		_, _, err := p.GetTokenMappings(10, 5) // page 10 with only 1 record and page size 5
+		_, _, err := p.GetTokenMappings(context.Background(), 10, 5) // page 10 with only 1 record and page size 5
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid page number")
 	})

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2448,3 +2448,43 @@ func createTestLegacyTokenMigration(blockNum uint64, blockPos int) *LegacyTokenM
 		Calldata:            []byte{},
 	}
 }
+
+func TestDatabaseQueryTimeout(t *testing.T) {
+	normalTimeout := 100 * time.Millisecond
+	shortTimeout := 1 * time.Nanosecond
+
+	path := path.Join(t.TempDir(), "bridgeSyncerProcessorTimeout.db")
+	logger := log.WithFields("module", "bridge-syncer-timeout")
+
+	// Create processor with normal timeout for setup
+	p, err := newProcessor(path, "bridge-syncer-timeout", logger, normalTimeout)
+	require.NoError(t, err)
+
+	// Insert some test data to ensure the database is working
+	block := sync.Block{
+		Num:    1,
+		Hash:   common.HexToHash("0x123"),
+		Events: []any{},
+	}
+
+	ctx := context.Background()
+	err = p.ProcessBlock(ctx, block)
+	require.NoError(t, err)
+
+	// Create a new processor with short timeout for testing timeout behavior
+	pShortTimeout, err := newProcessor(path, "bridge-syncer-short-timeout", logger, shortTimeout)
+	require.NoError(t, err)
+
+	// Test that operations timeout with short timeout
+	_, err = pShortTimeout.GetLastProcessedBlock(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context deadline exceeded")
+
+	_, err = pShortTimeout.GetBridges(ctx, 1, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context deadline exceeded")
+
+	_, err = pShortTimeout.GetClaims(ctx, 1, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context deadline exceeded")
+}

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridge"
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
@@ -84,7 +85,7 @@ func TestBigIntString(t *testing.T) {
 func TestProcessor(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgeSyncerProcessor.db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 	actions := []processAction{
 		// processed: ~
@@ -817,7 +818,7 @@ func TestInsertAndGetClaim(t *testing.T) {
 	err := migrations.RunMigrations(path)
 	require.NoError(t, err)
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "foo", logger)
+	p, err := newProcessor(path, "foo", logger, 30*time.Second)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -902,7 +903,7 @@ func TestGetBridgesPublished(t *testing.T) {
 			path := path.Join(t.TempDir(), fmt.Sprintf("bridgesyncTestGetBridgesPublished_%s.sqlite", tc.name))
 			require.NoError(t, migrations.RunMigrations(path))
 			logger := log.WithFields("bridge-syncer", "foo")
-			p, err := newProcessor(path, "foo", logger)
+			p, err := newProcessor(path, "foo", logger, 30*time.Second)
 			require.NoError(t, err)
 
 			tx, err := p.db.BeginTx(context.Background(), nil)
@@ -935,7 +936,7 @@ func TestGetBridgesPublished(t *testing.T) {
 func TestProcessBlockInvalidIndex(t *testing.T) {
 	path := path.Join(t.TempDir(), "aggsenderTestProcessor.sqlite")
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "foo", logger)
+	p, err := newProcessor(path, "foo", logger, 30*time.Second)
 	require.NoError(t, err)
 	err = p.ProcessBlock(context.Background(), sync.Block{
 		Num: 0,
@@ -966,7 +967,7 @@ func TestGetBridgesPaged(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgesyncGetBridgesPaged.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -1205,7 +1206,7 @@ func TestGetClaimsPaged(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgesyncGetClaimsPaged.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -1333,7 +1334,7 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 
 	allTokenMappings := make([]*TokenMapping, 0, tokenMappingsCount)
@@ -1432,7 +1433,7 @@ func TestProcessor_GetLegacyTokenMigrations(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 
 	const (
@@ -1980,7 +1981,7 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 func TestQueryBlockRangeOrdering(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgeSyncerProcessorOrdering.db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 
 	// Create test data with events in different blocks and positions
@@ -2309,7 +2310,7 @@ func TestProcessor_DatabaseConnectionErrors(t *testing.T) {
 
 		// Now test with an offset that would cause a database error
 		p.db.Close()
-		_, err := p.fetchTokenMappings(5, 0)
+		_, err := p.fetchTokenMappings(context.Background(), 5, 0)
 		require.Error(t, err)
 	})
 }
@@ -2364,7 +2365,7 @@ func createTestProcessor(t *testing.T, dbName string) *processor {
 
 	path := path.Join(t.TempDir(), dbName+".db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, 30*time.Second)
 	require.NoError(t, err)
 	return p
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -614,12 +614,6 @@ func runBridgeSyncL1IfNeeded(
 		return nil
 	}
 
-	// Set default timeout if not configured
-	databaseQueryTimeout := cfg.DatabaseQueryTimeout.Duration
-	if databaseQueryTimeout <= 0 {
-		databaseQueryTimeout = 30 * time.Second
-	}
-
 	bridgeSyncL1, err := bridgesync.NewL1(
 		ctx,
 		cfg.DBPath,
@@ -634,7 +628,7 @@ func runBridgeSyncL1IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
-		databaseQueryTimeout,
+		cfg.DatabaseQueryTimeout.Duration,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -660,12 +654,6 @@ func runBridgeSyncL2IfNeeded(
 		return nil
 	}
 
-	// Set default timeout if not configured
-	databaseQueryTimeout := cfg.DatabaseQueryTimeout.Duration
-	if databaseQueryTimeout <= 0 {
-		databaseQueryTimeout = 30 * time.Second
-	}
-
 	bridgeSyncL2, err := bridgesync.NewL2(
 		ctx,
 		cfg.DBPath,
@@ -681,7 +669,7 @@ func runBridgeSyncL2IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
-		databaseQueryTimeout,
+		cfg.DatabaseQueryTimeout.Duration,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -614,6 +614,12 @@ func runBridgeSyncL1IfNeeded(
 		return nil
 	}
 
+	// Set default timeout if not configured
+	databaseQueryTimeout := cfg.DatabaseQueryTimeout.Duration
+	if databaseQueryTimeout <= 0 {
+		databaseQueryTimeout = 30 * time.Second
+	}
+
 	bridgeSyncL1, err := bridgesync.NewL1(
 		ctx,
 		cfg.DBPath,
@@ -628,6 +634,7 @@ func runBridgeSyncL1IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
+		databaseQueryTimeout,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -653,6 +660,12 @@ func runBridgeSyncL2IfNeeded(
 		return nil
 	}
 
+	// Set default timeout if not configured
+	databaseQueryTimeout := cfg.DatabaseQueryTimeout.Duration
+	if databaseQueryTimeout <= 0 {
+		databaseQueryTimeout = 30 * time.Second
+	}
+
 	bridgeSyncL2, err := bridgesync.NewL2(
 		ctx,
 		cfg.DBPath,
@@ -668,6 +681,7 @@ func runBridgeSyncL2IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
+		databaseQueryTimeout,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -628,7 +628,7 @@ func runBridgeSyncL1IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
-		cfg.DatabaseQueryTimeout.Duration,
+		cfg.DBQueryTimeout.Duration,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -669,7 +669,7 @@ func runBridgeSyncL2IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
-		cfg.DatabaseQueryTimeout.Duration,
+		cfg.DBQueryTimeout.Duration,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/config/default.go
+++ b/config/default.go
@@ -23,7 +23,7 @@ rollupManagerCreationBlockNumber = 0
 genesisBlockNumber = 0
 
 # Default database query timeout
-defaultDatabaseQueryTimeout = "30s"
+defaultDBQueryTimeout = "30s"
 
 [L1Config]
 	URL = "{{L1URL}}"
@@ -141,7 +141,7 @@ MaxRequestsPerIPAndSecond = 10
 [REST]
 Host = "0.0.0.0"
 Port = 5577
-ReadTimeout = "30s"
+ReadTimeout = "2s"
 WriteTimeout = "2s"
 MaxRequestsPerIPAndSecond = 10
 
@@ -154,7 +154,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
-DatabaseQueryTimeout = "{{defaultDatabaseQueryTimeout}}"
+DBQueryTimeout = "{{defaultDBQueryTimeout}}"
 
 [BridgeL2Sync]
 DBPath = "{{PathRWData}}/bridgel2sync.sqlite"
@@ -166,7 +166,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
-DatabaseQueryTimeout = "{{defaultDatabaseQueryTimeout}}"
+DBQueryTimeout = "{{defaultDB'QueryTimeout}}"
 
 [L2GERSync]
 DBPath = "{{PathRWData}}/l2gersync.sqlite"

--- a/config/default.go
+++ b/config/default.go
@@ -166,7 +166,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
-DBQueryTimeout = "{{defaultDB'QueryTimeout}}"
+DBQueryTimeout = "{{defaultDBQueryTimeout}}"
 
 [L2GERSync]
 DBPath = "{{PathRWData}}/l2gersync.sqlite"

--- a/config/default.go
+++ b/config/default.go
@@ -137,7 +137,7 @@ MaxRequestsPerIPAndSecond = 10
 [REST]
 Host = "0.0.0.0"
 Port = 5577
-ReadTimeout = "2s"
+ReadTimeout = "30s"
 WriteTimeout = "2s"
 MaxRequestsPerIPAndSecond = 10
 
@@ -150,6 +150,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
+DatabaseQueryTimeout = "30s"
 
 [BridgeL2Sync]
 DBPath = "{{PathRWData}}/bridgel2sync.sqlite"
@@ -161,6 +162,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
+DatabaseQueryTimeout = "30s"
 
 [L2GERSync]
 DBPath = "{{PathRWData}}/l2gersync.sqlite"
@@ -202,7 +204,7 @@ RequireValidatorCall = false
 	[AggSender.RetriesToBuildAndSendCertificate]
 		RetryMode = "delays"
 		Delays = [ "1m", "1m", "2m", "5m", "5m", "8m" ]
-		MaxRetries = 6 # 1+6 attempts, around 22m 
+		MaxRetries = 6 # 1+6 attempts, around 22m
 	[AggSender.AgglayerClient]
 		Cached = false
 		[AggSender.AgglayerClient.ConfigurationCache]

--- a/config/default.go
+++ b/config/default.go
@@ -21,6 +21,10 @@ polygonBridgeAddr = "0x0000000000000000000000000000000000000000"
 rollupCreationBlockNumber = 0
 rollupManagerCreationBlockNumber = 0
 genesisBlockNumber = 0
+
+# Default database query timeout
+defaultDatabaseQueryTimeout = "30s"
+
 [L1Config]
 	URL = "{{L1URL}}"
 	chainId = 0
@@ -150,7 +154,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
-DatabaseQueryTimeout = "30s"
+DatabaseQueryTimeout = "{{defaultDatabaseQueryTimeout}}"
 
 [BridgeL2Sync]
 DBPath = "{{PathRWData}}/bridgel2sync.sqlite"
@@ -162,7 +166,7 @@ RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
-DatabaseQueryTimeout = "30s"
+DatabaseQueryTimeout = "{{defaultDatabaseQueryTimeout}}"
 
 [L2GERSync]
 DBPath = "{{PathRWData}}/l2gersync.sqlite"

--- a/db/mocks/mock_d_ber.go
+++ b/db/mocks/mock_d_ber.go
@@ -219,6 +219,76 @@ func (_c *DBer_Query_Call) RunAndReturn(run func(string, ...interface{}) (*sql.R
 	return _c
 }
 
+// QueryContext provides a mock function with given fields: ctx, query, args
+func (_m *DBer) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryContext")
+	}
+
+	var r0 *sql.Rows
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (*sql.Rows, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Rows); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Rows)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DBer_QueryContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryContext'
+type DBer_QueryContext_Call struct {
+	*mock.Call
+}
+
+// QueryContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *DBer_Expecter) QueryContext(ctx interface{}, query interface{}, args ...interface{}) *DBer_QueryContext_Call {
+	return &DBer_QueryContext_Call{Call: _e.mock.On("QueryContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *DBer_QueryContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *DBer_QueryContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *DBer_QueryContext_Call) Return(_a0 *sql.Rows, _a1 error) *DBer_QueryContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *DBer_QueryContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (*sql.Rows, error)) *DBer_QueryContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QueryRow provides a mock function with given fields: query, args
 func (_m *DBer) QueryRow(query string, args ...interface{}) *sql.Row {
 	var _ca []interface{}
@@ -274,6 +344,66 @@ func (_c *DBer_QueryRow_Call) Return(_a0 *sql.Row) *DBer_QueryRow_Call {
 }
 
 func (_c *DBer_QueryRow_Call) RunAndReturn(run func(string, ...interface{}) *sql.Row) *DBer_QueryRow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// QueryRowContext provides a mock function with given fields: ctx, query, args
+func (_m *DBer) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRowContext")
+	}
+
+	var r0 *sql.Row
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Row); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Row)
+		}
+	}
+
+	return r0
+}
+
+// DBer_QueryRowContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryRowContext'
+type DBer_QueryRowContext_Call struct {
+	*mock.Call
+}
+
+// QueryRowContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *DBer_Expecter) QueryRowContext(ctx interface{}, query interface{}, args ...interface{}) *DBer_QueryRowContext_Call {
+	return &DBer_QueryRowContext_Call{Call: _e.mock.On("QueryRowContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *DBer_QueryRowContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *DBer_QueryRowContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *DBer_QueryRowContext_Call) Return(_a0 *sql.Row) *DBer_QueryRowContext_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *DBer_QueryRowContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) *sql.Row) *DBer_QueryRowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/mocks/mock_querier.go
+++ b/db/mocks/mock_querier.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	context "context"
 	sql "database/sql"
 
 	mock "github.com/stretchr/testify/mock"
@@ -159,6 +160,76 @@ func (_c *Querier_Query_Call) RunAndReturn(run func(string, ...interface{}) (*sq
 	return _c
 }
 
+// QueryContext provides a mock function with given fields: ctx, query, args
+func (_m *Querier) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryContext")
+	}
+
+	var r0 *sql.Rows
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (*sql.Rows, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Rows); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Rows)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Querier_QueryContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryContext'
+type Querier_QueryContext_Call struct {
+	*mock.Call
+}
+
+// QueryContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Querier_Expecter) QueryContext(ctx interface{}, query interface{}, args ...interface{}) *Querier_QueryContext_Call {
+	return &Querier_QueryContext_Call{Call: _e.mock.On("QueryContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Querier_QueryContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Querier_QueryContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Querier_QueryContext_Call) Return(_a0 *sql.Rows, _a1 error) *Querier_QueryContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Querier_QueryContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (*sql.Rows, error)) *Querier_QueryContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QueryRow provides a mock function with given fields: query, args
 func (_m *Querier) QueryRow(query string, args ...interface{}) *sql.Row {
 	var _ca []interface{}
@@ -214,6 +285,66 @@ func (_c *Querier_QueryRow_Call) Return(_a0 *sql.Row) *Querier_QueryRow_Call {
 }
 
 func (_c *Querier_QueryRow_Call) RunAndReturn(run func(string, ...interface{}) *sql.Row) *Querier_QueryRow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// QueryRowContext provides a mock function with given fields: ctx, query, args
+func (_m *Querier) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRowContext")
+	}
+
+	var r0 *sql.Row
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Row); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Row)
+		}
+	}
+
+	return r0
+}
+
+// Querier_QueryRowContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryRowContext'
+type Querier_QueryRowContext_Call struct {
+	*mock.Call
+}
+
+// QueryRowContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Querier_Expecter) QueryRowContext(ctx interface{}, query interface{}, args ...interface{}) *Querier_QueryRowContext_Call {
+	return &Querier_QueryRowContext_Call{Call: _e.mock.On("QueryRowContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Querier_QueryRowContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Querier_QueryRowContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Querier_QueryRowContext_Call) Return(_a0 *sql.Row) *Querier_QueryRowContext_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Querier_QueryRowContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) *sql.Row) *Querier_QueryRowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/mocks/mock_sql_txer.go
+++ b/db/mocks/mock_sql_txer.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	context "context"
 	sql "database/sql"
 
 	mock "github.com/stretchr/testify/mock"
@@ -204,6 +205,76 @@ func (_c *SQLTxer_Query_Call) RunAndReturn(run func(string, ...interface{}) (*sq
 	return _c
 }
 
+// QueryContext provides a mock function with given fields: ctx, query, args
+func (_m *SQLTxer) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryContext")
+	}
+
+	var r0 *sql.Rows
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (*sql.Rows, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Rows); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Rows)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SQLTxer_QueryContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryContext'
+type SQLTxer_QueryContext_Call struct {
+	*mock.Call
+}
+
+// QueryContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *SQLTxer_Expecter) QueryContext(ctx interface{}, query interface{}, args ...interface{}) *SQLTxer_QueryContext_Call {
+	return &SQLTxer_QueryContext_Call{Call: _e.mock.On("QueryContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *SQLTxer_QueryContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *SQLTxer_QueryContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SQLTxer_QueryContext_Call) Return(_a0 *sql.Rows, _a1 error) *SQLTxer_QueryContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SQLTxer_QueryContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (*sql.Rows, error)) *SQLTxer_QueryContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QueryRow provides a mock function with given fields: query, args
 func (_m *SQLTxer) QueryRow(query string, args ...interface{}) *sql.Row {
 	var _ca []interface{}
@@ -259,6 +330,66 @@ func (_c *SQLTxer_QueryRow_Call) Return(_a0 *sql.Row) *SQLTxer_QueryRow_Call {
 }
 
 func (_c *SQLTxer_QueryRow_Call) RunAndReturn(run func(string, ...interface{}) *sql.Row) *SQLTxer_QueryRow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// QueryRowContext provides a mock function with given fields: ctx, query, args
+func (_m *SQLTxer) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRowContext")
+	}
+
+	var r0 *sql.Row
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Row); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Row)
+		}
+	}
+
+	return r0
+}
+
+// SQLTxer_QueryRowContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryRowContext'
+type SQLTxer_QueryRowContext_Call struct {
+	*mock.Call
+}
+
+// QueryRowContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *SQLTxer_Expecter) QueryRowContext(ctx interface{}, query interface{}, args ...interface{}) *SQLTxer_QueryRowContext_Call {
+	return &SQLTxer_QueryRowContext_Call{Call: _e.mock.On("QueryRowContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *SQLTxer_QueryRowContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *SQLTxer_QueryRowContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SQLTxer_QueryRowContext_Call) Return(_a0 *sql.Row) *SQLTxer_QueryRowContext_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SQLTxer_QueryRowContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) *sql.Row) *SQLTxer_QueryRowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/mocks/mock_txer.go
+++ b/db/mocks/mock_txer.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	context "context"
 	sql "database/sql"
 
 	mock "github.com/stretchr/testify/mock"
@@ -270,6 +271,76 @@ func (_c *Txer_Query_Call) RunAndReturn(run func(string, ...interface{}) (*sql.R
 	return _c
 }
 
+// QueryContext provides a mock function with given fields: ctx, query, args
+func (_m *Txer) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryContext")
+	}
+
+	var r0 *sql.Rows
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (*sql.Rows, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Rows); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Rows)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Txer_QueryContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryContext'
+type Txer_QueryContext_Call struct {
+	*mock.Call
+}
+
+// QueryContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Txer_Expecter) QueryContext(ctx interface{}, query interface{}, args ...interface{}) *Txer_QueryContext_Call {
+	return &Txer_QueryContext_Call{Call: _e.mock.On("QueryContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Txer_QueryContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Txer_QueryContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Txer_QueryContext_Call) Return(_a0 *sql.Rows, _a1 error) *Txer_QueryContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Txer_QueryContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (*sql.Rows, error)) *Txer_QueryContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QueryRow provides a mock function with given fields: query, args
 func (_m *Txer) QueryRow(query string, args ...interface{}) *sql.Row {
 	var _ca []interface{}
@@ -325,6 +396,66 @@ func (_c *Txer_QueryRow_Call) Return(_a0 *sql.Row) *Txer_QueryRow_Call {
 }
 
 func (_c *Txer_QueryRow_Call) RunAndReturn(run func(string, ...interface{}) *sql.Row) *Txer_QueryRow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// QueryRowContext provides a mock function with given fields: ctx, query, args
+func (_m *Txer) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRowContext")
+	}
+
+	var r0 *sql.Row
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Row); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Row)
+		}
+	}
+
+	return r0
+}
+
+// Txer_QueryRowContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryRowContext'
+type Txer_QueryRowContext_Call struct {
+	*mock.Call
+}
+
+// QueryRowContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Txer_Expecter) QueryRowContext(ctx interface{}, query interface{}, args ...interface{}) *Txer_QueryRowContext_Call {
+	return &Txer_QueryRowContext_Call{Call: _e.mock.On("QueryRowContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Txer_QueryRowContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Txer_QueryRowContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Txer_QueryRowContext_Call) Return(_a0 *sql.Row) *Txer_QueryRowContext_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Txer_QueryRowContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) *sql.Row) *Txer_QueryRowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/types/interface.go
+++ b/db/types/interface.go
@@ -13,6 +13,8 @@ type Querier interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
 // DBer defines the interface for database operations, embedding the Querier interface

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -30,10 +30,10 @@ import (
 )
 
 const (
-	rollupID                    = uint32(1)
-	aggOracleCommitteeNonce     = 4
-	syncBlockChunkSize          = 10
-	defaultDatabaseQueryTimeout = 30 * time.Second
+	rollupID                = uint32(1)
+	aggOracleCommitteeNonce = 4
+	syncBlockChunkSize      = 10
+	defaultDBQueryTimeout   = 30 * time.Second
 )
 
 type L2GERManagerContractType int
@@ -152,13 +152,11 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 	testClient := NewTestClient(l1Client.Client(), WithRPCClienter(cfg.L1RPCClient))
 	dbPathBridgeSyncL1 := path.Join(t.TempDir(), "BridgeSyncL1.sqlite")
 
-	databaseQueryTimeout := defaultDatabaseQueryTimeout
-
 	bridgeL1Sync, err := bridgesync.NewL1(
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
 		syncBlockChunkSize, aggkittypes.LatestBlock, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true, databaseQueryTimeout)
+		retriesCount, originNetwork, false, true, defaultDBQueryTimeout)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -266,13 +264,11 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 		retriesCount           = 100
 	)
 
-	databaseQueryTimeout := defaultDatabaseQueryTimeout
-
 	bridgeL2Sync, err := bridgesync.NewL2(
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,
 		aggkittypes.LatestBlock, rdL2, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true, databaseQueryTimeout)
+		retriesCount, originNetwork, false, true, defaultDBQueryTimeout)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -150,11 +150,14 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 	// Bridge sync
 	testClient := NewTestClient(l1Client.Client(), WithRPCClienter(cfg.L1RPCClient))
 	dbPathBridgeSyncL1 := path.Join(t.TempDir(), "BridgeSyncL1.sqlite")
+
+	databaseQueryTimeout := 30 * time.Second
+
 	bridgeL1Sync, err := bridgesync.NewL1(
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
 		syncBlockChunkSize, aggkittypes.LatestBlock, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true)
+		retriesCount, originNetwork, false, true, databaseQueryTimeout)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -262,11 +265,13 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 		retriesCount           = 100
 	)
 
+	databaseQueryTimeout := 30 * time.Second
+
 	bridgeL2Sync, err := bridgesync.NewL2(
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,
 		aggkittypes.LatestBlock, rdL2, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true)
+		retriesCount, originNetwork, false, true, databaseQueryTimeout)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	rollupID                = uint32(1)
-	aggOracleCommitteeNonce = 4
-	syncBlockChunkSize      = 10
+	rollupID                    = uint32(1)
+	aggOracleCommitteeNonce     = 4
+	syncBlockChunkSize          = 10
+	defaultDatabaseQueryTimeout = 30 * time.Second
 )
 
 type L2GERManagerContractType int
@@ -151,7 +152,7 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 	testClient := NewTestClient(l1Client.Client(), WithRPCClienter(cfg.L1RPCClient))
 	dbPathBridgeSyncL1 := path.Join(t.TempDir(), "BridgeSyncL1.sqlite")
 
-	databaseQueryTimeout := 30 * time.Second
+	databaseQueryTimeout := defaultDatabaseQueryTimeout
 
 	bridgeL1Sync, err := bridgesync.NewL1(
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
@@ -265,7 +266,7 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 		retriesCount           = 100
 	)
 
-	databaseQueryTimeout := 30 * time.Second
+	databaseQueryTimeout := defaultDatabaseQueryTimeout
 
 	bridgeL2Sync, err := bridgesync.NewL2(
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,


### PR DESCRIPTION
## 🔄 Changes Summary
- This PR adds db query timeout for db tx

### Config Changes
- Added `DBQueryTimeout`  to `[BridgeL1Sync]` section
- Added `DBQueryTimeout`  to `[BridgeL2Sync]` section

### Purpose
Enables configurable database query timeouts for bridge db operations.

Issue: #835 
