### PR TITLE
fix: failed to validate the certificate

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="346e6c76bce576f29300a7de2d3b6efca09d9fdb"
+            COMMIT="dfa3430ceaf766d45ff1c4006f1bb7c8b0499624"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/aggsender/query/certificate_query.go
+++ b/aggsender/query/certificate_query.go
@@ -196,7 +196,7 @@ func (c *certificateQuerier) getBlockNumFromGlobalIndex(
 	ctx context.Context, globalIndex *big.Int, bridgeExitHash common.Hash) (uint64, error) {
 	claims, err := c.l2BridgeSyncer.GetClaimsByGlobalIndex(ctx, globalIndex)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get claim by global index %s: %w", globalIndex.String(), err)
+		return 0, fmt.Errorf("failed to get claim(s) by global index %s: %w", globalIndex.String(), err)
 	}
 
 	for _, claim := range claims {

--- a/aggsender/query/certificate_query_test.go
+++ b/aggsender/query/certificate_query_test.go
@@ -144,7 +144,7 @@ func TestGetLastSettledCertificateToBlock(t *testing.T) {
 				agglayerClient.EXPECT().GetNetworkInfo(ctx, uint32(0)).Return(networkStatus, nil)
 				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, networkStatus.SettledImportedBridgeExit.GlobalIndex).Return(nil, errors.New("claim not found"))
 			},
-			expectedErr: "failed to get claim by global index",
+			expectedErr: "failed to get claim(s) by global index",
 		},
 		{
 			name: "error getting last settled L2 block",
@@ -317,7 +317,7 @@ func TestGetNewCertificateToBlock(t *testing.T) {
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
 				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return(nil, errors.New("claim not found"))
 			},
-			expectedErr: "failed to get claim by global index",
+			expectedErr: "failed to get claim(s) by global index",
 		},
 		{
 			name: "multiple imported bridge exits uses last one",
@@ -694,7 +694,7 @@ func TestGetBlockNumFromGlobalIndex(t *testing.T) {
 			mockFn: func(bridgeSyncer *mocks.L2BridgeSyncer) {
 				bridgeSyncer.EXPECT().GetClaimsByGlobalIndex(ctx, testIbe.GlobalIndex.ToBigInt()).Return(nil, errors.New("database error"))
 			},
-			expectedErr: "failed to get claim by global index",
+			expectedErr: "failed to get claim(s) by global index",
 		},
 	}
 

--- a/aggsender/validator/validate_certificate.go
+++ b/aggsender/validator/validate_certificate.go
@@ -82,7 +82,7 @@ func (a *CertificateValidator) ValidateCertificate(ctx context.Context, params t
 	}
 
 	// Check if the previous certificate is settled
