### PR TITLE
feat: filter logs recursively

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -202,7 +202,7 @@ RequireValidatorCall = false
 	[AggSender.RetriesToBuildAndSendCertificate]
 		RetryMode = "delays"
 		Delays = [ "1m", "1m", "2m", "5m", "5m", "8m" ]
-		MaxRetries = 6 # 1+6 attempts, around 22m 
+		MaxRetries = 6 # 1+6 attempts, around 22m
 	[AggSender.AgglayerClient]
 		Cached = false
 		[AggSender.AgglayerClient.ConfigurationCache]

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/agglayer/aggkit/log"
@@ -325,6 +326,11 @@ func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context,
 	return d.getEventsByBlockRangeWithRetry(ctx, fromBlock, toBlock, 0)
 }
 
+func (d *EVMDownloaderImplementation) GetLogs(ctx context.Context, fromBlock, toBlock uint64) []types.Log {
+	unfilteredLogs := d.getUnfilteredLogs(ctx, fromBlock, toBlock)
+	return d.filterLogs(unfilteredLogs)
+}
+
 func (d *EVMDownloaderImplementation) getEventsByBlockRangeWithRetry(
 	ctx context.Context,
 	fromBlock, toBlock uint64, retryCount int,
@@ -395,7 +401,7 @@ func filterQueryToString(query ethereum.FilterQuery) string {
 		query.FromBlock.String(), query.ToBlock.String(), query.Addresses, query.Topics)
 }
 
