### PR TITLE
feat: upgrade golang

### DIFF
--- a/.github/workflows/build-aggkit-image.yml
+++ b/.github/workflows/build-aggkit-image.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare platform-safe variable
         id: platform_vars
@@ -118,7 +118,7 @@ jobs:
           - { suffix: "-dev", description: "development" }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download digests for production
         if: matrix.variant.suffix == ''

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.language == 'go' }}
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
 
       - name: Verify Go version
         if: ${{ matrix.language == 'go' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Setup environment
       - name: Setup Go

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,5 +14,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.24.6
+           go-version-input: 1.25.0
            go-package: ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   lint:
     runs-on: amd-runner-2204
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8.0.0
         with:
           version: v2.4.0
           args: --timeout=30m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.64.5
+          version: v2.4.0
           args: --timeout=30m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: 1.25.x
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4.0
           args: --timeout=30m

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: amd-runner-2204
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install mdBook and plugins
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           echo "PLATFORM_VARIANT=$PLATFORM_VARIANT" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker meta (prod)
         id: meta_prod

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -62,7 +62,7 @@ jobs:
   build-aggkit-image:
     uses: ./.github/workflows/build-aggkit-image.yml
     with:
-      go-version: 1.24.x
+      go-version: 1.25.x
       docker-image-name: aggkit
 
   read-aggkit-args:
@@ -128,7 +128,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build Aggsender Find Imported Bridge
         run: make build-tools
       - name: Upload Binary

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -85,7 +85,7 @@ jobs:
       kurtosis-cdk-args-5: ${{ steps.read-args.outputs.kurtosis-cdk-args-5 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Read kurtosis-cdk-args from file
         id: read-args
@@ -124,7 +124,7 @@ jobs:
     runs-on: amd-runner-2204
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: amd-runner-2204
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.4]
+        go-version: [1.25.0]
         goarch: ["amd64"]
     runs-on: amd-runner-2204
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,78 +1,85 @@
-# This file configures github.com/golangci/golangci-lint.
-
+version: "2"
 run:
-  timeout: 3m
   tests: true
-    
 linters:
-  disable-all: true
+  default: none
   enable:
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wastedassign # Finds wasted assignment statements
-    - unconvert  # Unnecessary type conversions
-    - tparallel # Detects inappropriate usage of t.Parallel() method in your Go test codes
-    - thelper # Detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - stylecheck # Stylecheck is a replacement for golint
-    - prealloc # Finds slice declarations that could potentially be pre-allocated
-    - predeclared # Finds code that shadows one of Go's predeclared identifiers
-    - nolintlint # Ill-formed or insufficient nolint directives
-    - misspell # Misspelled English words in comments
-    - makezero # Finds slice declarations with non-zero initial length
-    - lll # Long lines
-    - importas  # Enforces consistent import aliases
-    - gosec # Security problems
-    - gofmt # Whether the code was gofmt-ed
-    - goimports # Unused imports
-    - goconst # Repeated strings that could be replaced by a constant
-    - forcetypeassert # Finds forced type assertions
-    - dogsled # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
-    - dupl # Code clone detection
-    - errname # Checks that sentinel errors are prefixed with Err and error types are suffixed with Error
-    - errorlint # Error wrapping introduced in Go 1.13
-    - gocritic # gocritic is a Go source code linter that maintains checks that are not in other linters
-    - errcheck # Errcheck is a go lint rule for checking for unchecked errors
-    # - godox # Linter for TODOs and FIXMEs left in the code
-    - gci # Gci checks the consistency of the code with the Go code style guide
-    - mnd # mnd is a linter for magic numbers
-    # - revive
-    - unparam # Unused function parameters
+    - dogsled
+    - dupl
+    - errcheck
+    - errname
+    - errorlint
+    - forcetypeassert
+    - goconst
+    - gocritic
+    - gosec
+    - importas
+    - lll
+    - makezero
+    - misspell
+    - mnd
+    - nolintlint
+    - prealloc
+    - predeclared
+    - staticcheck
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
     - unused
-
-linters-settings:
-  gofmt:
-    simplify: true
-  gocritic:
-    enabled-checks:
-      - ruleguard
-    disabled-checks:
-      - ifElseChain
-  revive:
+    - wastedassign
+    - whitespace
+  settings:
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      enabled-checks:
+        - ruleguard
+      disabled-checks:
+        - ifElseChain
+    gosec:
+      excludes:
+        - G115
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: exported
-        arguments:
-          - disableStutteringCheck
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gosec:
-     excludes:
-      - G115  # Potential integer overflow when converting between integer types
-
+      - linters:
+          - gosec
+          - lll
+          - unparam
+        path: (_test\.go|^test/.*)
+      - linters:
+          - dupl
+        path: etherman/contracts/contracts_(banana|elderberry)\.go
+    paths:
+      - tests
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   whole-files: true
-  exclude-rules:
-    - path: '(_test\.go|^test/.*)'
-      linters:
-        - gosec
-        - unparam
-        - lll
-    - path: 'etherman/contracts/contracts_(banana|elderberry)\.go'
-      linters:
-        - dupl
-  exclude-dirs:
-    - tests
-  include:
-    - EXC0012 # Exported (.+) should have comment( \(or a comment on this block\))? or be unexported
-    - EXC0013 # Package comment should be of the form "(.+)...
-    - EXC0014 # Comment on exported (.+) should be of the form "(.+)..."
-    - EXC0015 # Should have a package comment
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - tests
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # STAGE 1: Build binary
 # ================================
-FROM --platform=${BUILDPLATFORM} golang:1.24.6-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25.0-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache gcc musl-dev make sqlite-dev

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build-docker-nc: ## Builds a docker image with the aggkit binary - but without b
 
 .PHONY: test-unit
 test-unit: ## Runs the unit tests
-	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -short -race -p 1 -covermode=atomic -coverprofile=coverage.out  -coverpkg ./... -timeout 15m ./...
+	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -short -race -p 1 -covermode=atomic -coverprofile=coverage.out -timeout 15m ./...
 
 .PHONY: lint
 lint: ## Runs the linter

--- a/aggsender/aggchainproofclient/aggchain_proof_client.go
+++ b/aggsender/aggchainproofclient/aggchain_proof_client.go
@@ -36,7 +36,7 @@ func NewAggchainProofClient(cfg *aggkitgrpc.ClientConfig) (*AggchainProofClient,
 
 func (c *AggchainProofClient) GenerateAggchainProof(ctx context.Context,
 	req *types.AggchainProofRequest) (*types.AggchainProof, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.grpcClientCfg.RequestTimeout.Duration)
+	ctx, cancel := context.WithTimeout(ctx, c.grpcClientCfg.RequestTimeout.Duration)
 	defer cancel()
 	request := convertAggchainProofRequestToGrpcRequest(req)
 	resp, err := c.client.GenerateAggchainProof(ctx, request)

--- a/aggsender/epoch_notifier_per_block.go
+++ b/aggsender/epoch_notifier_per_block.go
@@ -137,7 +137,7 @@ func (e *EpochNotifierPerBlock) startInternal(ctx context.Context, eventNewBlock
 			status, event = e.step(status, newBlock)
 			if event != nil {
 				e.logger.Debugf("new Epoch Event: %s", event.String())
-				e.GenericSubscriber.Publish(*event)
+				e.Publish(*event)
 			}
 		}
 	}

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -1235,7 +1235,7 @@ func TestGetLegacyTokenMigrationsHandler(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 		bridgeMocks.bridgeL1.EXPECT().
 			GetLegacyTokenMigrations(mock.Anything, mock.Anything, mock.Anything).
-			Return(nil, 0, fmt.Errorf(fooErrMsg))
+			Return(nil, 0, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set("network_id", "0")
@@ -1250,7 +1250,7 @@ func TestGetLegacyTokenMigrationsHandler(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 		bridgeMocks.bridgeL2.EXPECT().
 			GetLegacyTokenMigrations(mock.Anything, mock.Anything, mock.Anything).
-			Return(nil, 0, fmt.Errorf(barErrMsg))
+			Return(nil, 0, errors.New(barErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set("network_id", fmt.Sprintf("%d", l2NetworkID))
@@ -1385,7 +1385,7 @@ func TestL1InfoTreeIndexForBridgeHandler(t *testing.T) {
 
 		bridgeMocks.l1InfoTree.EXPECT().
 			GetLastInfo().
-			Return(nil, fmt.Errorf(fooErrMsg))
+			Return(nil, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set("network_id", "0")
@@ -1411,7 +1411,7 @@ func TestL1InfoTreeIndexForBridgeHandler(t *testing.T) {
 
 		bridgeMocks.bridgeL1.EXPECT().
 			GetRootByLER(mock.Anything, mock.Anything).
-			Return(nil, fmt.Errorf(barErrMsg))
+			Return(nil, errors.New(barErrMsg))
 
 		// With the fallback logic, it will try GetLastRoot when GetRootByLER fails
 		bridgeMocks.bridgeL1.EXPECT().
@@ -1533,7 +1533,7 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 
 		bridgeMocks.l1InfoTree.EXPECT().
 			GetInfoByIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
-			Return(nil, fmt.Errorf(fooErrMsg))
+			Return(nil, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, fmt.Sprintf("%d", mainnetNetworkID))
@@ -1551,7 +1551,7 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
-			Return(l2gersync.GlobalExitRootInfo{}, fmt.Errorf(barErrMsg))
+			Return(l2gersync.GlobalExitRootInfo{}, errors.New(barErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, fmt.Sprintf("%d", l2NetworkID))
@@ -1574,7 +1574,7 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 
 		bridgeMocks.l1InfoTree.EXPECT().
 			GetInfoByIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
-			Return(nil, fmt.Errorf(fooErrMsg))
+			Return(nil, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, fmt.Sprintf("%d", l2NetworkID))
@@ -1627,7 +1627,7 @@ func TestClaimProofHandler(t *testing.T) {
 
 		bridgeMocks.l1InfoTree.EXPECT().
 			GetInfoByIndex(mock.Anything, l1InfoTreeIndex).
-			Return(nil, fmt.Errorf(fooErrMsg))
+			Return(nil, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, strconv.Itoa(mainnetNetworkID))
@@ -1668,7 +1668,7 @@ func TestClaimProofHandler(t *testing.T) {
 
 		bridgeMocks.bridgeL1.EXPECT().
 			GetProof(mock.Anything, depositCount, l1InfoTreeLeaf.MainnetExitRoot).
-			Return(tree.Proof{}, fmt.Errorf(fooErrMsg))
+			Return(tree.Proof{}, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, fmt.Sprintf("%d", mainnetNetworkID))
@@ -1715,7 +1715,7 @@ func TestClaimProofHandler(t *testing.T) {
 
 		bridgeMocks.l1InfoTree.EXPECT().
 			GetLocalExitRoot(mock.Anything, l2NetworkID, l1InfoTreeLeaf.RollupExitRoot).
-			Return(common.Hash{}, fmt.Errorf(fooErrMsg))
+			Return(common.Hash{}, errors.New(fooErrMsg))
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, fmt.Sprintf("%d", l2NetworkID))
@@ -1899,7 +1899,7 @@ func TestGetLastReorgEventHandler(t *testing.T) {
 	t.Run("GetLastReorgEvent for L1 network failed", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 
-		bridgeMocks.bridgeL1.EXPECT().GetLastReorgEvent(mock.Anything).Return(nil, fmt.Errorf(fooErrMsg))
+		bridgeMocks.bridgeL1.EXPECT().GetLastReorgEvent(mock.Anything).Return(nil, errors.New(fooErrMsg))
 
 		response := performRequest(t, bridgeMocks.bridge.router, http.MethodGet,
 			fmt.Sprintf("%s/last-reorg-event?network_id=%d", BridgeV1Prefix, mainnetNetworkID), nil)
@@ -1910,7 +1910,7 @@ func TestGetLastReorgEventHandler(t *testing.T) {
 	t.Run("GetLastReorgEvent for L2 network failed", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 
-		bridgeMocks.bridgeL2.EXPECT().GetLastReorgEvent(mock.Anything).Return(nil, fmt.Errorf(barErrMsg))
+		bridgeMocks.bridgeL2.EXPECT().GetLastReorgEvent(mock.Anything).Return(nil, errors.New(barErrMsg))
 
 		response := performRequest(t, bridgeMocks.bridge.router, http.MethodGet,
 			fmt.Sprintf("%s/last-reorg-event?network_id=%d", BridgeV1Prefix, l2NetworkID), nil)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agglayer/aggkit
 
-go 1.24.6
+go 1.25.0
 
 require (
 	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250520190516-57743a879f16.2

--- a/hex/hex.go
+++ b/hex/hex.go
@@ -115,7 +115,7 @@ func DecodeBig(hexNum string) *big.Int {
 func IsValid(s string) bool {
 	str := strings.TrimPrefix(s, "0x")
 	for _, b := range []byte(str) {
-		if !(b >= '0' && b <= '9' || b >= 'a' && b <= 'f' || b >= 'A' && b <= 'F') {
+		if b < '0' || b > '9' && b < 'a' || b > 'f' && b < 'A' || b > 'F' {
 			return false
 		}
 	}

--- a/l2gersync/e2e_test.go
+++ b/l2gersync/e2e_test.go
@@ -127,9 +127,9 @@ func TestL2GERSync_GERRemoval(t *testing.T) {
 
 func TestL2GERSync_IndexLegacyGERManagerSC(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 	t.Skip("Skipping E2E test, this test is broken and needs a PR to be fixed. The lastProcessedBlock doesn't take in account empty blocks")
 
+	ctx := context.Background()
 	l1Setup, l2Setup := helpers.NewSimulatedEVMEnvironment(t, helpers.DefaultEnvironmentConfig(helpers.LegacyL2GERContract))
 
 	dbPathSyncer := path.Join(t.TempDir(), "l2GERSyncTestE2E.sqlite")

--- a/test/helpers/ethtxmanmock_e2e.go
+++ b/test/helpers/ethtxmanmock_e2e.go
@@ -134,7 +134,7 @@ func SendTx(ctx context.Context, client *SimulatedBackendWithMutex, auth *bind.T
 
 	// Synchronize access to the simulated backend to prevent race conditions
 	client.Mutex.Lock()
-	client.Backend.Commit()
+	client.Commit()
 	client.Mutex.Unlock()
 
 	return nil

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -173,12 +173,7 @@ if [ "$E2E_REPO_PATH" != "-" ]; then
         bats ./tests/aggkit/bridge-e2e-aggoracle-committee.bats
         ;;
     single-l2-network-fork12-pessimistic)
-        bats ./tests/aggkit/bridge-e2e.bats \
-             ./tests/aggkit/e2e-pp.bats \
-             ./tests/aggkit/bridge-e2e-custom-gas.bats \
-             ./tests/aggkit/bridge-e2e-nightly.bats \
-             ./tests/aggkit/internal-claims.bats \
-             ./tests/aggkit/claim-reetrancy.bats
+        bats ./tests/aggkit/bridge-e2e.bats
         ;;
     single-l2-network-fork12-global-index-pp-old-contracts)
         bats \

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -173,7 +173,12 @@ if [ "$E2E_REPO_PATH" != "-" ]; then
         bats ./tests/aggkit/bridge-e2e-aggoracle-committee.bats
         ;;
     single-l2-network-fork12-pessimistic)
-        bats ./tests/aggkit/bridge-e2e.bats
+        bats ./tests/aggkit/bridge-e2e.bats \
+             ./tests/aggkit/e2e-pp.bats \
+             ./tests/aggkit/bridge-e2e-custom-gas.bats \
+             ./tests/aggkit/bridge-e2e-nightly.bats \
+             ./tests/aggkit/internal-claims.bats \
+             ./tests/aggkit/claim-reetrancy.bats
         ;;
     single-l2-network-fork12-global-index-pp-old-contracts)
         bats \


### PR DESCRIPTION
## 🔄 Changes Summary
- upgrade golang to 1.25.0
- need to migrate the current lint file to the v2 (https://golangci-lint.run/docs/product/migration-guide/) and needed to adjust the failing checks

## 🐞 Issues
- Closes #900