### PR TITLE
fix: [cherry-pick] set block timestamp and tx hash to pre-etrog claims (#997)

### DIFF
--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -155,14 +155,13 @@ func buildClaimEventHandler(contract *polygonzkevmbridgev2.Polygonzkevmbridgev2,
 		claim := &Claim{
 			BlockNum:           b.Num,
 			BlockPos:           uint64(l.Index),
+			BlockTimestamp:     b.Timestamp,
+			TxHash:             l.TxHash,
 			GlobalIndex:        claimEvent.GlobalIndex,
 			OriginNetwork:      claimEvent.OriginNetwork,
 			OriginAddress:      claimEvent.OriginAddress,
 			DestinationAddress: claimEvent.DestinationAddress,
 			Amount:             claimEvent.Amount,
-			BlockTimestamp:     b.Timestamp,
-			TxHash:             l.TxHash,
-			FromAddress:        l.Address,
 		}
 
 		if syncFullClaims {
@@ -189,7 +188,9 @@ func buildClaimEventHandlerPreEtrog(contract *polygonzkevmbridge.Polygonzkevmbri
 		claim := &Claim{
 			BlockNum:           b.Num,
 			BlockPos:           uint64(l.Index),
-			GlobalIndex:        big.NewInt(int64(claimEvent.Index)),
+			BlockTimestamp:     b.Timestamp,
+			TxHash:             l.TxHash,
+			GlobalIndex:        new(big.Int).SetUint64(uint64(claimEvent.Index)),
 			OriginNetwork:      claimEvent.OriginNetwork,
 			OriginAddress:      claimEvent.OriginAddress,
 			DestinationAddress: claimEvent.DestinationAddress,


### PR DESCRIPTION
## 🔄 Changes Summary
- Notice that the claims that are done on the pre-Etrog bridge contracts, have the `block_timestamp` and `tx_hash` fields populated, which is not the case currently
(http://34.89.33.65:5577/bridge/v1/claims?network_id=0&page_number=2935).

## :warning: Note
It is necessary to re-index the data, in order to have the `block_timestamp` and `tx_hash` data populated for pre-Etrog claims.

## ⚠️ Breaking Changes
- 🛠️ **Config**: N/A
- 🔌 **API/CLI**: N/A
- 🗑️ **Deprecated Features**: N/A

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #1015