### PR TITLE
fix: [integration] remove block number and use the latest one when querying for the committee

### DIFF
--- a/aggsender/validator_poller.go
+++ b/aggsender/validator_poller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/validator"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/grpc"
+	aggkittypes "github.com/agglayer/aggkit/types"
 	signertypes "github.com/agglayer/go_signer/signer/types"
 )
 
@@ -101,7 +102,7 @@ func (vp *validatorPoller) validateRequest(req *types.ValidationRequest) error {
 // getValidators retrieves the actual multisig committee and creates a set of the validators
 // that are going to validate the provided certificate
 func (vp *validatorPoller) getValidators(ctx context.Context) ([]types.CertificateValidateAndSigner, *big.Int, error) {
-	committee, err := vp.multisigQuerier.GetMultisigCommittee(ctx, nil)
+	committee, err := vp.multisigQuerier.GetMultisigCommittee(ctx, big.NewInt(int64(aggkittypes.Latest)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to retrieve the latest multisig committee: %w", err)
 	}

--- a/aggsender/validator_poller.go
+++ b/aggsender/validator_poller.go
@@ -63,7 +63,7 @@ func (vp *validatorPoller) PollValidators(
 
 	vp.log.Infof("delegating certificate validation: %s", req.Certificate.Brief())
 
-	validators, threshold, err := vp.getValidators(ctx, req.LastL2BlockInCert)
+	validators, threshold, err := vp.getValidators(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validators: %w", err)
 	}
@@ -100,10 +100,8 @@ func (vp *validatorPoller) validateRequest(req *types.ValidationRequest) error {
 
 // getValidators retrieves the actual multisig committee and creates a set of the validators
 // that are going to validate the provided certificate
-func (vp *validatorPoller) getValidators(
-	ctx context.Context,
-	lastL2BlockInCert uint64) ([]types.CertificateValidateAndSigner, *big.Int, error) {
-	committee, err := vp.multisigQuerier.GetMultisigCommittee(ctx, new(big.Int).SetUint64(lastL2BlockInCert))
+func (vp *validatorPoller) getValidators(ctx context.Context) ([]types.CertificateValidateAndSigner, *big.Int, error) {
+	committee, err := vp.multisigQuerier.GetMultisigCommittee(ctx, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to retrieve the latest multisig committee: %w", err)
 	}

--- a/aggsender/validator_poller_test.go
+++ b/aggsender/validator_poller_test.go
@@ -321,7 +321,6 @@ func TestPollValidators(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -478,7 +477,7 @@ func TestGetValidators(t *testing.T) {
 				clientCfg,
 			)
 
-			validators, threshold, err := vp.getValidators(context.Background(), 10)
+			validators, threshold, err := vp.getValidators(context.Background())
 
 			if tc.expectedErr != "" {
 				require.ErrorContains(t, err, tc.expectedErr)


### PR DESCRIPTION
## 🔄 Changes Summary

When retrieveing the multisig committee, we were querying the L1 contract, namely the `AggchainECDSAMultisig`, by providing the L2 block number. From now on, we are going to query the state, against the latest L1 block.

### Log Excerpt
```json
[aggkit-001] {
   "level":"error",
   "ts":1757492234.1605856,
   "caller":"aggsender/aggsender.go:304",
   "msg":"error polling validator committee: failed to get validators: failed to retrieve the latest multisig committee: failed to query the signatures threshold for block 718: header not found",
   "pid":7,
   "version":"",
   "module":"aggsender",
   "stacktrace":"github.com/agglayer/aggkit/aggsender.(*AggSender).sendCertificateWithRetries.func1\n\t/app/aggsender/aggsender.go:304...}
```

## ⚠️ Breaking Changes
- 🛠️ **Config**: N/A
- 🔌 **API/CLI**: N/A
- 🗑️ **Deprecated Features**: N/A

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: N/A

## ✅ Testing
- 🤖 **Automatic**: N/A
- 🖱️ **Manual**:
1. Checkout `jhilliard/aggsender-validator-committee`
2. Run the following command to spin up the kurtosis cluster
```bash
$ kurtosis run --enclave=op --args-file=./.github/tests/op-geth/aggchain-ecdsa-multisig.yml .
```
3. When the certificate is built, make sure that there are no issues like this in the aggkit log
```
"error polling validator committee: failed to get validators: failed to retrieve the latest multisig committee
```
## 🐞 Issues
- Closes #981 

## 🔗 Related PRs
N/A

## 📝 Notes
N/A
