### PR TITLE
fix: [integration] optional `AggchainData` field treatment

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="5921c65d96e674b742080ceb5d19acc0e83ed0a9"
+            COMMIT="346e6c76bce576f29300a7de2d3b6efca09d9fdb"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/agglayer/grpc/conversion_to_agglayer.go
+++ b/agglayer/grpc/conversion_to_agglayer.go
@@ -296,7 +296,7 @@ func grpcAggchainDataToAgglayer(
 	aggchainData *v1types.AggchainData,
 ) (agglayertypes.AggchainData, error) {
 	if aggchainData == nil || aggchainData.Data == nil {
-		return nil, fmt.Errorf("grpcAggchainDataToAgglayer. aggchain data is nil. %w", ErrNilCertificate)
+		return nil, nil
 	}
 
 	switch ad := aggchainData.Data.(type) {

--- a/agglayer/grpc/conversion_to_agglayer_test.go
+++ b/agglayer/grpc/conversion_to_agglayer_test.go
@@ -154,14 +154,13 @@ func TestConvertProtoCertToAgglayer(t *testing.T) {
 		require.ErrorContains(t, err, "has nil L1InfoTreeLeafCount")
 	})
 
-	t.Run("nil AggchainData", func(t *testing.T) {
+	t.Run("undefined AggchainData", func(t *testing.T) {
 		protoCert, err := ConvertCertToProtoCertificate(exampleTestAgglayerCert)
 		require.NoError(t, err)
 		protoCert.AggchainData = nil
 		result, err := ConvertProtoCertToAgglayer(protoCert)
-		require.Nil(t, result)
-		require.ErrorIs(t, err, ErrNilCertificate)
-		require.ErrorContains(t, err, "aggchain data is nil")
+		require.NoError(t, err)
+		require.Nil(t, result.AggchainData)
 	})
 
 	t.Run("successful conversion", func(t *testing.T) {

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -498,6 +498,22 @@ func (c *Certificate) CertificateID() common.Hash {
 	)
 }
 
+// ExtractAggchainParams extracts the aggchain params field from the certificate
+// with handling different types of aggchain data.
+func (c *Certificate) ExtractAggchainParams() []byte {
+	switch data := c.AggchainData.(type) {
+	case *AggchainDataProof:
+		return data.AggchainParams.Bytes()
+
+	case *AggchainDataMultisigWithProof:
+		if data.AggchainProof != nil {
+			return data.AggchainProof.AggchainParams.Bytes()
+		}
+	}
+
+	return aggkitcommon.ZeroHash.Bytes()
+}
+
 // SignedCertificate is the struct that contains the certificate and the signature of the signer
 // NOTE: this is an old and deprecated struct, only to be used for backward compatibility
 type SignedCertificate struct {

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -111,7 +111,7 @@ func TestCertificateHeaderString(t *testing.T) {
 	require.Equal(t, "nil", certNil.String())
 }
 
-func TestMarshalJSON(t *testing.T) {
+func TestCertificateMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	t.Run("MarshalJSON with empty proofs", func(t *testing.T) {
@@ -267,6 +267,56 @@ func TestMarshalJSON(t *testing.T) {
 		require.Equal(t, "0xe1a594db4275e6e5ab302057e48955c7faf53a8910497590a742b3da89046320", cert.ImportedBridgeExits[0].Hash().String())
 		require.Equal(t, "0xcc9e20b86e9984d9f68b0252f224cb4bc774981c320ef375fb63706220f5af4d", cert.ImportedBridgeExits[1].Hash().String())
 	})
+}
+
+func TestCertificate_ExtractAggchainParams(t *testing.T) {
+	hash1 := common.HexToHash("0x1111")
+	hash2 := common.HexToHash("0x2222")
+
+	tests := []struct {
+		name     string
+		data     AggchainData
+		expected []byte
+	}{
+		{
+			name: "AggchainDataProof returns its params",
+			data: &AggchainDataProof{
+				AggchainParams: hash1,
+			},
+			expected: hash1.Bytes(),
+		},
+		{
+			name: "AggchainDataMultisigWithProof returns nested params",
+			data: &AggchainDataMultisigWithProof{
+				AggchainProof: &AggchainDataProof{
+					AggchainParams: hash2,
+				},
+			},
+			expected: hash2.Bytes(),
+		},
+		{
+			name: "AggchainDataMultisigWithProof with nil proof returns ZeroHash",
+			data: &AggchainDataMultisigWithProof{
+				AggchainProof: nil,
+			},
+			expected: aggkitcommon.ZeroHash.Bytes(),
+		},
+		{
+			name:     "Nil AggchainData returns ZeroHash",
+			data:     nil,
+			expected: aggkitcommon.ZeroHash.Bytes(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := &Certificate{
+				AggchainData: tt.data,
+			}
+			actual := cert.ExtractAggchainParams()
+			require.Equal(t, tt.expected, actual)
+		})
+	}
 }
 
 func TestGlobalIndex_UnmarshalFromMap(t *testing.T) {

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -328,28 +328,27 @@ func (a *AggchainProverFlow) BuildCertificate(ctx context.Context,
 	return cert, nil
 }
 
-// UpdateAggchainData updates the AggchainData field in certificate with the multisig if needed
+// UpdateAggchainData updates the AggchainData field in certificate with the multisig if provided.
 func (a *AggchainProverFlow) UpdateAggchainData(
 	cert *agglayertypes.Certificate,
 	multisig *agglayertypes.Multisig,
 ) error {
 	if multisig == nil {
-		// multisig not turned on, we don't need to update the certificate
+		// Multisig not enabled, nothing to do
 		return nil
 	}
 
-	proof, ok := cert.AggchainData.(*agglayertypes.AggchainDataProof)
-	if !ok {
-		proofWithMultisig, ok := cert.AggchainData.(*agglayertypes.AggchainDataMultisigWithProof)
-		if !ok {
-			return errors.New("aggchainProverFlow - aggchain data field not " +
-				"AggchainDataProof nor AggchainDataMultisigWithProof")
-		}
+	var proof *agglayertypes.AggchainDataProof
 
-		proof = proofWithMultisig.AggchainProof
+	switch data := cert.AggchainData.(type) {
+	case *agglayertypes.AggchainDataProof:
+		proof = data
+	case *agglayertypes.AggchainDataMultisigWithProof:
+		proof = data.AggchainProof
+	default:
+		return fmt.Errorf("aggchainProverFlow: AggchainData of unknown type %T received", data)
 	}
 
-	// update the agchain data with multisig
 	cert.AggchainData = &agglayertypes.AggchainDataMultisigWithProof{
 		Multisig:      multisig,
 		AggchainProof: proof,

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -899,7 +899,7 @@ func Test_AggchainProverFlow_UpdateAggchainData(t *testing.T) {
 				AggchainData: &agglayertypes.AggchainDataSignature{}, // wrong type
 			},
 			multisig:      &agglayertypes.Multisig{},
-			expectedError: "aggchainProverFlow - aggchain data field not AggchainDataProof",
+			expectedError: "aggchainProverFlow: AggchainData of unknown type *types.AggchainDataSignature received",
 		},
 		{
 			name: "successful update - wraps proof with multisig",

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -147,6 +147,8 @@ func (c *certificateQuerier) CalculateCertificateType(
 		// AggchainDataMultisig → PP type
 		return types.CertificateTypePP
 	case *agglayertypes.AggchainDataProof:
+		// AggchainDataProof → FEP type
+		return types.CertificateTypeFEP
 	case *agglayertypes.AggchainDataMultisigWithProof:
 		// AggchainDataProof and AggchainDataMultisigWithProof → FEP type
 		return types.CertificateTypeFEP

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -140,18 +140,19 @@ func (c *certificateQuerier) GetNewCertificateToBlock(
 
 // CalculateCertificateType determines the type of certificate based on the last block number in certificate
 func (c *certificateQuerier) CalculateCertificateType(
-	cert *agglayertypes.Certificate, certToBlock uint64) types.CertificateType {
-	if cert.AggchainData != nil {
-		// if AggchainData is present, we can use it to determine the certificate type
-		_, ok := cert.AggchainData.(*agglayertypes.AggchainDataProof)
-		if !ok {
-			return types.CertificateTypeFEP
-		}
-
+	cert *agglayertypes.Certificate, certToBlock uint64,
+) types.CertificateType {
+	switch cert.AggchainData.(type) {
+	case *agglayertypes.AggchainDataMultisig:
+		// AggchainDataMultisig → PP type
 		return types.CertificateTypePP
+	case *agglayertypes.AggchainDataProof:
+	case *agglayertypes.AggchainDataMultisigWithProof:
+		// AggchainDataProof and AggchainDataMultisigWithProof → FEP type
+		return types.CertificateTypeFEP
 	}
 
-	// if AggchainData is not present, must try to determine the type based on the block number
+	// no AggchainData → fallback on block-based logic
 	return c.CalculateCertificateTypeFromToBlock(certToBlock)
 }
 

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -138,7 +138,9 @@ func (c *certificateQuerier) GetNewCertificateToBlock(
 	return max(lastBridgeExitBlock, lastImportedBridgeExitBlock), nil
 }
 
-// CalculateCertificateType determines the type of certificate based on the last block number in certificate
+// CalculateCertificateType determines the type of certificate.
+// If AggchainData is present, the type is inferred from its variant (PP or FEP).
+// Otherwise, it is derived from the last block number in certificate
 func (c *certificateQuerier) CalculateCertificateType(
 	cert *agglayertypes.Certificate, certToBlock uint64,
 ) types.CertificateType {

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -150,7 +150,7 @@ func (c *certificateQuerier) CalculateCertificateType(
 		// AggchainDataProof → FEP type
 		return types.CertificateTypeFEP
 	case *agglayertypes.AggchainDataMultisigWithProof:
-		// AggchainDataProof and AggchainDataMultisigWithProof → FEP type
+		// AggchainDataMultisigWithProof → FEP type
 		return types.CertificateTypeFEP
 	}
 

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -143,6 +143,9 @@ func (c *certificateQuerier) CalculateCertificateType(
 	cert *agglayertypes.Certificate, certToBlock uint64,
 ) types.CertificateType {
 	switch cert.AggchainData.(type) {
+	case *agglayertypes.AggchainDataSignature:
+		// AggchainDataSignature → PP type
+		return types.CertificateTypePP
 	case *agglayertypes.AggchainDataMultisig:
 		// AggchainDataMultisig → PP type
 		return types.CertificateTypePP

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -504,17 +504,9 @@ func TestCalculateCertificateType(t *testing.T) {
 		expectedCertType types.CertificateType
 	}{
 		{
-			name: "AggchainData is AggchainDataProof - returns PP",
+			name: "AggchainData is AggchainDataProof - returns FEP",
 			certificate: &agglayertypes.Certificate{
 				AggchainData: &agglayertypes.AggchainDataProof{},
-			},
-			certToBlock:      100,
-			expectedCertType: types.CertificateTypePP,
-		},
-		{
-			name: "AggchainData is not AggchainDataProof - returns FEP",
-			certificate: &agglayertypes.Certificate{
-				AggchainData: &agglayertypes.AggchainDataSignature{},
 			},
 			certToBlock:      100,
 			expectedCertType: types.CertificateTypeFEP,

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -520,6 +520,14 @@ func TestCalculateCertificateType(t *testing.T) {
 			expectedCertType: types.CertificateTypeFEP,
 		},
 		{
+			name: "AggchainData is AggchainDataMultisigWithProof - returns FEP",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataMultisigWithProof{},
+			},
+			certToBlock:      100,
+			expectedCertType: types.CertificateTypeFEP,
+		},
+		{
 			name: "AggchainData is nil - falls back to CalculateCertificateTypeFromToBlock with FEP network and block before start",
 			certificate: &agglayertypes.Certificate{
 				AggchainData: nil,

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -520,6 +520,22 @@ func TestCalculateCertificateType(t *testing.T) {
 			expectedCertType: types.CertificateTypeFEP,
 		},
 		{
+			name: "AggchainData is AggchainDataSignature - returns PP",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataSignature{},
+			},
+			certToBlock:      100,
+			expectedCertType: types.CertificateTypePP,
+		},
+		{
+			name: "AggchainData is AggchainDataMultisig - returns PP",
+			certificate: &agglayertypes.Certificate{
+				AggchainData: &agglayertypes.AggchainDataMultisig{},
+			},
+			certToBlock:      100,
+			expectedCertType: types.CertificateTypePP,
+		},
+		{
 			name: "AggchainData is nil - falls back to CalculateCertificateTypeFromToBlock with FEP network and block before start",
 			certificate: &agglayertypes.Certificate{
 				AggchainData: nil,

--- a/aggsender/validator/cert_hash.go
+++ b/aggsender/validator/cert_hash.go
@@ -22,8 +22,7 @@ func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error)
 	}
 
 	claimsHash := crypto.Keccak256(claimsRawMetadata)
-
-	aggchainParams := getAggchainParams(cert)
+	aggchainParams := cert.ExtractAggchainParams()
 
 	return crypto.Keccak256Hash(
 		cert.NewLocalExitRoot.Bytes(),
@@ -32,20 +31,4 @@ func HashCertificateToSign(cert *agglayertypes.Certificate) (common.Hash, error)
 		aggchainParams,
 		cert.CertificateID().Bytes(),
 	), nil
-}
-
-// getAggchainParams extracts the aggchain params field from the certificate
-// with handling different types of aggchain data.
-func getAggchainParams(cert *agglayertypes.Certificate) []byte {
-	aggchainDataProof, ok := cert.AggchainData.(*agglayertypes.AggchainDataProof)
-	if ok {
-		return aggchainDataProof.AggchainParams.Bytes()
-	}
-
-	aggchainDataProofWithMultisig, ok := cert.AggchainData.(*agglayertypes.AggchainDataMultisigWithProof)
-	if ok && aggchainDataProofWithMultisig.AggchainProof != nil {
-		return aggchainDataProofWithMultisig.AggchainProof.AggchainParams.Bytes()
-	}
-
-	return aggkitcommon.ZeroHash.Bytes()
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- Make `AggchainData` field optional when converting from protobuf to internal `Certificate` type,
- Make `AggchainData` underlying type determination more readable, by relying on switch-case and data unboxing
- Fixed the certificate type determination based on the `AggchainData` underlying type:
   - `AggchainDataSignature` or `AggchainDataMultisig` => PP certificates
   - `AggchainDataProof` or `AggchainDataMultisigWithProof` => FEP certificates

Version: `v0.7.0-beta2`

## ⚠️ Breaking Changes
- 🛠️ **Config**: N/A
- 🔌 **API/CLI**: N/A
- 🗑️ **Deprecated Features**: N/A

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: N/A

## ✅ Testing
- 🤖 **Automatic**: Unit tests for the aggsender
- 🖱️ **Manual**: N/A

## 🐞 Issues
- Closes #https://github.com/agglayer/aggkit/issues/986

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
