### PR TITLE
fix: hash to sign on validator

### DIFF
--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -346,7 +346,7 @@ func (c *Certificate) CertificateID() common.Hash {
 	importedBridgeExitsPart := crypto.Keccak256(importedBridgeExitsHashes...)
 
 	return crypto.Keccak256Hash(
-		aggkitcommon.Uint32ToBytes(c.NetworkID),
+		aggkitcommon.Uint32ToBigEndianBytes(c.NetworkID),
 		aggkitcommon.Uint64ToBigEndianBytes(c.Height),
 		c.PrevLocalExitRoot.Bytes(),
 		c.NewLocalExitRoot.Bytes(),

--- a/aggsender/validator/cert_hash.go
+++ b/aggsender/validator/cert_hash.go
@@ -15,5 +15,5 @@ func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error)
 	}
 	return crypto.Keccak256Hash(
 		cert.CertificateID().Bytes(),
-		aggkitcommon.Uint32ToBytes(cert.L1InfoTreeLeafCount)), nil
+		aggkitcommon.Uint32ToLittleEndianBytes(cert.L1InfoTreeLeafCount)), nil
 }

--- a/aggsender/validator/cert_hash_test.go
+++ b/aggsender/validator/cert_hash_test.go
@@ -46,19 +46,19 @@ func TestHashCertificateToSign(t *testing.T) {
 		_, cert := getCertFromAggsenderDBForTest(t)
 		hash, err := HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0xe927a8204f8f4750e4cc2c3938e43b88eaccc7ddb5f21b54ede4a69843e87b3d", hash.String())
+		require.Equal(t, "0x4916e5a0df28fcd1b53169780ca69b1e94e45423a3c40b5a150ef2b63d2d413d", hash.String())
 		cert.NetworkID += 1
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x84ecc0220119803af79a5be33d9efcaea76862da70ef044151d5ae1d7b12fd4c", hash.String())
+		require.Equal(t, "0xe641ff67323c6d21e960090bc3f57847a77deba552b4fef97b601e7aa19c767d", hash.String())
 		cert.Height += 1
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x88cfb3efdb3802f8a86ab1d6484ca7e2a00310da5545b4de8ae8c9011994316b", hash.String())
+		require.Equal(t, "0xe9b32db20304fad88adc02ba06bf53c08ca7ba2afd5dd5b29a2dcef67ce0aac7", hash.String())
 		cert.Metadata = [32]byte{6, 7, 8, 9, 10}
 		hash, err = HashCertificateToSign(cert)
 		require.NoError(t, err)
-		require.Equal(t, "0x73a8e14ed3b09cb31c27a8a833f1257cbd6507c6d5716eb55d99b7bbedabbae6", hash.String())
+		require.Equal(t, "0x3c0656f208c2342b11da2a2fcc5e508de23e6653bb6703be34327418f0754960", hash.String())
 	})
 }
 
@@ -68,7 +68,7 @@ func TestCertificateIdHash(t *testing.T) {
 	require.Equal(t, cert.Header.CertificateID, id)
 	hash, err := HashCertificateToSign(unmarshalCert)
 	require.NoError(t, err)
-	require.Equal(t, "0xe927a8204f8f4750e4cc2c3938e43b88eaccc7ddb5f21b54ede4a69843e87b3d", hash.String())
+	require.Equal(t, "0x4916e5a0df28fcd1b53169780ca69b1e94e45423a3c40b5a150ef2b63d2d413d", hash.String())
 }
 
 // Returns aggsender and agglayer cert

--- a/common/common.go
+++ b/common/common.go
@@ -59,6 +59,14 @@ func Uint32ToBigEndianBytes(num uint32) []byte {
 	return Uint32ToBytes(num)
 }
 
+// Uint32ToLittleEndianBytes converts a uint32 to a byte slice in little-endian order
+func Uint32ToLittleEndianBytes(num uint32) []byte {
+	bytes := make([]byte, Uint32ByteSize)
+	binary.LittleEndian.PutUint32(bytes, num)
+
+	return bytes
+}
+
 // Uint32ToBytes converts a uint32 to a byte slice in big-endian order
 func Uint32ToBytes(num uint32) []byte {
 	bytes := make([]byte, Uint32ByteSize)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -343,3 +343,54 @@ func TestUint64ToLittleEndianBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestUint32ToLittleEndianBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    uint32
+		expected []byte
+	}{
+		{
+			name:     "Zero value",
+			input:    0,
+			expected: []byte{0, 0, 0, 0},
+		},
+		{
+			name:     "Small value",
+			input:    1,
+			expected: []byte{1, 0, 0, 0},
+		},
+		{
+			name:     "Max uint32 value",
+			input:    ^uint32(0),
+			expected: []byte{255, 255, 255, 255},
+		},
+		{
+			name:     "Arbitrary value",
+			input:    1234567890,
+			expected: []byte{210, 2, 150, 73},
+		},
+		{
+			name:     "Value with MSB set",
+			input:    0x80000000,
+			expected: []byte{0, 0, 0, 128},
+		},
+		{
+			name:     "Value 256",
+			input:    256,
+			expected: []byte{0, 1, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Uint32ToLittleEndianBytes(tt.input)
+			require.Equal(t, tt.expected, result)
+			require.Len(t, result, Uint32ByteSize)
+		})
+	}
+}


### PR DESCRIPTION
## 🔄 Changes Summary
This PR fixes the hash to sign on `aggsender-validator` found while testing the `Phase II` `aggsender beethoven` setup.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI
