### PR TITLE
feat: new `aggsender` metrics

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -454,10 +454,14 @@ func (a *AggSender) pollValidators(
 	type signResult struct {
 		signature []byte
 		err       error
+		validator types.CertificateValidateAndSigner
 	}
 
 	resultsCh := make(chan signResult, len(validators))
 	var wg sync.WaitGroup
+
+	start := time.Now()
+	defer func() { metrics.ValidateTime(time.Since(start).Seconds()) }()
 
 	for _, v := range validators {
 		wg.Add(1)
@@ -473,7 +477,7 @@ func (a *AggSender) pollValidators(
 			status, err := v.HealthCheck(ctx)
 			if err != nil {
 				a.log.Warnf("error checking validator health (URL=%s): %v", v.URL(), err)
-				resultsCh <- signResult{err: err}
+				resultsCh <- signResult{err: err, validator: v}
 				return
 			}
 
@@ -487,11 +491,11 @@ func (a *AggSender) pollValidators(
 			sig, err := v.ValidateAndSignCertificate(ctx, certificate, lastL2BlockInCert)
 			if err != nil {
 				a.log.Errorf("validator %v failed to validate the certificate: %v", v, err)
-				resultsCh <- signResult{err: err}
+				resultsCh <- signResult{err: err, validator: v}
 				return
 			}
 
-			resultsCh <- signResult{signature: sig}
+			resultsCh <- signResult{signature: sig, validator: v}
 		}(v)
 	}
 
@@ -506,6 +510,19 @@ func (a *AggSender) pollValidators(
 	for res := range resultsCh {
 		if res.err != nil {
 			errs = append(errs, res.err)
+			metrics.ValidatorError(res.validator.Address())
+
+			continue
+		}
+
+		if len(res.signature) != aggkitcommon.SignatureSize {
+			a.log.Errorf("validator %v returned an invalid signature with length %d",
+				res.validator.String(), len(res.signature))
+			metrics.ValidatorInvalidSignature(res.validator.Address())
+
+			errs = append(errs, fmt.Errorf("validator %s returned an invalid signature with length %d",
+				res.validator.String(), len(res.signature)))
+
 			continue
 		}
 
@@ -516,9 +533,12 @@ func (a *AggSender) pollValidators(
 	}
 
 	if uint32(len(signatures)) < signaturesThreshold {
+		metrics.MultiSigThresholdNotReached()
+
 		if len(errs) > 0 {
 			return signatures, errors.Join(errs...)
 		}
+
 		return signatures, fmt.Errorf("threshold not reached: %d/%d", len(signatures), signaturesThreshold)
 	}
 
@@ -539,7 +559,7 @@ func (a *AggSender) getValidators(ctx context.Context) ([]types.CertificateValid
 	validators := make([]types.CertificateValidateAndSigner, 0, committee.Size())
 	for _, signer := range committee.Signers() {
 		clientCfg := a.cfg.ValidatorClient.WithURL(signer.URL)
-		validator, err := validator.NewRemoteValidator(&clientCfg, a.storage)
+		validator, err := validator.NewRemoteValidator(&clientCfg, a.storage, signer.Address)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to create a remote validator for committee signer (Address=%s, URL=%s): %w",
 				signer.Address, signer.URL, err)

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -461,7 +461,6 @@ func (a *AggSender) pollValidators(
 	var wg sync.WaitGroup
 
 	start := time.Now()
-	defer func() { metrics.ValidateTime(time.Since(start).Seconds()) }()
 
 	for _, v := range validators {
 		wg.Add(1)
@@ -502,6 +501,7 @@ func (a *AggSender) pollValidators(
 	go func() {
 		wg.Wait()
 		close(resultsCh)
+		metrics.ValidateTime(time.Since(start).Seconds())
 	}()
 
 	signatures := make([][]byte, 0, len(validators))

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -216,7 +216,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 	mockValidator.EXPECT().URL().Return("http://localhost")
 	mockValidator.EXPECT().
 		ValidateAndSignCertificate(mock.Anything, mock.Anything, mock.Anything).
-		Return(common.Hex2Bytes("0x5ca1e"), nil).Once()
+		Return(make([]byte, aggkitcommon.SignatureSize), nil).Once()
 	aggSender := &AggSender{
 		log:             logger,
 		storage:         mockStorage,
@@ -335,7 +335,7 @@ func TestSendCertificate(t *testing.T) {
 				mockValidator.EXPECT().URL().Return("http://localhost")
 				mockValidator.EXPECT().
 					ValidateAndSignCertificate(mock.Anything, mock.Anything, mock.Anything).
-					Return(common.Hex2Bytes("0x5ca1e"), nil).Once()
+					Return(make([]byte, aggkitcommon.SignatureSize), nil).Once()
 				return mockValidator
 			},
 			expectedError: "error sending certificate",
@@ -364,7 +364,7 @@ func TestSendCertificate(t *testing.T) {
 				mockValidator.EXPECT().URL().Return("http://localhost")
 				mockValidator.EXPECT().
 					ValidateAndSignCertificate(mock.Anything, mock.Anything, mock.Anything).
-					Return(common.Hex2Bytes("0x5ca1e"), nil).Once()
+					Return(make([]byte, aggkitcommon.SignatureSize), nil).Once()
 				return mockValidator
 			},
 			expectedError: "error saving last sent certificate",
@@ -392,6 +392,7 @@ func TestSendCertificate(t *testing.T) {
 				mockValidator.EXPECT().HealthCheck(mock.Anything).Return(&aggsendertypes.HealthCheckResponse{Status: aggsendertypes.HealthCheckStatusOK}, nil)
 				mockValidator.EXPECT().URL().Return("http://localhost")
 				mockValidator.EXPECT().String().Return("local validator")
+				mockValidator.EXPECT().Address().Return(common.HexToAddress("0x1"))
 				mockValidator.EXPECT().
 					ValidateAndSignCertificate(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil, errors.New("some error")).Once()
@@ -413,7 +414,7 @@ func TestSendCertificate(t *testing.T) {
 					NewLocalExitRoot: common.HexToHash("0x11"),
 					BridgeExits:      []*agglayertypes.BridgeExit{{}},
 				}, nil).Once()
-				mockAgglayerClient.EXPECT().SendCertificate(mock.Anything, mock.Anything, common.Hex2Bytes("0x123456")).
+				mockAgglayerClient.EXPECT().SendCertificate(mock.Anything, mock.Anything, mock.Anything).
 					Return(common.HexToHash("0x22"), nil).Once()
 				mockStorage.EXPECT().SaveLastSentCertificate(mock.Anything, mock.Anything).Return(nil).Once()
 			},
@@ -423,7 +424,7 @@ func TestSendCertificate(t *testing.T) {
 					HealthCheckResponse{Status: aggsendertypes.HealthCheckStatusOK}, nil)
 				mockValidator.EXPECT().URL().Return("http://localhost")
 				mockValidator.EXPECT().ValidateAndSignCertificate(mock.Anything, mock.Anything, mock.Anything).
-					Return(common.Hex2Bytes("0x123456"), nil).Once()
+					Return(make([]byte, aggkitcommon.SignatureSize), nil).Once()
 				return mockValidator
 			},
 		},
@@ -451,7 +452,7 @@ func TestSendCertificate(t *testing.T) {
 				mockValidator.EXPECT().URL().Return("http://localhost")
 				mockValidator.EXPECT().
 					ValidateAndSignCertificate(mock.Anything, mock.Anything, mock.Anything).
-					Return(common.Hex2Bytes("0x12345"), nil).Once()
+					Return(make([]byte, aggkitcommon.SignatureSize), nil).Once()
 				return mockValidator
 			},
 		},
@@ -527,7 +528,7 @@ func TestGetValidators(t *testing.T) {
 
 				validators := make([]aggsendertypes.CertificateValidateAndSigner, 0, len(signers))
 				for _, signer := range signers {
-					validator, err := validator.NewRemoteValidator(&grpc.ClientConfig{URL: signer.URL}, nil)
+					validator, err := validator.NewRemoteValidator(&grpc.ClientConfig{URL: signer.URL}, nil, signer.Address)
 					require.NoError(t, err)
 					validators = append(validators, validator)
 				}

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -44,28 +44,12 @@ func Register() {
 			Help: "[AGGSENDER] number of certificates settled",
 		},
 		{
-			Name: certificateBuildTime,
-			Help: "[AGGSENDER] certificate build time",
-		},
-		{
-			Name: proverTime,
-			Help: "[AGGSENDER] prover time",
-		},
-		{
 			Name: numberOfProverErrors,
 			Help: "[AGGSENDER] number of prover errors",
 		},
 		{
-			Name: validateTime,
-			Help: "[AGGSENDER] time taken to validate a certificate",
-		},
-		{
 			Name: multiSigThresholdNotReached,
 			Help: "[AGGSENDER] number of times multisig threshold was not reached",
-		},
-		{
-			Name: certificateSettlementTime,
-			Help: "[AGGSENDER] certificate settlement time",
 		},
 	}
 	prometheus.RegisterGauges(gauges...)
@@ -87,6 +71,31 @@ func Register() {
 		},
 	}
 	prometheus.RegisterCounterVecs(counterVecs...)
+
+	histograms := []prometheusClient.HistogramOpts{
+		{
+			Name:    validateTime,
+			Help:    "[AGGSENDER] time taken to validate a certificate",
+			Buckets: prometheusClient.DefBuckets,
+		},
+		{
+			Name:    proverTime,
+			Help:    "[AGGSENDER] time taken by the prover",
+			Buckets: prometheusClient.DefBuckets,
+		},
+		{
+			Name:    certificateSettlementTime,
+			Help:    "[AGGSENDER] time taken to settle a certificate",
+			Buckets: prometheusClient.DefBuckets,
+		},
+		{
+			Name:    certificateBuildTime,
+			Help:    "[AGGSENDER] time taken to build a certificate",
+			Buckets: prometheusClient.DefBuckets,
+		},
+	}
+
+	prometheus.RegisterHistograms(histograms...)
 
 	log.Info("Registered prometheus aggsender metrics")
 }
@@ -113,17 +122,17 @@ func Settled() {
 
 // CertificateBuildTime sets the gauge for the certificate build time
 func CertificateBuildTime(value float64) {
-	prometheus.GaugeSet(certificateBuildTime, value)
+	prometheus.HistogramObserve(certificateBuildTime, value)
 }
 
 // ProverTime sets the gauge for the prover time
 func ProverTime(value float64) {
-	prometheus.GaugeSet(proverTime, value)
+	prometheus.HistogramObserve(proverTime, value)
 }
 
 // CertificateSettlementTime sets the gauge for the certificate settlement time
 func CertificateSettlementTime(value float64) {
-	prometheus.GaugeSet(certificateSettlementTime, value)
+	prometheus.HistogramObserve(certificateSettlementTime, value)
 }
 
 // ProverError increments the gauge for the number of prover errors
@@ -144,7 +153,7 @@ func ValidatorInvalidSignature(validator common.Address) {
 
 // ValidateTime sets the gauge for the time taken to validate a certificate
 func ValidateTime(value float64) {
-	prometheus.GaugeSet(validateTime, value)
+	prometheus.HistogramObserve(validateTime, value)
 }
 
 // MultiSigThresholdNotReached increments the gauge for the number of times

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -74,12 +74,14 @@ func Register() {
 		{
 			CounterOpts: prometheusClient.CounterOpts{
 				Name: validatorErrorNumber,
+				Help: "[AGGSENDER] total number of errors returned by a validator over time",
 			},
 			Labels: []string{aggsenderValidator},
 		},
 		{
 			CounterOpts: prometheusClient.CounterOpts{
 				Name: validatorInvalidSignature,
+				Help: "[AGGSENDER] number of times a validator returned an invalid signature",
 			},
 			Labels: []string{aggsenderValidator},
 		},

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -3,17 +3,25 @@ package metrics
 import (
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/prometheus"
+	"github.com/ethereum/go-ethereum/common"
 	prometheusClient "github.com/prometheus/client_golang/prometheus"
 )
 
 const (
 	prefix                      = "aggsender_"
+	aggsenderValidator          = "aggsender-validator"
 	numberOfCertificatesSent    = prefix + "number_of_certificates_sent"
 	numberOfCertificatesInError = prefix + "number_of_certificates_in_error"
 	numberOfSendingRetries      = prefix + "number_of_sending_retries"
 	numberOfCertificatesSettled = prefix + "number_of_sending_settled"
 	certificateBuildTime        = prefix + "certificate_build_time"
 	proverTime                  = prefix + "prover_time"
+	numberOfProverErrors        = prefix + "number_of_prover_errors"
+	validatorErrorNumber        = prefix + "validator_errors_total"
+	validatorInvalidSignature   = prefix + "validator_invalid_signature_total"
+	validateTime                = prefix + "validate_time"
+	multiSigThresholdNotReached = prefix + "multisig_threshold_not_reached"
+	certificateSettlementTime   = prefix + "certificate_settlement_time"
 )
 
 // Register the metrics for the aggsender package
@@ -43,8 +51,41 @@ func Register() {
 			Name: proverTime,
 			Help: "[AGGSENDER] prover time",
 		},
+		{
+			Name: numberOfProverErrors,
+			Help: "[AGGSENDER] number of prover errors",
+		},
+		{
+			Name: validateTime,
+			Help: "[AGGSENDER] time taken to validate a certificate",
+		},
+		{
+			Name: multiSigThresholdNotReached,
+			Help: "[AGGSENDER] number of times multisig threshold was not reached",
+		},
+		{
+			Name: certificateSettlementTime,
+			Help: "[AGGSENDER] certificate settlement time",
+		},
 	}
 	prometheus.RegisterGauges(gauges...)
+
+	counterVecs := []prometheus.CounterVecOpts{
+		{
+			CounterOpts: prometheusClient.CounterOpts{
+				Name: validatorErrorNumber,
+			},
+			Labels: []string{aggsenderValidator},
+		},
+		{
+			CounterOpts: prometheusClient.CounterOpts{
+				Name: validatorInvalidSignature,
+			},
+			Labels: []string{aggsenderValidator},
+		},
+	}
+	prometheus.RegisterCounterVecs(counterVecs...)
+
 	log.Info("Registered prometheus aggsender metrics")
 }
 
@@ -76,4 +117,36 @@ func CertificateBuildTime(value float64) {
 // ProverTime sets the gauge for the prover time
 func ProverTime(value float64) {
 	prometheus.GaugeSet(proverTime, value)
+}
+
+// CertificateSettlementTime sets the gauge for the certificate settlement time
+func CertificateSettlementTime(value float64) {
+	prometheus.GaugeSet(certificateSettlementTime, value)
+}
+
+// ProverError increments the gauge for the number of prover errors
+func ProverError() {
+	prometheus.GaugeInc(numberOfProverErrors)
+}
+
+// ValidatorError increments the counter for the number of validator errors, labeled by validator address
+func ValidatorError(validator common.Address) {
+	prometheus.CounterVecInc(validatorErrorNumber, validator.String())
+}
+
+// ValidatorInvalidSignature increments the counter for the number of
+// invalid signatures from a validator, labeled by validator address
+func ValidatorInvalidSignature(validator common.Address) {
+	prometheus.CounterVecInc(validatorInvalidSignature, validator.String())
+}
+
+// ValidateTime sets the gauge for the time taken to validate a certificate
+func ValidateTime(value float64) {
+	prometheus.GaugeSet(validateTime, value)
+}
+
+// MultiSigThresholdNotReached increments the gauge for the number of times
+// the multisig threshold was not reached
+func MultiSigThresholdNotReached() {
+	prometheus.GaugeInc(multiSigThresholdNotReached)
 }

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	prefix                      = "aggsender_"
-	aggsenderValidator          = "aggsender-validator"
+	aggsenderValidator          = "aggsender_validator"
 	numberOfCertificatesSent    = prefix + "number_of_certificates_sent"
 	numberOfCertificatesInError = prefix + "number_of_certificates_in_error"
 	numberOfSendingRetries      = prefix + "number_of_sending_retries"

--- a/aggsender/mocks/mock_certificate_validate_and_signer.go
+++ b/aggsender/mocks/mock_certificate_validate_and_signer.go
@@ -3,9 +3,10 @@
 package mocks
 
 import (
-	context "context"
-
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	common "github.com/ethereum/go-ethereum/common"
+
+	context "context"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -23,6 +24,53 @@ type CertificateValidateAndSigner_Expecter struct {
 
 func (_m *CertificateValidateAndSigner) EXPECT() *CertificateValidateAndSigner_Expecter {
 	return &CertificateValidateAndSigner_Expecter{mock: &_m.Mock}
+}
+
+// Address provides a mock function with no fields
+func (_m *CertificateValidateAndSigner) Address() common.Address {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Address")
+	}
+
+	var r0 common.Address
+	if rf, ok := ret.Get(0).(func() common.Address); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(common.Address)
+		}
+	}
+
+	return r0
+}
+
+// CertificateValidateAndSigner_Address_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Address'
+type CertificateValidateAndSigner_Address_Call struct {
+	*mock.Call
+}
+
+// Address is a helper method to define mock.On call
+func (_e *CertificateValidateAndSigner_Expecter) Address() *CertificateValidateAndSigner_Address_Call {
+	return &CertificateValidateAndSigner_Address_Call{Call: _e.mock.On("Address")}
+}
+
+func (_c *CertificateValidateAndSigner_Address_Call) Run(run func()) *CertificateValidateAndSigner_Address_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CertificateValidateAndSigner_Address_Call) Return(_a0 common.Address) *CertificateValidateAndSigner_Address_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *CertificateValidateAndSigner_Address_Call) RunAndReturn(run func() common.Address) *CertificateValidateAndSigner_Address_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // HealthCheck provides a mock function with given fields: ctx

--- a/aggsender/query/aggchain_proof_query.go
+++ b/aggsender/query/aggchain_proof_query.go
@@ -156,6 +156,9 @@ func (a *aggchainProofQuery) generateOptimisticAggchainProof(ctx context.Context
 		request.String())
 
 	start := time.Now()
+	defer func() {
+		metrics.ProverTime(time.Since(start).Seconds())
+	}()
 
 	aggchainProof, err := a.aggchainProofClient.GenerateOptimisticAggchainProof(request, sign)
 	if err != nil {
@@ -163,7 +166,6 @@ func (a *aggchainProofQuery) generateOptimisticAggchainProof(ctx context.Context
 		return nil, fmt.Errorf("generateOptimisticAggchainProof - error request aggkit-prover optimistic: %w", err)
 	}
 
-	metrics.ProverTime(time.Since(start).Seconds())
 	return aggchainProof, nil
 }
 

--- a/aggsender/query/aggchain_proof_query.go
+++ b/aggsender/query/aggchain_proof_query.go
@@ -3,9 +3,11 @@ package query
 import (
 	"context"
 	"fmt"
+	"time"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggsender/converters"
+	"github.com/agglayer/aggkit/aggsender/metrics"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/grpc"
@@ -152,10 +154,16 @@ func (a *aggchainProofQuery) generateOptimisticAggchainProof(ctx context.Context
 	certBuildParams.ExtraData = extraData
 	a.log.Infof("generateOptimisticAggchainProof - signed aggchain proof request with new local exit root: %s",
 		request.String())
+
+	start := time.Now()
+
 	aggchainProof, err := a.aggchainProofClient.GenerateOptimisticAggchainProof(request, sign)
 	if err != nil {
+		metrics.ProverError()
 		return nil, fmt.Errorf("generateOptimisticAggchainProof - error request aggkit-prover optimistic: %w", err)
 	}
+
+	metrics.ProverTime(time.Since(start).Seconds())
 	return aggchainProof, nil
 }
 

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -125,7 +125,7 @@ func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) 
 		c.log.Debugf("agglayerClient.GetCertificateHeader status [%s] of certificate %s  elapsed time:%s",
 			certificateHeader.Status,
 			certificateHeader.ID(),
-			certificateLocal.ElapsedTimeSinceCreation())
+			certificateLocal.ElapsedTimeSinceCreationString())
 		appearsNewInErrorCert = appearsNewInErrorCert ||
 			(!certificateLocal.Status.IsInError() && certificateHeader.Status.IsInError())
 
@@ -136,7 +136,7 @@ func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) 
 
 		if !certificateLocal.IsClosed() {
 			c.log.Infof("certificate %s is still pending, elapsed time:%s ",
-				certificateHeader.ID(), certificateLocal.ElapsedTimeSinceCreation())
+				certificateHeader.ID(), certificateLocal.ElapsedTimeSinceCreationString())
 			thereArePendingCerts = true
 		}
 	}
@@ -154,12 +154,18 @@ func (c *certStatusChecker) updateCertificateStatus(ctx context.Context,
 		return nil
 	}
 	c.log.Infof("certificate %s changed status from [%s] to [%s] elapsed time: %s full_cert (agglayer): %s",
-		localCert.ID(), localCert.Status, agglayerCert.Status, localCert.ElapsedTimeSinceCreation(),
+		localCert.ID(), localCert.Status, agglayerCert.Status, localCert.ElapsedTimeSinceCreationString(),
 		agglayerCert.String())
 
 	switch agglayerCert.Status {
 	case agglayertypes.Settled:
 		metrics.Settled()
+		t := localCert.ElapsedTimeSinceCreation()
+		if t > 0 {
+			// log certificate settlement time only if we have a set creation time
+			// it can be 0 only if the certificate was synced from agglayer
+			metrics.CertificateSettlementTime(t.Seconds())
+		}
 	case agglayertypes.InError:
 		metrics.InError()
 	}
@@ -172,6 +178,7 @@ func (c *certStatusChecker) updateCertificateStatus(ctx context.Context,
 
 	localCert.Status = agglayerCert.Status
 	localCert.UpdatedAt = uint32(time.Now().UTC().Unix())
+
 	if err := c.storage.UpdateCertificateStatus(
 		ctx,
 		localCert.CertificateID,

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -231,6 +231,7 @@ type CertificateValidateAndSigner interface {
 	) ([]byte, error)
 	URL() string
 	String() string
+	Address() common.Address
 }
 
 // ValidatorClient is an interface defining functions that a ValidatorClient should implement

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -270,12 +270,22 @@ func (c *CertificateHeader) IsClosed() bool {
 	return c.Status.IsClosed()
 }
 
-// ElapsedTimeSinceCreation returns the time elapsed since the certificate was created
-func (c *CertificateHeader) ElapsedTimeSinceCreation() string {
-	if c == nil || c.CreatedAt == 0 {
+// ElapsedTimeSinceCreationString returns the time elapsed since the certificate was created as a string
+func (c *CertificateHeader) ElapsedTimeSinceCreationString() string {
+	t := c.ElapsedTimeSinceCreation()
+	if t == 0 {
 		return NAStr
 	}
-	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0)).String()
+
+	return t.String()
+}
+
+// ElapsedTimeSinceCreation returns the time elapsed since the certificate was created
+func (c *CertificateHeader) ElapsedTimeSinceCreation() time.Duration {
+	if c == nil || c.CreatedAt == 0 {
+		return 0
+	}
+	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0))
 }
 
 type Certificate struct {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -280,12 +280,19 @@ func (c *CertificateHeader) ElapsedTimeSinceCreationString() string {
 	return t.String()
 }
 
-// ElapsedTimeSinceCreation returns the time elapsed since the certificate was created
+// ElapsedTimeSinceCreation returns the time elapsed since the certificate was created.
 func (c *CertificateHeader) ElapsedTimeSinceCreation() time.Duration {
 	if c == nil || c.CreatedAt == 0 {
 		return 0
 	}
-	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0))
+	createdAt := time.Unix(int64(c.CreatedAt), 0).UTC()
+	elapsed := time.Since(createdAt)
+
+	if elapsed < 0 {
+		return 0
+	}
+
+	return elapsed
 }
 
 type Certificate struct {

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -223,18 +223,18 @@ func TestCertificateSource_String(t *testing.T) {
 func TestCertificateHeader_ElapsedTimeSinceCreation(t *testing.T) {
 	t.Run("NilCertificateHeader", func(t *testing.T) {
 		var ch *CertificateHeader
-		require.Equal(t, NAStr, ch.ElapsedTimeSinceCreation())
+		require.Equal(t, NAStr, ch.ElapsedTimeSinceCreationString())
 	})
 
 	t.Run("CreatedAtIsZero", func(t *testing.T) {
 		ch := &CertificateHeader{CreatedAt: 0}
-		require.Equal(t, NAStr, ch.ElapsedTimeSinceCreation())
+		require.Equal(t, NAStr, ch.ElapsedTimeSinceCreationString())
 	})
 
 	t.Run("CreatedAtIsNow", func(t *testing.T) {
 		now := uint32(time.Now().Unix())
 		ch := &CertificateHeader{CreatedAt: now}
-		result := ch.ElapsedTimeSinceCreation()
+		result := ch.ElapsedTimeSinceCreationString()
 		// Should be a duration string, e.g., "0s"
 		require.Contains(t, result, "s")
 	})
@@ -242,7 +242,7 @@ func TestCertificateHeader_ElapsedTimeSinceCreation(t *testing.T) {
 	t.Run("CreatedAtIsPast", func(t *testing.T) {
 		past := uint32(time.Now().Add(-10 * time.Second).Unix())
 		ch := &CertificateHeader{CreatedAt: past}
-		result := ch.ElapsedTimeSinceCreation()
+		result := ch.ElapsedTimeSinceCreationString()
 		// Should be at least 10s
 		dur, err := time.ParseDuration(result)
 		require.NoError(t, err)

--- a/aggsender/validator/local_validator.go
+++ b/aggsender/validator/local_validator.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const localValidatorName = "LocalValidator"
+const localValidatorIdentifier = "LocalValidator"
 
 var _ types.CertificateValidateAndSigner = (*LocalValidator)(nil)
 
@@ -41,7 +41,7 @@ func NewLocalValidator(
 
 // String returns a string representation of the LocalValidator.
 func (a *LocalValidator) String() string {
-	return localValidatorName
+	return localValidatorIdentifier
 }
 
 // URL returns an URL for the LocalValidator
@@ -90,7 +90,7 @@ func (a *LocalValidator) ValidateAndSignCertificate(
 	a.log.Infof("certificate validation passed: %s", certificate.Brief())
 
 	// local validator does not sign the certificate, it just validates it
-	return make([]byte, aggkitcommon.SignatureSize), nil
+	return aggkitcommon.EmptySignature, nil
 }
 
 // getPreviousCertificate retrieves the previous certificate based on the new certificate's height.

--- a/aggsender/validator/local_validator.go
+++ b/aggsender/validator/local_validator.go
@@ -9,7 +9,10 @@ import (
 	"github.com/agglayer/aggkit/aggsender/db"
 	"github.com/agglayer/aggkit/aggsender/types"
 	aggkitcommon "github.com/agglayer/aggkit/common"
+	"github.com/ethereum/go-ethereum/common"
 )
+
+const localValidatorName = "LocalValidator"
 
 var _ types.CertificateValidateAndSigner = (*LocalValidator)(nil)
 
@@ -38,12 +41,17 @@ func NewLocalValidator(
 
 // String returns a string representation of the LocalValidator.
 func (a *LocalValidator) String() string {
-	return "LocalValidator"
+	return localValidatorName
 }
 
 // URL returns an URL for the LocalValidator
 func (a *LocalValidator) URL() string {
 	return "N/A"
+}
+
+// Address returns the Ethereum address of the LocalValidator
+func (a *LocalValidator) Address() common.Address {
+	return common.Address{}
 }
 
 func (a *LocalValidator) HealthCheck(ctx context.Context) (*types.HealthCheckResponse, error) {
@@ -82,7 +90,7 @@ func (a *LocalValidator) ValidateAndSignCertificate(
 	a.log.Infof("certificate validation passed: %s", certificate.Brief())
 
 	// local validator does not sign the certificate, it just validates it
-	return nil, nil
+	return make([]byte, aggkitcommon.SignatureSize), nil
 }
 
 // getPreviousCertificate retrieves the previous certificate based on the new certificate's height.

--- a/aggsender/validator/local_validator_test.go
+++ b/aggsender/validator/local_validator_test.go
@@ -31,7 +31,7 @@ func TestValidateAndSignCertificate_Success(t *testing.T) {
 
 	signature, err := localValidator.ValidateAndSignCertificate(context.Background(), certificate, 0)
 	require.NoError(t, err)
-	require.Len(t, signature, aggkitcommon.SignatureSize)
+	require.Equal(t, signature, aggkitcommon.EmptySignature)
 	require.NotNil(t, localValidator.String())
 
 	storage.AssertExpectations(t)

--- a/aggsender/validator/local_validator_test.go
+++ b/aggsender/validator/local_validator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggsender/mocks"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestValidateAndSignCertificate_Success(t *testing.T) {
 
 	signature, err := localValidator.ValidateAndSignCertificate(context.Background(), certificate, 0)
 	require.NoError(t, err)
-	require.Nil(t, signature)
+	require.Len(t, signature, aggkitcommon.SignatureSize)
 	require.NotNil(t, localValidator.String())
 
 	storage.AssertExpectations(t)

--- a/aggsender/validator/remote_validator.go
+++ b/aggsender/validator/remote_validator.go
@@ -35,6 +35,7 @@ func NewRemoteValidator(cfg *grpc.ClientConfig,
 		url:     cfg.URL,
 		client:  client,
 		storage: storage,
+		address: address,
 	}, nil
 }
 

--- a/aggsender/validator/remote_validator.go
+++ b/aggsender/validator/remote_validator.go
@@ -17,13 +17,15 @@ var _ types.CertificateValidateAndSigner = (*RemoteValidator)(nil)
 // required to interact with the AggsenderValidator service.
 type RemoteValidator struct {
 	url     string
+	address common.Address
 	client  types.ValidatorClient
 	storage db.AggSenderStorage
 }
 
 // NewRemoteValidator initializes a new RemoteValidator with the provided gRPC client configuration.
 // It returns an error if the gRPC client cannot be created.
-func NewRemoteValidator(cfg *grpc.ClientConfig, storage db.AggSenderStorage) (*RemoteValidator, error) {
+func NewRemoteValidator(cfg *grpc.ClientConfig,
+	storage db.AggSenderStorage, address common.Address) (*RemoteValidator, error) {
 	client, err := NewValidatorClient(cfg)
 	if err != nil {
 		return nil, err
@@ -38,12 +40,17 @@ func NewRemoteValidator(cfg *grpc.ClientConfig, storage db.AggSenderStorage) (*R
 
 // String returns a string representation of the RemoteValidator.
 func (v *RemoteValidator) String() string {
-	return fmt.Sprintf("RemoteValidator (URL=%s)", v.url)
+	return fmt.Sprintf("RemoteValidator (URL=%s, Address=%s)", v.url, v.address.String())
 }
 
 // URL returns an URL for the remote validator
 func (v *RemoteValidator) URL() string {
 	return v.url
+}
+
+// Address returns the Ethereum address of the remote validator
+func (v *RemoteValidator) Address() common.Address {
+	return v.address
 }
 
 // HealthCheck performs a health check on the AggsenderValidator service.

--- a/common/common.go
+++ b/common/common.go
@@ -24,6 +24,8 @@ var (
 const (
 	Uint32ByteSize = 4
 	Uint64ByteSize = 8
+
+	SignatureSize = 65
 )
 
 // Uint64ToBigEndianBytes converts a uint64 to a byte slice in big-endian order

--- a/common/common.go
+++ b/common/common.go
@@ -19,6 +19,7 @@ var (
 	ZeroHash       = common.HexToHash("0x0")
 	EmptyBytesHash = crypto.Keccak256(nil)
 	ZeroAddress    = common.HexToAddress("0x0")
+	EmptySignature = make([]byte, SignatureSize)
 )
 
 const (


### PR DESCRIPTION
## 🔄 Changes Summary
Added new metrics to the `aggsender-proposer` side:
- `aggsender_prover_time` - time needed for the prover to return a successfully built `aggchain proof`.
- `aggsender_number_of_prover_errors` - number of errors gotten from the `aggkit prover` over time.
- `aggsender_validator_errors_total` - total number of errors returned by a validator over time. Validators are registered to the metric by their `ethereum` address.
- `aggsender_validator_invalid_signature_total` - number of times a validator returned an invalid signature. Validators are registered to the metric by their `ethereum` address.
- `aggsender_validate_time` - time needed for the validation of a proposed certificate to finish (total time for all validators).
- `aggsender_multisig_threshold_not_reached` - number of times a threshold for `multisig` was not reached.
- `aggsender_certificate_settlement_time` - time needed for a certificate to settle.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**:  `aggkit` CI

## 🐞 Issues
- Closes #915