### PR TITLE
feat: utilize network status `api` from `agglayer`

### DIFF
--- a/agglayer/agglayer_client_cache.go
+++ b/agglayer/agglayer_client_cache.go
@@ -126,9 +126,8 @@ func (c *AgglayerClientCache) GetLatestPendingCertificateHeader(ctx context.Cont
 	return c.agglayerClient.GetLatestPendingCertificateHeader(ctx, networkID)
 }
 
-// GetLatestSettledImportedBridgeExit retrieves the latest settled
-// imported bridge exit from the Agglayer client. (no cache)
-func (c *AgglayerClientCache) GetLatestSettledImportedBridgeExit(
-	ctx context.Context) (*agglayertypes.GlobalIndex, common.Hash, error) {
-	return c.agglayerClient.GetLatestSettledImportedBridgeExit(ctx)
+// GetNetworkStatus retrieves the network status for a given network ID from the Agglayer client. (no cache)
+func (c *AgglayerClientCache) GetNetworkStatus(
+	ctx context.Context, networkID uint32) (agglayertypes.NetworkStatus, error) {
+	return c.agglayerClient.GetNetworkStatus(ctx, networkID)
 }

--- a/agglayer/client.go
+++ b/agglayer/client.go
@@ -30,7 +30,7 @@ type AggLayerClientCertificateIDQuerier interface {
 type AgglayerClientInterface interface {
 	SendCertificate(ctx context.Context, certificate *types.Certificate, validatorSignature []byte) (common.Hash, error)
 	GetCertificateHeader(ctx context.Context, certificateHash common.Hash) (*types.CertificateHeader, error)
-	GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, common.Hash, error)
+	GetNetworkStatus(ctx context.Context, networkID uint32) (types.NetworkStatus, error)
 	AggLayerClientGetEpochConfiguration
 	AggLayerClientRecoveryQuerier
 	AggLayerClientCertificateIDQuerier

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -164,24 +164,27 @@ func (a *AgglayerGRPCClient) GetNetworkStatus(ctx context.Context, networkID uin
 }
 
 func convertProtoNetworkStatus(status *v1nodetypes.NetworkStatus) (types.NetworkStatus, error) {
-	var settledCertID common.Hash
+	var settledCertID *common.Hash
 	if status.SettledCertificateId != nil {
-		settledCertID = common.BytesToHash(status.SettledCertificateId.Value.Value)
+		certID := common.BytesToHash(status.SettledCertificateId.Value.Value)
+		settledCertID = &certID
 	}
 
-	var settledPPRoot common.Hash
+	var settledPPRoot *common.Hash
 	if status.SettledPpRoot != nil {
-		settledPPRoot = common.BytesToHash(status.SettledPpRoot.Value)
+		ppRoot := common.BytesToHash(status.SettledPpRoot.Value)
+		settledPPRoot = &ppRoot
 	}
 
-	var settledLER common.Hash
+	var settledLER *common.Hash
 	if status.SettledLer != nil {
-		settledLER = common.BytesToHash(status.SettledLer.Value)
+		lER := common.BytesToHash(status.SettledLer.Value)
+		settledLER = &lER
 	}
 
-	var settledClaim *types.SettledClaim
+	var settledClaim *types.SettledImportedBridgeExit
 	if status.SettledClaim != nil {
-		settledClaim = &types.SettledClaim{
+		settledClaim = &types.SettledImportedBridgeExit{
 			BridgeExitHash: common.BytesToHash(status.SettledClaim.BridgeExitHash.Value),
 			GlobalIndex:    new(big.Int).SetBytes(status.SettledClaim.GlobalIndex.Value),
 		}
@@ -205,7 +208,7 @@ func convertProtoNetworkStatus(status *v1nodetypes.NetworkStatus) (types.Network
 		SettledPPRoot:             settledPPRoot,
 		SettledLER:                settledLER,
 		SettledLETLeafCount:       status.SettledLetLeafCount,
-		SettledClaim:              settledClaim,
+		SettledImportedBridgeExit: settledClaim,
 		LatestPendingHeight:       status.LatestPendingHeight,
 		LatestPendingStatus:       latestPendingStatus,
 		LatestPendingError:        status.LatestPendingError,

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	node "buf.build/gen/go/agglayer/agglayer/grpc/go/agglayer/node/v1/nodev1grpc"
 	v1nodetypes "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/types/v1"
@@ -146,10 +147,70 @@ func (a *AgglayerGRPCClient) GetCertificateHeader(
 	return convertProtoCertificateHeader(response.CertificateHeader), nil
 }
 
-func (a *AgglayerGRPCClient) GetLatestSettledImportedBridgeExit(
-	ctx context.Context) (*types.GlobalIndex, common.Hash, error) {
-	// TODO - implement this method once agglayer supports it
-	return &types.GlobalIndex{}, common.Hash{}, nil
+func (a *AgglayerGRPCClient) GetNetworkStatus(ctx context.Context, networkID uint32) (types.NetworkStatus, error) {
+	status, err := a.networkStateService.GetNetworkStatus(ctx, &v1.GetNetworkStatusRequest{
+		NetworkId: networkID,
+	})
+	if err != nil {
+		return types.NetworkStatus{}, fmt.Errorf("failed to get network status: %w",
+			aggkitgrpc.RepackGRPCErrorWithDetails(err))
+	}
+
+	if !status.HasNetworkStatus() {
+		return types.NetworkStatus{}, errors.New("network status is not available")
+	}
+
+	return convertProtoNetworkStatus(status.NetworkStatus)
+}
+
+func convertProtoNetworkStatus(status *v1nodetypes.NetworkStatus) (types.NetworkStatus, error) {
+	var settledCertID common.Hash
+	if status.SettledCertificateId != nil {
+		settledCertID = common.BytesToHash(status.SettledCertificateId.Value.Value)
+	}
+
+	var settledPPRoot common.Hash
+	if status.SettledPpRoot != nil {
+		settledPPRoot = common.BytesToHash(status.SettledPpRoot.Value)
+	}
+
+	var settledLER common.Hash
+	if status.SettledLer != nil {
+		settledLER = common.BytesToHash(status.SettledLer.Value)
+	}
+
+	var settledClaim *types.SettledClaim
+	if status.SettledClaim != nil {
+		settledClaim = &types.SettledClaim{
+			BridgeExitHash: common.BytesToHash(status.SettledClaim.BridgeExitHash.Value),
+			GlobalIndex:    new(big.Int).SetBytes(status.SettledClaim.GlobalIndex.Value),
+		}
+	}
+
+	latestPendingStatus := types.Pending
+	if status.LatestPendingStatus != "" {
+		if err := latestPendingStatus.UnmarshalJSON([]byte(status.LatestPendingStatus)); err != nil {
+			return types.NetworkStatus{},
+				fmt.Errorf("failed to unmarshal latest pending status %q from NetworkStatus struct: %w",
+					status.LatestPendingStatus, err)
+		}
+	}
+
+	return types.NetworkStatus{
+		NetworkStatus:             status.NetworkStatus,
+		NetworkType:               status.NetworkType,
+		NetworkID:                 status.NetworkId,
+		SettledCertificateID:      settledCertID,
+		SettledHeight:             status.SettledHeight,
+		SettledPPRoot:             settledPPRoot,
+		SettledLER:                settledLER,
+		SettledLETLeafCount:       status.SettledLetLeafCount,
+		SettledClaim:              settledClaim,
+		LatestPendingHeight:       status.LatestPendingHeight,
+		LatestPendingStatus:       latestPendingStatus,
+		LatestPendingError:        status.LatestPendingError,
+		LatestEpochWithSettlement: status.LatestEpochWithSettlement,
+	}, nil
 }
 
 // ConvertCertToProtoCertificate converts a types.Certificate to a grpc v1nodetypes.Certificate

--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -200,7 +200,7 @@ func convertProtoNetworkStatus(status *v1nodetypes.NetworkStatus) (types.Network
 	}
 
 	return types.NetworkStatus{
-		NetworkStatus:             status.NetworkStatus,
+		Status:                    status.NetworkStatus,
 		NetworkType:               status.NetworkType,
 		NetworkID:                 status.NetworkId,
 		SettledCertificateID:      settledCertID,

--- a/agglayer/grpc/agglayer_grpc_client_test.go
+++ b/agglayer/grpc/agglayer_grpc_client_test.go
@@ -550,15 +550,106 @@ func TestExploratory_EstimateCertSize(t *testing.T) {
 	fmt.Printf("aggchain data signature size: %d bytes\n", size)
 }
 
-func TestGetLatestSettledImportedBridgeExit(t *testing.T) {
+func TestGetNetworkStatus(t *testing.T) {
 	t.Parallel()
 
-	client := &AgglayerGRPCClient{}
-	gi, h, err := client.GetLatestSettledImportedBridgeExit(t.Context())
+	ctx := t.Context()
+	networkID := uint32(1)
 
-	require.NoError(t, err)
-	require.Equal(t, &types.GlobalIndex{}, gi)
-	require.Equal(t, common.Hash{}, h)
+	t.Run("returns error from network state service", func(t *testing.T) {
+		t.Parallel()
+
+		networkStateServiceMock := mocks.NewNodeStateServiceClient(t)
+		client := &AgglayerGRPCClient{
+			networkStateService: networkStateServiceMock,
+			cfg:                 aggkitgrpc.DefaultConfig(),
+		}
+
+		networkStateServiceMock.EXPECT().GetNetworkStatus(mock.Anything, mock.Anything).Return(nil, errors.New("test error"))
+
+		_, err := client.GetNetworkStatus(ctx, networkID)
+		require.ErrorContains(t, err, "test error")
+	})
+
+	t.Run("returns error when network status not available", func(t *testing.T) {
+		t.Parallel()
+
+		networkStateServiceMock := mocks.NewNodeStateServiceClient(t)
+		client := &AgglayerGRPCClient{
+			networkStateService: networkStateServiceMock,
+			cfg:                 aggkitgrpc.DefaultConfig(),
+		}
+
+		// empty response -> HasNetworkStatus() == false
+		networkStateServiceMock.EXPECT().GetNetworkStatus(mock.Anything, mock.Anything).Return(&node.GetNetworkStatusResponse{}, nil)
+
+		_, err := client.GetNetworkStatus(ctx, networkID)
+		require.ErrorContains(t, err, "network status is not available")
+	})
+
+	t.Run("returns response on success", func(t *testing.T) {
+		t.Parallel()
+
+		networkStateServiceMock := mocks.NewNodeStateServiceClient(t)
+		client := &AgglayerGRPCClient{
+			networkStateService: networkStateServiceMock,
+			cfg:                 aggkitgrpc.DefaultConfig(),
+		}
+
+		settledClaimIdx := big.NewInt(84)
+
+		expectedProto := &v1nodetypes.NetworkStatus{
+			NetworkStatus: "ok",
+			NetworkType:   "test",
+			NetworkId:     networkID,
+			SettledCertificateId: &v1nodetypes.CertificateId{Value: &v1types.FixedBytes32{
+				Value: common.HexToHash("0x010203").Bytes(),
+			}},
+			SettledHeight:       55,
+			SettledPpRoot:       &v1types.FixedBytes32{Value: common.HexToHash("0x010204").Bytes()},
+			SettledLer:          &v1types.FixedBytes32{Value: common.HexToHash("0x010205").Bytes()},
+			SettledLetLeafCount: 100,
+			SettledClaim: &v1nodetypes.SettledClaim{
+				GlobalIndex:    &v1types.FixedBytes32{Value: common.BigToHash(settledClaimIdx).Bytes()},
+				BridgeExitHash: &v1types.FixedBytes32{Value: common.HexToHash("0x010206").Bytes()},
+			},
+			LatestPendingHeight:       99,
+			LatestPendingStatus:       "Settled",
+			LatestPendingError:        "some error",
+			LatestEpochWithSettlement: 3,
+		}
+
+		networkStateServiceMock.EXPECT().GetNetworkStatus(mock.Anything, mock.Anything).Return(&node.GetNetworkStatusResponse{
+			NetworkStatus: expectedProto,
+		}, nil)
+
+		resp, err := client.GetNetworkStatus(ctx, networkID)
+		require.NoError(t, err)
+
+		require.Equal(t, expectedProto.NetworkStatus, resp.NetworkStatus)
+		require.Equal(t, expectedProto.NetworkType, resp.NetworkType)
+		require.Equal(t, expectedProto.NetworkId, resp.NetworkID)
+		require.Equal(t, expectedProto.SettledHeight, resp.SettledHeight)
+		require.Equal(t, expectedProto.LatestPendingHeight, resp.LatestPendingHeight)
+		require.Equal(t, expectedProto.LatestPendingError, resp.LatestPendingError)
+		require.Equal(t, expectedProto.LatestEpochWithSettlement, resp.LatestEpochWithSettlement)
+		require.Equal(t, expectedProto.SettledLetLeafCount, resp.SettledLETLeafCount)
+
+		// compare hashes
+		require.Equal(t, expectedProto.SettledCertificateId.Value.Value, resp.SettledCertificateID.Bytes())
+		require.Equal(t, expectedProto.SettledPpRoot.Value, resp.SettledPPRoot.Bytes())
+		require.Equal(t, expectedProto.SettledLer.Value, resp.SettledLER.Bytes())
+
+		// compare settled claim
+		expectedClaim := &types.SettledClaim{
+			GlobalIndex:    new(big.Int).SetBytes(expectedProto.SettledClaim.GlobalIndex.Value),
+			BridgeExitHash: common.BytesToHash(expectedProto.SettledClaim.BridgeExitHash.Value),
+		}
+		require.Equal(t, expectedClaim, resp.SettledClaim)
+
+		// LatestPendingStatus defaults to types.Pending when proto field is empty
+		require.Equal(t, types.Settled, resp.LatestPendingStatus)
+	})
 }
 
 func estimateRequestSize(t *testing.T, req proto.Message) int {

--- a/agglayer/grpc/agglayer_grpc_client_test.go
+++ b/agglayer/grpc/agglayer_grpc_client_test.go
@@ -641,11 +641,11 @@ func TestGetNetworkStatus(t *testing.T) {
 		require.Equal(t, expectedProto.SettledLer.Value, resp.SettledLER.Bytes())
 
 		// compare settled claim
-		expectedClaim := &types.SettledClaim{
+		expectedClaim := &types.SettledImportedBridgeExit{
 			GlobalIndex:    new(big.Int).SetBytes(expectedProto.SettledClaim.GlobalIndex.Value),
 			BridgeExitHash: common.BytesToHash(expectedProto.SettledClaim.BridgeExitHash.Value),
 		}
-		require.Equal(t, expectedClaim, resp.SettledClaim)
+		require.Equal(t, expectedClaim, resp.SettledImportedBridgeExit)
 
 		// LatestPendingStatus defaults to types.Pending when proto field is empty
 		require.Equal(t, types.Settled, resp.LatestPendingStatus)

--- a/agglayer/grpc/agglayer_grpc_client_test.go
+++ b/agglayer/grpc/agglayer_grpc_client_test.go
@@ -626,7 +626,7 @@ func TestGetNetworkStatus(t *testing.T) {
 		resp, err := client.GetNetworkStatus(ctx, networkID)
 		require.NoError(t, err)
 
-		require.Equal(t, expectedProto.NetworkStatus, resp.NetworkStatus)
+		require.Equal(t, expectedProto.NetworkStatus, resp.Status)
 		require.Equal(t, expectedProto.NetworkType, resp.NetworkType)
 		require.Equal(t, expectedProto.NetworkId, resp.NetworkID)
 		require.Equal(t, expectedProto.SettledHeight, resp.SettledHeight)

--- a/agglayer/mocks/mock_agglayer_client.go
+++ b/agglayer/mocks/mock_agglayer_client.go
@@ -260,69 +260,59 @@ func (_c *AgglayerClientMock_GetLatestSettledCertificateHeader_Call) RunAndRetur
 	return _c
 }
 
-// GetLatestSettledImportedBridgeExit provides a mock function with given fields: ctx
-func (_m *AgglayerClientMock) GetLatestSettledImportedBridgeExit(ctx context.Context) (*types.GlobalIndex, common.Hash, error) {
-	ret := _m.Called(ctx)
+// GetNetworkStatus provides a mock function with given fields: ctx, networkID
+func (_m *AgglayerClientMock) GetNetworkStatus(ctx context.Context, networkID uint32) (types.NetworkStatus, error) {
+	ret := _m.Called(ctx, networkID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetLatestSettledImportedBridgeExit")
+		panic("no return value specified for GetNetworkStatus")
 	}
 
-	var r0 *types.GlobalIndex
-	var r1 common.Hash
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context) (*types.GlobalIndex, common.Hash, error)); ok {
-		return rf(ctx)
+	var r0 types.NetworkStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32) (types.NetworkStatus, error)); ok {
+		return rf(ctx, networkID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) *types.GlobalIndex); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, uint32) types.NetworkStatus); ok {
+		r0 = rf(ctx, networkID)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.GlobalIndex)
-		}
+		r0 = ret.Get(0).(types.NetworkStatus)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) common.Hash); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, uint32) error); ok {
+		r1 = rf(ctx, networkID)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(common.Hash)
-		}
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
-		r2 = rf(ctx)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
-// AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestSettledImportedBridgeExit'
-type AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call struct {
+// AgglayerClientMock_GetNetworkStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNetworkStatus'
+type AgglayerClientMock_GetNetworkStatus_Call struct {
 	*mock.Call
 }
 
-// GetLatestSettledImportedBridgeExit is a helper method to define mock.On call
+// GetNetworkStatus is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *AgglayerClientMock_Expecter) GetLatestSettledImportedBridgeExit(ctx interface{}) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
-	return &AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call{Call: _e.mock.On("GetLatestSettledImportedBridgeExit", ctx)}
+//   - networkID uint32
+func (_e *AgglayerClientMock_Expecter) GetNetworkStatus(ctx interface{}, networkID interface{}) *AgglayerClientMock_GetNetworkStatus_Call {
+	return &AgglayerClientMock_GetNetworkStatus_Call{Call: _e.mock.On("GetNetworkStatus", ctx, networkID)}
 }
 
-func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) Run(run func(ctx context.Context)) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
+func (_c *AgglayerClientMock_GetNetworkStatus_Call) Run(run func(ctx context.Context, networkID uint32)) *AgglayerClientMock_GetNetworkStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(uint32))
 	})
 	return _c
 }
 
