### PR TITLE
fix: aggsender proposer override multisig committee URL

### DIFF
--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -89,7 +89,7 @@ type Config struct {
 	// RequireCommitteeMembershipCheck indicates whether to check if the signer is part of the committee
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 	// It allow to change committee URL for testing purposes
-	CommiteeOverride query.CommiteeOverride `mapstructure:"CommiteeOverride"`
+	CommitteeOverride query.CommitteeOverride `mapstructure:"CommitteeOverride"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -89,7 +89,7 @@ type Config struct {
 	// RequireCommitteeMembershipCheck indicates whether to check if the signer is part of the committee
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 	// It allow to change committee URL for testing purposes
-	CommiteeOverride query.CommiteeURLOverride `mapstructure:"CommiteeURLOverride"`
+	CommiteeOverride query.CommiteeOverride `mapstructure:"CommiteeOverride"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer"
 	"github.com/agglayer/aggkit/aggsender/optimistic"
+	"github.com/agglayer/aggkit/aggsender/query"
 	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/config/types"
@@ -87,6 +88,8 @@ type Config struct {
 	RetriesToBuildAndSendCertificate common.RetryPolicyGenericConfig `mapstructure:"RetriesToBuildAndSendCertificate"`
 	// RequireCommitteeMembershipCheck indicates whether to check if the signer is part of the committee
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
+	// It allow to change commitee URL for testing purposes
+	CommiteeOverride query.CommiteeURLOverride `mapstructure:"CommiteeURLOverride"`
 }
 
 func (c Config) CheckCertConfigBriefString() string {

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -88,7 +88,7 @@ type Config struct {
 	RetriesToBuildAndSendCertificate common.RetryPolicyGenericConfig `mapstructure:"RetriesToBuildAndSendCertificate"`
 	// RequireCommitteeMembershipCheck indicates whether to check if the signer is part of the committee
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
-	// It allow to change commitee URL for testing purposes
+	// It allow to change committee URL for testing purposes
 	CommiteeOverride query.CommiteeURLOverride `mapstructure:"CommiteeURLOverride"`
 }
 

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -30,6 +30,9 @@ type CommitteeOverride struct {
 }
 
 func (c *CommitteeOverride) String() string {
+	if c == nil {
+		return "CommitteeOverride{nil}"
+	}
 	return fmt.Sprintf("CommitteeOverride{URL: %v}", c.URLMapping)
 }
 

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -18,22 +18,44 @@ var (
 )
 
 type BaseMultisigCommitteeQuery struct {
-	multisigCommitteeSC   types.MultisigContract
-	multisigCommitteeAddr common.Address
+	sovereignRollupAddrSC types.MultisigContract
+	sovereignRollupAddr   common.Address
+	overrideURL           *CommiteeURLOverride
+}
+
+type CommiteeURLOverride struct {
+	URL map[common.Address]string
+}
+
+func (m *CommiteeURLOverride) ReplaceURL(committee []aggchainbase.IAggchainSignersSignerInfo) []aggchainbase.IAggchainSignersSignerInfo {
+	if m == nil || len(m.URL) == 0 {
+		return nil
+	}
+	newCommittee := make([]aggchainbase.IAggchainSignersSignerInfo, 0, len(committee))
+	for _, member := range committee {
+		newMember := member
+		if url, ok := m.URL[member.Addr]; ok {
+			newMember.Url = url
+		}
+		newCommittee = append(newCommittee, newMember)
+	}
+	return newCommittee
 }
 
 // NewBaseMultisigCommitteeQuery creates a new instance of BaseMultisigCommitteeQuery
-func NewBaseMultisigCommitteeQuery(multisigCommitteeAddr common.Address,
-	l1Client aggkittypes.BaseEthereumClienter) (*BaseMultisigCommitteeQuery, error) {
-	multisigCommitteeSC, err := aggchainbase.NewAggchainbaseCaller(
-		multisigCommitteeAddr, l1Client)
+func NewBaseMultisigCommitteeQuery(sovereignRollupAddr common.Address,
+	l1Client aggkittypes.BaseEthereumClienter,
+	overrideURL *CommiteeURLOverride) (*BaseMultisigCommitteeQuery, error) {
+	sovereignRollupAddrSC, err := aggchainbase.NewAggchainbaseCaller(
+		sovereignRollupAddr, l1Client)
 	if err != nil {
 		return nil, err
 	}
 
 	return &BaseMultisigCommitteeQuery{
-		multisigCommitteeSC:   multisigCommitteeSC,
-		multisigCommitteeAddr: multisigCommitteeAddr,
+		sovereignRollupAddrSC: sovereignRollupAddrSC,
+		sovereignRollupAddr:   sovereignRollupAddr,
+		overrideURL:           overrideURL,
 	}, nil
 }
 
@@ -41,14 +63,19 @@ func NewBaseMultisigCommitteeQuery(multisigCommitteeAddr common.Address,
 func (m *BaseMultisigCommitteeQuery) GetMultisigCommittee(
 	ctx context.Context, blockNum *big.Int) (*types.MultisigCommittee, error) {
 	callOpts := &bind.CallOpts{Pending: false, BlockNumber: blockNum}
-	threshold, err := m.multisigCommitteeSC.Threshold(callOpts)
+	threshold, err := m.sovereignRollupAddrSC.Threshold(callOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query the signatures threshold for block %d: %w", blockNum, err)
+		return nil, fmt.Errorf("failed to query the signatures threshold from for block %d to rollupAddr %s : %w",
+			blockNum, m.sovereignRollupAddr.String(), err)
 	}
 
-	aggChainSigners, err := m.multisigCommitteeSC.GetAggchainSignerInfos(callOpts)
+	aggChainSigners, err := m.sovereignRollupAddrSC.GetAggchainSignerInfos(callOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query the committee signers for block %d: %w", blockNum, err)
+		return nil, fmt.Errorf("failed to query the committee signers for block %d to rollupAddr %s: %w",
+			blockNum, m.sovereignRollupAddr.String(), err)
+	}
+	if m.overrideURL != nil {
+		aggChainSigners = m.overrideURL.ReplaceURL(aggChainSigners)
 	}
 
 	signerInfos := make([]*types.SignerInfo, 0, len(aggChainSigners))

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -25,7 +25,7 @@ type BaseMultisigCommitteeQuery struct {
 
 // CommitteeOverride is used to override the URLs of the committee members
 type CommitteeOverride struct {
-	// URL[oldURL] = newURL
+	// oldURL -> newURL
 	URLMapping map[string]string
 }
 
@@ -76,13 +76,13 @@ func (m *BaseMultisigCommitteeQuery) GetMultisigCommittee(
 	callOpts := &bind.CallOpts{Pending: false, BlockNumber: blockNum}
 	threshold, err := m.sovereignRollupAddrSC.Threshold(callOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query the signatures threshold from for block %d to rollupAddr %s : %w",
+		return nil, fmt.Errorf("failed to query the signatures threshold for block %d (rollupAddr %s): %w",
 			blockNum, m.sovereignRollupAddr.String(), err)
 	}
 
 	aggChainSigners, err := m.sovereignRollupAddrSC.GetAggchainSignerInfos(callOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query the committee signers for block %d to rollupAddr %s: %w",
+		return nil, fmt.Errorf("failed to query the committee signers for block %d (rollupAddr %s): %w",
 			blockNum, m.sovereignRollupAddr.String(), err)
 	}
 	if m.overrideURL != nil {

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -20,21 +20,21 @@ var (
 type BaseMultisigCommitteeQuery struct {
 	sovereignRollupAddrSC types.MultisigContract
 	sovereignRollupAddr   common.Address
-	overrideURL           *CommiteeOverride
+	overrideURL           *CommitteeOverride
 }
 
-// CommiteeOverride is used to override the URLs of the committee members
-type CommiteeOverride struct {
+// CommitteeOverride is used to override the URLs of the committee members
+type CommitteeOverride struct {
 	// URL[oldURL] = newURL
 	URLMapping map[string]string
 }
 
-func (c *CommiteeOverride) String() string {
-	return fmt.Sprintf("CommiteeOverride{URL: %v}", c.URLMapping)
+func (c *CommitteeOverride) String() string {
+	return fmt.Sprintf("CommitteeOverride{URL: %v}", c.URLMapping)
 }
 
 // ReplaceURL replaces the URLs of the committee members with the ones in the override map
-func (m *CommiteeOverride) ReplaceURL(
+func (m *CommitteeOverride) ReplaceURL(
 	committee []aggchainbase.IAggchainSignersSignerInfo) []aggchainbase.IAggchainSignersSignerInfo {
 	if m == nil || len(m.URLMapping) == 0 {
 		return committee
@@ -53,7 +53,7 @@ func (m *CommiteeOverride) ReplaceURL(
 // NewBaseMultisigCommitteeQuery creates a new instance of BaseMultisigCommitteeQuery
 func NewBaseMultisigCommitteeQuery(sovereignRollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
-	overrideURL *CommiteeOverride) (*BaseMultisigCommitteeQuery, error) {
+	overrideURL *CommitteeOverride) (*BaseMultisigCommitteeQuery, error) {
 	sovereignRollupAddrSC, err := aggchainbase.NewAggchainbaseCaller(
 		sovereignRollupAddr, l1Client)
 	if err != nil {

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -23,11 +23,15 @@ type BaseMultisigCommitteeQuery struct {
 	overrideURL           *CommiteeURLOverride
 }
 
+// CommiteeURLOverride is used to override the URLs of the committee members
 type CommiteeURLOverride struct {
+	// URL[address] = newURL
 	URL map[common.Address]string
 }
 
-func (m *CommiteeURLOverride) ReplaceURL(committee []aggchainbase.IAggchainSignersSignerInfo) []aggchainbase.IAggchainSignersSignerInfo {
+// ReplaceURL replaces the URLs of the committee members with the ones in the override map
+func (m *CommiteeURLOverride) ReplaceURL(
+	committee []aggchainbase.IAggchainSignersSignerInfo) []aggchainbase.IAggchainSignersSignerInfo {
 	if m == nil || len(m.URL) == 0 {
 		return nil
 	}

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -20,25 +20,29 @@ var (
 type BaseMultisigCommitteeQuery struct {
 	sovereignRollupAddrSC types.MultisigContract
 	sovereignRollupAddr   common.Address
-	overrideURL           *CommiteeURLOverride
+	overrideURL           *CommiteeOverride
 }
 
-// CommiteeURLOverride is used to override the URLs of the committee members
-type CommiteeURLOverride struct {
-	// URL[address] = newURL
-	URL map[common.Address]string
+// CommiteeOverride is used to override the URLs of the committee members
+type CommiteeOverride struct {
+	// URL[oldURL] = newURL
+	URLMapping map[string]string
+}
+
+func (c *CommiteeOverride) String() string {
+	return fmt.Sprintf("CommiteeOverride{URL: %v}", c.URLMapping)
 }
 
 // ReplaceURL replaces the URLs of the committee members with the ones in the override map
-func (m *CommiteeURLOverride) ReplaceURL(
+func (m *CommiteeOverride) ReplaceURL(
 	committee []aggchainbase.IAggchainSignersSignerInfo) []aggchainbase.IAggchainSignersSignerInfo {
-	if m == nil || len(m.URL) == 0 {
-		return nil
+	if m == nil || len(m.URLMapping) == 0 {
+		return committee
 	}
 	newCommittee := make([]aggchainbase.IAggchainSignersSignerInfo, 0, len(committee))
 	for _, member := range committee {
 		newMember := member
-		if url, ok := m.URL[member.Addr]; ok {
+		if url, ok := m.URLMapping[member.Url]; ok {
 			newMember.Url = url
 		}
 		newCommittee = append(newCommittee, newMember)
@@ -49,7 +53,7 @@ func (m *CommiteeURLOverride) ReplaceURL(
 // NewBaseMultisigCommitteeQuery creates a new instance of BaseMultisigCommitteeQuery
 func NewBaseMultisigCommitteeQuery(sovereignRollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
-	overrideURL *CommiteeURLOverride) (*BaseMultisigCommitteeQuery, error) {
+	overrideURL *CommiteeOverride) (*BaseMultisigCommitteeQuery, error) {
 	sovereignRollupAddrSC, err := aggchainbase.NewAggchainbaseCaller(
 		sovereignRollupAddr, l1Client)
 	if err != nil {

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/aggchain-ecdsa-multisig/aggchainbase"
 	"github.com/agglayer/aggkit/aggsender/mocks"
+	typesmocks "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -17,10 +18,12 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 		name               string
 		threshold          *big.Int
 		signerInfos        []aggchainbase.IAggchainSignersSignerInfo
+		overrideURL        *CommitteeOverride
 		thresholdErr       error
 		getSignersErr      error
 		expectedErr        string
 		expectedNumSigners int
+		expectedSigner     string
 	}
 
 	testCases := []testCase{
@@ -51,6 +54,29 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 			getSignersErr: errors.New("signers error"),
 			expectedErr:   "failed to query the committee signers",
 		},
+		{
+			name:      "successfully returns committee",
+			threshold: big.NewInt(2),
+			signerInfos: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://localhost:8001",
+				},
+				{
+					Addr: common.HexToAddress("0x2"),
+					Url:  "http://localhost:8002",
+				},
+			},
+			overrideURL: &CommitteeOverride{
+				URLMapping: map[string]string{
+					"http://localhost:8001": "http://override1:8001",
+					"http://localhost:8002": "http://override2:8002",
+				},
+			},
+			expectedErr:        "",
+			expectedNumSigners: 2,
+			expectedSigner:     "{Committee: {0x0000000000000000000000000000000000000001=http://override1:8001, 0x0000000000000000000000000000000000000002=http://override2:8002},  Threshold: 2}",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -68,6 +94,7 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 			q := &BaseMultisigCommitteeQuery{
 				sovereignRollupAddrSC: mockSC,
 				sovereignRollupAddr:   common.Address{},
+				overrideURL:           tc.overrideURL,
 			}
 
 			blockNum := big.NewInt(100)
@@ -82,6 +109,9 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 				require.NotNil(t, committee)
 				require.Equal(t, tc.threshold, committee.Threshold())
 				require.Len(t, committee.Signers(), tc.expectedNumSigners)
+				if tc.expectedSigner != "" {
+					require.Equal(t, tc.expectedSigner, committee.String())
+				}
 			}
 
 			mockSC.AssertExpectations(t)
@@ -89,7 +119,7 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 	}
 }
 
-func Test_CommiteeURLOverride(t *testing.T) {
+func Test_CommitteeURLOverride(t *testing.T) {
 	t.Run("ReplaceURL replaces URLs based on the override map", func(t *testing.T) {
 		override := &CommitteeOverride{
 			URLMapping: map[string]string{
@@ -159,4 +189,32 @@ func Test_CommiteeURLOverride(t *testing.T) {
 		result := override.ReplaceURL(committee)
 		require.Equal(t, committee, result)
 	})
+}
+
+func Test_CommitteeURLOverride_String(t *testing.T) {
+	require.Equal(t, "CommitteeOverride{URL: map[oldURL1:newURL1 oldURL2:newURL2]}", (&CommitteeOverride{
+		URLMapping: map[string]string{
+			"oldURL1": "newURL1",
+			"oldURL2": "newURL2",
+		},
+	}).String())
+	require.Equal(t, "CommitteeOverride{URL: map[]}", (&CommitteeOverride{}).String())
+	var CommitteeOverride *CommitteeOverride = nil
+	require.Equal(t, "CommitteeOverride{nil}", CommitteeOverride.String())
+}
+
+func Test_NewBaseMultisigCommitteeQuery(t *testing.T) {
+	t.Run("successfully creates a new BaseMultisigCommitteeQuery", func(t *testing.T) {
+		mockClient := typesmocks.NewEthClienter(t)
+		rollupAddr := common.HexToAddress("0x123")
+
+		//mockClient.EXPECT().CodeAt(mock.Anything, rollupAddr, mock.Anything).Return([]byte{0x1, 0x2}, nil)
+
+		query, err := NewBaseMultisigCommitteeQuery(rollupAddr, mockClient, nil)
+		require.NoError(t, err)
+		require.NotNil(t, query)
+		require.Equal(t, rollupAddr, query.sovereignRollupAddr)
+		require.NotNil(t, query.sovereignRollupAddrSC)
+	})
+
 }

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -120,75 +120,93 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 }
 
 func Test_CommitteeURLOverride(t *testing.T) {
-	t.Run("ReplaceURL replaces URLs based on the override map", func(t *testing.T) {
-		override := &CommitteeOverride{
-			URLMapping: map[string]string{
-				"http://original1": "http://override1",
-				"http://original3": "http://override3",
-			},
-		}
+	type testCase struct {
+		name      string
+		override  *CommitteeOverride
+		committee []aggchainbase.IAggchainSignersSignerInfo
+		expected  []aggchainbase.IAggchainSignersSignerInfo
+	}
 
-		committee := []aggchainbase.IAggchainSignersSignerInfo{
-			{
-				Addr: common.HexToAddress("0x1"),
-				Url:  "http://original1",
+	testCases := []testCase{
+		{
+			name: "ReplaceURL replaces URLs based on the override map",
+			override: &CommitteeOverride{
+				URLMapping: map[string]string{
+					"http://original1": "http://override1",
+					"http://original3": "http://override3",
+				},
 			},
-			{
-				Addr: common.HexToAddress("0x2"),
-				Url:  "http://original2",
+			committee: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://original1",
+				},
+				{
+					Addr: common.HexToAddress("0x2"),
+					Url:  "http://original2",
+				},
+				{
+					Addr: common.HexToAddress("0x3"),
+					Url:  "http://original3",
+				},
 			},
-			{
-				Addr: common.HexToAddress("0x3"),
-				Url:  "http://original3",
+			expected: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://override1",
+				},
+				{
+					Addr: common.HexToAddress("0x2"),
+					Url:  "http://original2",
+				},
+				{
+					Addr: common.HexToAddress("0x3"),
+					Url:  "http://override3",
+				},
 			},
-		}
+		},
+		{
+			name:     "ReplaceURL returns input if override is nil",
+			override: nil,
+			committee: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://original1",
+				},
+			},
+			expected: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://original1",
+				},
+			},
+		},
+		{
+			name: "ReplaceURL returns input if override map is empty",
+			override: &CommitteeOverride{
+				URLMapping: map[string]string{},
+			},
+			committee: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://original1",
+				},
+			},
+			expected: []aggchainbase.IAggchainSignersSignerInfo{
+				{
+					Addr: common.HexToAddress("0x1"),
+					Url:  "http://original1",
+				},
+			},
+		},
+	}
 
-		expected := []aggchainbase.IAggchainSignersSignerInfo{
-			{
-				Addr: common.HexToAddress("0x1"),
-				Url:  "http://override1",
-			},
-			{
-				Addr: common.HexToAddress("0x2"),
-				Url:  "http://original2",
-			},
-			{
-				Addr: common.HexToAddress("0x3"),
-				Url:  "http://override3",
-			},
-		}
-
-		result := override.ReplaceURL(committee)
-		require.Equal(t, expected, result)
-	})
-	t.Run("ReplaceURL returns nil if override is nil", func(t *testing.T) {
-		var override *CommitteeOverride = nil
-
-		committee := []aggchainbase.IAggchainSignersSignerInfo{
-			{
-				Addr: common.HexToAddress("0x1"),
-				Url:  "http://original1",
-			},
-		}
-
-		result := override.ReplaceURL(committee)
-		require.Equal(t, committee, result)
-	})
-	t.Run("ReplaceURL returns nil if override map is empty", func(t *testing.T) {
-		override := &CommitteeOverride{
-			URLMapping: map[string]string{},
-		}
-
-		committee := []aggchainbase.IAggchainSignersSignerInfo{
-			{
-				Addr: common.HexToAddress("0x1"),
-				Url:  "http://original1",
-			},
-		}
-
-		result := override.ReplaceURL(committee)
-		require.Equal(t, committee, result)
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.override.ReplaceURL(tc.committee)
+			require.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func Test_CommitteeURLOverride_String(t *testing.T) {

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -91,10 +91,10 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 
 func Test_CommiteeURLOverride(t *testing.T) {
 	t.Run("ReplaceURL replaces URLs based on the override map", func(t *testing.T) {
-		override := &CommiteeURLOverride{
-			URL: map[common.Address]string{
-				common.HexToAddress("0x1"): "http://override1",
-				common.HexToAddress("0x3"): "http://override3",
+		override := &CommiteeOverride{
+			URLMapping: map[string]string{
+				"http://original1": "http://override1",
+				"http://original3": "http://override3",
 			},
 		}
 
@@ -132,7 +132,7 @@ func Test_CommiteeURLOverride(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 	t.Run("ReplaceURL returns nil if override is nil", func(t *testing.T) {
-		var override *CommiteeURLOverride = nil
+		var override *CommiteeOverride = nil
 
 		committee := []aggchainbase.IAggchainSignersSignerInfo{
 			{
@@ -142,11 +142,11 @@ func Test_CommiteeURLOverride(t *testing.T) {
 		}
 
 		result := override.ReplaceURL(committee)
-		require.Nil(t, result)
+		require.Equal(t, committee, result)
 	})
 	t.Run("ReplaceURL returns nil if override map is empty", func(t *testing.T) {
-		override := &CommiteeURLOverride{
-			URL: map[common.Address]string{},
+		override := &CommiteeOverride{
+			URLMapping: map[string]string{},
 		}
 
 		committee := []aggchainbase.IAggchainSignersSignerInfo{
@@ -157,6 +157,6 @@ func Test_CommiteeURLOverride(t *testing.T) {
 		}
 
 		result := override.ReplaceURL(committee)
-		require.Nil(t, result)
+		require.Equal(t, committee, result)
 	})
 }

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -207,14 +207,10 @@ func Test_NewBaseMultisigCommitteeQuery(t *testing.T) {
 	t.Run("successfully creates a new BaseMultisigCommitteeQuery", func(t *testing.T) {
 		mockClient := typesmocks.NewEthClienter(t)
 		rollupAddr := common.HexToAddress("0x123")
-
-		//mockClient.EXPECT().CodeAt(mock.Anything, rollupAddr, mock.Anything).Return([]byte{0x1, 0x2}, nil)
-
 		query, err := NewBaseMultisigCommitteeQuery(rollupAddr, mockClient, nil)
 		require.NoError(t, err)
 		require.NotNil(t, query)
 		require.Equal(t, rollupAddr, query.sovereignRollupAddr)
 		require.NotNil(t, query.sovereignRollupAddrSC)
 	})
-
 }

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -66,8 +66,8 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 			}
 
 			q := &BaseMultisigCommitteeQuery{
-				multisigCommitteeSC:   mockSC,
-				multisigCommitteeAddr: common.Address{},
+				sovereignRollupAddrSC: mockSC,
+				sovereignRollupAddr:   common.Address{},
 			}
 
 			blockNum := big.NewInt(100)
@@ -87,4 +87,76 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 			mockSC.AssertExpectations(t)
 		})
 	}
+}
+
+func Test_CommiteeURLOverride(t *testing.T) {
+	t.Run("ReplaceURL replaces URLs based on the override map", func(t *testing.T) {
+		override := &CommiteeURLOverride{
+			URL: map[common.Address]string{
+				common.HexToAddress("0x1"): "http://override1",
+				common.HexToAddress("0x3"): "http://override3",
+			},
+		}
+
+		committee := []aggchainbase.IAggchainSignersSignerInfo{
+			{
+				Addr: common.HexToAddress("0x1"),
+				Url:  "http://original1",
+			},
+			{
+				Addr: common.HexToAddress("0x2"),
+				Url:  "http://original2",
+			},
+			{
+				Addr: common.HexToAddress("0x3"),
+				Url:  "http://original3",
+			},
+		}
+
+		expected := []aggchainbase.IAggchainSignersSignerInfo{
+			{
+				Addr: common.HexToAddress("0x1"),
+				Url:  "http://override1",
+			},
+			{
+				Addr: common.HexToAddress("0x2"),
+				Url:  "http://original2",
+			},
+			{
+				Addr: common.HexToAddress("0x3"),
+				Url:  "http://override3",
+			},
+		}
+
+		result := override.ReplaceURL(committee)
+		require.Equal(t, expected, result)
+	})
+	t.Run("ReplaceURL returns nil if override is nil", func(t *testing.T) {
+		var override *CommiteeURLOverride = nil
+
+		committee := []aggchainbase.IAggchainSignersSignerInfo{
+			{
+				Addr: common.HexToAddress("0x1"),
+				Url:  "http://original1",
+			},
+		}
+
+		result := override.ReplaceURL(committee)
+		require.Nil(t, result)
+	})
+	t.Run("ReplaceURL returns nil if override map is empty", func(t *testing.T) {
+		override := &CommiteeURLOverride{
+			URL: map[common.Address]string{},
+		}
+
+		committee := []aggchainbase.IAggchainSignersSignerInfo{
+			{
+				Addr: common.HexToAddress("0x1"),
+				Url:  "http://original1",
+			},
+		}
+
+		result := override.ReplaceURL(committee)
+		require.Nil(t, result)
+	})
 }

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -91,7 +91,7 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 
 func Test_CommiteeURLOverride(t *testing.T) {
 	t.Run("ReplaceURL replaces URLs based on the override map", func(t *testing.T) {
-		override := &CommiteeOverride{
+		override := &CommitteeOverride{
 			URLMapping: map[string]string{
 				"http://original1": "http://override1",
 				"http://original3": "http://override3",
@@ -132,7 +132,7 @@ func Test_CommiteeURLOverride(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 	t.Run("ReplaceURL returns nil if override is nil", func(t *testing.T) {
-		var override *CommiteeOverride = nil
+		var override *CommitteeOverride = nil
 
 		committee := []aggchainbase.IAggchainSignersSignerInfo{
 			{
@@ -145,7 +145,7 @@ func Test_CommiteeURLOverride(t *testing.T) {
 		require.Equal(t, committee, result)
 	})
 	t.Run("ReplaceURL returns nil if override map is empty", func(t *testing.T) {
-		override := &CommiteeOverride{
+		override := &CommitteeOverride{
 			URLMapping: map[string]string{},
 		}
 

--- a/aggsender/types/multisig_committee.go
+++ b/aggsender/types/multisig_committee.go
@@ -116,14 +116,14 @@ func (m *MultisigCommittee) IsMember(address common.Address) bool {
 
 // String returns a string representation of the committee
 func (m *MultisigCommittee) String() string {
-	s := "[Committee: "
+	s := "{Committee: {"
 	for i, signer := range m.signers {
-		s += signer.Address.Hex()
+		s += signer.Address.Hex() + "=" + signer.URL
 		if i < len(m.signers)-1 {
 			s += ", "
 		}
 	}
-	s += fmt.Sprintf(" Threshold: %d]", m.threshold)
+	s += fmt.Sprintf("},  Threshold: %d}", m.threshold)
 	return s
 }
 

--- a/aggsender/types/multisig_committee_test.go
+++ b/aggsender/types/multisig_committee_test.go
@@ -167,19 +167,19 @@ func TestMultisigCommittee_String(t *testing.T) {
 			name:      "single signer",
 			members:   []*SignerInfo{s1},
 			threshold: big.NewInt(1),
-			expected:  "[Committee: " + s1.Address.Hex() + " Threshold: 1]",
+			expected:  "{Committee: {0x0000000000000000000000000000000000000001=http://localhost:7001},  Threshold: 1}",
 		},
 		{
 			name:      "two signers",
 			members:   []*SignerInfo{s1, s2},
 			threshold: big.NewInt(2),
-			expected:  "[Committee: " + s1.Address.Hex() + ", " + s2.Address.Hex() + " Threshold: 2]",
+			expected:  "{Committee: {0x0000000000000000000000000000000000000001=http://localhost:7001, 0x0000000000000000000000000000000000000002=http://localhost:7002},  Threshold: 2}",
 		},
 		{
 			name:      "three signers, threshold less than size",
 			members:   []*SignerInfo{s1, s2, s3},
 			threshold: big.NewInt(2),
-			expected:  "[Committee: " + s1.Address.Hex() + ", " + s2.Address.Hex() + ", " + s3.Address.Hex() + " Threshold: 2]",
+			expected:  "{Committee: {0x0000000000000000000000000000000000000001=http://localhost:7001, 0x0000000000000000000000000000000000000002=http://localhost:7002, 0x0000000000000000000000000000000000000003=http://localhost:7003},  Threshold: 2}",
 		},
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -95,7 +95,7 @@ func start(cliCtx *cli.Context) error {
 		cliCtx.Context, components, cfg.L2GERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
 
-	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client, cfg.AggSender.CommiteeOverride)
+	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client, &cfg.AggSender.CommiteeOverride)
 
 	var rpcServices []jRPC.Service
 	for _, component := range components {
@@ -737,7 +737,7 @@ func runAggsenderMultisigCommitteeIfNeeded(
 	components []string,
 	rollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
-	cfg query.CommiteeURLOverride,
+	cfg *query.CommiteeURLOverride,
 ) aggsendertypes.MultisigQuerier {
 	if !isNeeded([]string{aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR}, components) {
 		return nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -95,7 +95,7 @@ func start(cliCtx *cli.Context) error {
 		cliCtx.Context, components, cfg.L2GERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
 
-	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client)
+	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client, cfg.AggSender.CommiteeOverride)
 
 	var rpcServices []jRPC.Service
 	for _, component := range components {
@@ -737,12 +737,13 @@ func runAggsenderMultisigCommitteeIfNeeded(
 	components []string,
 	rollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
+	cfg query.CommiteeURLOverride,
 ) aggsendertypes.MultisigQuerier {
 	if !isNeeded([]string{aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR}, components) {
 		return nil
 	}
 
-	committeeQuerier, err := query.NewBaseMultisigCommitteeQuery(rollupAddr, l1Client)
+	committeeQuerier, err := query.NewBaseMultisigCommitteeQuery(rollupAddr, l1Client, cfg)
 	if err != nil {
 		log.Fatalf("failed to create ECDSA multisig committee querier (SC address: %s): %s", rollupAddr, err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -95,7 +95,8 @@ func start(cliCtx *cli.Context) error {
 		cliCtx.Context, components, cfg.L2GERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
 
-	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client, &cfg.AggSender.CommiteeOverride)
+	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client,
+		&cfg.AggSender.CommiteeOverride)
 
 	var rpcServices []jRPC.Service
 	for _, component := range components {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -96,7 +96,7 @@ func start(cliCtx *cli.Context) error {
 	)
 
 	committeeQuerier := runAggsenderMultisigCommitteeIfNeeded(components, cfg.L1NetworkConfig.RollupAddr, l1Client,
-		&cfg.AggSender.CommiteeOverride)
+		&cfg.AggSender.CommitteeOverride)
 
 	var rpcServices []jRPC.Service
 	for _, component := range components {
@@ -738,7 +738,7 @@ func runAggsenderMultisigCommitteeIfNeeded(
 	components []string,
 	rollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
-	cfg *query.CommiteeOverride,
+	cfg *query.CommitteeOverride,
 ) aggsendertypes.MultisigQuerier {
 	if !isNeeded([]string{aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR}, components) {
 		return nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -738,7 +738,7 @@ func runAggsenderMultisigCommitteeIfNeeded(
 	components []string,
 	rollupAddr common.Address,
 	l1Client aggkittypes.BaseEthereumClienter,
-	cfg *query.CommiteeURLOverride,
+	cfg *query.CommiteeOverride,
 ) aggsendertypes.MultisigQuerier {
 	if !isNeeded([]string{aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR}, components) {
 		return nil

--- a/config/default.go
+++ b/config/default.go
@@ -244,8 +244,8 @@ RequireCommitteeMembershipCheck = false
 		MinConnectTimeout = "5s"
 		RequestTimeout = "30s"
 		UseTLS = false
-# Overide a commitee URL to point to a local service
-#  	[AggSender.CommiteeOverride]
+# Overide a committee URL to point to a local service
+#  	[AggSender.CommitteeOverride]
 #		URLMapping = { "http://aggkit-001-aggsender-validator-001:5578" = "http://localhost:32954" }
 	
 [Prometheus]

--- a/config/default.go
+++ b/config/default.go
@@ -244,6 +244,8 @@ RequireCommitteeMembershipCheck = false
 		MinConnectTimeout = "5s"
 		RequestTimeout = "30s"
 		UseTLS = false
+	[AggSender.CommiteeOverride]
+		URL = [ "0x00000000000000000000000": "http://localhost:8080" ]
 
 [Prometheus]
 Enabled = true

--- a/config/default.go
+++ b/config/default.go
@@ -244,9 +244,10 @@ RequireCommitteeMembershipCheck = false
 		MinConnectTimeout = "5s"
 		RequestTimeout = "30s"
 		UseTLS = false
-	[AggSender.CommiteeOverride]
-		URL = [ "0x00000000000000000000000": "http://localhost:8080" ]
-
+# Overide a commitee URL to point to a local service
+#  	[AggSender.CommiteeOverride]
+#		URLMapping = { "http://aggkit-001-aggsender-validator-001:5578" = "http://localhost:32954" }
+	
 [Prometheus]
 Enabled = true
 Host = "localhost"

--- a/scripts/local_config_helper
+++ b/scripts/local_config_helper
@@ -277,20 +277,20 @@ function common_export_ports_from_kurtosis() {
     export agglayer_grpc_url="http://localhost:${agglayer_grpc_port}"
 }
 ###############################################################################
-function common_aggsender_commitee_override_urls(){
-    export aggsender_commitee_override_urls=""
+function common_aggsender_committee_override_urls(){
+    export aggsender_committee_override_urls=""
     local _VALIDATOR
     for _VALIDATOR in $(kurtosis enclave inspect $KURTOSIS_ENCLAVE | grep aggkit-001-aggsender-validator | sed -r "s/\ +/\ /g" | cut -f 2 -d ' '); do
         
         export_portnum_from_kurtosis_or_fail _LOCAL_PORT_VALIDATOR $_VALIDATOR validator-grpc
         log_debug "Found validator: $_VALIDATOR port=$_LOCAL_PORT_VALIDATOR" 
-        aggsender_commitee_override_urls="${aggsender_commitee_override_urls} \"http://${_VALIDATOR}:5578\" = \"http://localhost:${_LOCAL_PORT_VALIDATOR}\","
+        aggsender_committee_override_urls="${aggsender_committee_override_urls} \"http://${_VALIDATOR}:5578\" = \"http://localhost:${_LOCAL_PORT_VALIDATOR}\","
     done
-    if [ ! -z "$aggsender_commitee_override_urls" ]; then
+    if [ ! -z "$aggsender_committee_override_urls" ]; then
         # Remove last ',' and add the {}
-        aggsender_commitee_override_urls="{ ${aggsender_commitee_override_urls::-1} }"
+        aggsender_committee_override_urls="{ ${aggsender_committee_override_urls::-1} }"
     fi
-    log_debug "aggsender_commitee_override_urls=${aggsender_commitee_override_urls}"
+    log_debug "aggsender_committee_override_urls=${aggsender_committee_override_urls}"
 }
 ###############################################################################
 function check_generated_config_file() {
@@ -342,7 +342,7 @@ function main(){
     check_requirements
     create_dest_folder
 
-    common_aggsender_commitee_override_urls
+    common_aggsender_committee_override_urls
     download_kurtosis_artifacts
 
   

--- a/scripts/local_config_helper
+++ b/scripts/local_config_helper
@@ -276,7 +276,22 @@ function common_export_ports_from_kurtosis() {
     export l1_rpc_url="http://localhost:${l1_rpc_port}"
     export agglayer_grpc_url="http://localhost:${agglayer_grpc_port}"
 }
-
+###############################################################################
+function common_aggsender_commitee_override_urls(){
+    export aggsender_commitee_override_urls=""
+    local _VALIDATOR
+    for _VALIDATOR in $(kurtosis enclave inspect $KURTOSIS_ENCLAVE | grep aggkit-001-aggsender-validator | sed -r "s/\ +/\ /g" | cut -f 2 -d ' '); do
+        
+        export_portnum_from_kurtosis_or_fail _LOCAL_PORT_VALIDATOR $_VALIDATOR validator-grpc
+        log_debug "Found validator: $_VALIDATOR port=$_LOCAL_PORT_VALIDATOR" 
+        aggsender_commitee_override_urls="${aggsender_commitee_override_urls} \"http://${_VALIDATOR}:5578\" = \"http://localhost:${_LOCAL_PORT_VALIDATOR}\","
+    done
+    if [ ! -z "$aggsender_commitee_override_urls" ]; then
+        # Remove last ',' and add the {}
+        aggsender_commitee_override_urls="{ ${aggsender_commitee_override_urls::-1} }"
+    fi
+    log_debug "aggsender_commitee_override_urls=${aggsender_commitee_override_urls}"
+}
 ###############################################################################
 function check_generated_config_file() {
     grep "<no value>" $DEST_TEMPLATE_FILE >/dev/null
@@ -327,8 +342,10 @@ function main(){
     check_requirements
     create_dest_folder
 
+    common_aggsender_commitee_override_urls
     download_kurtosis_artifacts
 
+  
     export_ports_from_kurtosis
     export_values_of_aggkit_config $DEST/config.toml
     export_forced_values

--- a/scripts/local_config_pp
+++ b/scripts/local_config_pp
@@ -14,13 +14,14 @@ function export_values_of_aggkit_config() {
 ###############################################################################
 function export_ports_from_kurtosis() {
     common_export_ports_from_kurtosis
-    export_portnum_from_kurtosis_or_fail zkevm_rpc_http_port cdk-erigon-rpc-001 http-rpc rpc
-    export l2_rpc_url="http://localhost:${zkevm_rpc_http_port}"
+    export_portnum_from_kurtosis_or_fail op_el_rpc_port op-el-1-op-geth-op-node-001 rpc
+     export op_el_rpc_url="http://localhost:${op_el_rpc_port}"
+    export l2_rpc_url=$op_el_rpc_url
     export agglayer_grpc_url="http://localhost:${agglayer_grpc_port}"
 }
 ###############################################################################
 # MAIN
 ###############################################################################
-ORIG_TEMPLATE_FILE=test/config/fep-config.toml.template
+ORIG_TEMPLATE_FILE=test/config/pp-config.toml.template
 DEST_TEMPLATE_FILE=$DEST/test.kurtosis.toml
 main $*

--- a/test/config/pp-config.toml.template
+++ b/test/config/pp-config.toml.template
@@ -235,6 +235,8 @@ SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}"
 # ------------------------------------------------------------------------------
 # EnableRPC = false
 
+[AggSender.CommiteeOverride]
+    URLMapping = {{.aggsender_commitee_override_urls}}
 # ==============================================================================
 #     _    ____  ____  ___  ____      _    ____ _     _____
 #    / \  / ___|/ ___|/ _ \|  _ \    / \  / ___| |   | ____|

--- a/test/config/pp-config.toml.template
+++ b/test/config/pp-config.toml.template
@@ -235,8 +235,8 @@ SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}"
 # ------------------------------------------------------------------------------
 # EnableRPC = false
 
-[AggSender.CommiteeOverride]
-    URLMapping = {{.aggsender_commitee_override_urls}}
+[AggSender.CommitteeOverride]
+    URLMapping = {{.aggsender_committee_override_urls}}
 # ==============================================================================
 #     _    ____  ____  ___  ____      _    ____ _     _____
 #    / \  / ___|/ ___|/ _ \|  _ \    / \  / ___| |   | ____|


### PR DESCRIPTION
## 🔄 Changes Summary
- Allow to override URL from the signCommitte in order to: 
    -  To debug: Point to validator that is running locally to debug
    - To infra: if a validator is under a proxy or a private net that the URL is not the same as the one in the contract you can override to point to the right URL.
  
**☣️ Keep in mind that you can't modify the address so you can't use this feature as a attack vector**



## 📋 Config Updates
- 🧾 **Diff/Config snippet**:
- You can configure using this map oldURL to newURL
```
[AggSender.CommiteeOverride]
        URLMapping = { "http://aggkit-001-aggsender-validator-001:5578" = "http://localhost:32954" }
``
