### PR TITLE
fix: #912 store non-accepted-cert in file

### DIFF
--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -522,6 +522,7 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 	shouldRollback := true
 	defer func() {
 		if shouldRollback {
+			a.logger.Infof("saveNonAcceptedCertificate Rolling back transaction")
 			if errRllbck := tx.Rollback(); errRllbck != nil {
 				a.logger.Errorf(errWhileRollbackFormat, errRllbck)
 			}
@@ -556,8 +557,8 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 
 	shouldRollback = false
 
-	a.logger.Debugf("inserted non-accepted certificate - Height: %d. CreatedAt: %s",
-		nonAcceptedCert.Height, time.Unix(int64(nonAcceptedCert.CreatedAt), 0))
+	a.logger.Debugf("inserted non-accepted certificate - Height: %d. CreatedAt: %s Filename: %s",
+		nonAcceptedCert.Height, time.Unix(int64(nonAcceptedCert.CreatedAt), 0), fullPathFilename)
 
 	return nil
 }

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -18,12 +18,14 @@ import (
 	"github.com/agglayer/aggkit/db"
 	dbtypes "github.com/agglayer/aggkit/db/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/iden3/go-iden3-crypto/keccak256"
 	"github.com/russross/meddler"
 )
 
 const (
-	errWhileRollbackFormat = "error while rolling back tx: %w"
-	nonAcceptedCertKey     = "non_accepted_cert"
+	errWhileRollbackFormat  = "error while rolling back tx: %w"
+	nonAcceptedCertKey      = "non_accepted_cert"
+	nonAcceptedCertFilename = "last_rejected_cert.json"
 )
 
 var newTxer = db.NewTx
@@ -278,18 +280,14 @@ func (a *AggSenderSQLStorage) SaveOrUpdateCertificate(ctx context.Context, certi
 // saveSignedCertificateToFile saves the signed certificate content to a file in the configured certificate directory
 // and returns the file path
 func (a *AggSenderSQLStorage) saveSignedCertificateToFile(
-	certificateHeight uint64,
-	certificateID common.Hash,
-	signedCertContent string,
-	retryCount int) (string, error) {
+	fileName string,
+	signedCertContent string) (string, error) {
 	// Use the configured certificate directory
 	certDir := a.cfg.CertificatesDir
 	if err := os.MkdirAll(certDir, 0755); err != nil { //nolint:mnd
 		return "", fmt.Errorf("failed to create certificates directory %s: %w", certDir, err)
 	}
 
-	// Create a filename using the certificate ID
-	fileName := fmt.Sprintf("signed_cert_%d_%s_%d.json", certificateHeight, certificateID, retryCount)
 	filePath := filepath.Join(certDir, fileName)
 
 	// Write the signed certificate content to the file
@@ -513,6 +511,9 @@ func (a *AggSenderSQLStorage) GetLastSentCertificateHeaderWithProofIfInError(
 // and to allow for debugging and analysis of why they were not accepted.
 func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 	ctx context.Context, nonAcceptedCert *NonAcceptedCertificate) error {
+	if nonAcceptedCert == nil {
+		return fmt.Errorf("saveNonAcceptedCertificate param nonAcceptedCert is nil")
+	}
 	tx, err := newTxer(ctx, a.db)
 	if err != nil {
 		return fmt.Errorf("failed to create db transaction for non-accepted certificate persistence: %w", err)
@@ -526,8 +527,19 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 			}
 		}
 	}()
-
-	raw, err := json.Marshal(nonAcceptedCert)
+	filename := nonAcceptedCertFilename
+	fullPathFilename, err := a.saveSignedCertificateToFile(filename, nonAcceptedCert.SignedCertificate)
+	if err != nil {
+		return fmt.Errorf("saveNonAcceptedCertificate: failed to save signed certificate to file: %w", err)
+	}
+	entry := &NonAcceptedCertificate{
+		Height:            nonAcceptedCert.Height,
+		CreatedAt:         nonAcceptedCert.CreatedAt,
+		Error:             nonAcceptedCert.Error,
+		SignedCertificate: "@" + fullPathFilename,
+		CertificateHash:   common.BytesToHash(keccak256.Hash([]byte(nonAcceptedCert.SignedCertificate))),
+	}
+	raw, err := json.Marshal(entry)
 	if err != nil {
 		return fmt.Errorf("failed to marshal non-accepted certificate struct: %w", err)
 	}
@@ -564,6 +576,21 @@ func (a *AggSenderSQLStorage) GetNonAcceptedCertificate() (*NonAcceptedCertifica
 	if err := json.Unmarshal([]byte(val), &nonAcceptedCert); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal non-accepted certificate: %w", err)
 	}
+	if nonAcceptedCert.SignedCertificate != "" && nonAcceptedCert.SignedCertificate[0] == '@' {
+		// The content is pointing to a file
+		FullFilename := nonAcceptedCert.SignedCertificate[1:]
+		data, err := os.ReadFile(FullFilename)
+		if err != nil {
+			return nil, fmt.Errorf("getNonAcceptedCertificate: failed to read signed certificate file %s: %w",
+				FullFilename, err)
+		}
+		certHash := common.BytesToHash(keccak256.Hash([]byte(string(data))))
+		if certHash != nonAcceptedCert.CertificateHash {
+			return nil, fmt.Errorf("getNonAcceptedCertificate: certificate hash mismatch: expected %s, got %s (file: %s)",
+				nonAcceptedCert.CertificateHash.String(), certHash.String(), FullFilename)
+		}
+		nonAcceptedCert.SignedCertificate = string(data)
+	}
 
 	return &nonAcceptedCert, nil
 }
@@ -571,11 +598,10 @@ func (a *AggSenderSQLStorage) GetNonAcceptedCertificate() (*NonAcceptedCertifica
 // handleCertificateFile Handle signed certificate file storage before database operations
 func (a *AggSenderSQLStorage) handleCertificateFile(certificate *types.Certificate) error {
 	if certificate.SignedCertificate != nil && *certificate.SignedCertificate != "" {
+		fileName := fmt.Sprintf("signed_cert_%d_%s_%d.json", certificate.Header.Height, certificate.Header.CertificateID, certificate.Header.RetryCount)
 		filePath, err := a.saveSignedCertificateToFile(
-			certificate.Header.Height,
-			certificate.Header.CertificateID,
+			fileName,
 			*certificate.SignedCertificate,
-			certificate.Header.RetryCount,
 		)
 		if err != nil {
 			return fmt.Errorf("error saving signed certificate to file: %w", err)

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -598,7 +598,8 @@ func (a *AggSenderSQLStorage) GetNonAcceptedCertificate() (*NonAcceptedCertifica
 // handleCertificateFile Handle signed certificate file storage before database operations
 func (a *AggSenderSQLStorage) handleCertificateFile(certificate *types.Certificate) error {
 	if certificate.SignedCertificate != nil && *certificate.SignedCertificate != "" {
-		fileName := fmt.Sprintf("signed_cert_%d_%s_%d.json", certificate.Header.Height, certificate.Header.CertificateID, certificate.Header.RetryCount)
+		fileName := fmt.Sprintf("signed_cert_%d_%s_%d.json", certificate.Header.Height,
+			certificate.Header.CertificateID, certificate.Header.RetryCount)
 		filePath, err := a.saveSignedCertificateToFile(
 			fileName,
 			*certificate.SignedCertificate,

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -18,7 +18,7 @@ import (
 	"github.com/agglayer/aggkit/db"
 	dbtypes "github.com/agglayer/aggkit/db/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/iden3/go-iden3-crypto/keccak256"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/russross/meddler"
 )
 
@@ -26,6 +26,7 @@ const (
 	errWhileRollbackFormat  = "error while rolling back tx: %w"
 	nonAcceptedCertKey      = "non_accepted_cert"
 	nonAcceptedCertFilename = "last_rejected_cert.json"
+	prefixFilename          = "@"
 )
 
 var newTxer = db.NewTx
@@ -537,8 +538,8 @@ func (a *AggSenderSQLStorage) SaveNonAcceptedCertificate(
 		Height:            nonAcceptedCert.Height,
 		CreatedAt:         nonAcceptedCert.CreatedAt,
 		Error:             nonAcceptedCert.Error,
-		SignedCertificate: "@" + fullPathFilename,
-		CertificateHash:   common.BytesToHash(keccak256.Hash([]byte(nonAcceptedCert.SignedCertificate))),
+		SignedCertificate: prefixFilename + fullPathFilename,
+		CertificateHash:   crypto.Keccak256Hash([]byte(nonAcceptedCert.SignedCertificate)),
 	}
 	raw, err := json.Marshal(entry)
 	if err != nil {
@@ -577,18 +578,18 @@ func (a *AggSenderSQLStorage) GetNonAcceptedCertificate() (*NonAcceptedCertifica
 	if err := json.Unmarshal([]byte(val), &nonAcceptedCert); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal non-accepted certificate: %w", err)
 	}
-	if nonAcceptedCert.SignedCertificate != "" && nonAcceptedCert.SignedCertificate[0] == '@' {
+	if strings.HasPrefix(nonAcceptedCert.SignedCertificate, prefixFilename) {
 		// The content is pointing to a file
-		FullFilename := nonAcceptedCert.SignedCertificate[1:]
-		data, err := os.ReadFile(FullFilename)
+		certificateFilePath := nonAcceptedCert.SignedCertificate[1:]
+		data, err := os.ReadFile(certificateFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("getNonAcceptedCertificate: failed to read signed certificate file %s: %w",
-				FullFilename, err)
+				certificateFilePath, err)
 		}
-		certHash := common.BytesToHash(keccak256.Hash([]byte(string(data))))
+		certHash := crypto.Keccak256Hash([]byte(string(data)))
 		if certHash != nonAcceptedCert.CertificateHash {
 			return nil, fmt.Errorf("getNonAcceptedCertificate: certificate hash mismatch: expected %s, got %s (file: %s)",
-				nonAcceptedCert.CertificateHash.String(), certHash.String(), FullFilename)
+				nonAcceptedCert.CertificateHash.String(), certHash.String(), certificateFilePath)
 		}
 		nonAcceptedCert.SignedCertificate = string(data)
 	}

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -586,7 +586,7 @@ func (a *AggSenderSQLStorage) GetNonAcceptedCertificate() (*NonAcceptedCertifica
 			return nil, fmt.Errorf("getNonAcceptedCertificate: failed to read signed certificate file %s: %w",
 				certificateFilePath, err)
 		}
-		certHash := crypto.Keccak256Hash([]byte(string(data)))
+		certHash := crypto.Keccak256Hash(data)
 		if certHash != nonAcceptedCert.CertificateHash {
 			return nil, fmt.Errorf("getNonAcceptedCertificate: certificate hash mismatch: expected %s, got %s (file: %s)",
 				nonAcceptedCert.CertificateHash.String(), certHash.String(), certificateFilePath)

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -786,6 +786,19 @@ func Test_GetLastSentCertificateHeaderWithProofIfInError(t *testing.T) {
 	})
 }
 
+func Test_SaveNonAcceptedCertificate_Nil(t *testing.T) {
+	path := path.Join(t.TempDir(), "aggsenderTest_SaveNonAcceptedCertificate.sqlite")
+	log.Debugf("sqlite path: %s", path)
+	cfg := AggSenderSQLStorageConfig{
+		DBPath:          path,
+		CertificatesDir: filepath.Join(filepath.Dir(path), "certificates"),
+	}
+	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
+	require.NoError(t, err)
+	err = storage.SaveNonAcceptedCertificate(context.Background(), nil)
+	require.ErrorContains(t, err, "param nonAcceptedCert is nil")
+}
+
 func Test_SaveNonAcceptedCertificate(t *testing.T) {
 	ctx := context.Background()
 
@@ -813,11 +826,12 @@ func Test_SaveNonAcceptedCertificate(t *testing.T) {
 	createdAt := uint32(time.Now().UTC().UnixMilli())
 
 	testCases := []struct {
-		name          string
-		mockDBFn      func()
-		certificates  []*agglayertypes.Certificate
-		certError     string
-		expectedError string
+		name                string
+		mockDBFn            func()
+		certificates        []*agglayertypes.Certificate
+		OverrideFileContent bool
+		certError           string
+		expectedError       string
 	}{
 		{
 			name: "SaveNonAcceptedCertificate_Success_PP_Certificate",
@@ -912,6 +926,26 @@ func Test_SaveNonAcceptedCertificate(t *testing.T) {
 			},
 			expectedError: "failed to commit tx",
 		},
+		{
+			name: "SaveNonAcceptedCertificate_Mismatch_file_on_disk",
+			certificates: []*agglayertypes.Certificate{
+				{
+					Height:              11,
+					PrevLocalExitRoot:   common.HexToHash("0x11"),
+					NewLocalExitRoot:    common.HexToHash("0x22"),
+					Metadata:            common.HexToHash("0x33"),
+					NetworkID:           2,
+					BridgeExits:         bridgeExits,
+					ImportedBridgeExits: importedBridgeExits,
+					L1InfoTreeLeafCount: 12,
+					AggchainData: &agglayertypes.AggchainDataSignature{
+						Signature: common.Hex2Bytes("0x1234567890abcdef"),
+					},
+				},
+			},
+			certError:           "yet another error occurred",
+			OverrideFileContent: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -944,19 +978,29 @@ func Test_SaveNonAcceptedCertificate(t *testing.T) {
 					require.NoError(t, err, "should save non-accepted certificate without error")
 				}
 			}
+			if tc.OverrideFileContent {
+				// Override the content of the last saved certificate file to simulate file read error
+				certFilePath := filepath.Join(cfg.CertificatesDir, nonAcceptedCertFilename)
+				err = os.WriteFile(certFilePath, []byte("invalid json"), 0o644)
+				require.NoError(t, err, "should override certificate file content without error")
+			}
 
 			if tc.expectedError == "" {
 				nonAcceptedCert, err := storage.GetNonAcceptedCertificate()
-				require.NoError(t, err, "should retrieve one non-accepted certificate from DB even though multiple were saved")
+				if tc.OverrideFileContent {
+					require.ErrorContains(t, err, "certificate hash mismatch")
+				} else {
+					require.NoError(t, err, "should retrieve one non-accepted certificate from DB even though multiple were saved")
 
-				var certificate agglayertypes.Certificate
-				if err = json.Unmarshal([]byte(nonAcceptedCert.SignedCertificate), &certificate); err != nil {
-					t.Fatalf("error unmarshalling non-accepted certificate: %v", err)
+					var certificate agglayertypes.Certificate
+					if err = json.Unmarshal([]byte(nonAcceptedCert.SignedCertificate), &certificate); err != nil {
+						t.Fatalf("error unmarshalling non-accepted certificate: %v", err)
+					}
+
+					require.Equal(t, tc.certificates[len(tc.certificates)-1], &certificate, "last saved certificate should match the one retrieved from DB")
+					require.Equal(t, tc.certError, nonAcceptedCert.Error, "error message should match the expected error")
+					require.Equal(t, createdAt, nonAcceptedCert.CreatedAt, "created at timestamp should match the expected value")
 				}
-
-				require.Equal(t, tc.certificates[len(tc.certificates)-1], &certificate, "last saved certificate should match the one retrieved from DB")
-				require.Equal(t, tc.certError, nonAcceptedCert.Error, "error message should match the expected error")
-				require.Equal(t, createdAt, nonAcceptedCert.CreatedAt, "created at timestamp should match the expected value")
 			}
 		})
 	}

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -623,7 +623,7 @@ func Test_StorageAggchainProof(t *testing.T) {
 		DBPath:                  dbPath,
 		KeepCertificatesHistory: true,
 	}
-	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
+	storage, err := NewAggSenderSQLStorage(log.WithFields("module", "aggsender-db"), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, storage)
 
@@ -911,21 +911,6 @@ func Test_SaveNonAcceptedCertificate(t *testing.T) {
 			},
 			certError: "yet another error occurred",
 		},
-
-		{
-			name:         "SaveNonAcceptedCertificate_CommitAndRollbackFails",
-			certificates: []*agglayertypes.Certificate{{}},
-			mockDBFn: func() {
-				txnMock := dbmocks.NewTxer(t)
-				newTxer = func(_ context.Context, _ dbtypes.DBer) (dbtypes.Txer, error) {
-					return txnMock, nil
-				}
-				txnMock.EXPECT().Exec(mock.Anything, aggkitcommon.AGGSENDER, nonAcceptedCertKey, mock.Anything, mock.Anything).Return(nil, nil)
-				txnMock.EXPECT().Commit().Return(errors.New("failed to commit tx"))
-				txnMock.EXPECT().Rollback().Return(errors.New("failed to rollback tx"))
-			},
-			expectedError: "failed to commit tx",
-		},
 		{
 			name: "SaveNonAcceptedCertificate_Mismatch_file_on_disk",
 			certificates: []*agglayertypes.Certificate{
@@ -946,6 +931,20 @@ func Test_SaveNonAcceptedCertificate(t *testing.T) {
 			certError:           "yet another error occurred",
 			OverrideFileContent: true,
 		},
+		{
+			name:         "SaveNonAcceptedCertificate_CommitAndRollbackFails",
+			certificates: []*agglayertypes.Certificate{{}},
+			mockDBFn: func() {
+				txnMock := dbmocks.NewTxer(t)
+				newTxer = func(_ context.Context, _ dbtypes.DBer) (dbtypes.Txer, error) {
+					return txnMock, nil
+				}
+				txnMock.EXPECT().Exec(mock.Anything, aggkitcommon.AGGSENDER, nonAcceptedCertKey, mock.Anything, mock.Anything).Return(nil, nil).Once()
+				txnMock.EXPECT().Commit().Return(errors.New("failed to commit tx")).Once()
+				txnMock.EXPECT().Rollback().Return(errors.New("failed to rollback tx")).Once()
+			},
+			expectedError: "failed to commit tx",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -955,13 +954,13 @@ func Test_SaveNonAcceptedCertificate(t *testing.T) {
 				err     error
 			)
 
-			path := path.Join(t.TempDir(), "aggsenderTest_SaveNonAcceptedCertificate.sqlite")
+			path := path.Join(t.TempDir(), "aggsenderTest_SaveNonAcceptedCertificate"+tc.name+".sqlite")
 			log.Debugf("sqlite path: %s", path)
 			cfg := AggSenderSQLStorageConfig{
 				DBPath:          path,
 				CertificatesDir: filepath.Join(filepath.Dir(path), "certificates"),
 			}
-			storage, err = NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
+			storage, err = NewAggSenderSQLStorage(log.WithFields("module", "aggsender-db"), cfg)
 			require.NoError(t, err)
 
 			if tc.mockDBFn != nil {

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -84,9 +84,10 @@ func (c *certificateInfo) ID() string {
 }
 
 type NonAcceptedCertificate struct {
-	Height            uint64 `meddler:"height"`
-	SignedCertificate string `meddler:"signed_certificate"`
-	CreatedAt         uint32 `meddler:"created_at"`
+	Height            uint64      `meddler:"height"`
+	SignedCertificate string      `meddler:"signed_certificate"`
+	CreatedAt         uint32      `meddler:"created_at"`
+	CertificateHash   common.Hash `meddler:"certificate_hash,hash"`
 	// Error message indicating why the certificate was not accepted
 	Error string `meddler:"error"`
 }

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -88,7 +88,7 @@ type NonAcceptedCertificate struct {
 	// SignedCertificate is "@<file_path>" or the actual JSON content of the certificate
 	SignedCertificate string `meddler:"signed_certificate"`
 	CreatedAt         uint32 `meddler:"created_at"`
-	// CertificateHash of the file that containt the certificate in JSON format
+	// CertificateHash of the file that contains the certificate in JSON format
 	CertificateHash common.Hash `meddler:"certificate_hash,hash"`
 	// Error message indicating why the certificate was not accepted
 	Error string `meddler:"error"`

--- a/aggsender/db/types.go
+++ b/aggsender/db/types.go
@@ -84,10 +84,12 @@ func (c *certificateInfo) ID() string {
 }
 
 type NonAcceptedCertificate struct {
-	Height            uint64      `meddler:"height"`
-	SignedCertificate string      `meddler:"signed_certificate"`
-	CreatedAt         uint32      `meddler:"created_at"`
-	CertificateHash   common.Hash `meddler:"certificate_hash,hash"`
+	Height uint64 `meddler:"height"`
+	// SignedCertificate is "@<file_path>" or the actual JSON content of the certificate
+	SignedCertificate string `meddler:"signed_certificate"`
+	CreatedAt         uint32 `meddler:"created_at"`
+	// CertificateHash of the file that containt the certificate in JSON format
+	CertificateHash common.Hash `meddler:"certificate_hash,hash"`
 	// Error message indicating why the certificate was not accepted
 	Error string `meddler:"error"`
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- A rejected certificates must be stored on filesystem instead of database due the sqlite limitation to 1Gb
- The content of the **non_accepted_cert** in table KV have changed the format (still compatible): 
    - Inside the JSON stored the field `SignedCertificate` if stars with *@* means a full path filename with the JSON of the certificate and the field `CertificateHash`have the hash of the JSON of the certificate


## 🐞 Issues
- Closes #912

