### PR TITLE
chore: fix typos in comments and test descriptions

### DIFF
--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -480,7 +480,7 @@ func (f *baseFlow) VerifyBlockRangeGaps(
 }
 
 // getLastSentBlockAndRetryCount returns the last sent block of the last sent certificate
-// if there is no previosly sent certificate, it returns startL2Block and 0
+// if there is no previously sent certificate, it returns startL2Block and 0
 func (f *baseFlow) getLastSentBlockAndRetryCount(lastSentCertificateInfo *types.CertificateHeader) (uint64, int) {
 	if lastSentCertificateInfo == nil {
 		// this is the first certificate so we start from what we have set in start L2 block

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -230,7 +230,7 @@ func (c *CertificateHeader) String() string {
 	)
 }
 
-// ID returns a string with the unique identifier of the cerificate (height+certificateID)
+// ID returns a string with the unique identifier of the certificate (height+certificateID)
 func (c *CertificateHeader) ID() string {
 	if c == nil {
 		return NilStr

--- a/common/retry_config_test.go
+++ b/common/retry_config_test.go
@@ -112,7 +112,7 @@ func TestRetryPolicyGenericConfig_Factory(t *testing.T) {
 		require.NotNil(t, cfg)
 		require.Equal(t, "RetryDelaysConfig{Delays: [], MaxRetries: NO RETRIES}", cfg.String())
 	})
-	t.Run("factory mode=delays with errrors", func(t *testing.T) {
+	t.Run("factory mode=delays with errors", func(t *testing.T) {
 		sut := &RetryPolicyGenericConfig{
 			Mode:       RetryConfigModeDelays,
 			MaxRetries: -2,


### PR DESCRIPTION


This PR addresses several typographical errors found in comments and test descriptions:

### Changes
- **`aggsender/flows/flow_base.go`**: Fixed "previosly" → "previously" in comment
- **`aggsender/types/types.go`**: Fixed "cerificate" → "certificate" in comment  
- **`common/retry_config_test.go`**: Fixed "errrors" → "errors" in test description



---
