### PR TITLE
feat: support multiple `claims` by `global index`

### DIFF
--- a/agglayer/agglayer_client_cache.go
+++ b/agglayer/agglayer_client_cache.go
@@ -129,6 +129,6 @@ func (c *AgglayerClientCache) GetLatestPendingCertificateHeader(ctx context.Cont
 // GetLatestSettledImportedBridgeExit retrieves the latest settled
 // imported bridge exit from the Agglayer client. (no cache)
 func (c *AgglayerClientCache) GetLatestSettledImportedBridgeExit(
-	ctx context.Context) (*agglayertypes.GlobalIndex, error) {
+	ctx context.Context) (*agglayertypes.GlobalIndex, common.Hash, error) {
 	return c.agglayerClient.GetLatestSettledImportedBridgeExit(ctx)
 }

--- a/agglayer/client.go
+++ b/agglayer/client.go
@@ -30,7 +30,7 @@ type AggLayerClientCertificateIDQuerier interface {
 type AgglayerClientInterface interface {
 	SendCertificate(ctx context.Context, certificate *types.Certificate, validatorSignature []byte) (common.Hash, error)
 	GetCertificateHeader(ctx context.Context, certificateHash common.Hash) (*types.CertificateHeader, error)
-	GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, error)
+	GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, common.Hash, error)
 	AggLayerClientGetEpochConfiguration
 	AggLayerClientRecoveryQuerier
 	AggLayerClientCertificateIDQuerier

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -146,7 +146,8 @@ func (a *AgglayerGRPCClient) GetCertificateHeader(
 	return convertProtoCertificateHeader(response.CertificateHeader), nil
 }
 
-func (a *AgglayerGRPCClient) GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, common.Hash, error) {
+func (a *AgglayerGRPCClient) GetLatestSettledImportedBridgeExit(
+	ctx context.Context) (*types.GlobalIndex, common.Hash, error) {
 	// TODO - implement this method once agglayer supports it
 	return &types.GlobalIndex{}, common.Hash{}, nil
 }

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -146,9 +146,9 @@ func (a *AgglayerGRPCClient) GetCertificateHeader(
 	return convertProtoCertificateHeader(response.CertificateHeader), nil
 }
 
-func (a *AgglayerGRPCClient) GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, error) {
+func (a *AgglayerGRPCClient) GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, common.Hash, error) {
 	// TODO - implement this method once agglayer supports it
-	return &types.GlobalIndex{}, nil
+	return &types.GlobalIndex{}, common.Hash{}, nil
 }
 
 // ConvertCertToProtoCertificate converts a types.Certificate to a grpc v1nodetypes.Certificate

--- a/agglayer/grpc/agglayer_grpc_client_test.go
+++ b/agglayer/grpc/agglayer_grpc_client_test.go
@@ -550,6 +550,17 @@ func TestExploratory_EstimateCertSize(t *testing.T) {
 	fmt.Printf("aggchain data signature size: %d bytes\n", size)
 }
 
+func TestGetLatestSettledImportedBridgeExit(t *testing.T) {
+	t.Parallel()
+
+	client := &AgglayerGRPCClient{}
+	gi, h, err := client.GetLatestSettledImportedBridgeExit(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, &types.GlobalIndex{}, gi)
+	require.Equal(t, common.Hash{}, h)
+}
+
 func estimateRequestSize(t *testing.T, req proto.Message) int {
 	t.Helper()
 

--- a/agglayer/mocks/mock_agglayer_client.go
+++ b/agglayer/mocks/mock_agglayer_client.go
@@ -261,7 +261,7 @@ func (_c *AgglayerClientMock_GetLatestSettledCertificateHeader_Call) RunAndRetur
 }
 
 // GetLatestSettledImportedBridgeExit provides a mock function with given fields: ctx
-func (_m *AgglayerClientMock) GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, error) {
+func (_m *AgglayerClientMock) GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, common.Hash, error) {
 	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
@@ -269,8 +269,9 @@ func (_m *AgglayerClientMock) GetLatestSettledImportedBridgeExit(ctx context.Con
 	}
 
 	var r0 *types.GlobalIndex
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (*types.GlobalIndex, error)); ok {
+	var r1 common.Hash
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*types.GlobalIndex, common.Hash, error)); ok {
 		return rf(ctx)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context) *types.GlobalIndex); ok {
@@ -281,13 +282,21 @@ func (_m *AgglayerClientMock) GetLatestSettledImportedBridgeExit(ctx context.Con
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context) common.Hash); ok {
 		r1 = rf(ctx)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(common.Hash)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestSettledImportedBridgeExit'
@@ -308,12 +317,12 @@ func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) Run(run fu
 	return _c
 }
 
