### PR TITLE
feat: sanity check if `proposer` and `validator` are committee members

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -96,6 +96,7 @@ func New(
 		l1InfoTreeSyncer,
 		l2Syncer,
 		rollupDataQuerier,
+		committeeQuerier,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating flow manager: %w", err)

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -76,6 +76,7 @@ func TestAggSenderStart(t *testing.T) {
 	epochNotifierMock := mocks.NewEpochNotifier(t)
 	bridgeL2SyncerMock := mocks.NewL2BridgeSyncer(t)
 	rollupQuerierMock := mocks.NewRollupDataQuerier(t)
+	committeQuerierMock := mocks.NewMultisigQuerier(t)
 	ch := make(chan aggsendertypes.EpochEvent)
 	epochNotifierMock.EXPECT().Subscribe("aggsender").Return(ch)
 	epochNotifierMock.EXPECT().GetEpochStatus().Return(aggsendertypes.EpochStatus{}).Once()
@@ -84,6 +85,9 @@ func TestAggSenderStart(t *testing.T) {
 	aggLayerMock.EXPECT().GetLatestPendingCertificateHeader(mock.Anything, mock.Anything).Return(nil, nil)
 	aggLayerMock.EXPECT().GetLatestSettledCertificateHeader(mock.Anything, mock.Anything).Return(nil, nil)
 	rollupQuerierMock.EXPECT().GetRollupChainID().Return(uint64(1234), nil)
+	committee, err := aggsendertypes.NewMultisigCommittee([]*aggsendertypes.SignerInfo{aggsendertypes.NewSignerInfo("", common.Address{})}, 1)
+	require.NoError(t, err)
+	committeQuerierMock.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Once()
 
 	ctx := t.Context()
 	aggSender, err := New(
@@ -104,7 +108,7 @@ func TestAggSenderStart(t *testing.T) {
 		nil, // l1 client
 		nil, // l2 client
 		rollupQuerierMock,
-		nil, // committee querier
+		committeQuerierMock,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, aggSender)
@@ -570,8 +574,13 @@ func TestGetValidators(t *testing.T) {
 func TestNewAggSender(t *testing.T) {
 	mockBridgeSyncer := mocks.NewL2BridgeSyncer(t)
 	mockRollupQuerier := mocks.NewRollupDataQuerier(t)
+	mockCommitteeQuerier := mocks.NewMultisigQuerier(t)
 	mockBridgeSyncer.EXPECT().OriginNetwork().Return(uint32(1)).Times(2)
 	mockRollupQuerier.EXPECT().GetRollupChainID().Return(uint64(1234), nil)
+	committee, err := aggsendertypes.NewMultisigCommittee([]*aggsendertypes.SignerInfo{aggsendertypes.NewSignerInfo("", common.Address{})}, 1)
+	require.NoError(t, err)
+	mockCommitteeQuerier.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Once()
+
 	sut, err := New(context.TODO(), log.WithFields("module", "ut"), config.Config{
 		AggsenderPrivateKey: signertypes.SignerConfig{
 			Method: signertypes.MethodNone,
@@ -582,7 +591,7 @@ func TestNewAggSender(t *testing.T) {
 		nil, // l1 client
 		nil, // l2 client
 		mockRollupQuerier,
-		nil, // committee querier
+		mockCommitteeQuerier,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, sut)

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -87,6 +87,8 @@ type Config struct {
 	ValidatorClient *grpc.ClientConfig `mapstructure:"ValidatorClient"`
 	// RetriesToBuildAndSendCertificate is the configuration for the retries to build and send a certificate
 	RetriesToBuildAndSendCertificate common.RetryPolicyGenericConfig `mapstructure:"RetriesToBuildAndSendCertificate"`
+	// RequireCommitteeMembershipCheck indicates whether to check if the signer is part of the committee
+	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -204,7 +204,12 @@ func initializeSigner(
 
 	multisigCommittee, err := committeeQuerier.GetMultisigCommittee(ctx, big.NewInt(int64(aggkittypes.Latest)))
 	if err != nil {
-		return nil, fmt.Errorf("error getting multisig committee: %w", err)
+		if requireCommitteeMembershipCheck {
+			return nil, fmt.Errorf("error getting multisig committee: %w", err)
+		}
+
+		logger.Warnf("error getting multisig committee: %v", err)
+		return signer, nil
 	}
 
 	if !multisigCommittee.IsMember(signer.PublicAddress()) {

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -3,6 +3,7 @@ package flows
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/agglayer/aggkit/aggsender/aggchainproofclient"
@@ -34,11 +35,14 @@ func NewFlow(
 	l1InfoTreeSyncer types.L1InfoTreeSyncer,
 	l2Syncer types.L2BridgeSyncer,
 	rollupDataQuerier types.RollupDataQuerier,
+	committeeQuerier types.MultisigQuerier,
 ) (types.AggsenderFlow, error) {
 	switch types.AggsenderMode(cfg.Mode) {
 	case types.PessimisticProofMode:
 		commonFlowComponents, err := CreateCommonFlowComponents(
-			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier, 0, false,
+			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer,
+			rollupDataQuerier, committeeQuerier,
+			0, false,
 			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
 			true,
@@ -81,7 +85,8 @@ func NewFlow(
 		}
 
 		commonFlowComponents, err := CreateCommonFlowComponents(
-			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier,
+			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer,
+			rollupDataQuerier, committeeQuerier,
 			aggchainFEPQuerier.StartL2Block(), cfg.RequireNoFEPBlockGap,
 			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
@@ -139,6 +144,7 @@ func CreateCommonFlowComponents(
 	l1InfoTreeSyncer types.L1InfoTreeSyncer,
 	l2Syncer types.L2BridgeSyncer,
 	rollupDataQuerier types.RollupDataQuerier,
+	committeeQuerier types.MultisigQuerier,
 	startL2Block uint64,
 	requireNoFEPBlockGap bool,
 	maxCertSize uint,
@@ -152,7 +158,7 @@ func CreateCommonFlowComponents(
 		return nil, fmt.Errorf("error getting rollup chain id: %w", err)
 	}
 
-	signer, err := initializeSigner(ctx, signerCfg, logger, l2ChainID)
+	signer, err := initializeSigner(ctx, signerCfg, logger, l2ChainID, committeeQuerier)
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +186,7 @@ func initializeSigner(
 	signerCfg signertypes.SignerConfig,
 	logger *log.Logger,
 	l2ChainID uint64,
+	committeeQuerier types.MultisigQuerier,
 ) (signertypes.Signer, error) {
 	signer, err := signer.NewSigner(ctx, l2ChainID, signerCfg, aggkitcommon.AGGSENDER, logger)
 	if err != nil {
@@ -188,6 +195,16 @@ func initializeSigner(
 
 	if err := signer.Initialize(ctx); err != nil {
 		return nil, fmt.Errorf("error signer.Initialize. Err: %w", err)
+	}
+
+	multisigCommittee, err := committeeQuerier.GetMultisigCommittee(ctx, big.NewInt(int64(aggkittypes.Latest)))
+	if err != nil {
+		return nil, fmt.Errorf("error getting multisig committee: %w", err)
+	}
+
+	if !multisigCommittee.IsMember(signer.PublicAddress()) {
+		return nil, fmt.Errorf("signer address %s is not part of the multisig committee: %s",
+			signer.PublicAddress(), multisigCommittee.String())
 	}
 
 	return signer, nil

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -46,6 +46,7 @@ func NewFlow(
 			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
 			true,
+			cfg.RequireCommitteeMembershipCheck,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -91,6 +92,7 @@ func NewFlow(
 			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
 			true,
+			cfg.RequireCommitteeMembershipCheck,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -152,13 +154,15 @@ func CreateCommonFlowComponents(
 	delayBetweenRetries time.Duration,
 	signerCfg signertypes.SignerConfig,
 	fullClaimsRequired bool,
+	requireCommitteeMembershipCheck bool,
 ) (*CommonFlowComponents, error) {
 	l2ChainID, err := rollupDataQuerier.GetRollupChainID()
 	if err != nil {
 		return nil, fmt.Errorf("error getting rollup chain id: %w", err)
 	}
 
-	signer, err := initializeSigner(ctx, signerCfg, logger, l2ChainID, committeeQuerier)
+	signer, err := initializeSigner(ctx, signerCfg, logger, l2ChainID,
+		committeeQuerier, requireCommitteeMembershipCheck)
 	if err != nil {
 		return nil, err
 	}
@@ -187,6 +191,7 @@ func initializeSigner(
 	logger *log.Logger,
 	l2ChainID uint64,
 	committeeQuerier types.MultisigQuerier,
+	requireCommitteeMembershipCheck bool,
 ) (signertypes.Signer, error) {
 	signer, err := signer.NewSigner(ctx, l2ChainID, signerCfg, aggkitcommon.AGGSENDER, logger)
 	if err != nil {
@@ -203,7 +208,12 @@ func initializeSigner(
 	}
 
 	if !multisigCommittee.IsMember(signer.PublicAddress()) {
-		return nil, fmt.Errorf("signer address %s is not part of the multisig committee: %s",
+		if requireCommitteeMembershipCheck {
+			return nil, fmt.Errorf("signer address %s is not part of the multisig committee: %s",
+				signer.PublicAddress(), multisigCommittee.String())
+		}
+
+		logger.Warnf("signer address %s is not part of the multisig committee: %s",
 			signer.PublicAddress(), multisigCommittee.String())
 	}
 

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agglayer/aggkit/log"
 	typesmocks "github.com/agglayer/aggkit/types/mocks"
 	signertypes "github.com/agglayer/go_signer/signer/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -26,6 +27,7 @@ func TestNewFlow(t *testing.T) {
 	testCases := []struct {
 		name          string
 		cfg           config.Config
+		mockFn        func(*mocks.MultisigQuerier)
 		expectedError string
 	}{
 		{
@@ -36,6 +38,33 @@ func TestNewFlow(t *testing.T) {
 				MaxCertSize:         100,
 				AggkitProverClient:  aggkitgrpc.DefaultConfig(),
 			},
+			mockFn: func(mockCommittee *mocks.MultisigQuerier) {
+				committee, err := types.NewMultisigCommittee([]*types.SignerInfo{types.NewSignerInfo("", common.Address{})}, 1)
+				require.NoError(t, err)
+
+				mockCommittee.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Maybe()
+			},
+		},
+		{
+			name: "not member of committee",
+			cfg: config.Config{
+				Mode:                string(types.PessimisticProofMode),
+				AggsenderPrivateKey: signertypes.SignerConfig{Method: signertypes.MethodNone},
+				MaxCertSize:         100,
+				AggkitProverClient:  aggkitgrpc.DefaultConfig(),
+			},
+			mockFn: func(mockCommittee *mocks.MultisigQuerier) {
+				signers := []*types.SignerInfo{
+					types.NewSignerInfo("http://signer2", common.HexToAddress("0x2222222222222222222222222222222222222222")),
+					types.NewSignerInfo("http://signer3", common.HexToAddress("0x3333333333333333333333333333333333333333")),
+					types.NewSignerInfo("http://signer4", common.HexToAddress("0x4444444444444444444444444444444444444444")),
+				}
+
+				committee, err := types.NewMultisigCommittee(signers, 2)
+				require.NoError(t, err)
+				mockCommittee.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Maybe()
+			},
+			expectedError: "signer address 0x0000000000000000000000000000000000000000 is not part of the multisig committee",
 		},
 		{
 			name: "error creating signer in PessimisticProofMode",
@@ -84,6 +113,7 @@ func TestNewFlow(t *testing.T) {
 			mockL1InfoTreeSyncer := mocks.NewL1InfoTreeSyncer(t)
 			mockL2BridgeSyncer := mocks.NewL2BridgeSyncer(t)
 			mockRollupDataQuerier := mocks.NewRollupDataQuerier(t)
+			mockCommitteeQuerier := mocks.NewMultisigQuerier(t)
 
 			mockL2BridgeSyncer.EXPECT().OriginNetwork().Return(1).Maybe()
 			mockLogger := log.WithFields("test", "NewFlow")
@@ -93,6 +123,11 @@ func TestNewFlow(t *testing.T) {
 			mockL2Client.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return([]byte{1, 2, 3}, nil).Maybe()
 			mockL2Client.EXPECT().CodeAt(mock.Anything, mock.Anything, mock.Anything).Return([]byte{1, 2, 3}, nil).Maybe()
 			mockRollupDataQuerier.EXPECT().GetRollupChainID().Return(uint64(1234), nil).Maybe()
+
+			if tc.mockFn != nil {
+				tc.mockFn(mockCommitteeQuerier)
+			}
+
 			flow, err := NewFlow(
 				ctx,
 				tc.cfg,
@@ -103,6 +138,7 @@ func TestNewFlow(t *testing.T) {
 				mockL1InfoTreeSyncer,
 				mockL2BridgeSyncer,
 				mockRollupDataQuerier,
+				mockCommitteeQuerier,
 			)
 
 			if tc.expectedError != "" {

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -2,6 +2,7 @@ package flows
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -43,6 +44,33 @@ func TestNewFlow(t *testing.T) {
 				require.NoError(t, err)
 
 				mockCommittee.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Maybe()
+			},
+		},
+		{
+			name: "error getting multisig committee when RequireCommitteeMembershipCheck is true",
+			cfg: config.Config{
+				Mode:                            string(types.PessimisticProofMode),
+				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
+				MaxCertSize:                     100,
+				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
+				RequireCommitteeMembershipCheck: true,
+			},
+			mockFn: func(mockCommittee *mocks.MultisigQuerier) {
+				mockCommittee.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(nil, errors.New("test error")).Maybe()
+			},
+			expectedError: "error getting multisig committee: test error",
+		},
+		{
+			name: "error getting multisig committee when RequireCommitteeMembershipCheck is false",
+			cfg: config.Config{
+				Mode:                            string(types.PessimisticProofMode),
+				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
+				MaxCertSize:                     100,
+				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
+				RequireCommitteeMembershipCheck: false,
+			},
+			mockFn: func(mockCommittee *mocks.MultisigQuerier) {
+				mockCommittee.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(nil, errors.New("test error")).Maybe()
 			},
 		},
 		{

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -46,12 +46,34 @@ func TestNewFlow(t *testing.T) {
 			},
 		},
 		{
+			name: "committee membership check disabled with PessimisticProofMode",
+			cfg: config.Config{
+				Mode:                            string(types.PessimisticProofMode),
+				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
+				MaxCertSize:                     100,
+				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
+				RequireCommitteeMembershipCheck: false,
+			},
+			mockFn: func(mockCommittee *mocks.MultisigQuerier) {
+				signers := []*types.SignerInfo{
+					types.NewSignerInfo("http://signer2", common.HexToAddress("0x2222222222222222222222222222222222222222")),
+					types.NewSignerInfo("http://signer3", common.HexToAddress("0x3333333333333333333333333333333333333333")),
+					types.NewSignerInfo("http://signer4", common.HexToAddress("0x4444444444444444444444444444444444")),
+				}
+
+				committee, err := types.NewMultisigCommittee(signers, 2)
+				require.NoError(t, err)
+				mockCommittee.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Maybe()
+			},
+		},
+		{
 			name: "not member of committee",
 			cfg: config.Config{
-				Mode:                string(types.PessimisticProofMode),
-				AggsenderPrivateKey: signertypes.SignerConfig{Method: signertypes.MethodNone},
-				MaxCertSize:         100,
-				AggkitProverClient:  aggkitgrpc.DefaultConfig(),
+				Mode:                            string(types.PessimisticProofMode),
+				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
+				MaxCertSize:                     100,
+				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
+				RequireCommitteeMembershipCheck: true,
 			},
 			mockFn: func(mockCommittee *mocks.MultisigQuerier) {
 				signers := []*types.SignerInfo{

--- a/aggsender/types/multisig_committee.go
+++ b/aggsender/types/multisig_committee.go
@@ -100,3 +100,22 @@ func (m *MultisigCommittee) Signers() []SignerInfo {
 func (m *MultisigCommittee) Size() int {
 	return len(m.signers)
 }
+
+// IsMember checks if the given address is part of the committee
+func (m *MultisigCommittee) IsMember(address common.Address) bool {
+	_, exists := m.signersSet[address]
+	return exists
+}
+
+// String returns a string representation of the committee
+func (m *MultisigCommittee) String() string {
+	s := "[Committee: "
+	for i, signer := range m.signers {
+		s += signer.Address.Hex()
+		if i < len(m.signers)-1 {
+			s += ", "
+		}
+	}
+	s += fmt.Sprintf(" Threshold: %d]", m.threshold)
+	return s
+}

--- a/aggsender/types/multisig_committee_test.go
+++ b/aggsender/types/multisig_committee_test.go
@@ -129,3 +129,64 @@ func TestMultisigCommittee_Signers(t *testing.T) {
 	cpySigners[0].Address = common.HexToAddress("0x4")
 	require.NotEqual(t, signers, cpySigners)
 }
+
+func TestMultisigCommittee_IsMember(t *testing.T) {
+	s1 := NewSignerInfo("http://localhost:7001", common.HexToAddress("0x1"))
+	s2 := NewSignerInfo("http://localhost:7002", common.HexToAddress("0x2"))
+
+	mc, err := NewMultisigCommittee([]*SignerInfo{s1}, 1)
+	require.NoError(t, err)
+
+	// existing member
+	require.True(t, mc.IsMember(s1.Address))
+
+	// non-member
+	require.False(t, mc.IsMember(s2.Address))
+
+	// add new signer and verify membership
+	require.NoError(t, mc.AddSigner(s2))
+	require.True(t, mc.IsMember(s2.Address))
+
+	// zero address should not be a member
+	require.False(t, mc.IsMember(common.Address{}))
+}
+
+func TestMultisigCommittee_String(t *testing.T) {
+	s1 := NewSignerInfo("http://localhost:7001", common.HexToAddress("0x1"))
+	s2 := NewSignerInfo("http://localhost:7002", common.HexToAddress("0x2"))
+	s3 := NewSignerInfo("http://localhost:7003", common.HexToAddress("0x3"))
+
+	tests := []struct {
+		name      string
+		members   []*SignerInfo
+		threshold uint32
+		expected  string
+	}{
+		{
+			name:      "single signer",
+			members:   []*SignerInfo{s1},
+			threshold: 1,
+			expected:  "[Committee: " + s1.Address.Hex() + " Threshold: 1]",
+		},
+		{
+			name:      "two signers",
+			members:   []*SignerInfo{s1, s2},
+			threshold: 2,
+			expected:  "[Committee: " + s1.Address.Hex() + ", " + s2.Address.Hex() + " Threshold: 2]",
+		},
+		{
+			name:      "three signers, threshold less than size",
+			members:   []*SignerInfo{s1, s2, s3},
+			threshold: 2,
+			expected:  "[Committee: " + s1.Address.Hex() + ", " + s2.Address.Hex() + ", " + s3.Address.Hex() + " Threshold: 2]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mc, err := NewMultisigCommittee(tc.members, tc.threshold)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, mc.String())
+		})
+	}
+}

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	AgglayerClient agglayer.ClientConfig `mapstructure:"AgglayerClient"`
 	// Mode is the mode of the AggSender Validator (regular pessimistic proof mode or the aggchain proof mode)
 	Mode string `jsonschema:"enum=PessimisticProof, enum=AggchainProof" mapstructure:"Mode"`
+	// RequireCommitteeMembershipCheck indicates whether to check if the validator is part of the committee
+	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 }
 
 type PPConfig struct {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -95,6 +95,8 @@ func start(cliCtx *cli.Context) error {
 		cliCtx.Context, components, cfg.L2GERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
 
+	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client)
+
 	var rpcServices []jRPC.Service
 	for _, component := range components {
 		switch component {
@@ -114,13 +116,6 @@ func start(cliCtx *cli.Context) error {
 
 			go b.Start(cliCtx.Context)
 		case aggkitcommon.AGGSENDER:
-			// TODO: Check if the RollupAddr is the right SC address, or we should use some other.
-			committeeQuerier, err := query.NewECDSAMultisigCommitteeQuery(cfg.L1NetworkConfig.RollupAddr, l1Client)
-			if err != nil {
-				return fmt.Errorf("failed to create ECDSA multisig committee querier (SC address: %s): %w",
-					cfg.L1NetworkConfig.RollupAddr, err)
-			}
-
 			aggsender, err := createAggSender(
 				cliCtx.Context,
 				cfg.AggSender,
@@ -159,6 +154,7 @@ func start(cliCtx *cli.Context) error {
 				l2BridgeSync,
 				l1Client,
 				rollupDataQuerier,
+				committeeQuerier,
 			)
 			if err != nil {
 				log.Fatal(err)
@@ -223,6 +219,7 @@ func createAggSenderValidator(ctx context.Context,
 	l2Syncer *bridgesync.BridgeSync,
 	l1Client aggkittypes.BaseEthereumClienter,
 	rollupDataQuerier *etherman.RollupDataQuerier,
+	committeeQuerier *query.ECDSAMultisigCommitteeQuery,
 ) (*aggsender.AggsenderValidator, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid aggsender validator config: %w", err)
@@ -244,7 +241,7 @@ func createAggSenderValidator(ctx context.Context,
 		commonFlowComponents, err = flows.CreateCommonFlowComponents(
 			ctx, logger,
 			nil, // storage is not used in validator,
-			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, false,
+			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, committeeQuerier, 0, false,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
 			false, // full claims are not needed in validator mode
 		)
@@ -266,7 +263,8 @@ func createAggSenderValidator(ctx context.Context,
 		commonFlowComponents, err = flows.CreateCommonFlowComponents(
 			ctx, logger,
 			nil, // storage is not used in validator,
-			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, 0, cfg.FEPConfig.RequireNoBlockGap,
+			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, committeeQuerier,
+			0, cfg.FEPConfig.RequireNoBlockGap,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.Signer,
 			false, // full claims are not needed in validator mode
@@ -724,6 +722,23 @@ func runBridgeSyncL2IfNeeded(
 	go bridgeSyncL2.Start(ctx)
 
 	return bridgeSyncL2
+}
+
+func runAggsenderMultisigCommitteeIfNeeded(
+	components []string,
+	rollupAddr common.Address,
+	l1Client aggkittypes.BaseEthereumClienter,
+) *query.ECDSAMultisigCommitteeQuery {
+	if !isNeeded([]string{aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR}, components) {
+		return nil
+	}
+
+	committeeQuerier, err := query.NewECDSAMultisigCommitteeQuery(rollupAddr, l1Client)
+	if err != nil {
+		log.Fatalf("failed to create ECDSA multisig committee querier (SC address: %s): %w", rollupAddr, err)
+	}
+
+	return committeeQuerier
 }
 
 func createBridgeService(

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -219,7 +219,7 @@ func createAggSenderValidator(ctx context.Context,
 	l2Syncer *bridgesync.BridgeSync,
 	l1Client aggkittypes.BaseEthereumClienter,
 	rollupDataQuerier *etherman.RollupDataQuerier,
-	committeeQuerier *query.ECDSAMultisigCommitteeQuery,
+	committeeQuerier aggsendertypes.MultisigQuerier,
 ) (*aggsender.AggsenderValidator, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid aggsender validator config: %w", err)
@@ -730,7 +730,7 @@ func runAggsenderMultisigCommitteeIfNeeded(
 	components []string,
 	rollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
-) *query.ECDSAMultisigCommitteeQuery {
+) aggsendertypes.MultisigQuerier {
 	if !isNeeded([]string{aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR}, components) {
 		return nil
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -244,6 +244,7 @@ func createAggSenderValidator(ctx context.Context,
 			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, committeeQuerier, 0, false,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
 			false, // full claims are not needed in validator mode
+			cfg.RequireCommitteeMembershipCheck,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)
@@ -267,7 +268,8 @@ func createAggSenderValidator(ctx context.Context,
 			0, cfg.FEPConfig.RequireNoBlockGap,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.Signer,
-			false, // full claims are not needed in validator mode
+			false, // full claims are not needed in validator mode,
+			cfg.RequireCommitteeMembershipCheck,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create common flow components: %w", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -735,7 +735,7 @@ func runAggsenderMultisigCommitteeIfNeeded(
 
 	committeeQuerier, err := query.NewECDSAMultisigCommitteeQuery(rollupAddr, l1Client)
 	if err != nil {
-		log.Fatalf("failed to create ECDSA multisig committee querier (SC address: %s): %w", rollupAddr, err)
+		log.Fatalf("failed to create ECDSA multisig committee querier (SC address: %s): %s", rollupAddr, err)
 	}
 
 	return committeeQuerier

--- a/config/default.go
+++ b/config/default.go
@@ -204,6 +204,7 @@ RollupCreationBlockL1 = {{rollupCreationBlockNumber}}
 MaxL2BlockNumber = 0
 StopOnFinishedSendingAllCertificates = false
 RequireValidatorCall = false
+RequireCommitteeMembershipCheck = false
 	[AggSender.RetriesToBuildAndSendCertificate]
 		RetryMode = "delays"
 		Delays = [ "1m", "1m", "2m", "5m", "5m", "8m" ]
@@ -272,6 +273,7 @@ MaxL2BlockNumber = "{{AggSender.MaxL2BlockNumber}}"
 DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
 # PessimisticProof or AggchainProof
 Mode = "PessimisticProof"
+RequireCommitteeMembershipCheck = {{AggSender.RequireCommitteeMembershipCheck}}
 [Validator.ServerConfig]
 	Host = "0.0.0.0"
 	Port = 5578


### PR DESCRIPTION
## 🔄 Changes Summary
This PR adds a sanity check on `aggsender-proposer` and `aggsender-validator` startup to check if they are a member of the `multisig` committee.

This PR also added config parameter called `RequireCommitteeMembershipCheck` to `Aggsender` and `Validator` configurations, which users can use to either require the proposer to be a member of the committee and also the same for the validator.

Note that for now we put this config parameter by default to `false`, but once we have new contracts setup in `kurtosis-cdk` we will change this to `true`, since it is decided that in regular cases, both the `aggsender-proposer` and `aggsender-validator` should be in the `multisig committee`.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
Added:

```toml
AggSender.RequireCommitteeMembershipCheck = false

Validator.RequireCommitteeMembershipCheck = false
```

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI

## 🐞 Issues
- Closes #936
- Closes #937
