### PR TITLE
feat: support `FEP` in `aggsender-validator`

### DIFF
--- a/aggsender/aggsender_validator.go
+++ b/aggsender/aggsender_validator.go
@@ -31,14 +31,14 @@ type AggsenderValidator struct {
 func NewAggsenderValidator(ctx context.Context,
 	logger aggkitcommon.Logger,
 	cfg validator.Config,
-	flowPP validator.FlowInterface,
+	flow validator.FlowInterface,
 	l1InfoTreeDataQuerier validator.L1InfoTreeRootByLeafQuerier,
 	aggLayerClient agglayer.AggLayerClientCertificateIDQuerier,
 	certQuerier types.CertificateQuerier,
 	lerQuerier types.LERQuerier,
 	signer signertypes.Signer) (*AggsenderValidator, error) {
 	validatorCert := validator.NewAggsenderValidator(
-		logger, flowPP, l1InfoTreeDataQuerier, certQuerier, lerQuerier)
+		logger, flow, l1InfoTreeDataQuerier, certQuerier, lerQuerier)
 	grpcServer, err := grpc.NewServer(cfg.ServerConfig)
 	if err != nil {
 		return nil, err

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -119,8 +119,11 @@ func (c Config) String() string {
 // Validate checks if the configuration is valid
 func (c Config) Validate() error {
 	if c.RequireValidatorCall {
-		if c.Mode != aggsendertypes.PessimisticProofMode.String() {
-			return fmt.Errorf("RequireValidatorCall can only be true in PessimisticProof mode, got %s", c.Mode)
+		if c.Mode != aggsendertypes.PessimisticProofMode.String() &&
+			c.Mode != aggsendertypes.AggchainProofMode.String() {
+			return fmt.Errorf(
+				"RequireValidatorCall can only be true in PessimisticProof or AggchainProof mode, got %s",
+				c.Mode)
 		}
 
 		if c.ValidatorClient == nil || c.ValidatorClient.URL == "" {

--- a/aggsender/config/config_test.go
+++ b/aggsender/config/config_test.go
@@ -20,16 +20,16 @@ func TestValidate(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name: "RequireValidatorCall not PP mode",
+			name: "RequireValidatorCall not PP or FEP mode",
 			config: Config{
-				Mode:                 aggsendertypes.AggchainProofMode.String(),
+				Mode:                 "some-other-mode",
 				RequireValidatorCall: true,
 				ValidatorClient: &grpc.ClientConfig{
 					URL:               "http://localhost:8080",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
 				},
 			},
-			expectedErr: "RequireValidatorCall can only be true in PessimisticProof mode",
+			expectedErr: "RequireValidatorCall can only be true in PessimisticProof or AggchainProof mode",
 		},
 		{
 			name: "RequireValidatorCall is true with ValidatorClient URL set",

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -3,6 +3,7 @@ package flows
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/agglayer/aggkit/aggsender/aggchainproofclient"
 	"github.com/agglayer/aggkit/aggsender/config"
@@ -15,7 +16,7 @@ import (
 	"github.com/agglayer/aggkit/log"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/agglayer/go_signer/signer"
-	signerTypes "github.com/agglayer/go_signer/signer/types"
+	signertypes "github.com/agglayer/go_signer/signer/types"
 )
 
 var (
@@ -23,7 +24,6 @@ var (
 	l2GERReaderFactory = l2gersync.NewL2EVMGERReader
 )
 
-// NewFlow creates a new Aggsender flow based on the provided configuration.
 func NewFlow(
 	ctx context.Context,
 	cfg config.Config,
@@ -37,8 +37,9 @@ func NewFlow(
 ) (types.AggsenderFlow, error) {
 	switch types.AggsenderMode(cfg.Mode) {
 	case types.PessimisticProofMode:
-		commonFlowComponents, err := createCommonComponents(
-			ctx, cfg, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier, 0, false,
+		commonFlowComponents, err := CreateCommonFlowComponents(
+			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier, 0, false,
+			cfg.MaxCertSize, cfg.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -46,19 +47,15 @@ func NewFlow(
 
 		return NewPPFlow(
 			logger,
-			commonFlowComponents.baseFlow,
+			commonFlowComponents.BaseFlow,
 			storage,
-			commonFlowComponents.l1InfoTreeDataQuerier,
-			commonFlowComponents.l2BridgeQuerier,
-			commonFlowComponents.signer,
+			commonFlowComponents.L1InfoTreeDataQuerier,
+			commonFlowComponents.L2BridgeQuerier,
+			commonFlowComponents.Signer,
 			cfg.RequireOneBridgeInPPCertificate,
 			cfg.MaxL2BlockNumber,
 		), nil
 	case types.AggchainProofMode:
-		if err := cfg.AggkitProverClient.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid aggkit prover client config: %w", err)
-		}
-
 		aggchainProofClient, err := aggchainproofclient.NewAggchainProofClient(cfg.AggkitProverClient)
 		if err != nil {
 			return nil, fmt.Errorf("aggchainProverFlow - error creating aggkit prover client: %w", err)
@@ -76,9 +73,10 @@ func NewFlow(
 			return nil, fmt.Errorf("aggchainProverFlow - error creating aggchain FEP querier: %w", err)
 		}
 
-		commonFlowComponents, err := createCommonComponents(
-			ctx, cfg, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier,
+		commonFlowComponents, err := CreateCommonFlowComponents(
+			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier,
 			aggchainFEPQuerier.StartL2Block(), cfg.RequireNoFEPBlockGap,
+			cfg.MaxCertSize, cfg.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -89,27 +87,24 @@ func NewFlow(
 			return nil, fmt.Errorf("failed to create L2 GER reader: %w", err)
 		}
 
-		gerQuerier := query.NewGERDataQuerier(commonFlowComponents.l1InfoTreeDataQuerier, l2GERReader)
-
 		aggchainProofQuerier := query.NewAggchainProofQuery(
 			logger,
 			aggchainProofClient,
-			commonFlowComponents.l1InfoTreeDataQuerier,
+			commonFlowComponents.L1InfoTreeDataQuerier,
 			optimisticSigner,
-			commonFlowComponents.baseFlow,
-			gerQuerier,
+			commonFlowComponents.BaseFlow,
+			query.NewGERDataQuerier(commonFlowComponents.L1InfoTreeDataQuerier, l2GERReader),
 		)
 
 		return NewAggchainProverFlow(
 			logger,
 			NewAggchainProverFlowConfig(cfg.MaxL2BlockNumber),
-			commonFlowComponents.baseFlow,
+			commonFlowComponents.BaseFlow,
 			storage,
-			commonFlowComponents.l1InfoTreeDataQuerier,
-			commonFlowComponents.l2BridgeQuerier,
-			gerQuerier,
+			commonFlowComponents.L1InfoTreeDataQuerier,
+			commonFlowComponents.L2BridgeQuerier,
 			l1Client,
-			commonFlowComponents.signer,
+			commonFlowComponents.Signer,
 			optimisticModeQuerier,
 			aggchainProofQuerier,
 		), nil
@@ -119,17 +114,16 @@ func NewFlow(
 	}
 }
 
-type commonFlowComponents struct {
-	l2BridgeQuerier       types.BridgeQuerier
-	l1InfoTreeDataQuerier types.L1InfoTreeDataQuerier
-	lerQuerier            types.LERQuerier
-	baseFlow              types.AggsenderFlowBaser
-	signer                signerTypes.Signer
+type CommonFlowComponents struct {
+	L2BridgeQuerier       types.BridgeQuerier
+	L1InfoTreeDataQuerier types.L1InfoTreeDataQuerier
+	LERQuerier            types.LERQuerier
+	BaseFlow              types.AggsenderFlowBaser
+	Signer                signertypes.Signer
 }
 
-func createCommonComponents(
+func CreateCommonFlowComponents(
 	ctx context.Context,
-	cfg config.Config,
 	logger *log.Logger,
 	storage db.AggSenderStorage,
 	l1Client aggkittypes.BaseEthereumClienter,
@@ -138,35 +132,39 @@ func createCommonComponents(
 	rollupDataQuerier types.RollupDataQuerier,
 	startL2Block uint64,
 	requireNoFEPBlockGap bool,
-) (commonFlowComponents, error) {
-	signer, err := initializeSigner(ctx, cfg.AggsenderPrivateKey, logger)
+	maxCertSize uint,
+	rollupCreationBlockL1 uint64,
+	delayBetweenRetries time.Duration,
+	signerCfg signertypes.SignerConfig,
+) (*CommonFlowComponents, error) {
+	signer, err := initializeSigner(ctx, signerCfg, logger)
 	if err != nil {
-		return commonFlowComponents{}, err
+		return nil, err
 	}
 
-	l2BridgeQuerier := query.NewBridgeDataQuerier(logger, l2Syncer, cfg.DelayBetweenRetries.Duration)
+	l2BridgeQuerier := query.NewBridgeDataQuerier(logger, l2Syncer, delayBetweenRetries)
 	l1InfoTreeQuerier := query.NewL1InfoTreeDataQuerier(l1Client, l1InfoTreeSyncer)
-	lerQuerier := query.NewLERDataQuerier(cfg.RollupCreationBlockL1, rollupDataQuerier)
+	lerQuerier := query.NewLERDataQuerier(rollupCreationBlockL1, rollupDataQuerier)
 
 	baseFlow := NewBaseFlow(
 		logger, l2BridgeQuerier, storage, l1InfoTreeQuerier, lerQuerier,
-		NewBaseFlowConfig(cfg.MaxCertSize, startL2Block, requireNoFEPBlockGap),
+		NewBaseFlowConfig(maxCertSize, startL2Block, requireNoFEPBlockGap),
 	)
 
-	return commonFlowComponents{
-		l2BridgeQuerier:       l2BridgeQuerier,
-		l1InfoTreeDataQuerier: l1InfoTreeQuerier,
-		lerQuerier:            lerQuerier,
-		baseFlow:              baseFlow,
-		signer:                signer,
+	return &CommonFlowComponents{
+		L2BridgeQuerier:       l2BridgeQuerier,
+		L1InfoTreeDataQuerier: l1InfoTreeQuerier,
+		LERQuerier:            lerQuerier,
+		BaseFlow:              baseFlow,
+		Signer:                signer,
 	}, nil
 }
 
 func initializeSigner(
 	ctx context.Context,
-	signerCfg signerTypes.SignerConfig,
+	signerCfg signertypes.SignerConfig,
 	logger *log.Logger,
-) (signerTypes.Signer, error) {
+) (signertypes.Signer, error) {
 	signer, err := signer.NewSigner(ctx, 0, signerCfg, aggkitcommon.AGGSENDER, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error NewSigner. Err: %w", err)

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -49,14 +49,6 @@ func TestNewFlow(t *testing.T) {
 			expectedError: "error signer.Initialize",
 		},
 		{
-			name: "error missing AggkitProverClient in AggchainProofMode",
-			cfg: config.Config{
-				Mode:                string(types.AggchainProofMode),
-				AggsenderPrivateKey: signertypes.SignerConfig{Method: signertypes.MethodNone},
-			},
-			expectedError: "invalid aggkit prover client config: gRPC client configuration cannot be nil",
-		},
-		{
 			name: "unsupported Aggsender mode",
 			cfg: config.Config{
 				Mode: "unsupported-mode",

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+var _ types.AggsenderFlow = (*AggchainProverFlow)(nil)
+
 // AggchainProverFlow is a struct that holds the logic for the AggchainProver prover type flow
 type AggchainProverFlow struct {
 	baseFlow types.AggsenderFlowBaser
@@ -24,7 +26,6 @@ type AggchainProverFlow struct {
 	l1InfoTreeDataQuerier types.L1InfoTreeDataQuerier
 	l2BridgeQuerier       types.BridgeQuerier
 
-	gerQuerier            types.GERQuerier
 	certificateSigner     signertypes.Signer
 	optimisticModeQuerier types.OptimisticModeQuerier
 	aggchainProofQuerier  types.AggchainProofQuerier
@@ -77,7 +78,6 @@ func NewAggchainProverFlow(
 	storage db.AggSenderStorage,
 	l1InfoTreeQuerier types.L1InfoTreeDataQuerier,
 	l2BridgeQuerier types.BridgeQuerier,
-	gerQuerier types.GERQuerier,
 	l1Client aggkittypes.BaseEthereumClienter,
 	signer signertypes.Signer,
 	optimisticModeQuerier types.OptimisticModeQuerier,
@@ -94,7 +94,6 @@ func NewAggchainProverFlow(
 		storage:               storage,
 		l1InfoTreeDataQuerier: l1InfoTreeQuerier,
 		l2BridgeQuerier:       l2BridgeQuerier,
-		gerQuerier:            gerQuerier,
 		config:                aggChainProverConfig,
 		certificateSigner:     signer,
 		optimisticModeQuerier: optimisticModeQuerier,
@@ -144,9 +143,25 @@ func (a *AggchainProverFlow) getCertificateTypeToGenerate() (types.CertificateTy
 	return types.CertificateTypeFEP, nil
 }
 
+// GeneratePreBuildParams generates the pre-build parameters for the AggchainProverFlow
+// Only used in aggsender validator
 func (a *AggchainProverFlow) GenerateBuildParams(ctx context.Context,
 	preParams *types.CertificatePreBuildParams) (*types.CertificateBuildParams, error) {
-	return nil, fmt.Errorf("aggchainProverFlow - GenerateBuildParams is not implemented")
+	if preParams == nil {
+		return nil, fmt.Errorf("ppFlow - preParams is nil")
+	}
+
+	params, err := a.baseFlow.GenerateBuildParams(ctx, *preParams)
+	if err != nil {
+		return nil, fmt.Errorf("ppFlow - error generating build params: %w", err)
+	}
+
+	// we do not limit the size of the certificate in FEP flow,
+	// it was already resized and limited by the prover when proposer called it
+	// when building the certificate, so the block range is already limited
+	// when it gets to the validator
+
+	return params, nil
 }
 
 // GetCertificateBuildParams returns the parameters to build a certificate
@@ -296,15 +311,19 @@ func (a *AggchainProverFlow) BuildCertificate(ctx context.Context,
 		return nil, fmt.Errorf("aggchainProverFlow - error building certificate: %w", err)
 	}
 
-	cert.AggchainData = &agglayertypes.AggchainDataProof{
-		Proof:          buildParams.AggchainProof.SP1StarkProof.Proof,
-		Version:        buildParams.AggchainProof.SP1StarkProof.Version,
-		Vkey:           buildParams.AggchainProof.SP1StarkProof.Vkey,
-		AggchainParams: buildParams.AggchainProof.AggchainParams,
-		Context:        buildParams.AggchainProof.Context,
-	}
+	if buildParams.AggchainProof != nil {
+		// this case can happen only when aggsender validator calls this function
+		// since the validator does not call the aggchain prover to get the proof
+		cert.AggchainData = &agglayertypes.AggchainDataProof{
+			Proof:          buildParams.AggchainProof.SP1StarkProof.Proof,
+			Version:        buildParams.AggchainProof.SP1StarkProof.Version,
+			Vkey:           buildParams.AggchainProof.SP1StarkProof.Vkey,
+			AggchainParams: buildParams.AggchainProof.AggchainParams,
+			Context:        buildParams.AggchainProof.Context,
+		}
 
-	cert.CustomChainData = buildParams.AggchainProof.CustomChainData
+		cert.CustomChainData = buildParams.AggchainProof.CustomChainData
+	}
 
 	signedCert, err := a.signCertificate(ctx, cert)
 	if err != nil {
@@ -380,4 +399,18 @@ func (a *AggchainProverFlow) signCertificate(
 	)
 
 	return cert, nil
+}
+
+// ValidateCertificate validates the certificate for the FEP specific things
+func (a *AggchainProverFlow) ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error {
+	if cert == nil {
+		return fmt.Errorf("aggchainProverFlow - ValidateCertificate - certificate is nil")
+	}
+
+	_, ok := cert.AggchainData.(*agglayertypes.AggchainDataProof)
+	if !ok {
+		return fmt.Errorf("aggchainProverFlow - ValidateCertificate - AggchainData is not of type AggchainDataProof")
+	}
+
+	return nil
 }

--- a/aggsender/flows/flow_aggchain_prover_optimistic_test.go
+++ b/aggsender/flows/flow_aggchain_prover_optimistic_test.go
@@ -107,7 +107,6 @@ type AggchainProverFlowTestData struct {
 	mockStorage               *mocks.AggSenderStorage
 	mockL2BridgeQuerier       *mocks.BridgeQuerier
 	mockL1InfoTreeQuerier     *mocks.L1InfoTreeDataQuerier
-	mockGERQuerier            *mocks.GERQuerier
 	mockL1Client              *aggkittypesmocks.BaseEthereumClienter
 	mockOptimisticModeQuerier *mocks.OptimisticModeQuerier
 	mockSigner                *mocks.Signer
@@ -125,7 +124,6 @@ func NewAggchainProverFlowTestData(t *testing.T, cfgBase BaseFlowConfig) *Aggcha
 		mockStorage:               mocks.NewAggSenderStorage(t),
 		mockL2BridgeQuerier:       mocks.NewBridgeQuerier(t),
 		mockL1InfoTreeQuerier:     mocks.NewL1InfoTreeDataQuerier(t),
-		mockGERQuerier:            mocks.NewGERQuerier(t),
 		mockL1Client:              aggkittypesmocks.NewBaseEthereumClienter(t),
 		mockOptimisticModeQuerier: mocks.NewOptimisticModeQuerier(t),
 		mockSigner:                mocks.NewSigner(t),
@@ -144,7 +142,6 @@ func NewAggchainProverFlowTestData(t *testing.T, cfgBase BaseFlowConfig) *Aggcha
 		res.mockStorage,
 		res.mockL1InfoTreeQuerier,
 		res.mockL2BridgeQuerier,
-		res.mockGERQuerier,
 		res.mockL1Client,
 		res.mockSigner,
 		res.mockOptimisticModeQuerier,

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -38,7 +38,6 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			*mocks.BridgeQuerier,
 			*mocks.AggchainProofQuerier,
 			*mocks.L1InfoTreeDataQuerier,
-			*mocks.GERQuerier,
 		)
 		expectedParams *types.CertificateBuildParams
 		expectedError  string
@@ -48,8 +47,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				mockStorage.EXPECT().GetLastSentCertificateHeaderWithProofIfInError(ctx).Return(nil, nil, errors.New("some error"))
 			},
 			expectedError: "some error",
@@ -59,8 +57,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
@@ -119,8 +116,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
@@ -179,8 +175,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
@@ -206,8 +201,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				mockStorage.EXPECT().GetLastSentCertificateHeaderWithProofIfInError(ctx).Return(nil, nil, nil).Once()
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(nil, nil).Once()
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
@@ -226,8 +220,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
@@ -279,8 +272,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockFn: func(mockStorage *mocks.AggSenderStorage,
 				mockL2BridgeQuerier *mocks.BridgeQuerier,
 				mockAggchainProofQuerier *mocks.AggchainProofQuerier,
-				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier,
-				mockGERQuerier *mocks.GERQuerier) {
+				mockL1InfoDataQuery *mocks.L1InfoTreeDataQuerier) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := calculateGER(mer, rer)
@@ -338,7 +330,6 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 			mockAggchainProofQuerier := mocks.NewAggchainProofQuerier(t)
 			mockStorage := mocks.NewAggSenderStorage(t)
 			mockL2BridgeQuerier := mocks.NewBridgeQuerier(t)
-			mockGERQuerier := mocks.NewGERQuerier(t)
 			mockOptimistic := mocks.NewOptimisticModeQuerier(t)
 			mockL1InfoTreeDataQuerier := mocks.NewL1InfoTreeDataQuerier(t)
 			mockLERQuerier := mocks.NewLERQuerier(t)
@@ -359,14 +350,13 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockStorage,
 				mockL1InfoTreeDataQuerier,
 				mockL2BridgeQuerier,
-				mockGERQuerier,
 				nil,
 				mockSigner,
 				mockOptimistic,
 				mockAggchainProofQuerier,
 			)
 			mockOptimistic.EXPECT().IsOptimisticModeOn().Return(false, nil).Maybe()
-			tc.mockFn(mockStorage, mockL2BridgeQuerier, mockAggchainProofQuerier, mockL1InfoTreeDataQuerier, mockGERQuerier)
+			tc.mockFn(mockStorage, mockL2BridgeQuerier, mockAggchainProofQuerier, mockL1InfoTreeDataQuerier)
 
 			params, err := aggchainFlow.GetCertificateBuildParams(ctx)
 			if tc.expectedError != "" {
@@ -479,7 +469,6 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 				nil, // mockStorage
 				nil, // mockL1InfoTreeDataQuerier
 				nil, // mockL2BridgeQuerier
-				nil, // mockGERQuerier
 				nil, // mockOptimistic
 				nil, // mockSigner
 				nil, // optimisticModeQuerier
@@ -602,7 +591,6 @@ func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 				nil, // mockStorage
 				nil, // mockL1InfoTreeDataQuerier
 				mockL2BridgeQuerier,
-				nil, // mockGERQuerier
 				nil, // mockOptimistic
 				mockSigner,
 				nil, // optimisticModeQuerier
@@ -791,6 +779,73 @@ func Test_AggchainProverFlow_CheckInitialStatus(t *testing.T) {
 			mockStorage.AssertExpectations(t)
 			mockBaseFlow.AssertExpectations(t)
 			mockL2BridgeSyncer.AssertExpectations(t)
+		})
+	}
+}
+
+func Test_AggchainProverFlow_ValidateCertificate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name          string
+		certificate   *agglayertypes.Certificate
+		expectedError string
+	}{
+		{
+			name:          "certificate is nil",
+			certificate:   nil,
+			expectedError: "aggchainProverFlow - ValidateCertificate - certificate is nil",
+		},
+		{
+			name: "AggchainData is not of type AggchainDataProof",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataSignature{},
+			},
+			expectedError: "aggchainProverFlow - ValidateCertificate - AggchainData is not of type AggchainDataProof",
+		},
+		{
+			name: "AggchainData is nil",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: nil,
+			},
+			expectedError: "aggchainProverFlow - ValidateCertificate - AggchainData is not of type AggchainDataProof",
+		},
+		{
+			name: "success - valid certificate with AggchainDataProof",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataProof{
+					Proof:          []byte("some-proof"),
+					Version:        "0.1",
+					Vkey:           []byte("some-vkey"),
+					AggchainParams: common.HexToHash("0x123"),
+					Context: map[string][]byte{
+						"key1": []byte("value1"),
+					},
+					Signature: []byte("signature"),
+				},
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := log.WithFields("flowManager", "Test_AggchainProverFlow_ValidateCertificate")
+			flow := &AggchainProverFlow{
+				log: logger,
+			}
+
+			err := flow.ValidateCertificate(ctx, tc.certificate)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -786,7 +786,7 @@ func Test_AggchainProverFlow_CheckInitialStatus(t *testing.T) {
 func Test_AggchainProverFlow_ValidateCertificate(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testCases := []struct {
 		name          string
@@ -846,6 +846,96 @@ func Test_AggchainProverFlow_ValidateCertificate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func Test_AggchainProverFlow_GenerateBuildParams(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	testCases := []struct {
+		name           string
+		preParams      *types.CertificatePreBuildParams
+		mockFn         func(*mocks.AggsenderFlowBaser)
+		expectedParams *types.CertificateBuildParams
+		expectedError  string
+	}{
+		{
+			name:          "preParams is nil",
+			preParams:     nil,
+			expectedError: "ppFlow - preParams is nil",
+		},
+		{
+			name: "error generating build params from baseFlow",
+			preParams: &types.CertificatePreBuildParams{
+				BlockRange: types.NewBlockRange(1, 10),
+			},
+			mockFn: func(mockBaseFlow *mocks.AggsenderFlowBaser) {
+				mockBaseFlow.EXPECT().GenerateBuildParams(ctx, types.CertificatePreBuildParams{
+					BlockRange: types.NewBlockRange(1, 10),
+				}).Return(nil, errors.New("base flow error")).Once()
+			},
+			expectedError: "ppFlow - error generating build params: base flow error",
+		},
+		{
+			name: "success generating build params",
+			preParams: &types.CertificatePreBuildParams{
+				BlockRange: types.NewBlockRange(1, 10),
+			},
+			mockFn: func(mockBaseFlow *mocks.AggsenderFlowBaser) {
+				expectedParams := &types.CertificateBuildParams{
+					FromBlock:       1,
+					ToBlock:         10,
+					RetryCount:      0,
+					Bridges:         []bridgesync.Bridge{{}},
+					Claims:          []bridgesync.Claim{},
+					CreatedAt:       timeNowUTCForTest(),
+					CertificateType: types.CertificateTypeFEP,
+				}
+				mockBaseFlow.EXPECT().GenerateBuildParams(ctx, types.CertificatePreBuildParams{
+					BlockRange: types.NewBlockRange(1, 10),
+				}).Return(expectedParams, nil).Once()
+			},
+			expectedParams: &types.CertificateBuildParams{
+				FromBlock:       1,
+				ToBlock:         10,
+				RetryCount:      0,
+				Bridges:         []bridgesync.Bridge{{}},
+				Claims:          []bridgesync.Claim{},
+				CreatedAt:       timeNowUTCForTest(),
+				CertificateType: types.CertificateTypeFEP,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockBaseFlow := mocks.NewAggsenderFlowBaser(t)
+			logger := log.WithFields("flowManager", "Test_AggchainProverFlow_GenerateBuildParams")
+
+			if tc.mockFn != nil {
+				tc.mockFn(mockBaseFlow)
+			}
+
+			flow := &AggchainProverFlow{
+				log:      logger,
+				baseFlow: mockBaseFlow,
+			}
+
+			params, err := flow.GenerateBuildParams(ctx, tc.preParams)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				require.Nil(t, params)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedParams, params)
+			}
+
+			mockBaseFlow.AssertExpectations(t)
 		})
 	}
 }

--- a/aggsender/flows/flow_pp.go
+++ b/aggsender/flows/flow_pp.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+var _ types.AggsenderFlow = (*PPFlow)(nil)
+
 // PPFlow is a struct that holds the logic for the regular pessimistic proof flow
 type PPFlow struct {
 	baseFlow              types.AggsenderFlowBaser
@@ -52,10 +54,6 @@ func NewPPFlow(log types.Logger,
 // For PPFlow  there are no special checks to do, so it just returns nil
 func (p *PPFlow) CheckInitialStatus(ctx context.Context) error {
 	return nil
-}
-
-func (p *PPFlow) GeneratePreBuildParams(ctx context.Context) (*types.CertificatePreBuildParams, error) {
-	return p.baseFlow.GeneratePreBuildParams(ctx, types.CertificateTypePP)
 }
 
 func (p *PPFlow) GenerateBuildParams(ctx context.Context,
@@ -152,4 +150,18 @@ func (p *PPFlow) signCertificate(ctx context.Context,
 	}
 
 	return certificate, nil
+}
+
+// ValidateCertificate validates the certificate for the PP specific things
+func (p *PPFlow) ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error {
+	if cert == nil {
+		return fmt.Errorf("ppFlow - certificate is nil")
+	}
+
+	_, ok := cert.AggchainData.(*agglayertypes.AggchainDataSignature)
+	if !ok {
+		return fmt.Errorf("ppFlow - certificate AggchainData is not of type AggchainDataSignature")
+	}
+
+	return nil
 }

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -636,3 +636,78 @@ func Test_PPFlow_SignCertificate(t *testing.T) {
 		})
 	}
 }
+
+func Test_PPFlow_ValidateCertificate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		certificate   *agglayertypes.Certificate
+		expectedError string
+	}{
+		{
+			name:          "nil certificate",
+			certificate:   nil,
+			expectedError: "ppFlow - certificate is nil",
+		},
+		{
+			name: "certificate with nil AggchainData",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: nil,
+			},
+			expectedError: "ppFlow - certificate AggchainData is not of type AggchainDataSignature",
+		},
+		{
+			name: "certificate with wrong AggchainData type",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataProof{},
+			},
+			expectedError: "ppFlow - certificate AggchainData is not of type AggchainDataSignature",
+		},
+		{
+			name: "valid certificate with AggchainDataSignature",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataSignature{
+					Signature: []byte("mock_signature"),
+				},
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := log.WithFields("test", "Test_PPFlow_ValidateCertificate")
+			flowBase := NewBaseFlow(
+				logger,
+				nil, // mockL2BridgeQuerier,
+				nil, // mockStorage,
+				nil, // mockL1InfoTreeDataQuerier,
+				nil, // mockLERQuerier,
+				NewBaseFlowConfigDefault())
+
+			ppFlow := NewPPFlow(
+				logger,
+				flowBase,
+				nil,   // storage
+				nil,   // l1InfoTreeDataQuerier
+				nil,   // l2BridgeQuerier
+				nil,   // signer
+				false, // forceOneBridgeExit
+				0,     // maxL2BlockNumber
+			)
+
+			err := ppFlow.ValidateCertificate(ctx, tt.certificate)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/aggsender/mocks/mock_aggsender_flow.go
+++ b/aggsender/mocks/mock_aggsender_flow.go
@@ -247,6 +247,53 @@ func (_c *AggsenderFlow_GetCertificateBuildParams_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// ValidateCertificate provides a mock function with given fields: ctx, cert
+func (_m *AggsenderFlow) ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error {
+	ret := _m.Called(ctx, cert)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateCertificate")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *agglayertypes.Certificate) error); ok {
+		r0 = rf(ctx, cert)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// AggsenderFlow_ValidateCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateCertificate'
+type AggsenderFlow_ValidateCertificate_Call struct {
+	*mock.Call
+}
+
+// ValidateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - cert *agglayertypes.Certificate
+func (_e *AggsenderFlow_Expecter) ValidateCertificate(ctx interface{}, cert interface{}) *AggsenderFlow_ValidateCertificate_Call {
+	return &AggsenderFlow_ValidateCertificate_Call{Call: _e.mock.On("ValidateCertificate", ctx, cert)}
+}
+
+func (_c *AggsenderFlow_ValidateCertificate_Call) Run(run func(ctx context.Context, cert *agglayertypes.Certificate)) *AggsenderFlow_ValidateCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*agglayertypes.Certificate))
+	})
+	return _c
+}
+
+func (_c *AggsenderFlow_ValidateCertificate_Call) Return(_a0 error) *AggsenderFlow_ValidateCertificate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *AggsenderFlow_ValidateCertificate_Call) RunAndReturn(run func(context.Context, *agglayertypes.Certificate) error) *AggsenderFlow_ValidateCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewAggsenderFlow creates a new instance of AggsenderFlow. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewAggsenderFlow(t interface {

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -30,6 +30,7 @@ type AggsenderFlow interface {
 	// GenerateBuildParams generates the build parameters based on the preParams
 	GenerateBuildParams(ctx context.Context,
 		preParams *CertificatePreBuildParams) (*CertificateBuildParams, error)
+	// ValidateCertificate validates the built certificate
 	ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error
 }
 

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -30,6 +30,7 @@ type AggsenderFlow interface {
 	// GenerateBuildParams generates the build parameters based on the preParams
 	GenerateBuildParams(ctx context.Context,
 		preParams *CertificatePreBuildParams) (*CertificateBuildParams, error)
+	ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error
 }
 
 type AggsenderFlowBaser interface {

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -1,7 +1,10 @@
 package validator
 
 import (
+	"fmt"
+
 	"github.com/agglayer/aggkit/agglayer"
+	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/config/types"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	signertypes "github.com/agglayer/go_signer/signer/types"
@@ -29,9 +32,13 @@ type Config struct {
 	// which is used to query the LER data from the RollupManager contract
 	LerQuerier LerQuerierConfig `mapstructure:"LerQuerierConfig"`
 	// PPConfig specific configuration for Pessimistic mode
-	PPConfig `mapstructure:"PPConfig"`
+	PPConfig PPConfig `mapstructure:"PPConfig"`
+	// FEPConfig specific configuration for FEP mode
+	FEPConfig FEPConfig `mapstructure:"FEPConfig"`
 	// AgglayerClient is the Agglayer gRPC client configuration
 	AgglayerClient agglayer.ClientConfig `mapstructure:"AgglayerClient"`
+	// Mode is the mode of the AggSender Validator (regular pessimistic proof mode or the aggchain proof mode)
+	Mode string `jsonschema:"enum=PessimisticProof, enum=AggchainProof" mapstructure:"Mode"`
 }
 
 type PPConfig struct {
@@ -40,9 +47,34 @@ type PPConfig struct {
 	RequireOneBridgeInPPCertificate bool `mapstructure:"RequireOneBridgeInPPCertificate"`
 }
 
+type FEPConfig struct {
+	// SovereignRollupAddr is the address of the sovereign rollup contract on L1
+	SovereignRollupAddr ethCommon.Address `mapstructure:"SovereignRollupAddr"`
+	// RequireNoFEPBlockGap is true if the AggSender should not accept a gap between
+	// lastBlock from lastCertificate and first block of FEP
+	RequireNoFEPBlockGap bool `mapstructure:"RequireNoFEPBlockGap"`
+}
+
 type LerQuerierConfig struct {
 	// RollupManagerAddr is the address of the RollupManager contract on L1
 	RollupManagerAddr ethCommon.Address `mapstructure:"RollupManagerAddr"`
 	// RollupCreationBlockL1 is the block number when the rollup was created on L1
 	RollupCreationBlockL1 uint64 `mapstructure:"RollupCreationBlockL1"`
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	if c.Mode != aggsendertypes.PessimisticProofMode.String() &&
+		c.Mode != aggsendertypes.AggchainProofMode.String() {
+		return fmt.Errorf("invalid mode %s, must be one of %s or %s",
+			c.Mode,
+			aggsendertypes.PessimisticProofMode.String(),
+			aggsendertypes.AggchainProofMode.String())
+	}
+
+	if err := c.AgglayerClient.Validate(); err != nil {
+		return fmt.Errorf("invalid agglayer client config: %w", err)
+	}
+
+	return nil
 }

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer"
 	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/config/types"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	signertypes "github.com/agglayer/go_signer/signer/types"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 )
+
+var errInvalidSovereignRollupAddr = fmt.Errorf("SovereignRollupAddr must be set for AggchainProof mode")
 
 // Config defines the configuration for the validator validator service.
 type Config struct {
@@ -50,9 +53,9 @@ type PPConfig struct {
 type FEPConfig struct {
 	// SovereignRollupAddr is the address of the sovereign rollup contract on L1
 	SovereignRollupAddr ethCommon.Address `mapstructure:"SovereignRollupAddr"`
-	// RequireNoFEPBlockGap is true if the AggSender should not accept a gap between
+	// RequireNoBlockGap is true if the AggSender should not accept a gap between
 	// lastBlock from lastCertificate and first block of FEP
-	RequireNoFEPBlockGap bool `mapstructure:"RequireNoFEPBlockGap"`
+	RequireNoBlockGap bool `mapstructure:"RequireNoBlockGap"`
 }
 
 type LerQuerierConfig struct {
@@ -70,6 +73,12 @@ func (c *Config) Validate() error {
 			c.Mode,
 			aggsendertypes.PessimisticProofMode.String(),
 			aggsendertypes.AggchainProofMode.String())
+	}
+
+	if c.Mode == aggsendertypes.AggchainProofMode.String() {
+		if c.FEPConfig.SovereignRollupAddr == aggkitcommon.ZeroAddress {
+			return errInvalidSovereignRollupAddr
+		}
 	}
 
 	if err := c.AgglayerClient.Validate(); err != nil {

--- a/aggsender/validator/config_test.go
+++ b/aggsender/validator/config_test.go
@@ -1,0 +1,88 @@
+package validator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/agglayer"
+	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
+	"github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/grpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatorConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		config      Config
+		expectedErr string
+	}{
+		{
+			name: "Valid PessimisticProof mode",
+			config: Config{
+				Mode: aggsendertypes.PessimisticProofMode.String(),
+				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
+					URL:               "http://localhost:9090",
+					MinConnectTimeout: types.NewDuration(5 * time.Second),
+				}},
+			},
+		},
+		{
+			name: "Valid AggchainProof mode",
+			config: Config{
+				Mode: aggsendertypes.AggchainProofMode.String(),
+				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
+					URL:               "http://localhost:9090",
+					MinConnectTimeout: types.NewDuration(5 * time.Second),
+				}},
+			},
+		},
+		{
+			name: "Invalid mode",
+			config: Config{
+				Mode: "invalid-mode",
+				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
+					URL:               "http://localhost:9090",
+					MinConnectTimeout: types.NewDuration(5 * time.Second),
+				}},
+			},
+			expectedErr: "invalid mode invalid-mode, must be one of",
+		},
+		{
+			name: "Empty mode",
+			config: Config{
+				Mode: "",
+				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
+					URL:               "http://localhost:9090",
+					MinConnectTimeout: types.NewDuration(5 * time.Second),
+				}},
+			},
+			expectedErr: "invalid mode , must be one of",
+		},
+		{
+			name: "Invalid AgglayerClient configuration",
+			config: Config{
+				Mode: aggsendertypes.PessimisticProofMode.String(),
+				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
+					URL: "",
+				}},
+			},
+			expectedErr: "invalid agglayer client config",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/aggsender/validator/config_test.go
+++ b/aggsender/validator/config_test.go
@@ -8,6 +8,7 @@ import (
 	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/grpc"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,11 +34,28 @@ func TestValidatorConfigValidate(t *testing.T) {
 			name: "Valid AggchainProof mode",
 			config: Config{
 				Mode: aggsendertypes.AggchainProofMode.String(),
+				FEPConfig: FEPConfig{
+					SovereignRollupAddr: common.HexToAddress("0x1"),
+				},
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
 				}},
 			},
+		},
+		{
+			name: "Invalid AggchainProof mode",
+			config: Config{
+				Mode: aggsendertypes.AggchainProofMode.String(),
+				FEPConfig: FEPConfig{
+					SovereignRollupAddr: common.HexToAddress("0x0"), // Zero address
+				},
+				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
+					URL:               "http://localhost:9090",
+					MinConnectTimeout: types.NewDuration(5 * time.Second),
+				}},
+			},
+			expectedErr: errInvalidSovereignRollupAddr.Error(),
 		},
 		{
 			name: "Invalid mode",

--- a/aggsender/validator/mocks/mock_flow_interface.go
+++ b/aggsender/validator/mocks/mock_flow_interface.go
@@ -143,6 +143,53 @@ func (_c *FlowInterface_GenerateBuildParams_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// ValidateCertificate provides a mock function with given fields: ctx, cert
+func (_m *FlowInterface) ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error {
+	ret := _m.Called(ctx, cert)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateCertificate")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *agglayertypes.Certificate) error); ok {
+		r0 = rf(ctx, cert)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// FlowInterface_ValidateCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateCertificate'
+type FlowInterface_ValidateCertificate_Call struct {
+	*mock.Call
+}
+
+// ValidateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - cert *agglayertypes.Certificate
+func (_e *FlowInterface_Expecter) ValidateCertificate(ctx interface{}, cert interface{}) *FlowInterface_ValidateCertificate_Call {
+	return &FlowInterface_ValidateCertificate_Call{Call: _e.mock.On("ValidateCertificate", ctx, cert)}
+}
+
+func (_c *FlowInterface_ValidateCertificate_Call) Run(run func(ctx context.Context, cert *agglayertypes.Certificate)) *FlowInterface_ValidateCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*agglayertypes.Certificate))
+	})
+	return _c
+}
+
+func (_c *FlowInterface_ValidateCertificate_Call) Return(_a0 error) *FlowInterface_ValidateCertificate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *FlowInterface_ValidateCertificate_Call) RunAndReturn(run func(context.Context, *agglayertypes.Certificate) error) *FlowInterface_ValidateCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewFlowInterface creates a new instance of FlowInterface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewFlowInterface(t interface {

--- a/aggsender/validator/validate_certificate.go
+++ b/aggsender/validator/validate_certificate.go
@@ -23,6 +23,7 @@ type FlowInterface interface {
 		preParams *types.CertificatePreBuildParams) (*types.CertificateBuildParams, error)
 	BuildCertificate(ctx context.Context,
 		buildParams *types.CertificateBuildParams) (*agglayertypes.Certificate, error)
+	ValidateCertificate(ctx context.Context, cert *agglayertypes.Certificate) error
 }
 
 type L1InfoTreeRootByLeafQuerier interface {
@@ -33,7 +34,7 @@ type L1InfoTreeRootByLeafQuerier interface {
 // CertificateValidator is a object to validate a certificate
 type CertificateValidator struct {
 	log                   aggkitcommon.Logger
-	flowPP                FlowInterface
+	flow                  FlowInterface
 	l1InfoTreeDataQuerier L1InfoTreeRootByLeafQuerier
 	certQuerier           types.CertificateQuerier
 	lerQuerier            types.LERQuerier
@@ -46,7 +47,7 @@ func NewAggsenderValidator(logger aggkitcommon.Logger,
 	lerQuerier types.LERQuerier) *CertificateValidator {
 	return &CertificateValidator{
 		log:                   logger,
-		flowPP:                flowPP,
+		flow:                  flowPP,
 		l1InfoTreeDataQuerier: l1InfoTreeDataQuerier,
 		certQuerier:           certQuerier,
 		lerQuerier:            lerQuerier,
@@ -85,6 +86,7 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 		return fmt.Errorf("failed CheckContigousCertificates: %w", err)
 	}
 
+	// Check if the previous certificate is settled
 	if err := a.checkPreviousCertificate(params.PreviousCertificate); err != nil {
 		return fmt.Errorf("failed CheckCertificatesContents: %w", err)
 	}
@@ -97,16 +99,24 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 
 	a.log.Debugf("aggsender-validator: preBuild: %s", preBuildParams.String())
 
-	buildParams, err := a.flowPP.GenerateBuildParams(ctx, preBuildParams)
+	// Generate build params
+	buildParams, err := a.flow.GenerateBuildParams(ctx, preBuildParams)
 	if err != nil {
 		return fmt.Errorf("failed flow.GenerateBuildParams: %w", err)
 	}
 
-	certificate, err := a.flowPP.BuildCertificate(ctx, buildParams)
+	// Build the certificate
+	certificate, err := a.flow.BuildCertificate(ctx, buildParams)
 	if err != nil {
 		return fmt.Errorf("failed flow.BuildCertificate: %w", err)
 	}
 
+	// Validate flow specific things
+	if err := a.flow.ValidateCertificate(ctx, certificate); err != nil {
+		return fmt.Errorf("failed flow.ValidateCertificate: %w", err)
+	}
+
+	// Compare the incoming certificate with the one generated
 	err = a.compareCertificates(params.Certificate, certificate)
 	if err != nil {
 		return fmt.Errorf("certificate not equal to expected: %w", err)
@@ -115,6 +125,7 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 	return nil
 }
 
+// checkPreviousCertificate checks if the previous certificate is settled
 func (a *CertificateValidator) checkPreviousCertificate(previousCertificate *agglayertypes.CertificateHeader) error {
 	if previousCertificate != nil {
 		if !previousCertificate.Status.IsSettled() {
@@ -226,7 +237,6 @@ func (a *CertificateValidator) getCertificatePreBuildParams(
 
 	return &types.CertificatePreBuildParams{
 		BlockRange:          blockRange,
-		RetryCount:          0, // TODO: ???
 		CertificateType:     certType,
 		LastSentCertificate: lastSentCertificate,
 		L1InfoTreeToProve: &types.CertificateL1InfoTreeData{

--- a/aggsender/validator/validate_certificate.go
+++ b/aggsender/validator/validate_certificate.go
@@ -41,13 +41,13 @@ type CertificateValidator struct {
 }
 
 func NewAggsenderValidator(logger aggkitcommon.Logger,
-	flowPP FlowInterface,
+	flow FlowInterface,
 	l1InfoTreeDataQuerier L1InfoTreeRootByLeafQuerier,
 	certQuerier types.CertificateQuerier,
 	lerQuerier types.LERQuerier) *CertificateValidator {
 	return &CertificateValidator{
 		log:                   logger,
-		flow:                  flowPP,
+		flow:                  flow,
 		l1InfoTreeDataQuerier: l1InfoTreeDataQuerier,
 		certQuerier:           certQuerier,
 		lerQuerier:            lerQuerier,
@@ -87,7 +87,7 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 	}
 
 	// Check if the previous certificate is settled
-	if err := a.checkPreviousCertificate(params.PreviousCertificate); err != nil {
+	if err := a.checkisPreviousCertificateSettled(params.PreviousCertificate); err != nil {
 		return fmt.Errorf("failed CheckCertificatesContents: %w", err)
 	}
 
@@ -125,8 +125,9 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 	return nil
 }
 
-// checkPreviousCertificate checks if the previous certificate is settled
-func (a *CertificateValidator) checkPreviousCertificate(previousCertificate *agglayertypes.CertificateHeader) error {
+// checkisPreviousCertificateSettled checks if the previous certificate is settled
+func (a *CertificateValidator) checkisPreviousCertificateSettled(
+	previousCertificate *agglayertypes.CertificateHeader) error {
 	if previousCertificate != nil {
 		if !previousCertificate.Status.IsSettled() {
 			return fmt.Errorf("previous certificate %s is not settled (status:%s)",

--- a/aggsender/validator/validate_certificate_test.go
+++ b/aggsender/validator/validate_certificate_test.go
@@ -209,6 +209,7 @@ func TestValidateCertificate(t *testing.T) {
 			BuildCertificate(testData.ctx, mock.Anything).Return(&agglayertypes.Certificate{
 			Metadata: aggkitcommon.ZeroHash,
 		}, nil)
+		testData.mockFlow.EXPECT().ValidateCertificate(testData.ctx, mock.Anything).Return(nil)
 		err := testData.sut.ValidateCertificate(testData.ctx, types.VerifyIncomingRequest{
 			Certificate: &agglayertypes.Certificate{
 				Height:              0,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender"
 	aggsendercfg "github.com/agglayer/aggkit/aggsender/config"
 	"github.com/agglayer/aggkit/aggsender/flows"
+	"github.com/agglayer/aggkit/aggsender/optimistic"
 	"github.com/agglayer/aggkit/aggsender/prover"
 	"github.com/agglayer/aggkit/aggsender/query"
 	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
@@ -38,7 +39,6 @@ import (
 	"github.com/agglayer/aggkit/prometheus"
 	"github.com/agglayer/aggkit/reorgdetector"
 	aggkittypes "github.com/agglayer/aggkit/types"
-	"github.com/agglayer/go_signer/signer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
@@ -214,49 +214,87 @@ func createAggSenderValidator(ctx context.Context,
 	l2Syncer *bridgesync.BridgeSync,
 	l1Client aggkittypes.BaseEthereumClienter,
 	rollupDataQuerier *etherman.RollupDataQuerier) (*aggsender.AggsenderValidator, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid aggsender validator config: %w", err)
+	}
+
 	logger := log.WithFields("module", aggkitcommon.AGGSENDERVALIDATOR)
-
-	signer, err := signer.NewSigner(ctx, 0, cfg.Signer, aggkitcommon.AGGSENDERVALIDATOR, logger)
-	if err != nil {
-		return nil, fmt.Errorf("error NewSigner. Err: %w", err)
-	}
-	if err := signer.Initialize(ctx); err != nil {
-		return nil, fmt.Errorf("error signer.Initialize. Err: %w", err)
-	}
-
-	l2BridgeQuerier := query.NewBridgeDataQuerier(logger, l2Syncer, cfg.DelayBetweenRetries.Duration)
-	l1InfoTreeQuerier := query.NewL1InfoTreeDataQuerier(l1Client, l1InfoTreeSync)
-	lerQuerier := query.NewLERDataQuerier(cfg.LerQuerier.RollupCreationBlockL1, rollupDataQuerier)
 	agglayerClient, err := agglayer.NewAgglayerClient(cfg.AgglayerClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agglayer grpc client: %w", err)
 	}
-	flowPP := flows.NewPPFlow(
-		logger,
-		flows.NewBaseFlow(
-			logger,
-			l2BridgeQuerier,
-			nil, // storage
-			l1InfoTreeQuerier,
-			lerQuerier,
-			flows.BaseFlowConfig{
-				MaxCertSize:          cfg.MaxCertSize,
-				StartL2Block:         0,
-				RequireNoFEPBlockGap: false, //  for PP doesnt apply it
-			},
-		),
-		nil, // storage
-		l1InfoTreeQuerier,
-		l2BridgeQuerier,
-		signer, // we reuse the signer, but the PP signature is not use
-		cfg.RequireOneBridgeInPPCertificate,
-		cfg.MaxL2BlockNumber,
+
+	var (
+		flow                 validator.FlowInterface
+		commonFlowComponents *flows.CommonFlowComponents
 	)
+
+	switch cfg.Mode {
+	case aggsendertypes.PessimisticProofMode.String():
+		commonFlowComponents, err = flows.CreateCommonFlowComponents(
+			ctx, logger,
+			nil, // storage is not used in validator,
+			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, false,
+			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create common flow components: %w", err)
+		}
+
+		flow = flows.NewPPFlow(
+			logger,
+			flows.NewBaseFlow(
+				logger,
+				commonFlowComponents.L2BridgeQuerier,
+				nil, // storage is not used in validator
+				commonFlowComponents.L1InfoTreeDataQuerier,
+				commonFlowComponents.LERQuerier,
+				flows.NewBaseFlowConfig(cfg.MaxCertSize, 0, false),
+			),
+			nil, // storage is not used in validator
+			commonFlowComponents.L1InfoTreeDataQuerier,
+			commonFlowComponents.L2BridgeQuerier,
+			commonFlowComponents.Signer,
+			cfg.PPConfig.RequireOneBridgeInPPCertificate,
+			cfg.MaxL2BlockNumber,
+		)
+	case aggsendertypes.AggchainProofMode.String():
+		commonFlowComponents, err = flows.CreateCommonFlowComponents(
+			ctx, logger,
+			nil, // storage is not used in validator,
+			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, cfg.FEPConfig.RequireNoFEPBlockGap,
+			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create common flow components: %w", err)
+		}
+
+		optimisticModeQuerier, err := optimistic.NewOptimisticModeQuerierFromContract(
+			cfg.FEPConfig.SovereignRollupAddr, l1Client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create optimistic mode querier: %w", err)
+		}
+
+		flow = flows.NewAggchainProverFlow(
+			logger,
+			flows.NewAggchainProverFlowConfig(cfg.MaxL2BlockNumber),
+			commonFlowComponents.BaseFlow,
+			nil, // storage is not used in validator
+			commonFlowComponents.L1InfoTreeDataQuerier,
+			commonFlowComponents.L2BridgeQuerier,
+			l1Client,
+			commonFlowComponents.Signer,
+			optimisticModeQuerier,
+			nil, // we don't query the prover in validator mode
+		)
+	default:
+		return nil, fmt.Errorf("unsupported mode %s", cfg.Mode)
+	}
 
 	aggchainFEPQuerier, err := query.NewAggchainFEPQuerier(
 		logger,
-		aggsendertypes.PessimisticProofMode,
-		aggkitcommon.ZeroAddress,
+		aggsendertypes.AggsenderMode(cfg.Mode),
+		cfg.FEPConfig.SovereignRollupAddr,
 		l1Client,
 	)
 	if err != nil {
@@ -269,8 +307,14 @@ func createAggSenderValidator(ctx context.Context,
 		agglayerClient,
 	)
 
-	return aggsender.NewAggsenderValidator(ctx, logger, cfg, flowPP,
-		l1InfoTreeQuerier, agglayerClient, certQuerier, lerQuerier, signer)
+	return aggsender.NewAggsenderValidator(
+		ctx, logger, cfg, flow,
+		commonFlowComponents.L1InfoTreeDataQuerier,
+		agglayerClient,
+		certQuerier,
+		commonFlowComponents.LERQuerier,
+		commonFlowComponents.Signer,
+	)
 }
 
 func createAggSender(

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -262,7 +262,7 @@ func createAggSenderValidator(ctx context.Context,
 		commonFlowComponents, err = flows.CreateCommonFlowComponents(
 			ctx, logger,
 			nil, // storage is not used in validator,
-			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, cfg.FEPConfig.RequireNoFEPBlockGap,
+			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, cfg.FEPConfig.RequireNoBlockGap,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
 		)
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -367,31 +367,29 @@ func createAggSender(
 		return nil, fmt.Errorf("failed to create AggSender: %w", err)
 	}
 
-	if cfg.Mode == aggsendertypes.PessimisticProofMode.String() {
-		// validatorObj is only supported in PessimisticProof mode
-		var validatorObj aggsendertypes.CertificateValidateAndSigner
-		if cfg.RequireValidatorCall {
-			validatorObj, err = validator.NewRemoteValidator(cfg.ValidatorClient, aggsender.GetStorage())
-			if err != nil {
-				return nil, fmt.Errorf("failed to create RemoteValidatorClient: %w", err)
-			}
-		} else {
-			// this is only temporary, until we test it in local, then we will only use the remote validator
-			validatorObj = validator.NewLocalValidator(
-				logger,
-				aggsender.GetStorage(),
-				validator.NewAggsenderValidator(
-					logger,
-					aggsender.GetFlow(),
-					query.NewL1InfoTreeDataQuerier(l1EthClient, l1InfoTreeSync),
-					aggsender.GetCertQuerier(),
-					aggsender.GetLERQuerier(),
-				),
-			)
+	// validatorObj is only supported in PessimisticProof mode
+	var validatorObj aggsendertypes.CertificateValidateAndSigner
+	if cfg.RequireValidatorCall {
+		validatorObj, err = validator.NewRemoteValidator(cfg.ValidatorClient, aggsender.GetStorage())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create RemoteValidatorClient: %w", err)
 		}
-
-		aggsender.AttachValidator(validatorObj)
+	} else {
+		// this is only temporary, until we test it in local, then we will only use the remote validator
+		validatorObj = validator.NewLocalValidator(
+			logger,
+			aggsender.GetStorage(),
+			validator.NewAggsenderValidator(
+				logger,
+				aggsender.GetFlow(),
+				query.NewL1InfoTreeDataQuerier(l1EthClient, l1InfoTreeSync),
+				aggsender.GetCertQuerier(),
+				aggsender.GetLERQuerier(),
+			),
+		)
 	}
+
+	aggsender.AttachValidator(validatorObj)
 
 	return aggsender, nil
 }

--- a/config/default.go
+++ b/config/default.go
@@ -279,6 +279,7 @@ Mode = "PessimisticProof"
 	RequireOneBridgeInPPCertificate = "{{AggSender.RequireOneBridgeInPPCertificate}}"
 [Validator.FEPConfig]
 	SovereignRollupAddr = "{{AggSender.SovereignRollupAddr}}"
+	RequireNoFEPBlockGap = "{{AggSender.RequireNoFEPBlockGap}}"
 [Validator.AgglayerClient]
 	Cached = true
 	[Validator.AgglayerClient.ConfigurationCache]

--- a/config/default.go
+++ b/config/default.go
@@ -279,7 +279,7 @@ Mode = "PessimisticProof"
 	RequireOneBridgeInPPCertificate = "{{AggSender.RequireOneBridgeInPPCertificate}}"
 [Validator.FEPConfig]
 	SovereignRollupAddr = "{{AggSender.SovereignRollupAddr}}"
-	RequireNoFEPBlockGap = "{{AggSender.RequireNoFEPBlockGap}}"
+	RequireNoBlockGap = "{{AggSender.RequireNoFEPBlockGap}}"
 [Validator.AgglayerClient]
 	Cached = true
 	[Validator.AgglayerClient.ConfigurationCache]

--- a/config/default.go
+++ b/config/default.go
@@ -185,7 +185,7 @@ KeepCertificatesHistory = true
 MaxCertSize = 8388608
 DryRun = false
 EnableRPC = true
-# PessimisticProof or AggchainProver
+# PessimisticProof or AggchainProof
 Mode = "PessimisticProof"
 CheckStatusCertificateInterval = "5m"
 RetryCertAfterInError = false
@@ -265,6 +265,8 @@ Signer = {{AggsenderPrivateKey}}
 MaxCertSize = "{{AggSender.MaxCertSize}}"
 MaxL2BlockNumber = "{{AggSender.MaxL2BlockNumber}}"
 DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
+# PessimisticProof or AggchainProof
+Mode = "PessimisticProof"
 [Validator.ServerConfig]
 	Host = "0.0.0.0"
 	Port = 5578
@@ -275,6 +277,8 @@ DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
 	RollupCreationBlockL1 = "{{AggSender.RollupCreationBlockL1}}"
 [Validator.PPConfig]
 	RequireOneBridgeInPPCertificate = "{{AggSender.RequireOneBridgeInPPCertificate}}"
+[Validator.FEPConfig]
+	SovereignRollupAddr = "{{AggSender.SovereignRollupAddr}}"
 [Validator.AgglayerClient]
 	Cached = true
 	[Validator.AgglayerClient.ConfigurationCache]


### PR DESCRIPTION
## 🔄 Changes Summary
This PR adds support for FEP certificates validation in `aggsender-validator`.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
Added new config parameters to `Validator` config:
- `Mode` - mode of the validator. Similar to regular `aggsender` (proposer) it can be `PessimisticProof` or `AggchainProof` based on if the network is a `PP` or `FEP`.
- `FEPConfig` - `FEP` (`AggchainProof` mode) network specific configuration:
   - `SovereignRollupAddr` - address of the `AggchainFEP` contract.
   - `RequireNoFEPBlockGap` - true if the AggSender should not accept a gap between last block from last certificate and first block of `FEP` network.

- 🧾 **Diff/Config snippet**:
```toml
[Validator]
# PessimisticProof or AggchainProof
Mode = "PessimisticProof"
[Validator.FEPConfig]
   SovereignRollupAddr = "{{AggSender.SovereignRollupAddr}}"
   RequireNoFEPBlockGap = "{{AggSender.RequireNoFEPBlockGap}}"
```

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI

## 🐞 Issues
- Closes #803 