-func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) Return(_a0 *types.GlobalIndex, _a1 error) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) Return(_a0 *types.GlobalIndex, _a1 common.Hash, _a2 error) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) RunAndReturn(run func(context.Context) (*types.GlobalIndex, error)) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
+func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) RunAndReturn(run func(context.Context) (*types.GlobalIndex, common.Hash, error)) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/converters/imported_bridge_exit_converter_test.go
+++ b/aggsender/converters/imported_bridge_exit_converter_test.go
@@ -17,6 +17,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBre(t *testing.T) {
+	ibe := &agglayertypes.ImportedBridgeExit{
+		GlobalIndex: &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1},
+		BridgeExit: &agglayertypes.BridgeExit{
+			LeafType: agglayertypes.LeafTypeAsset,
+			TokenInfo: &agglayertypes.TokenInfo{
+				OriginNetwork:      1,
+				OriginTokenAddress: common.HexToAddress("0x123"),
+			},
+			DestinationNetwork: 2,
+			DestinationAddress: common.HexToAddress("0x456"),
+			Amount:             big.NewInt(100),
+			Metadata:           crypto.Keccak256([]byte("metadata")),
+		},
+	}
+
+	fmt.Println(ibe.BridgeExit.Hash().String())
+}
+
 func TestConvertClaimToImportedBridgeExit(t *testing.T) {
 	t.Parallel()
 

--- a/aggsender/converters/imported_bridge_exit_converter_test.go
+++ b/aggsender/converters/imported_bridge_exit_converter_test.go
@@ -17,25 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBre(t *testing.T) {
-	ibe := &agglayertypes.ImportedBridgeExit{
-		GlobalIndex: &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1},
-		BridgeExit: &agglayertypes.BridgeExit{
-			LeafType: agglayertypes.LeafTypeAsset,
-			TokenInfo: &agglayertypes.TokenInfo{
-				OriginNetwork:      1,
-				OriginTokenAddress: common.HexToAddress("0x123"),
-			},
-			DestinationNetwork: 2,
-			DestinationAddress: common.HexToAddress("0x456"),
-			Amount:             big.NewInt(100),
-			Metadata:           crypto.Keccak256([]byte("metadata")),
-		},
-	}
-
-	fmt.Println(ibe.BridgeExit.Hash().String())
-}
-
 func TestConvertClaimToImportedBridgeExit(t *testing.T) {
 	t.Parallel()
 

--- a/aggsender/mocks/mock_l2_bridge_syncer.go
+++ b/aggsender/mocks/mock_l2_bridge_syncer.go
@@ -192,63 +192,6 @@ func (_c *L2BridgeSyncer_GetBridges_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// GetClaimByGlobalIndex provides a mock function with given fields: ctx, globalIndex
-func (_m *L2BridgeSyncer) GetClaimByGlobalIndex(ctx context.Context, globalIndex *big.Int) (bridgesync.Claim, error) {
-	ret := _m.Called(ctx, globalIndex)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetClaimByGlobalIndex")
-	}
-
-	var r0 bridgesync.Claim
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) (bridgesync.Claim, error)); ok {
-		return rf(ctx, globalIndex)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) bridgesync.Claim); ok {
-		r0 = rf(ctx, globalIndex)
-	} else {
-		r0 = ret.Get(0).(bridgesync.Claim)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *big.Int) error); ok {
-		r1 = rf(ctx, globalIndex)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// L2BridgeSyncer_GetClaimByGlobalIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetClaimByGlobalIndex'
-type L2BridgeSyncer_GetClaimByGlobalIndex_Call struct {
-	*mock.Call
-}
-
-// GetClaimByGlobalIndex is a helper method to define mock.On call
-//   - ctx context.Context
-//   - globalIndex *big.Int
-func (_e *L2BridgeSyncer_Expecter) GetClaimByGlobalIndex(ctx interface{}, globalIndex interface{}) *L2BridgeSyncer_GetClaimByGlobalIndex_Call {
-	return &L2BridgeSyncer_GetClaimByGlobalIndex_Call{Call: _e.mock.On("GetClaimByGlobalIndex", ctx, globalIndex)}
-}
-
-func (_c *L2BridgeSyncer_GetClaimByGlobalIndex_Call) Run(run func(ctx context.Context, globalIndex *big.Int)) *L2BridgeSyncer_GetClaimByGlobalIndex_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*big.Int))
-	})
-	return _c
-}
-
-func (_c *L2BridgeSyncer_GetClaimByGlobalIndex_Call) Return(_a0 bridgesync.Claim, _a1 error) *L2BridgeSyncer_GetClaimByGlobalIndex_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *L2BridgeSyncer_GetClaimByGlobalIndex_Call) RunAndReturn(run func(context.Context, *big.Int) (bridgesync.Claim, error)) *L2BridgeSyncer_GetClaimByGlobalIndex_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetClaims provides a mock function with given fields: ctx, fromBlock, toBlock
 func (_m *L2BridgeSyncer) GetClaims(ctx context.Context, fromBlock uint64, toBlock uint64) ([]bridgesync.Claim, error) {
 	ret := _m.Called(ctx, fromBlock, toBlock)
@@ -305,6 +248,65 @@ func (_c *L2BridgeSyncer_GetClaims_Call) Return(_a0 []bridgesync.Claim, _a1 erro
 }
 
 func (_c *L2BridgeSyncer_GetClaims_Call) RunAndReturn(run func(context.Context, uint64, uint64) ([]bridgesync.Claim, error)) *L2BridgeSyncer_GetClaims_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetClaimsByGlobalIndex provides a mock function with given fields: ctx, globalIndex
+func (_m *L2BridgeSyncer) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big.Int) ([]bridgesync.Claim, error) {
+	ret := _m.Called(ctx, globalIndex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetClaimsByGlobalIndex")
+	}
+
+	var r0 []bridgesync.Claim
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) ([]bridgesync.Claim, error)); ok {
+		return rf(ctx, globalIndex)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) []bridgesync.Claim); ok {
+		r0 = rf(ctx, globalIndex)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]bridgesync.Claim)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *big.Int) error); ok {
+		r1 = rf(ctx, globalIndex)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// L2BridgeSyncer_GetClaimsByGlobalIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetClaimsByGlobalIndex'
+type L2BridgeSyncer_GetClaimsByGlobalIndex_Call struct {
+	*mock.Call
+}
+
+// GetClaimsByGlobalIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - globalIndex *big.Int
+func (_e *L2BridgeSyncer_Expecter) GetClaimsByGlobalIndex(ctx interface{}, globalIndex interface{}) *L2BridgeSyncer_GetClaimsByGlobalIndex_Call {
+	return &L2BridgeSyncer_GetClaimsByGlobalIndex_Call{Call: _e.mock.On("GetClaimsByGlobalIndex", ctx, globalIndex)}
+}
+
+func (_c *L2BridgeSyncer_GetClaimsByGlobalIndex_Call) Run(run func(ctx context.Context, globalIndex *big.Int)) *L2BridgeSyncer_GetClaimsByGlobalIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*big.Int))
+	})
+	return _c
+}
+
+func (_c *L2BridgeSyncer_GetClaimsByGlobalIndex_Call) Return(_a0 []bridgesync.Claim, _a1 error) *L2BridgeSyncer_GetClaimsByGlobalIndex_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *L2BridgeSyncer_GetClaimsByGlobalIndex_Call) RunAndReturn(run func(context.Context, *big.Int) ([]bridgesync.Claim, error)) *L2BridgeSyncer_GetClaimsByGlobalIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggsender/converters"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -77,13 +78,13 @@ func (c *certificateQuerier) GetLastSettledCertificateToBlock(
 
 	// TODO - this might need to be changed once agglayer gives support for this
 	// 2. Get the latest settled imported bridge exit block number