-func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) Return(_a0 *types.GlobalIndex, _a1 common.Hash, _a2 error) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *AgglayerClientMock_GetNetworkStatus_Call) Return(_a0 types.NetworkStatus, _a1 error) *AgglayerClientMock_GetNetworkStatus_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call) RunAndReturn(run func(context.Context) (*types.GlobalIndex, common.Hash, error)) *AgglayerClientMock_GetLatestSettledImportedBridgeExit_Call {
+func (_c *AgglayerClientMock_GetNetworkStatus_Call) RunAndReturn(run func(context.Context, uint32) (types.NetworkStatus, error)) *AgglayerClientMock_GetNetworkStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/agglayer/mocks/mock_node_state_service_client.go
+++ b/agglayer/mocks/mock_node_state_service_client.go
@@ -173,6 +173,80 @@ func (_c *NodeStateServiceClient_GetLatestCertificateHeader_Call) RunAndReturn(r
 	return _c
 }
 
+// GetNetworkStatus provides a mock function with given fields: ctx, in, opts
+func (_m *NodeStateServiceClient) GetNetworkStatus(ctx context.Context, in *nodev1.GetNetworkStatusRequest, opts ...grpc.CallOption) (*nodev1.GetNetworkStatusResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNetworkStatus")
+	}
+
+	var r0 *nodev1.GetNetworkStatusResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *nodev1.GetNetworkStatusRequest, ...grpc.CallOption) (*nodev1.GetNetworkStatusResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *nodev1.GetNetworkStatusRequest, ...grpc.CallOption) *nodev1.GetNetworkStatusResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*nodev1.GetNetworkStatusResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *nodev1.GetNetworkStatusRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// NodeStateServiceClient_GetNetworkStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNetworkStatus'
+type NodeStateServiceClient_GetNetworkStatus_Call struct {
+	*mock.Call
+}
+
+// GetNetworkStatus is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *nodev1.GetNetworkStatusRequest
+//   - opts ...grpc.CallOption
+func (_e *NodeStateServiceClient_Expecter) GetNetworkStatus(ctx interface{}, in interface{}, opts ...interface{}) *NodeStateServiceClient_GetNetworkStatus_Call {
+	return &NodeStateServiceClient_GetNetworkStatus_Call{Call: _e.mock.On("GetNetworkStatus",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *NodeStateServiceClient_GetNetworkStatus_Call) Run(run func(ctx context.Context, in *nodev1.GetNetworkStatusRequest, opts ...grpc.CallOption)) *NodeStateServiceClient_GetNetworkStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*nodev1.GetNetworkStatusRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *NodeStateServiceClient_GetNetworkStatus_Call) Return(_a0 *nodev1.GetNetworkStatusResponse, _a1 error) *NodeStateServiceClient_GetNetworkStatus_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *NodeStateServiceClient_GetNetworkStatus_Call) RunAndReturn(run func(context.Context, *nodev1.GetNetworkStatusRequest, ...grpc.CallOption) (*nodev1.GetNetworkStatusResponse, error)) *NodeStateServiceClient_GetNetworkStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewNodeStateServiceClient creates a new instance of NodeStateServiceClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewNodeStateServiceClient(t interface {

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -1350,15 +1350,15 @@ type NetworkStatus struct {
 	// SettledHeight is the height of the latest settled certificate
 	SettledHeight uint64 `json:"settled_height"`
 	// SettledCertificateID is the ID of the latest settled certificate
-	SettledCertificateID common.Hash `json:"settled_certificate_id"`
+	SettledCertificateID *common.Hash `json:"settled_certificate_id"`
 	// SettledPPRoot pessimistic proof root of the latest settled certificate
-	SettledPPRoot common.Hash `json:"settled_pp_root"`
+	SettledPPRoot *common.Hash `json:"settled_pp_root"`
 	// SettledLER is the local exit root of the latest settled certificate
-	SettledLER common.Hash `json:"settled_ler"`
+	SettledLER *common.Hash `json:"settled_ler"`
 	// SettledLETLeafCount is the leaf count of the latest settled local exit tree
 	SettledLETLeafCount uint64 `json:"settled_let_leaf_count"`
-	// SettledClaim is the information about the latest settled claim
-	SettledClaim *SettledClaim `json:"settled_claim,omitempty"`
+	// SettledImportedBridgeExit is the information about the latest settled claim
+	SettledImportedBridgeExit *SettledImportedBridgeExit `json:"settled_claim,omitempty"`
 	// LatestPendingHeight is the height of the latest pending certificate
 	LatestPendingHeight uint64 `json:"latest_pending_height"`
 	// LatestPendingCertificateID is the status of the latest pending certificate (e.g., "Proven", "Pending", "InError")
@@ -1369,8 +1369,8 @@ type NetworkStatus struct {
 	LatestEpochWithSettlement uint64 `json:"latest_epoch_with_settlement"`
 }
 
-// SettledClaim represents the information about a settled claim
-type SettledClaim struct {
+// SettledImportedBridgeExit represents the information about a settled claim
+type SettledImportedBridgeExit struct {
 	GlobalIndex    *big.Int    `json:"global_index"`
 	BridgeExitHash common.Hash `json:"bridge_exit_hash"`
 }

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -1338,3 +1338,39 @@ type ClockConfiguration struct {
 func (c ClockConfiguration) String() string {
 	return fmt.Sprintf("EpochDuration: %d, GenesisBlock: %d", c.EpochDuration, c.GenesisBlock)
 }
+
+// NetworkStatus represents the status of the network returned by the interop_getNetworkStatus RPC call
+type NetworkStatus struct {
+	// NetworkStatus is the current status of the network (e.g., "active", "syncing", "error")
+	NetworkStatus string `json:"network_status"`
+	// NetworkType is the aggchain type of network
+	NetworkType string `json:"network_type"`
+	// NetworkID is the unique identifier of the network
+	NetworkID uint32 `json:"network_id"`
+	// SettledHeight is the height of the latest settled certificate
+	SettledHeight uint64 `json:"settled_height"`
+	// SettledCertificateID is the ID of the latest settled certificate
+	SettledCertificateID common.Hash `json:"settled_certificate_id"`
+	// SettledPPRoot pessimistic proof root of the latest settled certificate
+	SettledPPRoot common.Hash `json:"settled_pp_root"`
+	// SettledLER is the local exit root of the latest settled certificate
+	SettledLER common.Hash `json:"settled_ler"`
+	// SettledLETLeafCount is the leaf count of the latest settled local exit tree
+	SettledLETLeafCount uint64 `json:"settled_let_leaf_count"`
+	// SettledClaim is the information about the latest settled claim
+	SettledClaim *SettledClaim `json:"settled_claim,omitempty"`
+	// LatestPendingHeight is the height of the latest pending certificate
+	LatestPendingHeight uint64 `json:"latest_pending_height"`
+	// LatestPendingCertificateID is the status of the latest pending certificate (e.g., "Proven", "Pending", "InError")
+	LatestPendingStatus CertificateStatus `json:"latest_pending_status"`
+	// LatestPendingError is the error message of the latest pending certificate, if any
+	LatestPendingError string `json:"latest_pending_error"`
+	// LatestEpochWithSettlement is the epoch number of the latest settlement
+	LatestEpochWithSettlement uint64 `json:"latest_epoch_with_settlement"`
+}
+
+// SettledClaim represents the information about a settled claim
+type SettledClaim struct {
+	GlobalIndex    *big.Int    `json:"global_index"`
+	BridgeExitHash common.Hash `json:"bridge_exit_hash"`
+}

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -1341,8 +1341,8 @@ func (c ClockConfiguration) String() string {
 
 // NetworkStatus represents the status of the network returned by the interop_getNetworkStatus RPC call
 type NetworkStatus struct {
-	// NetworkStatus is the current status of the network (e.g., "active", "syncing", "error")
-	NetworkStatus string `json:"network_status"`
+	// Status is the current status of the network (e.g., "active", "syncing", "error")
+	Status string `json:"network_status"`
 	// NetworkType is the aggchain type of network
 	NetworkType string `json:"network_type"`
 	// NetworkID is the unique identifier of the network

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/agglayer/aggkit/agglayer"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
@@ -76,18 +77,18 @@ func (c *certificateQuerier) GetLastSettledCertificateToBlock(
 			cert.NewLocalExitRoot.String(), err)
 	}
 
-	// TODO - this might need to be changed once agglayer gives support for this
 	// 2. Get the latest settled imported bridge exit block number
-	latestSettledIbeGlobalIndex, bridgeExitHash, err := c.agglayerClient.GetLatestSettledImportedBridgeExit(ctx)
+	networkStatus, err := c.agglayerClient.GetNetworkStatus(ctx, cert.NetworkID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get latest settled imported bridge exit from agglayer: %w", err)
 	}
 
-	if latestSettledIbeGlobalIndex != nil {
-		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(ctx, latestSettledIbeGlobalIndex, bridgeExitHash)
+	if networkStatus.SettledClaim != nil {
+		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(
+			ctx, networkStatus.SettledClaim.GlobalIndex, networkStatus.SettledClaim.BridgeExitHash)
 		if err != nil {
 			return 0, fmt.Errorf("failed to resolve the block number for last imported bridge exit %s: %w",
-				latestSettledIbeGlobalIndex.String(), err)
+				networkStatus.SettledClaim.GlobalIndex.String(), err)
 		}
 	}
 
@@ -126,7 +127,7 @@ func (c *certificateQuerier) GetNewCertificateToBlock(
 		// if there are imported bridge exits, we can use the last one to determine the new certificate to block
 		lastImportedBridgeExit := cert.ImportedBridgeExits[len(cert.ImportedBridgeExits)-1]
 		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(
-			ctx, lastImportedBridgeExit.GlobalIndex, lastImportedBridgeExit.BridgeExit.Hash())
+			ctx, lastImportedBridgeExit.GlobalIndex.ToBigInt(), lastImportedBridgeExit.BridgeExit.Hash())
 		if err != nil {
 			return 0, fmt.Errorf("failed to resolve the block number for last imported bridge exit %s: %w",
 				lastImportedBridgeExit.GlobalIndex.String(), err)
@@ -183,11 +184,10 @@ func (c *certificateQuerier) getBlockNumFromLER(ctx context.Context, localExitRo
 }
 
 func (c *certificateQuerier) getBlockNumFromGlobalIndex(
-	ctx context.Context, globalIndex *agglayertypes.GlobalIndex, bridgeExitHash common.Hash) (uint64, error) {
-	bigGlobalIndex := globalIndex.ToBigInt()
-	claims, err := c.l2BridgeSyncer.GetClaimsByGlobalIndex(ctx, bigGlobalIndex)
+	ctx context.Context, globalIndex *big.Int, bridgeExitHash common.Hash) (uint64, error) {
+	claims, err := c.l2BridgeSyncer.GetClaimsByGlobalIndex(ctx, globalIndex)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get claim by global index %s: %w", bigGlobalIndex.String(), err)
+		return 0, fmt.Errorf("failed to get claim by global index %s: %w", globalIndex.String(), err)
 	}
 
 	for _, claim := range claims {

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -83,12 +83,13 @@ func (c *certificateQuerier) GetLastSettledCertificateToBlock(
 		return 0, fmt.Errorf("failed to get latest settled imported bridge exit from agglayer: %w", err)
 	}
 
-	if networkStatus.SettledImportedBridgeExit != nil {
-		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(
-			ctx, networkStatus.SettledImportedBridgeExit.GlobalIndex, networkStatus.SettledImportedBridgeExit.BridgeExitHash)
+	settledIBE := networkStatus.SettledImportedBridgeExit
+	if settledIBE != nil {
+		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(ctx,
+			settledIBE.GlobalIndex, settledIBE.BridgeExitHash)
 		if err != nil {
 			return 0, fmt.Errorf("failed to resolve the block number for last imported bridge exit %s: %w",
-				networkStatus.SettledImportedBridgeExit.GlobalIndex.String(), err)
+				settledIBE.GlobalIndex.String(), err)
 		}
 	}
 

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -83,12 +83,12 @@ func (c *certificateQuerier) GetLastSettledCertificateToBlock(
 		return 0, fmt.Errorf("failed to get latest settled imported bridge exit from agglayer: %w", err)
 	}
 
-	if networkStatus.SettledClaim != nil {
+	if networkStatus.SettledImportedBridgeExit != nil {
 		lastImportedBridgeExitBlock, err = c.getBlockNumFromGlobalIndex(
-			ctx, networkStatus.SettledClaim.GlobalIndex, networkStatus.SettledClaim.BridgeExitHash)
+			ctx, networkStatus.SettledImportedBridgeExit.GlobalIndex, networkStatus.SettledImportedBridgeExit.BridgeExitHash)
 		if err != nil {
 			return 0, fmt.Errorf("failed to resolve the block number for last imported bridge exit %s: %w",
-				networkStatus.SettledClaim.GlobalIndex.String(), err)
+				networkStatus.SettledImportedBridgeExit.GlobalIndex.String(), err)
 		}
 	}
 

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -48,14 +48,14 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				}, nil)
 
 				networkStatus := agglayertypes.NetworkStatus{
-					SettledClaim: &agglayertypes.SettledClaim{
+					SettledImportedBridgeExit: &agglayertypes.SettledImportedBridgeExit{
 						BridgeExitHash: common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"),
 						GlobalIndex:    bridgesync.GenerateGlobalIndex(true, 0, 1),
 					},
 				}
 				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
 
-				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledClaim.GlobalIndex).Return([]bridgesync.Claim{
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledImportedBridgeExit.GlobalIndex).Return([]bridgesync.Claim{
 					{
 						BlockNum:    150,
 						GlobalIndex: bridgesync.GenerateGlobalIndex(true, 0, 1),
@@ -74,13 +74,13 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
 				networkStatus := agglayertypes.NetworkStatus{
-					SettledClaim: &agglayertypes.SettledClaim{
+					SettledImportedBridgeExit: &agglayertypes.SettledImportedBridgeExit{
 						GlobalIndex:    bridgesync.GenerateGlobalIndex(true, 0, 1),
 						BridgeExitHash: common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"),
 					},
 				}
 				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
-				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledClaim.GlobalIndex).Return([]bridgesync.Claim{
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledImportedBridgeExit.GlobalIndex).Return([]bridgesync.Claim{
 					{
 						BlockNum:    50,
 						GlobalIndex: bridgesync.GenerateGlobalIndex(true, 0, 1),
@@ -136,13 +136,13 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
 				networkStatus := agglayertypes.NetworkStatus{
-					SettledClaim: &agglayertypes.SettledClaim{
+					SettledImportedBridgeExit: &agglayertypes.SettledImportedBridgeExit{
 						GlobalIndex:    bridgesync.GenerateGlobalIndex(true, 0, 1),
 						BridgeExitHash: common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"),
 					},
 				}
 				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
-				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledClaim.GlobalIndex).Return(nil, errors.New("claim not found"))
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledImportedBridgeExit.GlobalIndex).Return(nil, errors.New("claim not found"))
 			},
 			expectedErr: "failed to get claim by global index",
 		},

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
-	aggkitcommon "github.com/agglayer/aggkit/common"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -48,10 +47,15 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 					BlockNum: uint64(100),
 				}, nil)
 
-				importedBridgeExit := &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1}
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"), nil)
+				networkStatus := agglayertypes.NetworkStatus{
+					SettledClaim: &agglayertypes.SettledClaim{
+						BridgeExitHash: common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"),
+						GlobalIndex:    bridgesync.GenerateGlobalIndex(true, 0, 1),
+					},
+				}
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
 
-				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return([]bridgesync.Claim{
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledClaim.GlobalIndex).Return([]bridgesync.Claim{
 					{
 						BlockNum:    150,
 						GlobalIndex: bridgesync.GenerateGlobalIndex(true, 0, 1),
@@ -69,9 +73,14 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				importedBridgeExit := &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1}
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"), nil)
-				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return([]bridgesync.Claim{
+				networkStatus := agglayertypes.NetworkStatus{
+					SettledClaim: &agglayertypes.SettledClaim{
+						GlobalIndex:    bridgesync.GenerateGlobalIndex(true, 0, 1),
+						BridgeExitHash: common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"),
+					},
+				}
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledClaim.GlobalIndex).Return([]bridgesync.Claim{
 					{
 						BlockNum:    50,
 						GlobalIndex: bridgesync.GenerateGlobalIndex(true, 0, 1),
@@ -91,7 +100,8 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				bridgeSyncer.EXPECT().GetExitRootByHash(ctx, common.HexToHash("0x456")).Return(&treetypes.Root{
 					BlockNum: uint64(300),
 				}, nil)
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, nil)
+				networkStatus := agglayertypes.NetworkStatus{}
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(250), nil)
 			},
 			expectedBlock: 300, // max of 300, 0, 250
@@ -114,7 +124,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, errors.New("agglayer error"))
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(agglayertypes.NetworkStatus{}, errors.New("agglayer error"))
 			},
 			expectedErr: "failed to get latest settled imported bridge exit from agglayer",
 		},
@@ -125,9 +135,14 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				importedBridgeExit := &agglayertypes.GlobalIndex{MainnetFlag: true, RollupIndex: 0, LeafIndex: 1}
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(importedBridgeExit, common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"), nil)
-				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, importedBridgeExit.ToBigInt()).Return(nil, errors.New("claim not found"))
+				networkStatus := agglayertypes.NetworkStatus{
+					SettledClaim: &agglayertypes.SettledClaim{
+						GlobalIndex:    bridgesync.GenerateGlobalIndex(true, 0, 1),
+						BridgeExitHash: common.HexToHash("0xe3e297278c7df4ae4f235be10155ac62c53b08e2a14ed09b7dd6b688952ee883"),
+					},
+				}
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(networkStatus, nil)
+				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledClaim.GlobalIndex).Return(nil, errors.New("claim not found"))
 			},
 			expectedErr: "failed to get claim by global index",
 		},
@@ -138,7 +153,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, nil)
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(agglayertypes.NetworkStatus{}, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(0), errors.New("L2 block query failed"))
 			},
 			expectedErr: "failed to get last settled L2 block",
@@ -150,7 +165,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				NewLocalExitRoot: types.EmptyLER,
 			},
 			mockFn: func(aggchainQuerier *mocks.AggchainFEPRollupQuerier, agglayerClient *agglayermocks.AgglayerClientMock, bridgeSyncer *mocks.L2BridgeSyncer) {
-				agglayerClient.EXPECT().GetLatestSettledImportedBridgeExit(ctx).Return(nil, aggkitcommon.ZeroHash, nil)
+				agglayerClient.EXPECT().GetNetworkStatus(ctx, uint32(0)).Return(agglayertypes.NetworkStatus{}, nil)
 				aggchainQuerier.EXPECT().GetLastSettledL2Block().Return(uint64(0), nil)
 			},
 			expectedBlock: 0,
@@ -681,7 +696,7 @@ func TestGetBlockNumFromGlobalIndex(t *testing.T) {
 				l2BridgeSyncer: mockL2BridgeSyncer,
 			}
 
-			blockNum, err := certQuerier.getBlockNumFromGlobalIndex(ctx, tc.globalIndex, tc.bridgeExitHash)
+			blockNum, err := certQuerier.getBlockNumFromGlobalIndex(ctx, tc.globalIndex.ToBigInt(), tc.bridgeExitHash)
 			if tc.expectedErr != "" {
 				require.ErrorContains(t, err, tc.expectedErr)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/agglayer/aggkit
 go 1.24.6
 
 require (
-	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250520190516-57743a879f16.2
-	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.7-20250520190516-57743a879f16.1
-	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.8-20250828125920-9f07d329a94b.1
+	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-00000000000000-f90c5d0c4997.2
+	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.8-00000000000000-f90c5d0c4997.1
+	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.8-20250519093743-85e8a3d9f59c.1
 	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250520163122-7efa0a2f81a8.2
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.7-20250520163122-7efa0a2f81a8.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250520190516-57743a879f16.2 h1:WaCaLIlQmBZVPeNKAb8/OlwOGBWkhqd0dCPFAuyiVaw=
-buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250520190516-57743a879f16.2/go.mod h1:qDtlbBtwnXbXCj6dj8RT44y8qfL5y6VuTTmEdCXNK1A=
-buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.7-20250520190516-57743a879f16.1 h1:tAk5WllgBSrTXUWnJkICk313jY6iODLjobdskuGZxjY=
-buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.7-20250520190516-57743a879f16.1/go.mod h1:OW00QW/yczP0o+aER7lsoIjLdDkmodvdGJYvvMpv2Gw=
-buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.8-20250828125920-9f07d329a94b.1 h1:3J8bmDqSadCKdCUIPeDnT0OcrdMzhXxkdJWh9wjJfEw=
-buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.8-20250828125920-9f07d329a94b.1/go.mod h1:xwTWh+PhAFSJfEUfDHHMjwoBXlmT1OAtiJzKfZ0pWDY=
+buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-00000000000000-f90c5d0c4997.2 h1:QJxR0y+PDtJDdS/wLDI9zPLbqYGw/hpBO8gL9IvEd2Q=
+buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-00000000000000-f90c5d0c4997.2/go.mod h1:xAHXtiEcd245Zgu5vmdR3parOZbpsStrQZgGSKVKW7M=
+buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.8-00000000000000-f90c5d0c4997.1 h1:iksFpz9bMgOCZtPV5Jw72K9W++zdiRkgO2E/u+Esj6E=
+buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.8-00000000000000-f90c5d0c4997.1/go.mod h1:OT5cDxRQ5ixa5nUeaOCY5ApXI52SXPts12ZLqkUmMHU=
+buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.8-20250519093743-85e8a3d9f59c.1 h1:9/nz+/m8tkTsgjUtIIpFKO9lWbl/iz1wqfOqNNxRnxo=
+buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.8-20250519093743-85e8a3d9f59c.1/go.mod h1:xwTWh+PhAFSJfEUfDHHMjwoBXlmT1OAtiJzKfZ0pWDY=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250520163122-7efa0a2f81a8.2 h1:gV+6xXfMHDXA4XI5jCpJmMITl6A51SUaoECeRO4/GAY=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250520163122-7efa0a2f81a8.2/go.mod h1:NJnqmcfr760oCyvQ8MC6H8HsXRTHtzqAkzhEj+ms0uU=
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.7-20250520163122-7efa0a2f81a8.1 h1:5tWNGmDGpAEMrQ0yS+C9fAH48rAmXi3lEW2tRXRK9qQ=


### PR DESCRIPTION
## 🔄 Changes Summary
This PR utilizes the `GetNetworkStatus` `API` from `agglayer` to get the latest settled imported bridge exit info.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI
