### PR TITLE
feat: don't use `debug` endpoint on `aggsender-validator`, instead verify proofs on `claims`

### DIFF
--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -318,7 +318,7 @@ func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1types.I
 	}
 
 	switch claimData := ibe.ClaimData.(type) {
-	case *types.ClaimFromMainnnet:
+	case *types.ClaimFromMainnet:
 		importedBridgeExit.Claim = &v1types.ImportedBridgeExit_Mainnet{
 			Mainnet: &v1types.ClaimFromMainnet{
 				ProofLeafMer: &v1types.MerkleProof{

--- a/agglayer/grpc/conversion_to_agglayer.go
+++ b/agglayer/grpc/conversion_to_agglayer.go
@@ -204,7 +204,7 @@ func grpcClaimDataToAgglayer(claim interface{}) (agglayertypes.Claim, error) {
 		if err != nil {
 			return nil, fmt.Errorf("grpcClaimDataToAgglayer. error converting Mainnet L1 leaf: %w", err)
 		}
-		return &agglayertypes.ClaimFromMainnnet{
+		return &agglayertypes.ClaimFromMainnet{
 			ProofLeafMER:     proofs[0],
 			ProofGERToL1Root: proofs[1],
 			L1Leaf:           l1feaf,

--- a/agglayer/grpc/conversion_to_agglayer_test.go
+++ b/agglayer/grpc/conversion_to_agglayer_test.go
@@ -53,7 +53,7 @@ var exampleTestAgglayerCert = &agglayertypes.Certificate{
 				RollupIndex: 0,
 				LeafIndex:   1,
 			},
-			ClaimData: &agglayertypes.ClaimFromMainnnet{
+			ClaimData: &agglayertypes.ClaimFromMainnet{
 				ProofLeafMER: &agglayertypes.MerkleProof{
 					Root:  common.HexToHash("0x010203"),
 					Proof: tree.EmptyProof,

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -787,20 +787,20 @@ type Claim interface {
 	Validate() error
 }
 
-// ClaimFromMainnnet represents a claim originating from the mainnet
-type ClaimFromMainnnet struct {
+// ClaimFromMainnet represents a claim originating from the mainnet
+type ClaimFromMainnet struct {
 	ProofLeafMER     *MerkleProof    `json:"proof_leaf_mer"`
 	ProofGERToL1Root *MerkleProof    `json:"proof_ger_l1root"`
 	L1Leaf           *L1InfoTreeLeaf `json:"l1_leaf"`
 }
 
 // Type is the implementation of Claim interface
-func (c ClaimFromMainnnet) Type() string {
+func (c ClaimFromMainnet) Type() string {
 	return "Mainnet"
 }
 
 // MarshalJSON is the implementation of Claim interface
-func (c *ClaimFromMainnnet) MarshalJSON() ([]byte, error) {
+func (c *ClaimFromMainnet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Child map[string]interface{} `json:"Mainnet"`
 	}{
@@ -812,7 +812,7 @@ func (c *ClaimFromMainnnet) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (c *ClaimFromMainnnet) UnmarshalJSON(data []byte) error {
+func (c *ClaimFromMainnet) UnmarshalJSON(data []byte) error {
 	if string(data) == nullStr {
 		return nil
 	}
@@ -835,7 +835,7 @@ func (c *ClaimFromMainnnet) UnmarshalJSON(data []byte) error {
 }
 
 // Hash is the implementation of Claim interface
-func (c *ClaimFromMainnnet) Hash() common.Hash {
+func (c *ClaimFromMainnet) Hash() common.Hash {
 	if c.Validate() != nil {
 		return common.Hash{}
 	}
@@ -846,12 +846,12 @@ func (c *ClaimFromMainnnet) Hash() common.Hash {
 	)
 }
 
-func (c *ClaimFromMainnnet) String() string {
+func (c *ClaimFromMainnet) String() string {
 	return fmt.Sprintf("ProofLeafMER: %s, ProofGERToL1Root: %s, L1Leaf: %s",
 		c.ProofLeafMER.String(), c.ProofGERToL1Root.String(), c.L1Leaf.String())
 }
 
-func (c *ClaimFromMainnnet) Validate() error {
+func (c *ClaimFromMainnet) Validate() error {
 	if c == nil {
 		return errors.New("ClaimFromMainnnet is nil")
 	}
@@ -865,7 +865,7 @@ func (c *ClaimFromMainnnet) Validate() error {
 }
 
 // VerifyProofs verifies the inclusion proofs for the given mainnet claim
-func (c *ClaimFromMainnnet) VerifyProofs(l1RootFromWhichToProof, leafHash common.Hash, leafIndex uint32) error {
+func (c *ClaimFromMainnet) VerifyProofs(l1RootFromWhichToProof, leafHash common.Hash, leafIndex uint32) error {
 	if c.ProofGERToL1Root.Root != l1RootFromWhichToProof {
 		return fmt.Errorf("ClaimFromMainnnet - Mismatch between the provided L1 root and the inclusion proof. "+
 			"GERToL1Root: %s != L1RootFromWhichToProof: %s",
@@ -1034,7 +1034,7 @@ func (c *ClaimSelector) UnmarshalJSON(data []byte) error {
 	}
 	var ok bool
 	if _, ok = obj["Mainnet"]; ok {
-		c.obj = &ClaimFromMainnnet{}
+		c.obj = &ClaimFromMainnet{}
 	} else if _, ok = obj["Rollup"]; ok {
 		c.obj = &ClaimFromRollup{}
 	} else {
@@ -1122,7 +1122,7 @@ func (c *ImportedBridgeExit) VerifyProofs(l1RootFromWhichToProve common.Hash) er
 	}
 
 	switch cl := c.ClaimData.(type) {
-	case *ClaimFromMainnnet:
+	case *ClaimFromMainnet:
 		if err := cl.VerifyProofs(l1RootFromWhichToProve, c.BridgeExit.Hash(), c.GlobalIndex.LeafIndex); err != nil {
 			return fmt.Errorf("ImportedBridgeExit - ClaimFromMainnnet verification failed: %w", err)
 		}

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agglayer/aggkit/bridgesync"
 	aggkitcommon "github.com/agglayer/aggkit/common"
+	"github.com/agglayer/aggkit/tree"
 	"github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -579,9 +580,9 @@ func (b *BridgeExit) Hash() common.Hash {
 
 	return crypto.Keccak256Hash(
 		[]byte{b.LeafType.Uint8()},
-		aggkitcommon.Uint32ToBytes(b.TokenInfo.OriginNetwork),
+		aggkitcommon.Uint32ToBigEndianBytes(b.TokenInfo.OriginNetwork),
 		b.TokenInfo.OriginTokenAddress.Bytes(),
-		aggkitcommon.Uint32ToBytes(b.DestinationNetwork),
+		aggkitcommon.Uint32ToBigEndianBytes(b.DestinationNetwork),
 		b.DestinationAddress.Bytes(),
 		common.BigToHash(b.Amount).Bytes(),
 		metaDataHash,
@@ -863,6 +864,37 @@ func (c *ClaimFromMainnnet) Validate() error {
 	return nil
 }
 
+// VerifyProofs verifies the inclusion proofs for the given mainnet claim
+func (c *ClaimFromMainnnet) VerifyProofs(l1RootFromWhichToProof, leafHash common.Hash, leafIndex uint32) error {
+	if c.ProofGERToL1Root.Root != l1RootFromWhichToProof {
+		return fmt.Errorf("ClaimFromMainnnet - Mismatch between the provided L1 root and the inclusion proof. "+
+			"GERToL1Root: %s != L1RootFromWhichToProof: %s",
+			c.ProofGERToL1Root.Root.String(), l1RootFromWhichToProof.String())
+	}
+
+	if c.ProofLeafMER.Root != c.L1Leaf.MainnetExitRoot {
+		return fmt.Errorf("ClaimFromMainnnet - Mismatch on the MER between the L1 leaf and the inclusion proof. "+
+			"ProofLeafMER: %s != L1Leaf.MainnetExitRoot: %s",
+			c.ProofLeafMER.Root.String(), c.L1Leaf.MainnetExitRoot.String())
+	}
+
+	if err := tree.VerifyProof(leafHash, c.ProofLeafMER.Proof,
+		leafIndex, c.ProofLeafMER.Root); err != nil {
+		return fmt.Errorf("ClaimFromMainnnet - Invalid merkle path from the leaf to the LER. "+
+			"ProofLeafMER: %s, leafHash: %s, leafIndex: %d, err: %w",
+			c.ProofLeafMER.String(), leafHash.String(), leafIndex, err)
+	}
+
+	if err := tree.VerifyProof(c.L1Leaf.Hash(), c.ProofGERToL1Root.Proof,
+		c.L1Leaf.L1InfoTreeIndex, c.ProofGERToL1Root.Root); err != nil {
+		return fmt.Errorf("ClaimFromMainnnet - Invalid merkle path from the GER to the L1 Info Root. "+
+			"ProofGERToL1Root: %s, L1Leaf: %s, leafIndex: %d, err: %w",
+			c.ProofGERToL1Root.String(), c.L1Leaf.String(), c.L1Leaf.L1InfoTreeIndex, err)
+	}
+
+	return nil
+}
+
 // ClaimFromRollup represents a claim originating from a rollup
 type ClaimFromRollup struct {
 	ProofLeafLER     *MerkleProof    `json:"proof_leaf_ler"`
@@ -944,6 +976,43 @@ func (c *ClaimFromRollup) Validate() error {
 func (c *ClaimFromRollup) String() string {
 	return fmt.Sprintf("ProofLeafLER: %s, ProofLERToRER: %s, ProofGERToL1Root: %s, L1Leaf: %s",
 		c.ProofLeafLER.String(), c.ProofLERToRER.String(), c.ProofGERToL1Root.String(), c.L1Leaf.String())
+}
+
+func (c *ClaimFromRollup) VerifyProofs(
+	l1RootFromWhichToProof, leafHash common.Hash, rollupIndex, leafIndex uint32) error {
+	if c.ProofGERToL1Root.Root != l1RootFromWhichToProof {
+		return fmt.Errorf("ClaimFromRollup - Mismatch between the provided L1 root and the inclusion proof. "+
+			"ProofGERToL1Root: %s != L1RootFromWhichToProof: %s",
+			c.ProofGERToL1Root.Root.String(), l1RootFromWhichToProof.String())
+	}
+
+	if c.ProofLERToRER.Root != c.L1Leaf.RollupExitRoot {
+		return fmt.Errorf("ClaimFromRollup - Mismatch on the RER between the L1 leaf and the inclusion proof. "+
+			"ProofLERToRER: %s != L1Leaf.RollupExitRoot: %s",
+			c.ProofLERToRER.Root.String(), c.L1Leaf.RollupExitRoot.String())
+	}
+
+	if err := tree.VerifyProof(leafHash, c.ProofLeafLER.Proof,
+		leafIndex, c.ProofLeafLER.Root); err != nil {
+		return fmt.Errorf("ClaimFromRollup - Invalid merkle path from the leaf to the LER. "+
+			"ProofLeafLER: %s, leafHash: %s, leafIndex: %d, err: %w",
+			c.ProofLeafLER.String(), leafHash.String(), leafIndex, err)
+	}
+
+	if err := tree.VerifyProof(c.L1Leaf.Hash(), c.ProofGERToL1Root.Proof,
+		c.L1Leaf.L1InfoTreeIndex, c.ProofGERToL1Root.Root); err != nil {
+		return fmt.Errorf("ClaimFromRollup - Invalid merkle path from the GER to the L1 Info Root. "+
+			"ProofGERToL1Root: %s, L1Leaf: %s, leafIndex: %d, err: %w",
+			c.ProofGERToL1Root.String(), c.L1Leaf.String(), c.L1Leaf.L1InfoTreeIndex, err)
+	}
+
+	if err := tree.VerifyProof(c.ProofLeafLER.Root, c.ProofLERToRER.Proof, rollupIndex, c.ProofLERToRER.Root); err != nil {
+		return fmt.Errorf("ClaimFromRollup - Invalid merkle path from the LER to the RER. "+
+			"ProofLERToRER: %s, LER: %s, rollupIndex: %d, err: %w",
+			c.ProofLERToRER.String(), c.ProofLeafLER.String(), rollupIndex, err)
+	}
+
+	return nil
 }
 
 // ClaimSelector is a helper struct that allow to decice which type of claim to unmarshal
@@ -1036,13 +1105,37 @@ func (c *ImportedBridgeExit) Validate() error {
 	if err := c.BridgeExit.Validate(); err != nil {
 		return fmt.Errorf("ImportedBridgeExit.BridgeExit not valid: %w", err)
 	}
-	if err := c.ClaimData.Validate(); err != nil {
-		return fmt.Errorf("ImportedBridgeExit.ClaimData exit not valid: %w", err)
-	}
 	if err := c.GlobalIndex.Validate(); err != nil {
 		return fmt.Errorf("ImportedBridgeExit.GlobalIndex exit not valid: %w", err)
 	}
 	return nil
+}
+
+// VerifyProofs verifies the inclusion proofs for the imported bridge exit
+func (c *ImportedBridgeExit) VerifyProofs(l1RootFromWhichToProve common.Hash) error {
+	if c == nil {
+		return errors.New("ImportedBridgeExit is nil")
+	}
+
+	if c.ClaimData == nil {
+		return errors.New("ImportedBridgeExit.ClaimData is nil")
+	}
+
+	switch cl := c.ClaimData.(type) {
+	case *ClaimFromMainnnet:
+		if err := cl.VerifyProofs(l1RootFromWhichToProve, c.BridgeExit.Hash(), c.GlobalIndex.LeafIndex); err != nil {
+			return fmt.Errorf("ImportedBridgeExit - ClaimFromMainnnet verification failed: %w", err)
+		}
+		return nil
+	case *ClaimFromRollup:
+		if err := cl.VerifyProofs(l1RootFromWhichToProve, c.BridgeExit.Hash(),
+			c.GlobalIndex.RollupIndex, c.GlobalIndex.LeafIndex); err != nil {
+			return fmt.Errorf("ImportedBridgeExit - ClaimFromRollup verification failed: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("ImportedBridgeExit - unknown claim type: %T", c.ClaimData)
+	}
 }
 
 // GlobalIndexToLittleEndianBytes converts the global index to a byte slice in little-endian format

--- a/agglayer/types/types_helpers_test.go
+++ b/agglayer/types/types_helpers_test.go
@@ -30,10 +30,10 @@ func createDummyGlobalIndex(t *testing.T) *GlobalIndex {
 }
 
 // Helper function to create a dummy Claim
-func createDummyClaim(t *testing.T) *ClaimFromMainnnet {
+func createDummyClaim(t *testing.T) *ClaimFromMainnet {
 	t.Helper()
 
-	return &ClaimFromMainnnet{
+	return &ClaimFromMainnet{
 		ProofLeafMER: &MerkleProof{
 			Root: common.HexToHash("0x1234"),
 			Proof: [common.HashLength]common.Hash{

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -194,7 +194,7 @@ func TestMarshalJSON(t *testing.T) {
 						RollupIndex: 0,
 						LeafIndex:   1,
 					},
-					ClaimData: &ClaimFromMainnnet{
+					ClaimData: &ClaimFromMainnet{
 						ProofLeafMER: &MerkleProof{
 							Root:  common.HexToHash("0x333"),
 							Proof: createDummyProof(t),
@@ -613,7 +613,7 @@ func TestClaimFromMainnnet_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	claim := &ClaimFromMainnnet{
+	claim := &ClaimFromMainnet{
 		ProofLeafMER:     merkleProof,
 		ProofGERToL1Root: merkleProof,
 		L1Leaf:           l1InfoTreeLeaf,
@@ -623,7 +623,7 @@ func TestClaimFromMainnnet_MarshalJSON(t *testing.T) {
 	expectedJSON, err := claim.MarshalJSON()
 	require.NoError(t, err)
 
-	var actualClaim ClaimFromMainnnet
+	var actualClaim ClaimFromMainnet
 	err = json.Unmarshal(expectedJSON, &actualClaim)
 	require.NoError(t, err)
 }
@@ -906,7 +906,7 @@ func TestClaimType(t *testing.T) {
 	}{
 		{
 			name:         "Mainnet claim",
-			claim:        &ClaimFromMainnnet{},
+			claim:        &ClaimFromMainnet{},
 			expectedType: "Mainnet",
 		},
 		{
@@ -983,7 +983,7 @@ func Test_UnmarshalImportedBridgeExit(t *testing.T) {
 		{
 			name: "Empty/ClaimFromMainnnet",
 			importedBridge: ImportedBridgeExit{
-				ClaimData: &ClaimFromMainnnet{
+				ClaimData: &ClaimFromMainnet{
 					ProofLeafMER: &MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: [types.DefaultHeight]common.Hash{common.HexToHash("0x2"), common.HexToHash("0x3")},
@@ -1008,7 +1008,7 @@ func Test_UnmarshalImportedBridgeExit(t *testing.T) {
 					Amount:             big.NewInt(1000),
 					Metadata:           []byte{0x01, 0x02, 0x03},
 				},
-				ClaimData: &ClaimFromMainnnet{},
+				ClaimData: &ClaimFromMainnet{},
 				GlobalIndex: &GlobalIndex{
 					MainnetFlag: true,
 					RollupIndex: 1,
@@ -1088,7 +1088,7 @@ func Test_UnmarshalBridgeExit(t *testing.T) {
 }
 
 func Test_UnmarshalClaimFromMainnnet(t *testing.T) {
-	claim := &ClaimFromMainnnet{
+	claim := &ClaimFromMainnet{
 		ProofLeafMER: &MerkleProof{
 			Root:  common.HexToHash("0x1"),
 			Proof: [types.DefaultHeight]common.Hash{common.HexToHash("0x2"), common.HexToHash("0x3")},
@@ -1098,7 +1098,7 @@ func Test_UnmarshalClaimFromMainnnet(t *testing.T) {
 	}
 	ser, err := json.Marshal(claim)
 	require.NoError(t, err)
-	unmarshalled := &ClaimFromMainnnet{}
+	unmarshalled := &ClaimFromMainnet{}
 	err = json.Unmarshal(ser, unmarshalled)
 	require.NoError(t, err)
 	require.Equal(t, claim, unmarshalled)
@@ -1324,7 +1324,7 @@ func TestCertificate_Validate(t *testing.T) {
 						DestinationNetwork: 1,
 						DestinationAddress: common.HexToAddress("0x1234"),
 					},
-					ClaimData: &ClaimFromMainnnet{
+					ClaimData: &ClaimFromMainnet{
 						ProofLeafMER:     &MerkleProof{},
 						ProofGERToL1Root: &MerkleProof{},
 						L1Leaf: &L1InfoTreeLeaf{
@@ -1364,9 +1364,9 @@ func TestBridgeExitHash(t *testing.T) {
 }
 
 func TestClaimFromMainnnetHash(t *testing.T) {
-	var sut *ClaimFromMainnnet
+	var sut *ClaimFromMainnet
 	require.Equal(t, common.Hash{}, sut.Hash())
-	var sut2 ClaimFromMainnnet
+	var sut2 ClaimFromMainnet
 	require.Equal(t, common.Hash{}, sut2.Hash())
 }
 
@@ -1459,7 +1459,7 @@ func TestImportedBridgeExit_VerifyProofs(t *testing.T) {
 
 		ibe := &ImportedBridgeExit{
 			BridgeExit: bridgeExits[0],
-			ClaimData: &ClaimFromMainnnet{
+			ClaimData: &ClaimFromMainnet{
 				ProofGERToL1Root: &MerkleProof{
 					Root:  lastL1InfoRoot.Hash,
 					Proof: proofFromL1InfoTree,
@@ -1486,7 +1486,7 @@ func TestImportedBridgeExit_VerifyProofs(t *testing.T) {
 
 		ibe := &ImportedBridgeExit{
 			BridgeExit: bridgeExits[0],
-			ClaimData: &ClaimFromMainnnet{
+			ClaimData: &ClaimFromMainnet{
 				ProofGERToL1Root: &MerkleProof{
 					Root:  common.HexToHash("0x12345678"), // Wrong root
 					Proof: proofFromL1InfoTree,
@@ -1511,7 +1511,7 @@ func TestImportedBridgeExit_VerifyProofs(t *testing.T) {
 
 		ibe := &ImportedBridgeExit{
 			BridgeExit: bridgeExits[0],
-			ClaimData: &ClaimFromMainnnet{
+			ClaimData: &ClaimFromMainnet{
 				ProofGERToL1Root: &MerkleProof{
 					Root:  lastL1InfoRoot.Hash,
 					Proof: proofFromRollupExitTree,
@@ -1544,7 +1544,7 @@ func TestImportedBridgeExit_VerifyProofs(t *testing.T) {
 
 		ibe := &ImportedBridgeExit{
 			BridgeExit: bridgeExits[0],
-			ClaimData: &ClaimFromMainnnet{
+			ClaimData: &ClaimFromMainnet{
 				ProofGERToL1Root: &MerkleProof{
 					Root:  lastL1InfoRoot.Hash,
 					Proof: proofFromL1InfoTree,
@@ -1578,7 +1578,7 @@ func TestImportedBridgeExit_VerifyProofs(t *testing.T) {
 
 		ibe := &ImportedBridgeExit{
 			BridgeExit: bridgeExits[0],
-			ClaimData: &ClaimFromMainnnet{
+			ClaimData: &ClaimFromMainnet{
 				ProofGERToL1Root: &MerkleProof{
 					Root:  lastL1InfoRoot.Hash,
 					Proof: proofFromL1InfoTree,

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -2,16 +2,22 @@ package types
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
+	"path"
 	"reflect"
 	"testing"
 
 	"github.com/agglayer/aggkit/bridgesync"
 	aggkitcommon "github.com/agglayer/aggkit/common"
+	"github.com/agglayer/aggkit/db"
+	"github.com/agglayer/aggkit/l1infotreesync"
+	"github.com/agglayer/aggkit/l1infotreesync/migrations"
 	"github.com/agglayer/aggkit/log"
+	"github.com/agglayer/aggkit/tree"
 	"github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -1342,41 +1348,6 @@ func TestCertificate_Validate(t *testing.T) {
 		require.NoError(t, sut.Validate())
 	})
 
-	t.Run("ClaimFromMainnnet validate", func(t *testing.T) {
-		var sut *ClaimFromMainnnet
-		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet is nil")
-		sut = &ClaimFromMainnnet{}
-		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet has nil proofs")
-		sut = &ClaimFromMainnnet{
-			ProofLeafMER:     &MerkleProof{},
-			ProofGERToL1Root: &MerkleProof{},
-		}
-		require.ErrorContains(t, sut.Validate(), "ClaimFromMainnnet L1Leaf error")
-		sut = &ClaimFromMainnnet{
-			ProofLeafMER:     &MerkleProof{},
-			ProofGERToL1Root: &MerkleProof{},
-			L1Leaf: &L1InfoTreeLeaf{
-				Inner: &L1InfoTreeLeafInner{},
-			},
-		}
-		require.NoError(t, sut.Validate())
-	})
-
-	t.Run("ClaimFromRollup nil", func(t *testing.T) {
-		var sut *ClaimFromRollup
-		require.ErrorContains(t, sut.Validate(), "ClaimFromRollup is nil")
-		sut = &ClaimFromRollup{}
-		require.ErrorContains(t, sut.Validate(), "ClaimFromRollup has nil proofs")
-		sut = &ClaimFromRollup{
-			ProofLeafLER:     &MerkleProof{},
-			ProofLERToRER:    &MerkleProof{},
-			ProofGERToL1Root: &MerkleProof{},
-		}
-		require.ErrorContains(t, sut.Validate(), "ClaimFromRollup has nil L1Leaf")
-		sut.L1Leaf = &L1InfoTreeLeaf{}
-		require.NoError(t, sut.Validate())
-	})
-
 	t.Run("ImportedBridgeExit nil", func(t *testing.T) {
 		var sut *ImportedBridgeExit
 		require.ErrorContains(t, sut.Validate(), "ImportedBridgeExit is nil")
@@ -1404,4 +1375,440 @@ func TestClaimFromRollupHash(t *testing.T) {
 	require.Equal(t, common.Hash{}, sut.Hash())
 	var sut2 ClaimFromRollup
 	require.Equal(t, common.Hash{}, sut2.Hash())
+}
+
+func TestImportedBridgeExit_VerifyProofs(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	treeDB := createTreeDBForTest(t)
+	rollupExitTree := tree.NewAppendOnlyTree(treeDB, migrations.RollupExitTreePrefix)
+	l1InfoTree := tree.NewAppendOnlyTree(treeDB, migrations.L1InfoTreePrefix)
+
+	numOfLeavesToAdd := 10
+
+	tx, err := db.NewTx(ctx, treeDB)
+	require.NoError(t, err)
+
+	bridgeExits := make([]*BridgeExit, numOfLeavesToAdd)
+	l1Leaves := make([]*L1InfoTreeLeaf, numOfLeavesToAdd)
+
+	// simulate rollup exit tree
+	for i := range numOfLeavesToAdd {
+		bridgeExits[i] = &BridgeExit{
+			LeafType: LeafTypeAsset,
+			TokenInfo: &TokenInfo{
+				OriginNetwork:      uint32(i),
+				OriginTokenAddress: common.HexToAddress(fmt.Sprintf("0x%040x", i)),
+			},
+			DestinationNetwork: uint32(i + 1),
+			DestinationAddress: common.HexToAddress(fmt.Sprintf("0x%040x", i+1)),
+			Amount:             big.NewInt(int64(i+1) * 1000),
+		}
+		require.NoError(t, rollupExitTree.AddLeaf(tx, uint64(i), 0, types.Leaf{
+			Index: uint32(i),
+			Hash:  bridgeExits[i].Hash(),
+		}))
+	}
+
+	require.NoError(t, tx.Commit())
+
+	tx, err = db.NewTx(ctx, treeDB)
+	require.NoError(t, err)
+
+	// simulate L1 info tree
+	for i := range numOfLeavesToAdd {
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(i))
+		require.NoError(t, err)
+
+		l1Leaves[i] = &L1InfoTreeLeaf{
+			L1InfoTreeIndex: uint32(i),
+			RollupExitRoot:  rer.Hash,
+			MainnetExitRoot: rer.Hash,
+			Inner: &L1InfoTreeLeafInner{
+				BlockHash:      common.HexToHash(fmt.Sprintf("0x%040x", i*4+1)),
+				Timestamp:      uint64(i * 1000),
+				GlobalExitRoot: l1infotreesync.CalculateGER(rer.Hash, rer.Hash),
+			},
+		}
+
+		require.NoError(t, l1InfoTree.AddLeaf(tx, uint64(i), 0, types.Leaf{
+			Index: uint32(i),
+			Hash:  l1Leaves[i].Hash(),
+		}))
+	}
+
+	require.NoError(t, tx.Commit())
+
+	// lastRER, err := rollupExitTree.GetLastRoot(nil)
+	// require.NoError(t, err)
+
+	lastL1InfoRoot, err := l1InfoTree.GetLastRoot(nil)
+	require.NoError(t, err)
+
+	t.Run("ClaimFromMainnet - Valid Proofs", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromMainnnet{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLeafMER: &MerkleProof{
+					Root:  l1Leaves[0].MainnetExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.NoError(t, ibe.VerifyProofs(lastL1InfoRoot.Hash))
+	})
+
+	t.Run("ClaimFromMainnet - Invalid Proofs - Wrong L1 Root", func(t *testing.T) {
+		t.Parallel()
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromMainnnet{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  common.HexToHash("0x12345678"), // Wrong root
+					Proof: proofFromL1InfoTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), " Mismatch between the provided L1 root and the inclusion proof")
+	})
+
+	t.Run("ClaimFromMainnet - Mismatch on MER", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromMainnnet{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromRollupExitTree,
+				},
+				ProofLeafMER: &MerkleProof{
+					Root:  common.HexToHash("0x12345678"), // Wrong root
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Mismatch on the MER between the L1 leaf and the inclusion proof")
+	})
+
+	t.Run("ClaimFromMainnet - Invalid merkle path from the leaf to LER", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+		proofFromRollupExitTree[0][0] ^= 0xFF // Corrupt the proof
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromMainnnet{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLeafMER: &MerkleProof{
+					Root:  l1Leaves[0].MainnetExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "nvalid merkle path from the leaf to the LER")
+	})
+
+	t.Run("ClaimFromMainnet - Invalid merkle path from the GER to the L1 Info Root", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		proofFromL1InfoTree[0][0] ^= 0xFF // Corrupt the proof
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromMainnnet{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLeafMER: &MerkleProof{
+					Root:  l1Leaves[0].MainnetExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Invalid merkle path from the GER to the L1 Info Root")
+	})
+
+	t.Run("ClaimRollup - Invalid Proofs - Wrong L1 Root", func(t *testing.T) {
+		t.Parallel()
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromRollup{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  common.HexToHash("0x12345678"), // Wrong root
+					Proof: proofFromL1InfoTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Mismatch between the provided L1 root and the inclusion proof")
+	})
+
+	t.Run("ClaimFromRollup - Mismatch on RER", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromRollup{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromRollupExitTree,
+				},
+				ProofLERToRER: &MerkleProof{
+					Root:  common.HexToHash("0x12345678"), // Wrong root
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Mismatch on the RER between the L1 leaf and the inclusion proof")
+	})
+
+	t.Run("ClaimFromRollup - Invalid merkle path from the leaf to LER", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+		proofFromRollupExitTree[0][0] ^= 0xFF // Corrupt the proof
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromRollup{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLERToRER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				ProofLeafLER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex:   0,
+				RollupIndex: 0,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Invalid merkle path from the leaf to the LER")
+	})
+
+	t.Run("ClaimFromRollup - Invalid merkle path from the LER to the RER", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		proofCopy := proofFromRollupExitTree
+		proofCopy[0][0] ^= 0xFF // Corrupt the proof
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromRollup{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLERToRER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				ProofLeafLER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex:   0,
+				RollupIndex: 1,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Invalid merkle path from the LER to the RER")
+	})
+
+	t.Run("ClaimFromRollup - Invalid merkle path from the GER to the L1 Info Root", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+		proofFromL1InfoTree[0][0] ^= 0xFF // Corrupt the proof
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromRollup{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLERToRER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				ProofLeafLER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex:   0,
+				RollupIndex: 1,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Invalid merkle path from the GER to the L1 Info Root")
+	})
+
+	t.Run("ClaimFromRollup - Invalid merkle path from the GER to the L1 Info Root", func(t *testing.T) {
+		t.Parallel()
+
+		rer, err := rollupExitTree.GetRootByIndex(ctx, uint32(0))
+		require.NoError(t, err)
+		proofFromRollupExitTree, err := rollupExitTree.GetProof(ctx, uint32(0), rer.Hash)
+		require.NoError(t, err)
+
+		proofFromL1InfoTree, err := l1InfoTree.GetProof(ctx, uint32(0), lastL1InfoRoot.Hash)
+		require.NoError(t, err)
+
+		ibe := &ImportedBridgeExit{
+			BridgeExit: bridgeExits[0],
+			ClaimData: &ClaimFromRollup{
+				ProofGERToL1Root: &MerkleProof{
+					Root:  lastL1InfoRoot.Hash,
+					Proof: proofFromL1InfoTree,
+				},
+				ProofLERToRER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				ProofLeafLER: &MerkleProof{
+					Root:  l1Leaves[0].RollupExitRoot,
+					Proof: proofFromRollupExitTree,
+				},
+				L1Leaf: l1Leaves[0],
+			},
+			GlobalIndex: &GlobalIndex{
+				LeafIndex:   0,
+				RollupIndex: 1,
+			},
+		}
+
+		require.ErrorContains(t, ibe.VerifyProofs(lastL1InfoRoot.Hash), "Invalid merkle path from the LER to the RER")
+	})
+}
+
+func createTreeDBForTest(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := path.Join(t.TempDir(), "tree_createTreeDBForTest.sqlite")
+	err := migrations.RunMigrations(dbPath)
+	require.NoError(t, err)
+	treeDB, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	return treeDB
 }

--- a/aggsender/aggchainproofclient/aggchain_proof_client_test.go
+++ b/aggsender/aggchainproofclient/aggchain_proof_client_test.go
@@ -139,7 +139,7 @@ func TestGenerateAggchainProof_Error(t *testing.T) {
 						RollupIndex: 1,
 						LeafIndex:   1,
 					},
-					ClaimData: &agglayer.ClaimFromMainnnet{
+					ClaimData: &agglayer.ClaimFromMainnet{
 						ProofLeafMER: &agglayer.MerkleProof{
 							Root:  common.HexToHash("0x3"),
 							Proof: tree.EmptyProof,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -162,7 +162,7 @@ func TestExploratoryGenerateCert(t *testing.T) {
 					Amount:             big.NewInt(100),
 					Metadata:           []byte("metadata"),
 				},
-				ClaimData: &agglayertypes.ClaimFromMainnnet{
+				ClaimData: &agglayertypes.ClaimFromMainnet{
 					ProofLeafMER: &agglayertypes.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: [32]common.Hash{},

--- a/aggsender/converters/imported_bridge_exit_converter.go
+++ b/aggsender/converters/imported_bridge_exit_converter.go
@@ -86,7 +86,7 @@ func ConvertToImportedBridgeExit(
 	}
 
 	if ibe.GlobalIndex.MainnetFlag {
-		ibe.ClaimData = &agglayertypes.ClaimFromMainnnet{
+		ibe.ClaimData = &agglayertypes.ClaimFromMainnet{
 			L1Leaf: &agglayertypes.L1InfoTreeLeaf{
 				L1InfoTreeIndex: l1Info.L1InfoTreeIndex,
 				RollupExitRoot:  claim.RollupExitRoot,

--- a/aggsender/converters/imported_bridge_exit_converter.go
+++ b/aggsender/converters/imported_bridge_exit_converter.go
@@ -176,3 +176,38 @@ func ConvertToImportedBridgeExits(
 
 	return importedBridgeExits, nil
 }
+
+// ConvertToImportedBridgeExitsWithoutClaimData converts a slice of bridgesync.Claim
+// objects to a slice of agglayertypes.ImportedBridgeExit objects without claim data.
+// It returns an empty slice if no claims are provided, and returns an error if any
+// individual claim conversion fails.
+// This is useful when the claim data is not needed, such as when we don't want to
+// use the debug endpoint to retrieve the claim data.
+//
+// Parameters:
+//   - claims: A slice of bridgesync.Claim objects to be converted
+//
+// Returns:
+//   - A slice of *agglayertypes.ImportedBridgeExit objects on success
+//   - An error if any claim conversion fails
+func ConvertToImportedBridgeExitsWithoutClaimData(
+	claims []bridgesync.Claim,
+) ([]*agglayertypes.ImportedBridgeExit, error) {
+	if len(claims) == 0 {
+		// no claims to convert
+		return []*agglayertypes.ImportedBridgeExit{}, nil
+	}
+
+	importedBridgeExits := make([]*agglayertypes.ImportedBridgeExit, 0, len(claims))
+
+	for _, claim := range claims {
+		ibe, err := ConvertToImportedBridgeExitWithoutClaimData(claim)
+		if err != nil {
+			return nil, fmt.Errorf("error converting claim to imported bridge exit without claim data: %w", err)
+		}
+
+		importedBridgeExits = append(importedBridgeExits, ibe)
+	}
+
+	return importedBridgeExits, nil
+}

--- a/aggsender/converters/imported_bridge_exit_converter_test.go
+++ b/aggsender/converters/imported_bridge_exit_converter_test.go
@@ -381,6 +381,82 @@ func TestGetImportedBridgeExits(t *testing.T) {
 	}
 }
 
+func TestConvertToImportedBridgeExitsWithoutClaimData_NoClaims(t *testing.T) {
+	t.Parallel()
+
+	exits, err := ConvertToImportedBridgeExitsWithoutClaimData([]bridgesync.Claim{})
+	require.NoError(t, err)
+	require.Equal(t, []*agglayertypes.ImportedBridgeExit{}, exits)
+}
+
+func TestConvertToImportedBridgeExitsWithoutClaimData_MultipleClaims(t *testing.T) {
+	t.Parallel()
+
+	claims := []bridgesync.Claim{
+		{
+			IsMessage:          false,
+			OriginNetwork:      1,
+			OriginAddress:      common.HexToAddress("0x123"),
+			DestinationAddress: common.HexToAddress("0x456"),
+			Amount:             big.NewInt(100),
+			GlobalIndex:        big.NewInt(1),
+			BlockNum:           100,
+			BlockPos:           1,
+		},
+		{
+			IsMessage:          true,
+			OriginNetwork:      3,
+			OriginAddress:      common.HexToAddress("0x789"),
+			DestinationAddress: common.HexToAddress("0xabc"),
+			Amount:             big.NewInt(200),
+			GlobalIndex:        big.NewInt(2),
+			BlockNum:           101,
+			BlockPos:           2,
+		},
+	}
+
+	expected := []*agglayertypes.ImportedBridgeExit{
+		{
+			BridgeExit: &agglayertypes.BridgeExit{
+				LeafType: agglayertypes.LeafTypeAsset,
+				TokenInfo: &agglayertypes.TokenInfo{
+					OriginNetwork:      1,
+					OriginTokenAddress: common.HexToAddress("0x123"),
+				},
+				DestinationAddress: common.HexToAddress("0x456"),
+				Amount:             big.NewInt(100),
+				Metadata:           crypto.Keccak256(nil),
+			},
+			GlobalIndex: &agglayertypes.GlobalIndex{
+				MainnetFlag: false,
+				RollupIndex: 0,
+				LeafIndex:   1,
+			},
+		},
+		{
+			BridgeExit: &agglayertypes.BridgeExit{
+				LeafType: agglayertypes.LeafTypeMessage,
+				TokenInfo: &agglayertypes.TokenInfo{
+					OriginNetwork:      3,
+					OriginTokenAddress: common.HexToAddress("0x789"),
+				},
+				DestinationAddress: common.HexToAddress("0xabc"),
+				Amount:             big.NewInt(200),
+				Metadata:           crypto.Keccak256(nil),
+			},
+			GlobalIndex: &agglayertypes.GlobalIndex{
+				MainnetFlag: false,
+				RollupIndex: 0,
+				LeafIndex:   2,
+			},
+		},
+	}
+
+	exits, err := ConvertToImportedBridgeExitsWithoutClaimData(claims)
+	require.NoError(t, err)
+	require.Equal(t, expected, exits)
+}
+
 func generateTestProof(t *testing.T) treetypes.Proof {
 	t.Helper()
 

--- a/aggsender/converters/imported_bridge_exit_converter_test.go
+++ b/aggsender/converters/imported_bridge_exit_converter_test.go
@@ -300,7 +300,7 @@ func TestGetImportedBridgeExits(t *testing.T) {
 						RollupIndex: 0,
 						LeafIndex:   2,
 					},
-					ClaimData: &agglayertypes.ClaimFromMainnnet{
+					ClaimData: &agglayertypes.ClaimFromMainnet{
 						L1Leaf: &agglayertypes.L1InfoTreeLeaf{
 							L1InfoTreeIndex: 1,
 							RollupExitRoot:  common.HexToHash("0xbbb"),

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -39,7 +39,9 @@ func NewFlow(
 	case types.PessimisticProofMode:
 		commonFlowComponents, err := CreateCommonFlowComponents(
 			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier, 0, false,
-			cfg.MaxCertSize, cfg.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
+			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
+			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
+			true,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -76,7 +78,9 @@ func NewFlow(
 		commonFlowComponents, err := CreateCommonFlowComponents(
 			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier,
 			aggchainFEPQuerier.StartL2Block(), cfg.RequireNoFEPBlockGap,
-			cfg.MaxCertSize, cfg.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
+			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
+			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
+			true,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -136,6 +140,7 @@ func CreateCommonFlowComponents(
 	rollupCreationBlockL1 uint64,
 	delayBetweenRetries time.Duration,
 	signerCfg signertypes.SignerConfig,
+	fullClaimsRequired bool,
 ) (*CommonFlowComponents, error) {
 	signer, err := initializeSigner(ctx, signerCfg, logger)
 	if err != nil {
@@ -148,7 +153,7 @@ func CreateCommonFlowComponents(
 
 	baseFlow := NewBaseFlow(
 		logger, l2BridgeQuerier, storage, l1InfoTreeQuerier, lerQuerier,
-		NewBaseFlowConfig(maxCertSize, startL2Block, requireNoFEPBlockGap),
+		NewBaseFlowConfig(maxCertSize, startL2Block, requireNoFEPBlockGap, fullClaimsRequired),
 	)
 
 	return &CommonFlowComponents{

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -460,7 +460,7 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 				nil, // sotrage
 				nil, // l1InfoTreeDataQuerier,
 				nil, // lerQuerier
-				NewBaseFlowConfig(0, tc.startL2Block, false),
+				NewBaseFlowConfig(0, tc.startL2Block, false, true),
 			)
 			flow := NewAggchainProverFlow(
 				logger,

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -39,6 +39,8 @@ type BaseFlowConfig struct {
 	// RequireNoFEPBlockGap indicates whether the flow requires no gap between the
 	// first FEP block and last settled certificate.
 	RequireNoFEPBlockGap bool
+	// FullClaimsNeeded indicates whether the flow requires full claims data
+	FullClaimsNeeded bool
 }
 
 // NewBaseFlowConfigDefault returns a BaseFlowConfig with default values
@@ -47,15 +49,22 @@ func NewBaseFlowConfigDefault() BaseFlowConfig {
 		MaxCertSize:          0,     // 0 means no limit
 		StartL2Block:         0,     // 0 means start from the first block
 		RequireNoFEPBlockGap: false, // default is false, can be set to true if needed
+		FullClaimsNeeded:     true,  // default is true, can be set to false if full claims are not needed
 	}
 }
 
 // NewBaseFlowConfig returns a BaseFlowConfig with the specified maxCertSize and startL2Block
-func NewBaseFlowConfig(maxCertSize uint, startL2Block uint64, requireNoFEPBlockGap bool) BaseFlowConfig {
+func NewBaseFlowConfig(
+	maxCertSize uint,
+	startL2Block uint64,
+	requireNoFEPBlockGap bool,
+	fullClaimsNeeded bool,
+) BaseFlowConfig {
 	return BaseFlowConfig{
 		MaxCertSize:          maxCertSize,
 		StartL2Block:         startL2Block,
 		RequireNoFEPBlockGap: requireNoFEPBlockGap,
+		FullClaimsNeeded:     fullClaimsNeeded,
 	}
 }
 
@@ -328,8 +337,12 @@ func (f *baseFlow) getImportedBridgeExits(
 	ctx context.Context, claims []bridgesync.Claim,
 	rootFromWhichToProve common.Hash,
 ) ([]*agglayertypes.ImportedBridgeExit, error) {
-	return converters.ConvertToImportedBridgeExits(
-		ctx, claims, rootFromWhichToProve, f.l1InfoTreeDataQuerier)
+	if f.cfg.FullClaimsNeeded {
+		return converters.ConvertToImportedBridgeExits(
+			ctx, claims, rootFromWhichToProve, f.l1InfoTreeDataQuerier)
+	}
+
+	return converters.ConvertToImportedBridgeExitsWithoutClaimData(claims)
 }
 
 // getNextHeightAndPreviousLER returns the height and previous LER for the new certificate

--- a/aggsender/flows/flow_base_test.go
+++ b/aggsender/flows/flow_base_test.go
@@ -123,7 +123,7 @@ func Test_baseFlow_limitCertSize(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				NewBaseFlowConfig(tt.maxCertSize, 0, false))
+				NewBaseFlowConfig(tt.maxCertSize, 0, false, true))
 
 			result, err := f.LimitCertSize(tt.fullCert)
 

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -228,6 +228,7 @@ func TestBuildCertificate(t *testing.T) {
 				l2BridgeQuerier:       mockL2BridgeQuerier,
 				l1InfoTreeDataQuerier: mockL1InfoTreeQuerier,
 				log:                   log.WithFields("test", "unittest"),
+				cfg:                   NewBaseFlowConfigDefault(),
 			}
 
 			certParam := &types.CertificateBuildParams{
@@ -539,7 +540,7 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			baseFlow := &baseFlow{cfg: NewBaseFlowConfig(0, tt.startL2Block, false)}
+			baseFlow := &baseFlow{cfg: NewBaseFlowConfig(0, tt.startL2Block, false, true)}
 
 			block, retryCount := baseFlow.getLastSentBlockAndRetryCount(tt.lastSentCertificate)
 

--- a/aggsender/validator/compare_certs.go
+++ b/aggsender/validator/compare_certs.go
@@ -56,9 +56,6 @@ func DiffsCertificate(
 
 	// BridgeExits
 	diffs = append(diffs, DiffsBridgeExits(expectedCertificate.BridgeExits, validatingCertificate.BridgeExits)...)
-	// ImportedBridgeExit
-	diffs = append(diffs, DiffsImportedBridgeExit(expectedCertificate.ImportedBridgeExits,
-		validatingCertificate.ImportedBridgeExits)...)
 
 	return diffs
 }
@@ -79,27 +76,6 @@ func DiffsBridgeExits(
 		if bridgeValidating.Hash() != expectedExit.Hash() {
 			diffs = append(diffs, fmt.Sprintf("BridgeExit %d hash mismatch. Expected: %s, Certificate: %s",
 				i, expectedExit.Hash().Hex(), bridgeValidating.Hash().Hex()))
-		}
-	}
-	return diffs
-}
-
-// DiffsImportedBridgeExit compares two slices of ImportedBridgeExit and returns a slice of strings
-// containing the differences between them.
-func DiffsImportedBridgeExit(expected []*agglayertypes.ImportedBridgeExit,
-	validating []*agglayertypes.ImportedBridgeExit) []string {
-	diffs := make([]string, 0)
-	if len(expected) != len(validating) {
-		diffs = append(diffs, fmt.Sprintf("BridgeExits length mismatch. Expected: %d, Certificate: %d",
-			len(expected), len(validating)))
-		return diffs
-	}
-	for i, expectedImportedBridge := range expected {
-		importedBridgeValidating := validating[i]
-		if importedBridgeValidating.Hash() != expectedImportedBridge.Hash() {
-			diffs = append(diffs, fmt.Sprintf("ImportedBridgeExit %d hash mismatch.\n Expected: %s,\n"+
-				"Certificate: %s",
-				i, expectedImportedBridge.String(), importedBridgeValidating.String()))
 		}
 	}
 	return diffs

--- a/aggsender/validator/validate_certificate.go
+++ b/aggsender/validator/validate_certificate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	treetypes "github.com/agglayer/aggkit/tree/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
@@ -116,10 +117,30 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 		return fmt.Errorf("failed flow.ValidateCertificate: %w", err)
 	}
 
+	// Verify claim proofs
+	if err := a.verifyClaimProofs(
+		params.Certificate.ImportedBridgeExits,
+		buildParams.L1InfoTreeRootFromWhichToProve); err != nil {
+		return fmt.Errorf("failed to verify claim proofs: %w", err)
+	}
+
 	// Compare the incoming certificate with the one generated
 	err = a.compareCertificates(params.Certificate, certificate)
 	if err != nil {
 		return fmt.Errorf("certificate not equal to expected: %w", err)
+	}
+
+	return nil
+}
+
+func (a *CertificateValidator) verifyClaimProofs(
+	importedBridgeExits []*agglayertypes.ImportedBridgeExit,
+	rootFromWhichToProve common.Hash,
+) error {
+	for _, ibe := range importedBridgeExits {
+		if err := ibe.VerifyProofs(rootFromWhichToProve); err != nil {
+			return fmt.Errorf("failed to verify imported bridge exit proof: %s. Err: %w", ibe.String(), err)
+		}
 	}
 
 	return nil

--- a/aggsender/validator/validator_client_test.go
+++ b/aggsender/validator/validator_client_test.go
@@ -57,7 +57,7 @@ func TestClient_ValidateCertificate(t *testing.T) {
 					Amount:             big.NewInt(100),
 					Metadata:           []byte("metadata-1"),
 				},
-				ClaimData: &agglayertypes.ClaimFromMainnnet{
+				ClaimData: &agglayertypes.ClaimFromMainnet{
 					ProofLeafMER: &agglayertypes.MerkleProof{
 						Root:  common.HexToHash("0x1"),
 						Proof: [32]common.Hash{},

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -181,6 +181,8 @@ func newBridgeSync(
 		return nil, err
 	}
 
+	logger.Infof("Bridge sync %s, syncing full claims: %t", syncerID.String(), syncFullClaims)
+
 	err = sanityCheckContract(logger, bridge, bridgeContractV2)
 	if err != nil {
 		logger.Errorf("sanityCheckContract(bridge:%s) fails sanity check. Err: %w",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -245,6 +245,7 @@ func createAggSenderValidator(ctx context.Context,
 			nil, // storage is not used in validator,
 			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, false,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
+			false, // full claims are not needed in validator mode
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -252,14 +253,7 @@ func createAggSenderValidator(ctx context.Context,
 
 		flow = flows.NewPPFlow(
 			logger,
-			flows.NewBaseFlow(
-				logger,
-				commonFlowComponents.L2BridgeQuerier,
-				nil, // storage is not used in validator
-				commonFlowComponents.L1InfoTreeDataQuerier,
-				commonFlowComponents.LERQuerier,
-				flows.NewBaseFlowConfig(cfg.MaxCertSize, 0, false),
-			),
+			commonFlowComponents.BaseFlow,
 			nil, // storage is not used in validator
 			commonFlowComponents.L1InfoTreeDataQuerier,
 			commonFlowComponents.L2BridgeQuerier,
@@ -272,7 +266,9 @@ func createAggSenderValidator(ctx context.Context,
 			ctx, logger,
 			nil, // storage is not used in validator,
 			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, cfg.FEPConfig.RequireNoBlockGap,
-			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
+			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1,
+			cfg.DelayBetweenRetries.Duration, cfg.Signer,
+			false, // full claims are not needed in validator mode
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -689,11 +685,17 @@ func runBridgeSyncL2IfNeeded(
 	l2Client aggkittypes.EthClienter,
 	rollupID uint32,
 ) *bridgesync.BridgeSync {
-	if !isNeeded([]string{
+	fullClaimsNeeded := isNeeded([]string{
 		aggkitcommon.BRIDGE,
 		aggkitcommon.AGGSENDER,
+		aggkitcommon.AGGCHAINPROOFGEN}, components)
+
+	fullClaimsNotNeeded := isNeeded([]string{
 		aggkitcommon.AGGSENDERVALIDATOR,
-		aggkitcommon.AGGCHAINPROOFGEN}, components) {
+	}, components)
+
+	if !fullClaimsNeeded && !fullClaimsNotNeeded {
+		// no bridge sync needed
 		return nil
 	}
 
@@ -710,7 +712,7 @@ func runBridgeSyncL2IfNeeded(
 		cfg.RetryAfterErrorPeriod.Duration,
 		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
-		true,
+		fullClaimsNeeded,
 		cfg.RequireStorageContentCompatibility,
 	)
 	if err != nil {

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -134,12 +134,16 @@ func (l *L1InfoTreeLeaf) GetHash() common.Hash {
 
 // GlobalExitRoot returns the GER
 func (l *L1InfoTreeLeaf) GetGlobalExitRoot() common.Hash {
+	return CalculateGER(l.MainnetExitRoot, l.RollupExitRoot)
+}
+
+// CalculateGER calculates the Global Exit Root (GER) based on the mainnet and rollup exit roots
+func CalculateGER(mainnetExitRoot, rollupExitRoot common.Hash) common.Hash {
 	var gerBytes [treeTypes.DefaultHeight]byte
 	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write(l.MainnetExitRoot[:])
-	hasher.Write(l.RollupExitRoot[:])
+	hasher.Write(mainnetExitRoot[:])
+	hasher.Write(rollupExitRoot[:])
 	copy(gerBytes[:], hasher.Sum(nil))
-
 	return gerBytes
 }
 

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -262,7 +262,7 @@ func CalculateRoot(leafHash common.Hash, proof [types.DefaultHeight]common.Hash,
 	node := leafHash
 
 	// Compute the Merkle root
-	for height := uint8(0); height < types.DefaultHeight; height++ {
+	for height := range types.DefaultHeight {
 		if (index>>height)&1 == 1 {
 			node = crypto.Keccak256Hash(proof[height].Bytes(), node.Bytes())
 		} else {
@@ -271,4 +271,18 @@ func CalculateRoot(leafHash common.Hash, proof [types.DefaultHeight]common.Hash,
 	}
 
 	return node
+}
+
+// VerifyProof validates a Merkle proof for a given leaf index against an expected root.
+// It returns nil when the proof is valid or an error describing the mismatch.
+func VerifyProof(leaf common.Hash, proof types.Proof, index uint32, expectedRoot common.Hash) error {
+	calculated := CalculateRoot(leaf, proof, index)
+	if calculated == expectedRoot {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"invalid proof: calculated root %s does not match expected root %s",
+		calculated.Hex(), expectedRoot.Hex(),
+	)
 }

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -262,7 +262,7 @@ func CalculateRoot(leafHash common.Hash, proof [types.DefaultHeight]common.Hash,
 	node := leafHash
 
 	// Compute the Merkle root
-	for height := range types.DefaultHeight {
+	for height := uint8(0); height < types.DefaultHeight; height++ {
 		if (index>>height)&1 == 1 {
 			node = crypto.Keccak256Hash(proof[height].Bytes(), node.Bytes())
 		} else {

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -198,6 +198,49 @@ func TestMTGetProof(t *testing.T) {
 	}
 }
 
+func TestVerifyProof(t *testing.T) {
+	ctx := context.Background()
+	treeDB := createTreeDBForTest(t)
+	tre := NewAppendOnlyTree(treeDB, "")
+
+	numOfLeavesToAdd := 11
+
+	// add a few leaves
+	tx, err := db.NewTx(ctx, treeDB)
+	require.NoError(t, err)
+	for i := range numOfLeavesToAdd {
+		require.NoError(t, tre.AddLeaf(tx, uint64(i), 0, types.Leaf{
+			Index: uint32(i),
+			Hash:  common.HexToHash(fmt.Sprintf("%x", i)),
+		}))
+	}
+	require.NoError(t, tx.Commit())
+
+	root, err := tre.GetLastRoot(nil)
+	require.NoError(t, err)
+
+	for i := range numOfLeavesToAdd {
+		leaf := common.HexToHash(fmt.Sprintf("%x", i))
+		proof, err := tre.GetProof(ctx, uint32(i), root.Hash)
+		require.NoError(t, err)
+
+		// valid proof should return nil
+		require.NoError(t, VerifyProof(leaf, proof, uint32(i), root.Hash))
+
+		// corrupted root should produce an error
+		corruptedRoot := root.Hash
+		corruptedRoot[0] ^= 0xFF
+		require.Error(t, VerifyProof(leaf, proof, uint32(i), corruptedRoot))
+
+		// wrong leaf should produce an error
+		wrongLeaf := common.HexToHash("deadbeef")
+		require.Error(t, VerifyProof(wrongLeaf, proof, uint32(i), root.Hash))
+
+		// wrong index should produce an error
+		require.Error(t, VerifyProof(leaf, proof, uint32(i+1), root.Hash))
+	}
+}
+
 func createTreeDBForTest(t *testing.T) *sql.DB {
 	t.Helper()
 	dbPath := path.Join(t.TempDir(), "tree_createTreeDBForTest.sqlite")


### PR DESCRIPTION
## 🔄 Changes Summary
This PR removes the dependency on the `debug` endpoint on an L2 rpc on the `aggsender-validator`, meaning, when `aggsender-validator` is run by itself on a separate container, without `bridge`, `aggsender` and `aggchain-proof-gen` components, it will not use sync the full claims.

What the `aggsender-validator` will do when verifying the new certificate gotten from the `aggsender-proposer` is that, it will verify the proofs for each `claim` (`imported bridge exit`) provided by the proposer by using the calculated finalized `L1 info tree root` on the validator.

This decouples the validator from the debug endpoints, which, depending on the rpc provider, can be supported, or in some cases, even not provided. Plus, checking the proofs on each `claim` by using the `L1 info tree root` the validator provided, makes an addition security check of validity of a proposed ceritifacte.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkti` CI

## 🐞 Issues
- Closes #892