-	latestSettledIbeGlobalIndex, err := c.agglayerClient.GetLatestSettledImportedBridgeExit(ctx)
+	latestSettledIbeGlobalIndex, bridgeExitHash, err := c.agglayerClient.GetLatestSettledImportedBridgeExit(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get latest settled imported bridge exit from agglayer: %w", err)
 	}
 
 	if latestSettledIbeGlobalIndex != nil {
-		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(ctx, latestSettledIbeGlobalIndex)
+		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(ctx, latestSettledIbeGlobalIndex, bridgeExitHash)
 		if err != nil {
 			return 0, fmt.Errorf("failed to resolve the block number for last imported bridge exit %s: %w",
 				latestSettledIbeGlobalIndex.String(), err)
@@ -124,7 +125,8 @@ func (c *certificateQuerier) GetNewCertificateToBlock(
 	if len(cert.ImportedBridgeExits) > 0 {
 		// if there are imported bridge exits, we can use the last one to determine the new certificate to block
 		lastImportedBridgeExit := cert.ImportedBridgeExits[len(cert.ImportedBridgeExits)-1]
-		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(ctx, lastImportedBridgeExit.GlobalIndex)
+		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(
+			ctx, lastImportedBridgeExit.GlobalIndex, lastImportedBridgeExit.BridgeExit.Hash())
 		if err != nil {
 			return 0, fmt.Errorf("failed to resolve the block number for last imported bridge exit %s: %w",
 				lastImportedBridgeExit.GlobalIndex.String(), err)
@@ -181,12 +183,25 @@ func (c *certificateQuerier) getBlockNumFromLER(ctx context.Context, localExitRo
 }
 
 func (c *certificateQuerier) getBlockNumFromGlobalIndex(
-	ctx context.Context, globalIndex *agglayertypes.GlobalIndex) (uint64, error) {
+	ctx context.Context, globalIndex *agglayertypes.GlobalIndex, bridgeExitHash common.Hash) (uint64, error) {
 	bigGlobalIndex := globalIndex.ToBigInt()
-	claim, err := c.l2BridgeSyncer.GetClaimByGlobalIndex(ctx, bigGlobalIndex)
+	claims, err := c.l2BridgeSyncer.GetClaimsByGlobalIndex(ctx, bigGlobalIndex)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get claim by global index %s: %w", bigGlobalIndex.String(), err)
 	}
 
-	return claim.BlockNum, nil
+	for _, claim := range claims {
+		ibe, err := converters.ConvertToImportedBridgeExitWithoutClaimData(claim)
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert claim to imported bridge exit: %w", err)
+		}
+
+		if ibe.BridgeExit.Hash() == bridgeExitHash {
+			// Found the claim with the matching bridge exit hash
+			return claim.BlockNum, nil
+		}
+	}
+
+	// If no claim matches the bridge exit hash, return an error
+	return 0, fmt.Errorf("no claim found for bridge exit hash %s", bridgeExitHash.String())
 }

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -584,3 +584,112 @@ func TestCalculateCertificateType(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBlockNumFromGlobalIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	testClaim := bridgesync.Claim{
+		GlobalIndex:        bridgesync.GenerateGlobalIndex(true, 0, 1),
+		IsMessage:          false,
+		Metadata:           crypto.Keccak256([]byte("test metadata")),
+		OriginNetwork:      1,
+		OriginAddress:      common.HexToAddress("0x123"),
+		DestinationNetwork: 2,
+		DestinationAddress: common.HexToAddress("0x456"),
+		Amount:             big.NewInt(100),
+		BlockNum:           150,
+	}
+
+	testIbe, err := converters.ConvertToImportedBridgeExitWithoutClaimData(testClaim)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name             string
+		globalIndex      *agglayertypes.GlobalIndex
+		bridgeExitHash   common.Hash
+		mockFn           func(*mocks.L2BridgeSyncer)
+		expectedErr      string
+		expectedBlockNum uint64
+	}{
+		{
+			name:           "successful match - single claim",
+			globalIndex:    testIbe.GlobalIndex,
+			bridgeExitHash: testIbe.BridgeExit.Hash(),
+			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{testClaim}, nil)
+			},
+			expectedBlockNum: 150,
+		},
+		{
+			name:           "successful match - multiple claims with matching hash",
+			globalIndex:    testIbe.GlobalIndex,
+			bridgeExitHash: testIbe.BridgeExit.Hash(),
+			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
+				claim1 := testClaim
+				claim1.BlockNum = 100
+				claim1.Amount = big.NewInt(50) // Different amount to generate different hash
+
+				claim2 := testClaim
+				claim2.BlockNum = 200 // This should be returned
+
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{claim1, claim2}, nil)
+			},
+			expectedBlockNum: 200,
+		},
+		{
+			name:           "no matching bridge exit hash",
+			globalIndex:    testIbe.GlobalIndex,
+			bridgeExitHash: common.HexToHash("0x999"), // Different hash that won't match
+			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{testClaim}, nil)
+			},
+			expectedErr: "no claim found for bridge exit hash",
+		},
+		{
+			name:           "empty claims slice",
+			globalIndex:    testIbe.GlobalIndex,
+			bridgeExitHash: testIbe.BridgeExit.Hash(),
+			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{}, nil)
+			},
+			expectedErr: "no claim found for bridge exit hash",
+		},
+		{
+			name:           "error getting claims by global index",
+			globalIndex:    testIbe.GlobalIndex,
+			bridgeExitHash: testIbe.BridgeExit.Hash(),
+			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return(nil, errors.New("database error"))
+			},
+			expectedErr: "failed to get claim by global index",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockL2BridgeSyncer := mocks.NewL2BridgeSyncer(t)
+
+			if tc.mockFn != nil {
+				tc.mockFn(mockL2BridgeSyncer)
+			}
+
+			certQuerier := &certificateQuerier{
+				l2BridgeSyncer: mockL2BridgeSyncer,
+			}
+
+			blockNum, err := certQuerier.getBlockNumFromGlobalIndex(ctx, tc.globalIndex, tc.bridgeExitHash)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedBlockNum, blockNum)
+			}
+
+			mockL2BridgeSyncer.AssertExpectations(t)
+		})
+	}
+}

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -2,15 +2,19 @@ package query
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	agglayermocks "github.com/agglayer/aggkit/agglayer/mocks"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggsender/converters"
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,11 +48,14 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 					BlockNum: uint64(100),
 				}, nil)
 
-				importedBridgeExit := &agglayertypes.GlobalIndex{}
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, nil)
+				importedBridgeExit := &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1}
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"), nil)
 
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(bridgesync.Claim{
-					BlockNum: 150,
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return([]bridgesync.Claim{
+					{
+						BlockNum:    150,
+						GlobalIndex: bridgesync.GenerateGlobalIndex(true, 0, 1),
+					},
 				}, nil)
 
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(200), nil)
@@ -62,10 +69,13 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				importedBridgeExit := &agglayertypes.GlobalIndex{}
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, nil)
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(bridgesync.Claim{
-					BlockNum: 50,
+				importedBridgeExit := &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1}
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"), nil)
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return([]bridgesync.Claim{
+					{
+						BlockNum:    50,
+						GlobalIndex: bridgesync.GenerateGlobalIndex(true, 0, 1),
+					},
 				}, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(75), nil)
 			},
@@ -81,7 +91,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				bridgeSyncer.EXPECT().GetExitRootByHash(ctx, common.HexToHash("0x456")).Return(&treetypes.Root{
 					BlockNum: uint64(300),
 				}, nil)
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, nil)
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(250), nil)
 			},
 			expectedBlock: 300, // max of 300, 0, 250
@@ -104,7 +114,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, errors.New("agglayer error"))
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, errors.New("agglayer error"))
 			},
 			expectedErr: "failed to get latest settled imported bridge exit from agglayer",
 		},
