### PR TITLE
fix: include retry count in signed certificate file name

### DIFF
--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -279,12 +279,13 @@ func (a *AggSenderSQLStorage) SaveOrUpdateCertificate(ctx context.Context, certi
 func (a *AggSenderSQLStorage) saveSignedCertificateToFile(
 	certificateHeight uint64,
 	certificateID common.Hash,
-	signedCertContent string) (string, error) {
+	signedCertContent string,
+	retryCount int) (string, error) {
 	// Get the directory where the database is stored
 	dbDir := filepath.Dir(a.cfg.DBPath)
 
 	// Create a filename using the certificate ID
-	fileName := fmt.Sprintf("signed_cert_%d_%s.json", certificateHeight, certificateID)
+	fileName := fmt.Sprintf("signed_cert_%d_%s_%d.json", certificateHeight, certificateID, retryCount)
 	filePath := filepath.Join(dbDir, fileName)
 
 	// Write the signed certificate content to the file
@@ -570,6 +571,7 @@ func (a *AggSenderSQLStorage) handleCertificateFile(certificate *types.Certifica
 			certificate.Header.Height,
 			certificate.Header.CertificateID,
 			*certificate.SignedCertificate,
+			certificate.Header.RetryCount,
 		)
 		if err != nil {
 			return fmt.Errorf("error saving signed certificate to file: %w", err)


### PR DESCRIPTION
## 🔄 Changes Summary

This pull request updates the certificate file handling logic to include retry information in the saved filenames. This change helps distinguish files generated from multiple retry attempts, making it easier to track and debug certificate processing.

**Certificate file naming improvements:**

* The `saveSignedCertificateToFile` method now accepts a new `retryCount` parameter and includes it in the generated filename, allowing each retry to produce a uniquely named file.
* The call to `saveSignedCertificateToFile` in the certificate handler now passes the certificate's retry count, ensuring the filename reflects the current attempt.

## ⚠️ Breaking Changes

NA

## 📋 Config Updates

NA

## ✅ Testing

Regular

## 🐞 Issues
- Closes #914 

## 🔗 Related PRs

#808 