-	if err := a.checkisPreviousCertificateSettled(params.PreviousCertificate); err != nil {
+	if err := a.checkIsPreviousCertificateSettled(params.PreviousCertificate); err != nil {
 		return fmt.Errorf("failed CheckCertificatesContents: %w", err)
 	}
 
@@ -135,23 +135,19 @@ func (a *CertificateValidator) verifyClaimProofs(
 	return nil
 }
 
-// checkisPreviousCertificateSettled checks if the previous certificate is settled
-func (a *CertificateValidator) checkisPreviousCertificateSettled(
+// checkIsPreviousCertificateSettled checks if the previous certificate is settled
+func (a *CertificateValidator) checkIsPreviousCertificateSettled(
 	previousCertificate *agglayertypes.CertificateHeader) error {
-	if previousCertificate != nil {
-		if !previousCertificate.Status.IsSettled() {
-			return fmt.Errorf("previous certificate %s is not settled (status:%s)",
-				previousCertificate.ID(), previousCertificate.Status.String())
-		}
+	if previousCertificate != nil && !previousCertificate.Status.IsSettled() {
+		return fmt.Errorf("previous certificate %s is not settled (status: %s)",
+			previousCertificate.ID(), previousCertificate.Status.String())
 	}
+
 	return nil
 }
 
 // checkContigousCertificates checks if the incoming certificate is contiguous with the previous one.
 func (a *CertificateValidator) checkContigousCertificates(params types.VerifyIncomingRequest) error {
-	if params.Certificate == nil {
-		return ErrNilCertificate
-	}
 	if params.PreviousCertificate == nil {
 		return a.checkFirstCertificateBlocks(params)
 	}
@@ -180,12 +176,11 @@ func (a *CertificateValidator) compareCertificates(
 	diffStr := strings.Join(diffs, "\n")
 	// This is redudant, but just in case
 	if incomingCertificate.CertificateID() != localCertificate.CertificateID() {
-		return fmt.Errorf("certificates hash mismatch, incoming: %s, local: %s.\n FullDiff: %s",
+		return fmt.Errorf("certificates ids mismatch, incoming: %s, local: %s.\n FullDiff: %s",
 			incomingCertificate.CertificateID().Hex(), localCertificate.CertificateID().Hex(), diffStr)
 	}
 	if len(diffs) > 0 {
-		return fmt.Errorf("certificates mismatch. FullDiff: %s",
-			diffStr)
+		return fmt.Errorf("certificates mismatch. FullDiff: %s", diffStr)
 	}
 	return nil
 }

--- a/aggsender/validator/validate_certificate_test.go
+++ b/aggsender/validator/validate_certificate_test.go
@@ -200,12 +200,6 @@ func TestValidateCertificate(t *testing.T) {
 }
 
 func TestCheckContigousCertificates(t *testing.T) {
-	t.Run("Nil New Cert", func(t *testing.T) {
-		testData := newTestDataCertificateValidator(t)
-		err := testData.sut.checkContigousCertificates(types.VerifyIncomingRequest{})
-		require.ErrorIs(t, err, ErrNilCertificate)
-	})
-
 	t.Run("Nil PreviousCertificate, err getting start LER", func(t *testing.T) {
 		testData := newTestDataCertificateValidator(t)
 		testData.mockLERQuerier.EXPECT().GetLastLocalExitRoot().Return(types.EmptyLER, errors.New("some error"))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -242,7 +242,7 @@ func createAggSenderValidator(ctx context.Context,
 			nil, // storage is not used in validator,
 			l1Client, l1InfoTreeSync, l2Syncer, rollupDataQuerier, committeeQuerier, 0, false,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
-			false, // full claims are not needed in validator mode
+			true, // full claims are (eventually) needed in validator mode
 			cfg.RequireCommitteeMembershipCheck,
 		)
 		if err != nil {
@@ -267,7 +267,7 @@ func createAggSenderValidator(ctx context.Context,
 			0, cfg.FEPConfig.RequireNoBlockGap,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.Signer,
-			false, // full claims are not needed in validator mode,
+			true, // full claims are (eventually) needed in validator mode
 			cfg.RequireCommitteeMembershipCheck,
 		)
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -697,11 +697,10 @@ func runBridgeSyncL2IfNeeded(
 		aggkitcommon.BRIDGE,
 		aggkitcommon.AGGSENDER,
 		aggkitcommon.AGGCHAINPROOFGEN,
-		aggkitcommon.L2BRIDGESYNC}, components)
+		aggkitcommon.L2BRIDGESYNC,
+		aggkitcommon.AGGSENDERVALIDATOR}, components)
 
-	fullClaimsNotNeeded := isNeeded([]string{
-		aggkitcommon.AGGSENDERVALIDATOR,
-	}, components)
+	fullClaimsNotNeeded := isNeeded([]string{}, components)
 
 	if !fullClaimsNeeded && !fullClaimsNotNeeded {
 		// no bridge sync needed


### PR DESCRIPTION
## 🔄 Changes Summary

TL;DR; The root cause of both issues described is that we are not running the full sync of claims.

### 1. Bridge exit hash mismatch issue
When validating a certificate, the validator is unable to [find](https://github.com/agglayer/aggkit/blob/cef286512e4c450ed600c854327c6f7577caa527/aggsender/query/certificate_query.go#L208-L211) the last settled imported bridge exit in the local db. The reason for it is because we were lacking the `LeafType` (namely `IsMessage`) and `Metadata` fields indexed in the `Claim`.

### 2. Panic when checking certificate ids
When validating a certificate and [comparing](https://github.com/agglayer/aggkit/blob/cef286512e4c450ed600c854327c6f7577caa527/aggsender/validator/validate_certificate.go#L178-L181) the `CertificateIDs` for the local and incoming certificate, there was a panic, because the `ClaimData` was undefined for locally built certificate. The root cause is again that we didn't have the full claim data synchronized on the validator.

Version: `v0.7.0-beta2`

## ⚠️ Breaking Changes
- 🛠️ **Config**: N/A
- 🔌 **API/CLI**: N/A
- 🗑️ **Deprecated Features**: N/A

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #987 

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- We needed to enable the full synchronization in the aggsender validator, which is not ideal, because we are relying on the debug endpoint atm.