@@ -115,9 +125,9 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				importedBridgeExit := &agglayertypes.GlobalIndex{}
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, nil)
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(bridgesync.Claim{}, errors.New("claim not found"))
+				importedBridgeExit := &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1}
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"), nil)
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(nil, errors.New("claim not found"))
 			},
 			expectedErr: "failed to get claim by global index",
 		},
@@ -128,7 +138,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, nil)
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(0), errors.New("L2 block query failed"))
 			},
 			expectedErr: "failed to get last settled L2 block",
@@ -140,7 +150,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, nil)
+				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(0), nil)
 			},
 			expectedBlock: 0,
@@ -185,6 +195,20 @@ func TestGetNewCertificateToBlock(t *testing.T) {
 
 	ctx := t.Context()
 
+	testClaim := bridgesync.Claim{
+		GlobalIndex:        bridgesync.GenerateGlobalIndex(true, 0, 1),
+		IsMessage:          false,
+		Metadata:           crypto.Keccak256([]byte("test metadata")),
+		OriginNetwork:      1,
+		OriginAddress:      common.HexToAddress("0x123"),
+		DestinationNetwork: 2,
+		DestinationAddress: common.HexToAddress("0x456"),
+		Amount:             big.NewInt(100),
+	}
+
+	testIbe, err := converters.ConvertToImportedBridgeExitWithoutClaimData(testClaim)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name          string
 		certificate   *agglayertypes.Certificate
@@ -198,33 +222,29 @@ func TestGetNewCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
 					{GlobalIndex: &agglayertypes.GlobalIndex{}},
-					{GlobalIndex: &agglayertypes.GlobalIndex{}},
+					testIbe,
 				},
 			},
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
 				bridgeSyncer.EXPECT().GetExitRootByHash(ctx, common.HexToHash("0x123")).Return(&treetypes.Root{
 					BlockNum: uint64(100),
 				}, nil)
-				lastImportedBridgeExit := &agglayertypes.GlobalIndex{}
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, lastImportedBridgeExit.ToBigInt()).Return(bridgesync.Claim{
-					BlockNum: 150,
-				}, nil)
+				claim := testClaim
+				claim.BlockNum = 150 // Simulate a claim with block number 150
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{claim}, nil)
 			},
 			expectedBlock: 150, // max of 100, 150
 		},
 		{
 			name: "empty local exit root with imported bridge exits",
 			certificate: &agglayertypes.Certificate{
-				NewLocalExitRoot: types.EmptyLER,
-				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
-					{GlobalIndex: &agglayertypes.GlobalIndex{}},
-				},
+				NewLocalExitRoot:    types.EmptyLER,
+				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{testIbe},
 			},
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
-				importedBridgeExit := &agglayertypes.GlobalIndex{}
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(bridgesync.Claim{
-					BlockNum: 75,
-				}, nil)
+				claim := testClaim
+				claim.BlockNum = 75 // Simulate a claim with block number 75
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{claim}, nil)
 			},
 			expectedBlock: 75, // max of 0, 75
 		},
@@ -276,14 +296,11 @@ func TestGetNewCertificateToBlock(t *testing.T) {
 		{
 			name: "error getting claim by global index",
 			certificate: &agglayertypes.Certificate{
-				NewLocalExitRoot: types.EmptyLER,
-				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
-					{GlobalIndex: &agglayertypes.GlobalIndex{}},
-				},
+				NewLocalExitRoot:    types.EmptyLER,
+				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{testIbe},
 			},
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
-				importedBridgeExit := &agglayertypes.GlobalIndex{}
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(bridgesync.Claim{}, errors.New("claim not found"))
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return(nil, errors.New("claim not found"))
 			},
 			expectedErr: "failed to get claim by global index",
 		},
@@ -294,35 +311,31 @@ func TestGetNewCertificateToBlock(t *testing.T) {
 				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
 					{GlobalIndex: &agglayertypes.GlobalIndex{}}, // First one - should not be used
 					{GlobalIndex: &agglayertypes.GlobalIndex{}}, // Second one - should not be used
-					{GlobalIndex: &agglayertypes.GlobalIndex{}}, // Last one - should be used
+					testIbe, // Last one - should be used
 				},
 			},
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
 				// Mock claim by global index for last imported bridge exit only
-				lastImportedBridgeExit := &agglayertypes.GlobalIndex{}
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, lastImportedBridgeExit.ToBigInt()).Return(bridgesync.Claim{
-					BlockNum: 250,
-				}, nil)
+				claim := testClaim
+				claim.BlockNum = 250 // Simulate a claim with block number 250
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{claim}, nil)
 			},
 			expectedBlock: 250, // max of 0, 250
 		},
 		{
 			name: "local exit root block higher than imported bridge exit block",
 			certificate: &agglayertypes.Certificate{
-				NewLocalExitRoot: common.HexToHash("0xdef"),
-				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{
-					{GlobalIndex: &agglayertypes.GlobalIndex{}},
-				},
+				NewLocalExitRoot:    common.HexToHash("0xdef"),
+				ImportedBridgeExits: []*agglayertypes.ImportedBridgeExit{testIbe},
 			},
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
 				bridgeSyncer.EXPECT().GetExitRootByHash(ctx, common.HexToHash("0xdef")).Return(&treetypes.Root{
 					BlockNum: uint64(400),
 				}, nil)
 
-				importedBridgeExit := &agglayertypes.GlobalIndex{}
-				bridgeSyncer.EXPECT().GetClaimByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(bridgesync.Claim{
-					BlockNum: 100,
-				}, nil)
+				claim := testClaim
+				claim.BlockNum = 100 // Simulate a claim with block number 100
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return([]bridgesync.Claim{claim}, nil)
 			},
 			expectedBlock: 400, // max of 400, 100
 		},

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -81,7 +81,7 @@ type L2BridgeSyncer interface {
 	BlockFinality() aggkittypes.BlockNumberFinality
 	GetLastProcessedBlock(ctx context.Context) (uint64, error)
 	GetExitRootByHash(ctx context.Context, root common.Hash) (*treetypes.Root, error)
-	GetClaimByGlobalIndex(ctx context.Context, globalIndex *big.Int) (bridgesync.Claim, error)
+	GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big.Int) ([]bridgesync.Claim, error)
 }
 
 // BridgeQuerier is an interface defining functions that an BridgeQuerier should implement

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -333,11 +333,11 @@ func (s *BridgeSync) GetExitRootByHash(ctx context.Context, root common.Hash) (*
 	return s.processor.exitTree.GetRootByHash(ctx, root)
 }
 