-func (d *EVMDownloaderImplementation) GetLogs(ctx context.Context, fromBlock, toBlock uint64) []types.Log {
+func (d *EVMDownloaderImplementation) getUnfilteredLogs(ctx context.Context, fromBlock, toBlock uint64) []types.Log {
 	var (
 		attempts       = 0
 		unfilteredLogs []types.Log
@@ -416,28 +422,49 @@ func (d *EVMDownloaderImplementation) GetLogs(ctx context.Context, fromBlock, to
 				return nil
 			}
 
+			errStr := err.Error()
+			if strings.Contains(errStr, "Query returned more than") && fromBlock < toBlock {
+				midBlock := (fromBlock + toBlock) / 2
+				if midBlock >= fromBlock {
+					d.log.Warnf("too many results for block range [%d, %d], splitting into [%d, %d] and [%d, %d]",
+						fromBlock, toBlock, fromBlock, midBlock, midBlock+1, toBlock)
+
+					firstHalf := d.getUnfilteredLogs(ctx, fromBlock, midBlock)
+					secondHalf := d.getUnfilteredLogs(ctx, midBlock+1, toBlock)
+
+					combined := make([]types.Log, 0, len(firstHalf)+len(secondHalf))
+					combined = append(combined, firstHalf...)
+					combined = append(combined, secondHalf...)
+
+					return combined
+				}
+			}
+
 			attempts++
-			d.log.Errorf("error calling FilterLogs to eth client: filter: %s err:%w ",
+			d.log.Errorf("error calling UnfilteredFilterLogs to eth client: filter: %s err:%w ",
 				filterQueryToString(query),
 				err,
 			)
-			d.rh.Handle(ctx, "getLogs", attempts)
+			d.rh.Handle(ctx, "getUnfilteredLogs", attempts)
 			continue
 		}
 		break
 	}
+	return unfilteredLogs
+}
 
-	logs := make([]types.Log, 0, len(unfilteredLogs))
+func (d *EVMDownloaderImplementation) filterLogs(unfilteredLogs []types.Log) []types.Log {
+	filteredLogs := make([]types.Log, 0, len(unfilteredLogs))
 	for _, l := range unfilteredLogs {
 		if l.Removed {
 			d.log.Warnf("log removed: %+v", l)
 			continue
 		}
 		if slices.Contains(d.topicsToQuery, l.Topics[0]) {
-			logs = append(logs, l)
+			filteredLogs = append(filteredLogs, l)
 		}
 	}
-	return logs
+	return filteredLogs
 }
 
 func (d *EVMDownloaderImplementation) GetBlockHeader(ctx context.Context, blockNum uint64) (EVMBlockHeader, bool) {

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -424,7 +424,7 @@ func (d *EVMDownloaderImplementation) getUnfilteredLogs(ctx context.Context, fro
 
 			errStr := err.Error()
 			if strings.Contains(errStr, "Query returned more than") && fromBlock < toBlock {
-				midBlock := (fromBlock + toBlock) / 2
+				midBlock := (fromBlock + toBlock) / 2 //nolint:gomnd
 				if midBlock >= fromBlock {
 					d.log.Warnf("too many results for block range [%d, %d], splitting into [%d, %d] and [%d, %d]",
 						fromBlock, toBlock, fromBlock, midBlock, midBlock+1, toBlock)

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -402,55 +402,66 @@ func filterQueryToString(query ethereum.FilterQuery) string {
 }
 
 func (d *EVMDownloaderImplementation) getUnfilteredLogs(ctx context.Context, fromBlock, toBlock uint64) []types.Log {
+	initialBatchSize := toBlock - fromBlock + 1
 	var (
-		attempts       = 0
-		unfilteredLogs []types.Log
-		err            error
+		results   []types.Log
+		batchSize = initialBatchSize
 	)
 
-	query := ethereum.FilterQuery{
-		Addresses: d.addressesToQuery,
-		FromBlock: new(big.Int).SetUint64(fromBlock),
-		ToBlock:   new(big.Int).SetUint64(toBlock),
-	}
+	for start := fromBlock; start <= toBlock; {
+		end := start + batchSize - 1
+		if end > toBlock {
+			end = toBlock
+		}
 
-	for {
-		unfilteredLogs, err = d.ethClient.FilterLogs(ctx, query)
-		if err != nil {
+		query := ethereum.FilterQuery{
+			Addresses: d.addressesToQuery,
+			FromBlock: new(big.Int).SetUint64(start),
+			ToBlock:   new(big.Int).SetUint64(end),
+		}
+
+		var attempts int
+		for {
+			logs, err := d.ethClient.FilterLogs(ctx, query)
+			if err == nil {
+				results = append(results, logs...)
+				break
+			}
+
 			if errors.Is(err, context.Canceled) {
 				// context is canceled, we don't want to fatal on max attempts in this case
+				d.log.Errorf("context is canceled getUnfilteredLogs, returning nil")
 				return nil
 			}
 
-			errStr := err.Error()
-			if strings.Contains(errStr, "Query returned more than") && fromBlock < toBlock {
-				midBlock := (fromBlock + toBlock) / 2 //nolint:mnd
-				if midBlock >= fromBlock {
-					d.log.Warnf("too many results for block range [%d, %d], splitting into [%d, %d] and [%d, %d]",
-						fromBlock, toBlock, fromBlock, midBlock, midBlock+1, toBlock)
-
-					firstHalf := d.getUnfilteredLogs(ctx, fromBlock, midBlock)
-					secondHalf := d.getUnfilteredLogs(ctx, midBlock+1, toBlock)
-
-					combined := make([]types.Log, 0, len(firstHalf)+len(secondHalf))
-					combined = append(combined, firstHalf...)
-					combined = append(combined, secondHalf...)
-
-					return combined
+			if strings.Contains(err.Error(), "Query returned more than") {
+				if batchSize == 1 {
+					d.log.Errorf("too many logs even in single block %d", start)
+					return nil
 				}
+
+				batchSize /= 2
+				d.log.Warnf("too many logs in range [%d,%d], reducing batch size to %d", start, end, batchSize)
+				end = start + batchSize - 1
+				if end > toBlock {
+					end = toBlock
+				}
+				// Update query with new range
+				query.ToBlock = new(big.Int).SetUint64(end)
+				continue
 			}
 
 			attempts++
-			d.log.Errorf("error calling UnfilteredFilterLogs to eth client: filter: %s err:%w ",
+			d.log.Errorf("error calling FilterLogs to eth client: filter: %s err:%w ",
 				filterQueryToString(query),
 				err,
 			)
 			d.rh.Handle(ctx, "getUnfilteredLogs", attempts)
-			continue
 		}
-		break
+		start = end + 1
 	}
-	return unfilteredLogs
+
+	return results
 }
 
 func (d *EVMDownloaderImplementation) filterLogs(unfilteredLogs []types.Log) []types.Log {

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -424,7 +424,7 @@ func (d *EVMDownloaderImplementation) getUnfilteredLogs(ctx context.Context, fro
 
 			errStr := err.Error()
 			if strings.Contains(errStr, "Query returned more than") && fromBlock < toBlock {
-				midBlock := (fromBlock + toBlock) / 2 //nolint:gomnd
+				midBlock := (fromBlock + toBlock) / 2 //nolint:mnd
 				if midBlock >= fromBlock {
 					d.log.Warnf("too many results for block range [%d, %d], splitting into [%d, %d] and [%d, %d]",
 						fromBlock, toBlock, fromBlock, midBlock, midBlock+1, toBlock)

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -616,19 +616,19 @@ func TestTooManyResultsErrorHandling(t *testing.T) {
 	tooManyResultsErr := errors.New("Query returned more than 20000 results.")
 	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(nil, tooManyResultsErr).Once()
 
-	// Second call for first half returns success
-	firstHalfLogs := []types.Log{
+	// Second call for first batch (100-149) succeeds
+	firstBatchLogs := []types.Log{
 		{
 			Address:     contractAddr,
-			BlockNumber: 150,
+			BlockNumber: 125,
 			Topics:      []common.Hash{eventSignature},
 			BlockHash:   common.HexToHash("0x123"),
 		},
 	}
-	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(firstHalfLogs, nil).Once()
+	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(firstBatchLogs, nil).Once()
 
-	// Third call for second half returns success
-	secondHalfLogs := []types.Log{
+	// Third call for second batch (150-199) succeeds
+	secondBatchLogs := []types.Log{
 		{
 			Address:     contractAddr,
 			BlockNumber: 175,
@@ -636,12 +636,25 @@ func TestTooManyResultsErrorHandling(t *testing.T) {
 			BlockHash:   common.HexToHash("0x456"),
 		},
 	}
-	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(secondHalfLogs, nil).Once()
+	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(secondBatchLogs, nil).Once()
+
+	// Fourth call for third batch (200-200) succeeds
+	thirdBatchLogs := []types.Log{
+		{
+			Address:     contractAddr,
+			BlockNumber: 200,
+			Topics:      []common.Hash{eventSignature},
+			BlockHash:   common.HexToHash("0x789"),
+		},
+	}
+	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(thirdBatchLogs, nil).Once()
+
 	result := sut.getUnfilteredLogs(ctx, fromBlock, toBlock)
 
-	// Should combine both halves
-	expected := make([]types.Log, 0, len(firstHalfLogs)+len(secondHalfLogs))
-	expected = append(expected, firstHalfLogs...)
-	expected = append(expected, secondHalfLogs...)
+	// Should combine all batches
+	expected := make([]types.Log, 0, len(firstBatchLogs)+len(secondBatchLogs)+len(thirdBatchLogs))
+	expected = append(expected, firstBatchLogs...)
+	expected = append(expected, secondBatchLogs...)
+	expected = append(expected, thirdBatchLogs...)
 	assert.Equal(t, expected, result)
 }

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -595,3 +595,53 @@ func runSteps(t *testing.T, fromBlock uint64, steps []evmTestStep) {
 		}
 	}
 }
+
+func TestTooManyResultsErrorHandling(t *testing.T) {
+	mockEthClient := aggkittypesmocks.NewBaseEthereumClienter(t)
+	sut := EVMDownloaderImplementation{
+		ethClient:        mockEthClient,
+		addressesToQuery: []common.Address{contractAddr},
+		log:              log.WithFields("test", "EVMDownloaderImplementation"),
+		rh: &RetryHandler{
+			RetryAfterErrorPeriod:      time.Millisecond,
+			MaxRetryAttemptsAfterError: 5,
+		},
+	}
+
+	ctx := context.Background()
+	fromBlock := uint64(100)
+	toBlock := uint64(200)
+
+	// First call returns "too many results" error
+	tooManyResultsErr := errors.New("Query returned more than 20000 results.")
+	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(nil, tooManyResultsErr).Once()
+
+	// Second call for first half returns success
+	firstHalfLogs := []types.Log{
+		{
+			Address:     contractAddr,
+			BlockNumber: 150,
+			Topics:      []common.Hash{eventSignature},
+			BlockHash:   common.HexToHash("0x123"),
+		},
+	}
+	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(firstHalfLogs, nil).Once()
+
+	// Third call for second half returns success
+	secondHalfLogs := []types.Log{
+		{
+			Address:     contractAddr,
+			BlockNumber: 175,
+			Topics:      []common.Hash{eventSignature},
+			BlockHash:   common.HexToHash("0x456"),
+		},
+	}
+	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(secondHalfLogs, nil).Once()
+
+	result := sut.getUnfilteredLogs(ctx, fromBlock, toBlock)
+	fmt.Println("result", result)
+
+	// Should combine both halves
+	expected := append(firstHalfLogs, secondHalfLogs...)
+	assert.Equal(t, expected, result)
+}

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -642,6 +642,8 @@ func TestTooManyResultsErrorHandling(t *testing.T) {
 	fmt.Println("result", result)
 
 	// Should combine both halves
-	expected := append(firstHalfLogs, secondHalfLogs...)
+	expected := make([]types.Log, 0, len(firstHalfLogs)+len(secondHalfLogs))
+	expected = append(expected, firstHalfLogs...)
+	expected = append(expected, secondHalfLogs...)
 	assert.Equal(t, expected, result)
 }

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -637,9 +637,7 @@ func TestTooManyResultsErrorHandling(t *testing.T) {
 		},
 	}
 	mockEthClient.EXPECT().FilterLogs(ctx, mock.Anything).Return(secondHalfLogs, nil).Once()
-
 	result := sut.getUnfilteredLogs(ctx, fromBlock, toBlock)
-	fmt.Println("result", result)
 
 	// Should combine both halves
 	expected := make([]types.Log, 0, len(firstHalfLogs)+len(secondHalfLogs))


### PR DESCRIPTION
## 🔄 Changes Summary
- This PR introduces change that makes `evmdownloader` fetch logs recursively using smaller block ranges when the original range contains too many logs.

## 🐞 Issues
- Closes #812 