-func (s *BridgeSync) GetClaimByGlobalIndex(ctx context.Context, globalIndex *big.Int) (Claim, error) {
+func (s *BridgeSync) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big.Int) ([]Claim, error) {
 	if s.processor.isHalted() {
-		return Claim{}, sync.ErrInconsistentState
+		return nil, sync.ErrInconsistentState
 	}
-	return s.processor.GetClaimByGlobalIndex(ctx, globalIndex)
+	return s.processor.GetClaimsByGlobalIndex(ctx, globalIndex)
 }
 
 func (s *BridgeSync) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([]Claim, error) {

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -172,6 +172,12 @@ func TestGetClaims(t *testing.T) {
 	require.ErrorIs(t, err, sync.ErrInconsistentState)
 }
 
+func TestGetClaimsByGlobalIndex(t *testing.T) {
+	s := BridgeSync{processor: &processor{halted: true}}
+	_, err := s.GetClaimsByGlobalIndex(context.Background(), new(big.Int))
+	require.ErrorIs(t, err, sync.ErrInconsistentState)
+}
+
 func TestBridgeSync_GetTokenMappings(t *testing.T) {
 	const (
 		syncBlockChunkSize         = uint64(100)

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -48,6 +48,9 @@ var (
 	// errBlockNotProcessedFormat indicates that the given block(s) have not been processed yet.
 	errBlockNotProcessedFormat = fmt.Sprintf("block %%d not processed, last processed: %%d")
 
+	// errFailToConvertClaims indicates that the conversion from []*Claim to []Claim failed.
+	errFailToConvertClaims = errors.New("failed to convert from []*Claim to []Claim")
+
 	// tableNameRegex is the regex pattern to validate table names
 	tableNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
@@ -435,31 +438,34 @@ func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([
 	claims, ok := claimsIface.([]Claim)
 	if !ok {
 		p.log.Errorf("GetClaims: failed to convert from []*Claim to []Claim for block range [%d..%d]", fromBlock, toBlock)
-		return nil, errors.New("failed to convert from []*Claim to []Claim")
+		return nil, errFailToConvertClaims
 	}
 	return claims, nil
 }
 
-func (p *processor) GetClaimByGlobalIndex(ctx context.Context, globalIndex *big.Int) (Claim, error) {
+func (p *processor) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big.Int) ([]Claim, error) {
 	if globalIndex == nil {
-		return Claim{}, fmt.Errorf("global index cannot be nil")
+		return nil, fmt.Errorf("global index cannot be nil")
 	}
 
-	var claim Claim
-	if err := meddler.QueryRow(p.db, &claim, fmt.Sprintf(`
+	var results []*Claim
+	if err := meddler.QueryAll(p.db, &results, fmt.Sprintf(`
 		SELECT *
 		FROM %s
 		WHERE global_index = $1
-		LIMIT 1;
+		ORDER BY block_num ASC, block_pos ASC;
 	`, claimTableName), globalIndex.String()); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return Claim{}, db.ErrNotFound
-		}
-
-		return Claim{}, err
+		return nil, fmt.Errorf("failed to query claims by global index: %s: %w", globalIndex.String(), err)
 	}
 
-	return claim, nil
+	claimsSlice := db.SlicePtrsToSlice(results)
+	claims, ok := claimsSlice.([]Claim)
+	if !ok {
+		p.log.Errorf("GetClaims: failed to convert from []*Claim to []Claim for global index: %s", globalIndex.String())
+		return nil, errFailToConvertClaims
+	}
+
+	return claims, nil
 }
 
 func (p *processor) GetBridgesPaged(

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -377,7 +377,6 @@ func newProcessor(dbPath string, name string, logger *log.Logger) (*processor, e
 	}, nil
 }
 
-//nolint:dupl
 func (p *processor) GetBridges(
 	ctx context.Context, fromBlock, toBlock uint64,
 ) ([]Bridge, error) {
@@ -411,7 +410,6 @@ func (p *processor) GetBridges(
 	return bridges, nil
 }
 
-//nolint:dupl
 func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([]Claim, error) {
 	rows, err := p.queryBlockRange(p.db, fromBlock, toBlock, claimTableName)
 	if err != nil {

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2146,13 +2146,13 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 		t.Parallel()
 
 		nonExistentGlobalIndex := big.NewInt(999999)
-		claim, err := p.GetClaimByGlobalIndex(ctx, nonExistentGlobalIndex)
-		require.Error(t, err)
-		require.True(t, errors.Is(err, db.ErrNotFound))
-		require.Equal(t, Claim{}, claim)
+		claims, err := p.GetClaimsByGlobalIndex(ctx, nonExistentGlobalIndex)
+		require.NoError(t, err)
+		require.Empty(t, claims)
 	})
 
 	// Test case 2: Insert claims and retrieve them
+	globalIndexToTest := GenerateGlobalIndex(true, 0, 2000)
 	testClaims := []*Claim{
 		{
 			BlockNum:            1,
@@ -2174,7 +2174,7 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 		{
 			BlockNum:            2,
 			BlockPos:            1,
-			GlobalIndex:         GenerateGlobalIndex(true, 0, 2000),
+			GlobalIndex:         globalIndexToTest,
 			OriginNetwork:       3,
 			OriginAddress:       common.HexToAddress("0x33"),
 			DestinationAddress:  common.HexToAddress("0x44"),
@@ -2190,20 +2190,20 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 		},
 		{
 			BlockNum:            3,
-			BlockPos:            2,
-			GlobalIndex:         GenerateGlobalIndex(false, 1, 3000),
-			OriginNetwork:       5,
-			OriginAddress:       common.HexToAddress("0x55"),
-			DestinationAddress:  common.HexToAddress("0x66"),
-			Amount:              big.NewInt(300),
+			BlockPos:            1,
+			GlobalIndex:         globalIndexToTest, // same global index as previous claim
+			OriginNetwork:       3,
+			OriginAddress:       common.HexToAddress("0x33"),
+			DestinationAddress:  common.HexToAddress("0x55"),
+			Amount:              big.NewInt(200),
 			ProofLocalExitRoot:  types.Proof{},
 			ProofRollupExitRoot: types.Proof{},
-			MainnetExitRoot:     common.HexToHash("0xmainnet3"),
-			RollupExitRoot:      common.HexToHash("0xrollup3"),
-			GlobalExitRoot:      common.HexToHash("0xglobal3"),
-			DestinationNetwork:  6,
-			Metadata:            nil,
-			IsMessage:           false,
+			MainnetExitRoot:     common.HexToHash("0xmainnet2"),
+			RollupExitRoot:      common.HexToHash("0xrollup2"),
+			GlobalExitRoot:      common.HexToHash("0xglobal2"),
+			DestinationNetwork:  4,
+			Metadata:            []byte("test metadata 2"),
+			IsMessage:           true,
 		},
 	}
 
@@ -2228,11 +2228,12 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 	// Test case 3: Retrieve existing claims by global index
 	t.Run("retrieve existing claims", func(t *testing.T) {
 		t.Parallel()
-		for _, expectedClaim := range testClaims {
-			actualClaim, err := p.GetClaimByGlobalIndex(ctx, expectedClaim.GlobalIndex)
-			require.NoError(t, err)
-			require.Equal(t, *expectedClaim, actualClaim)
-		}
+
+		claims, err := p.GetClaimsByGlobalIndex(ctx, globalIndexToTest)
+		require.NoError(t, err)
+		require.Len(t, claims, 2)                   // Two claims with the same global index
+		require.Equal(t, *testClaims[1], claims[0]) // Check first claim
+		require.Equal(t, *testClaims[2], claims[1]) // Check second claim
 	})
 
 	// Test case 4: Test with very large global index
@@ -2271,9 +2272,10 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 		require.NoError(t, tx.Commit())
 
 		// Retrieve the claim
-		retrievedClaim, err := p.GetClaimByGlobalIndex(ctx, largeGlobalIndex)
+		retrievedClaims, err := p.GetClaimsByGlobalIndex(ctx, largeGlobalIndex)
 		require.NoError(t, err)
-		require.Equal(t, *largeClaim, retrievedClaim)
+		require.Len(t, retrievedClaims, 1) // Should return one claim
+		require.Equal(t, *largeClaim, retrievedClaims[0])
 	})
 
 	// Test case 5: Test with zero global index
@@ -2310,18 +2312,19 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 		require.NoError(t, tx.Commit())
 
 		// Retrieve the claim
-		retrievedClaim, err := p.GetClaimByGlobalIndex(ctx, zeroGlobalIndex)
+		retrievedClaims, err := p.GetClaimsByGlobalIndex(ctx, zeroGlobalIndex)
 		require.NoError(t, err)
-		require.Equal(t, *zeroClaim, retrievedClaim)
+		require.Len(t, retrievedClaims, 1) // Should return one claim
+		require.Equal(t, *zeroClaim, retrievedClaims[0])
 	})
 
 	// Test case 6: Test with nil global index (should handle gracefully)
 	t.Run("nil global index", func(t *testing.T) {
 		t.Parallel()
 
-		claim, err := p.GetClaimByGlobalIndex(ctx, nil)
+		claims, err := p.GetClaimsByGlobalIndex(ctx, nil)
 		require.ErrorContains(t, err, "global index cannot be nil")
-		require.Equal(t, Claim{}, claim)
+		require.Empty(t, claims)
 	})
 }
 

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2132,8 +2132,6 @@ func TestBridgeSyncRuntimeData_IsCompatible(t *testing.T) {
 }
 
 func TestGetClaimByGlobalIndex(t *testing.T) {
-	t.Parallel()
-
 	path := path.Join(t.TempDir(), "bridgesyncTestGetClaimByGlobalIndex.sqlite")
 	logger := log.WithFields("module", "bridge-syncer")
 	p, err := newProcessor(path, "bridge-syncer", logger)
@@ -2143,8 +2141,6 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 
 	// Test case 1: Claim not found
 	t.Run("claim not found", func(t *testing.T) {
-		t.Parallel()
-
 		nonExistentGlobalIndex := big.NewInt(999999)
 		claims, err := p.GetClaimsByGlobalIndex(ctx, nonExistentGlobalIndex)
 		require.NoError(t, err)
@@ -2227,8 +2223,6 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 
 	// Test case 3: Retrieve existing claims by global index
 	t.Run("retrieve existing claims", func(t *testing.T) {
-		t.Parallel()
-
 		claims, err := p.GetClaimsByGlobalIndex(ctx, globalIndexToTest)
 		require.NoError(t, err)
 		require.Len(t, claims, 2)                   // Two claims with the same global index
@@ -2320,10 +2314,18 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 
 	// Test case 6: Test with nil global index (should handle gracefully)
 	t.Run("nil global index", func(t *testing.T) {
-		t.Parallel()
-
 		claims, err := p.GetClaimsByGlobalIndex(ctx, nil)
 		require.ErrorContains(t, err, "global index cannot be nil")
+		require.Empty(t, claims)
+	})
+
+	// Test case 7: db returns error
+	t.Run("db error", func(t *testing.T) {
+		p.db.Close() // Close the processor's DB to simulate an error
+
+		// Attempt to retrieve claims with the invalid processor
+		claims, err := p.GetClaimsByGlobalIndex(ctx, globalIndexToTest)
+		require.Error(t, err)
 		require.Empty(t, claims)
 	})
 }


### PR DESCRIPTION
## 🔄 Changes Summary
Because of `Remove Injected GER` feature, the `L2 Bridge Syncer` can have (in rare cases) two `claims` with the same `global index`, where one of them gets unclaimed.

Because of this, and since syncer's `db` has no constraints on `global index` field, the `aggsender-validator` needs to support this as well, when querying the `claim` based on `global index`.

The `agglayer` will return a `bridge exit hash` alongside `global index` for the last settled `imported bridge exit` (`claim`), which we can use to filter out the desired `claim`. 

The `aggsender-validator` will query all the `claims` from the syncer based on the last settled `global index` and then filter them out by their `bridge exit hash` to find a correct one.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI

## 🐞 Issues
- Closes #878
