### PR TITLE
feat: autoconfigure aggsender mode #948

### DIFF
--- a/agglayer/rate_limit_wrapper.go
+++ b/agglayer/rate_limit_wrapper.go
@@ -115,11 +115,6 @@ func (r *RateLimitWrapper) GetLatestPendingCertificateHeader(
 	return r.client.GetLatestPendingCertificateHeader(ctx, networkID)
 }
 
-func (r *RateLimitWrapper) GetNetworkInfo(ctx context.Context, networkID uint32) (types.NetworkInfo, error) {
-	r.applyRateLimit("GetNetworkInfo")
-	return r.client.GetNetworkInfo(ctx, networkID)
-}
-
 // String returns a string representation of the rate limit wrapper
 func (r *RateLimitWrapper) String() string {
 	r.mu.RLock()

--- a/agglayer/rate_limit_wrapper.go
+++ b/agglayer/rate_limit_wrapper.go
@@ -115,6 +115,11 @@ func (r *RateLimitWrapper) GetLatestPendingCertificateHeader(
 	return r.client.GetLatestPendingCertificateHeader(ctx, networkID)
 }
 
+func (r *RateLimitWrapper) GetNetworkInfo(ctx context.Context, networkID uint32) (types.NetworkInfo, error) {
+	r.applyRateLimit("GetNetworkInfo")
+	return r.client.GetNetworkInfo(ctx, networkID)
+}
+
 // String returns a string representation of the rate limit wrapper
 func (r *RateLimitWrapper) String() string {
 	r.mu.RLock()

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -72,7 +72,7 @@ func New(
 	rollupDataQuerier types.RollupDataQuerier,
 	committeeQuerier types.MultisigQuerier,
 ) (*AggSender, error) {
-	mode, err := cfg.Mode.ResolveAutoMode(committeeQuerier)
+	mode, err := committeeQuerier.ResolveAutoMode(cfg.Mode)
 	if err != nil {
 		return nil, err
 	}

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -58,6 +58,17 @@ type AggSender struct {
 	l2OriginNetwork uint32
 }
 
+func aggsenderMode(mode types.AggsenderMode, committeeQuerier types.MultisigQuerier) (types.AggsenderMode, error) {
+	var err error
+	if mode == types.AutoMode {
+		mode, err = committeeQuerier.ContractMode()
+		if err != nil {
+			return mode, fmt.Errorf("aggsender mode is AUTO, but can't get contract mode from rollup contract: %w", err)
+		}
+	}
+	return mode, err
+}
+
 // New returns a new AggSender instance
 func New(
 	ctx context.Context,
@@ -72,6 +83,16 @@ func New(
 	rollupDataQuerier types.RollupDataQuerier,
 	committeeQuerier types.MultisigQuerier,
 ) (*AggSender, error) {
+	mode, err := cfg.ModeCfg.ResolveAutoMode(committeeQuerier)
+	if err != nil {
+		return nil, err
+	}
+	// Override configuration with the resolved mode
+	if cfg.ModeCfg != mode {
+		log.Infof("aggsender mode from %s to %s", cfg.ModeCfg, mode)
+		cfg.ModeCfg = mode
+	}
+
 	storageConfig := db.AggSenderSQLStorageConfig{
 		DBPath:                  cfg.StoragePath,
 		CertificatesDir:         cfg.CertificatesDir,
@@ -99,6 +120,7 @@ func New(
 	}
 
 	logger.Infof("Aggsender Config: %s.", cfg.String())
+
 	l2OriginNetwork := l2Syncer.OriginNetwork()
 
 	compatibilityStoragedChecker := compatibility.NewCompatibilityCheck(
@@ -109,7 +131,7 @@ func New(
 		compatibility.NewKeyValueToCompatibilityStorage[db.RuntimeData](storage, aggkitcommon.AGGSENDER),
 	)
 
-	aggchainFEPCaller, err := query.NewAggchainFEPQuerier(logger, types.AggsenderMode(cfg.Mode),
+	aggchainFEPCaller, err := query.NewAggchainFEPQuerier(logger, mode,
 		cfg.SovereignRollupAddr, l1Client)
 	if err != nil {
 		return nil, fmt.Errorf("error creating aggchain FEP caller: %w", err)

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -58,17 +58,6 @@ type AggSender struct {
 	l2OriginNetwork uint32
 }
 
-func aggsenderMode(mode types.AggsenderMode, committeeQuerier types.MultisigQuerier) (types.AggsenderMode, error) {
-	var err error
-	if mode == types.AutoMode {
-		mode, err = committeeQuerier.ContractMode()
-		if err != nil {
-			return mode, fmt.Errorf("aggsender mode is AUTO, but can't get contract mode from rollup contract: %w", err)
-		}
-	}
-	return mode, err
-}
-
 // New returns a new AggSender instance
 func New(
 	ctx context.Context,
@@ -83,14 +72,14 @@ func New(
 	rollupDataQuerier types.RollupDataQuerier,
 	committeeQuerier types.MultisigQuerier,
 ) (*AggSender, error) {
-	mode, err := cfg.ModeCfg.ResolveAutoMode(committeeQuerier)
+	mode, err := cfg.Mode.ResolveAutoMode(committeeQuerier)
 	if err != nil {
 		return nil, err
 	}
 	// Override configuration with the resolved mode
-	if cfg.ModeCfg != mode {
-		log.Infof("aggsender mode from %s to %s", cfg.ModeCfg, mode)
-		cfg.ModeCfg = mode
+	if cfg.Mode != mode {
+		log.Infof("aggsender mode from %s to %s", cfg.Mode, mode)
+		cfg.Mode = mode
 	}
 
 	storageConfig := db.AggSenderSQLStorageConfig{

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -48,7 +48,7 @@ func TestConfigString(t *testing.T) {
 		AggsenderPrivateKey:         signer.NewLocalSignerConfig("/path/to/key", "password"),
 		URLRPCL2:                    "http://l2.rpc.url",
 		EpochNotificationPercentage: 50,
-		ModeCfg:                     "PP",
+		Mode:                        "PP",
 		SovereignRollupAddr:         common.HexToAddress("0x1"),
 	}
 
@@ -94,7 +94,7 @@ func TestAggSenderStart(t *testing.T) {
 		ctx,
 		log.WithFields("test", "unittest"),
 		config.Config{
-			ModeCfg:             "PessimisticProof",
+			Mode:                "PessimisticProof",
 			StoragePath:         path.Join(t.TempDir(), "aggsenderTestAggSenderStart.sqlite"),
 			DelayBetweenRetries: types.Duration{Duration: 1 * time.Microsecond},
 			AggsenderPrivateKey: signertypes.SignerConfig{
@@ -517,7 +517,7 @@ func TestNewAggSender(t *testing.T) {
 		AggsenderPrivateKey: signertypes.SignerConfig{
 			Method: signertypes.MethodNone,
 		},
-		ModeCfg: "PessimisticProof",
+		Mode: "PessimisticProof",
 	}, nil, nil, mockBridgeSyncer,
 		nil, // epoch notifier
 		nil, // l1 client

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -88,13 +88,13 @@ func TestAggSenderStart(t *testing.T) {
 	committee, err := aggsendertypes.NewMultisigCommittee([]*aggsendertypes.SignerInfo{aggsendertypes.NewSignerInfo("", common.Address{})}, big.NewInt(1))
 	require.NoError(t, err)
 	committeQuerierMock.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Once()
-
+	committeQuerierMock.EXPECT().ResolveAutoMode(mock.Anything).Return(aggsendertypes.PessimisticProofMode, nil).Once()
 	ctx := t.Context()
 	aggSender, err := New(
 		ctx,
 		log.WithFields("test", "unittest"),
 		config.Config{
-			Mode:                "PessimisticProof",
+			Mode:                aggsendertypes.PessimisticProofMode,
 			StoragePath:         path.Join(t.TempDir(), "aggsenderTestAggSenderStart.sqlite"),
 			DelayBetweenRetries: types.Duration{Duration: 1 * time.Microsecond},
 			AggsenderPrivateKey: signertypes.SignerConfig{
@@ -512,12 +512,12 @@ func TestNewAggSender(t *testing.T) {
 		big.NewInt(1))
 	require.NoError(t, err)
 	mockCommitteeQuerier.EXPECT().GetMultisigCommittee(mock.Anything, mock.Anything).Return(committee, nil).Once()
-
+	mockCommitteeQuerier.EXPECT().ResolveAutoMode(mock.Anything).Return(aggsendertypes.PessimisticProofMode, nil).Once()
 	sut, err := New(context.TODO(), log.WithFields("module", "ut"), config.Config{
 		AggsenderPrivateKey: signertypes.SignerConfig{
 			Method: signertypes.MethodNone,
 		},
-		Mode: "PessimisticProof",
+		Mode: aggsendertypes.PessimisticProofMode,
 	}, nil, nil, mockBridgeSyncer,
 		nil, // epoch notifier
 		nil, // l1 client

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -48,7 +48,7 @@ func TestConfigString(t *testing.T) {
 		AggsenderPrivateKey:         signer.NewLocalSignerConfig("/path/to/key", "password"),
 		URLRPCL2:                    "http://l2.rpc.url",
 		EpochNotificationPercentage: 50,
-		Mode:                        "PP",
+		ModeCfg:                     "PP",
 		SovereignRollupAddr:         common.HexToAddress("0x1"),
 	}
 
@@ -94,7 +94,7 @@ func TestAggSenderStart(t *testing.T) {
 		ctx,
 		log.WithFields("test", "unittest"),
 		config.Config{
-			Mode:                "PessimisticProof",
+			ModeCfg:             "PessimisticProof",
 			StoragePath:         path.Join(t.TempDir(), "aggsenderTestAggSenderStart.sqlite"),
 			DelayBetweenRetries: types.Duration{Duration: 1 * time.Microsecond},
 			AggsenderPrivateKey: signertypes.SignerConfig{
@@ -517,7 +517,7 @@ func TestNewAggSender(t *testing.T) {
 		AggsenderPrivateKey: signertypes.SignerConfig{
 			Method: signertypes.MethodNone,
 		},
-		Mode: "PessimisticProof",
+		ModeCfg: "PessimisticProof",
 	}, nil, nil, mockBridgeSyncer,
 		nil, // epoch notifier
 		nil, // l1 client

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	// AggkitProverClient is the config for the AggkitProver client
 	AggkitProverClient *grpc.ClientConfig `mapstructure:"AggkitProverClient"`
 	// Mode is the mode of the AggSender (regular pessimistic proof mode or the aggchain proof mode)
-	Mode string `jsonschema:"enum=PessimisticProof, enum=AggchainProof" mapstructure:"Mode"`
+	ModeCfg aggsendertypes.AggsenderMode `jsonschema:"enum=PessimisticProof, enum=AggchainProof, enum=Auto" mapstructure:"Mode"`
 	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
 	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
 	// RetryCertAfterInError when a cert pass to 'InError'
@@ -106,7 +106,7 @@ func (c Config) String() string {
 		"DryRun: " + fmt.Sprintf("%t", c.DryRun) + "\n" +
 		"EnableRPC: " + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
 		"AggkitProverClient: " + c.AggkitProverClient.String() + "\n" +
-		"Mode: " + c.Mode + "\n" +
+		"Mode: " + c.ModeCfg.String() + "\n" +
 		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
 		"RetryCertAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
 		"SovereignRollupAddr: " + c.SovereignRollupAddr.Hex() + "\n" +
@@ -120,7 +120,7 @@ func (c Config) Validate() error {
 		return fmt.Errorf("invalid agglayer client config: %w", err)
 	}
 
-	if c.Mode == aggsendertypes.AggchainProofMode.String() {
+	if c.ModeCfg == aggsendertypes.AggchainProofMode {
 		if err := c.AggkitProverClient.Validate(); err != nil {
 			return fmt.Errorf("invalid aggkit prover client config: %w", err)
 		}

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	// AggkitProverClient is the config for the AggkitProver client
 	AggkitProverClient *grpc.ClientConfig `mapstructure:"AggkitProverClient"`
 	// Mode is the mode of the AggSender (regular pessimistic proof mode or the aggchain proof mode)
-	ModeCfg aggsendertypes.AggsenderMode `jsonschema:"enum=PessimisticProof, enum=AggchainProof, enum=Auto" mapstructure:"Mode"`
+	Mode aggsendertypes.AggsenderMode `jsonschema:"enum=PessimisticProof, enum=AggchainProof, enum=Auto" mapstructure:"Mode"` //nolint:lll
 	// CheckStatusCertificateInterval is the interval at which the AggSender will check the certificate status in Agglayer
 	CheckStatusCertificateInterval types.Duration `mapstructure:"CheckStatusCertificateInterval"`
 	// RetryCertAfterInError when a cert pass to 'InError'
@@ -106,7 +106,7 @@ func (c Config) String() string {
 		"DryRun: " + fmt.Sprintf("%t", c.DryRun) + "\n" +
 		"EnableRPC: " + fmt.Sprintf("%t", c.EnableRPC) + "\n" +
 		"AggkitProverClient: " + c.AggkitProverClient.String() + "\n" +
-		"Mode: " + c.ModeCfg.String() + "\n" +
+		"Mode: " + c.Mode.String() + "\n" +
 		"CheckStatusCertificateInterval: " + c.CheckStatusCertificateInterval.String() + "\n" +
 		"RetryCertAfterInError: " + fmt.Sprintf("%t", c.RetryCertAfterInError) + "\n" +
 		"SovereignRollupAddr: " + c.SovereignRollupAddr.Hex() + "\n" +
@@ -120,7 +120,7 @@ func (c Config) Validate() error {
 		return fmt.Errorf("invalid agglayer client config: %w", err)
 	}
 
-	if c.ModeCfg == aggsendertypes.AggchainProofMode {
+	if c.Mode == aggsendertypes.AggchainProofMode {
 		if err := c.AggkitProverClient.Validate(); err != nil {
 			return fmt.Errorf("invalid aggkit prover client config: %w", err)
 		}

--- a/aggsender/config/config_test.go
+++ b/aggsender/config/config_test.go
@@ -35,7 +35,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "AggchainProof mode with AggkitProverClient not set",
 			config: Config{
-				ModeCfg: aggsendertypes.AggchainProofMode,
+				Mode: aggsendertypes.AggchainProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -50,7 +50,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "PessimisticProof mode with AggkitProverClient not set",
 			config: Config{
-				ModeCfg: aggsendertypes.PessimisticProofMode,
+				Mode: aggsendertypes.PessimisticProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -86,7 +86,7 @@ func TestConfigString(t *testing.T) {
 		EpochNotificationPercentage:    75,
 		DryRun:                         true,
 		EnableRPC:                      false,
-		ModeCfg:                        aggsendertypes.PessimisticProofMode,
+		Mode:                           aggsendertypes.PessimisticProofMode,
 		RetryCertAfterInError:          true,
 		RequireNoFEPBlockGap:           false,
 		CheckStatusCertificateInterval: types.NewDuration(5 * time.Minute),

--- a/aggsender/config/config_test.go
+++ b/aggsender/config/config_test.go
@@ -35,7 +35,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "AggchainProof mode with AggkitProverClient not set",
 			config: Config{
-				Mode: aggsendertypes.AggchainProofMode.String(),
+				ModeCfg: aggsendertypes.AggchainProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -50,7 +50,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "PessimisticProof mode with AggkitProverClient not set",
 			config: Config{
-				Mode: aggsendertypes.PessimisticProofMode.String(),
+				ModeCfg: aggsendertypes.PessimisticProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -86,7 +86,7 @@ func TestConfigString(t *testing.T) {
 		EpochNotificationPercentage:    75,
 		DryRun:                         true,
 		EnableRPC:                      false,
-		Mode:                           aggsendertypes.PessimisticProofMode.String(),
+		ModeCfg:                        aggsendertypes.PessimisticProofMode,
 		RetryCertAfterInError:          true,
 		RequireNoFEPBlockGap:           false,
 		CheckStatusCertificateInterval: types.NewDuration(5 * time.Minute),

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -37,7 +37,7 @@ func NewFlow(
 	rollupDataQuerier types.RollupDataQuerier,
 	committeeQuerier types.MultisigQuerier,
 ) (types.AggsenderFlow, error) {
-	switch types.AggsenderMode(cfg.Mode) {
+	switch cfg.ModeCfg {
 	case types.PessimisticProofMode:
 		commonFlowComponents, err := CreateCommonFlowComponents(
 			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer,
@@ -126,7 +126,7 @@ func NewFlow(
 		), nil
 
 	default:
-		return nil, fmt.Errorf("unsupported Aggsender mode: %s", cfg.Mode)
+		return nil, fmt.Errorf("unsupported Aggsender mode: %s", cfg.ModeCfg)
 	}
 }
 

--- a/aggsender/flows/factory.go
+++ b/aggsender/flows/factory.go
@@ -37,7 +37,7 @@ func NewFlow(
 	rollupDataQuerier types.RollupDataQuerier,
 	committeeQuerier types.MultisigQuerier,
 ) (types.AggsenderFlow, error) {
-	switch cfg.ModeCfg {
+	switch cfg.Mode {
 	case types.PessimisticProofMode:
 		commonFlowComponents, err := CreateCommonFlowComponents(
 			ctx, logger, storage, l1Client, l1InfoTreeSyncer, l2Syncer,
@@ -126,7 +126,7 @@ func NewFlow(
 		), nil
 
 	default:
-		return nil, fmt.Errorf("unsupported Aggsender mode: %s", cfg.ModeCfg)
+		return nil, fmt.Errorf("unsupported Aggsender mode: %s", cfg.Mode)
 	}
 }
 

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -34,7 +34,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "success with PessimisticProofMode",
 			cfg: config.Config{
-				ModeCfg:             types.PessimisticProofMode,
+				Mode:                types.PessimisticProofMode,
 				AggsenderPrivateKey: signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:         100,
 				AggkitProverClient:  aggkitgrpc.DefaultConfig(),
@@ -49,7 +49,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "error getting multisig committee when RequireCommitteeMembershipCheck is true",
 			cfg: config.Config{
-				ModeCfg:                         types.PessimisticProofMode,
+				Mode:                            types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -63,7 +63,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "error getting multisig committee when RequireCommitteeMembershipCheck is false",
 			cfg: config.Config{
-				ModeCfg:                         types.PessimisticProofMode,
+				Mode:                            types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -76,7 +76,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "committee membership check disabled with PessimisticProofMode",
 			cfg: config.Config{
-				ModeCfg:                         types.PessimisticProofMode,
+				Mode:                            types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -97,7 +97,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "not member of committee",
 			cfg: config.Config{
-				ModeCfg:                         types.PessimisticProofMode,
+				Mode:                            types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -119,7 +119,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "error creating signer in PessimisticProofMode",
 			cfg: config.Config{
-				ModeCfg: types.PessimisticProofMode,
+				Mode: types.PessimisticProofMode,
 				AggsenderPrivateKey: signertypes.SignerConfig{
 					Method: signertypes.MethodLocal,
 				},
@@ -130,14 +130,14 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "unsupported Aggsender mode",
 			cfg: config.Config{
-				ModeCfg: "unsupported-mode",
+				Mode: "unsupported-mode",
 			},
 			expectedError: "unsupported Aggsender mode: unsupported-mode",
 		},
 		{
 			name: "error optimistic mode fetching aggchain signers in AggchainProofMode",
 			cfg: config.Config{
-				ModeCfg:             types.AggchainProofMode,
+				Mode:                types.AggchainProofMode,
 				AggsenderPrivateKey: keyConfig,
 				AggkitProverClient: &aggkitgrpc.ClientConfig{
 					URL:               "http://127.0.0.1",

--- a/aggsender/flows/factory_test.go
+++ b/aggsender/flows/factory_test.go
@@ -34,7 +34,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "success with PessimisticProofMode",
 			cfg: config.Config{
-				Mode:                string(types.PessimisticProofMode),
+				ModeCfg:             types.PessimisticProofMode,
 				AggsenderPrivateKey: signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:         100,
 				AggkitProverClient:  aggkitgrpc.DefaultConfig(),
@@ -49,7 +49,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "error getting multisig committee when RequireCommitteeMembershipCheck is true",
 			cfg: config.Config{
-				Mode:                            string(types.PessimisticProofMode),
+				ModeCfg:                         types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -63,7 +63,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "error getting multisig committee when RequireCommitteeMembershipCheck is false",
 			cfg: config.Config{
-				Mode:                            string(types.PessimisticProofMode),
+				ModeCfg:                         types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -76,7 +76,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "committee membership check disabled with PessimisticProofMode",
 			cfg: config.Config{
-				Mode:                            string(types.PessimisticProofMode),
+				ModeCfg:                         types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -97,7 +97,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "not member of committee",
 			cfg: config.Config{
-				Mode:                            string(types.PessimisticProofMode),
+				ModeCfg:                         types.PessimisticProofMode,
 				AggsenderPrivateKey:             signertypes.SignerConfig{Method: signertypes.MethodNone},
 				MaxCertSize:                     100,
 				AggkitProverClient:              aggkitgrpc.DefaultConfig(),
@@ -119,7 +119,7 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "error creating signer in PessimisticProofMode",
 			cfg: config.Config{
-				Mode: string(types.PessimisticProofMode),
+				ModeCfg: types.PessimisticProofMode,
 				AggsenderPrivateKey: signertypes.SignerConfig{
 					Method: signertypes.MethodLocal,
 				},
@@ -130,14 +130,14 @@ func TestNewFlow(t *testing.T) {
 		{
 			name: "unsupported Aggsender mode",
 			cfg: config.Config{
-				Mode: "unsupported-mode",
+				ModeCfg: "unsupported-mode",
 			},
 			expectedError: "unsupported Aggsender mode: unsupported-mode",
 		},
 		{
 			name: "error optimistic mode fetching aggchain signers in AggchainProofMode",
 			cfg: config.Config{
-				Mode:                string(types.AggchainProofMode),
+				ModeCfg:             types.AggchainProofMode,
 				AggsenderPrivateKey: keyConfig,
 				AggkitProverClient: &aggkitgrpc.ClientConfig{
 					URL:               "http://127.0.0.1",

--- a/aggsender/mocks/mock_multisig_contract.go
+++ b/aggsender/mocks/mock_multisig_contract.go
@@ -25,6 +25,120 @@ func (_m *MultisigContract) EXPECT() *MultisigContract_Expecter {
 	return &MultisigContract_Expecter{mock: &_m.Mock}
 }
 
+// AGGCHAINTYPE provides a mock function with given fields: opts
+func (_m *MultisigContract) AGGCHAINTYPE(opts *bind.CallOpts) ([2]byte, error) {
+	ret := _m.Called(opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AGGCHAINTYPE")
+	}
+
+	var r0 [2]byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*bind.CallOpts) ([2]byte, error)); ok {
+		return rf(opts)
+	}
+	if rf, ok := ret.Get(0).(func(*bind.CallOpts) [2]byte); ok {
+		r0 = rf(opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([2]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*bind.CallOpts) error); ok {
+		r1 = rf(opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MultisigContract_AGGCHAINTYPE_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AGGCHAINTYPE'
+type MultisigContract_AGGCHAINTYPE_Call struct {
+	*mock.Call
+}
+
+// AGGCHAINTYPE is a helper method to define mock.On call
+//   - opts *bind.CallOpts
+func (_e *MultisigContract_Expecter) AGGCHAINTYPE(opts interface{}) *MultisigContract_AGGCHAINTYPE_Call {
+	return &MultisigContract_AGGCHAINTYPE_Call{Call: _e.mock.On("AGGCHAINTYPE", opts)}
+}
+
+func (_c *MultisigContract_AGGCHAINTYPE_Call) Run(run func(opts *bind.CallOpts)) *MultisigContract_AGGCHAINTYPE_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*bind.CallOpts))
+	})
+	return _c
+}
+
+func (_c *MultisigContract_AGGCHAINTYPE_Call) Return(_a0 [2]byte, _a1 error) *MultisigContract_AGGCHAINTYPE_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MultisigContract_AGGCHAINTYPE_Call) RunAndReturn(run func(*bind.CallOpts) ([2]byte, error)) *MultisigContract_AGGCHAINTYPE_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CONSENSUSTYPE provides a mock function with given fields: opts
+func (_m *MultisigContract) CONSENSUSTYPE(opts *bind.CallOpts) (uint32, error) {
+	ret := _m.Called(opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CONSENSUSTYPE")
+	}
+
+	var r0 uint32
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*bind.CallOpts) (uint32, error)); ok {
+		return rf(opts)
+	}
+	if rf, ok := ret.Get(0).(func(*bind.CallOpts) uint32); ok {
+		r0 = rf(opts)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	if rf, ok := ret.Get(1).(func(*bind.CallOpts) error); ok {
+		r1 = rf(opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MultisigContract_CONSENSUSTYPE_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CONSENSUSTYPE'
+type MultisigContract_CONSENSUSTYPE_Call struct {
+	*mock.Call
+}
+
+// CONSENSUSTYPE is a helper method to define mock.On call
+//   - opts *bind.CallOpts
+func (_e *MultisigContract_Expecter) CONSENSUSTYPE(opts interface{}) *MultisigContract_CONSENSUSTYPE_Call {
+	return &MultisigContract_CONSENSUSTYPE_Call{Call: _e.mock.On("CONSENSUSTYPE", opts)}
+}
+
+func (_c *MultisigContract_CONSENSUSTYPE_Call) Run(run func(opts *bind.CallOpts)) *MultisigContract_CONSENSUSTYPE_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*bind.CallOpts))
+	})
+	return _c
+}
+
+func (_c *MultisigContract_CONSENSUSTYPE_Call) Return(_a0 uint32, _a1 error) *MultisigContract_CONSENSUSTYPE_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MultisigContract_CONSENSUSTYPE_Call) RunAndReturn(run func(*bind.CallOpts) (uint32, error)) *MultisigContract_CONSENSUSTYPE_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAggchainSignerInfos provides a mock function with given fields: opts
 func (_m *MultisigContract) GetAggchainSignerInfos(opts *bind.CallOpts) ([]aggchainbase.IAggchainSignersSignerInfo, error) {
 	ret := _m.Called(opts)

--- a/aggsender/mocks/mock_multisig_querier.go
+++ b/aggsender/mocks/mock_multisig_querier.go
@@ -138,6 +138,62 @@ func (_c *MultisigQuerier_GetMultisigCommittee_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// ResolveAutoMode provides a mock function with given fields: cfgMode
+func (_m *MultisigQuerier) ResolveAutoMode(cfgMode types.AggsenderMode) (types.AggsenderMode, error) {
+	ret := _m.Called(cfgMode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveAutoMode")
+	}
+
+	var r0 types.AggsenderMode
+	var r1 error
+	if rf, ok := ret.Get(0).(func(types.AggsenderMode) (types.AggsenderMode, error)); ok {
+		return rf(cfgMode)
+	}
+	if rf, ok := ret.Get(0).(func(types.AggsenderMode) types.AggsenderMode); ok {
+		r0 = rf(cfgMode)
+	} else {
+		r0 = ret.Get(0).(types.AggsenderMode)
+	}
+
+	if rf, ok := ret.Get(1).(func(types.AggsenderMode) error); ok {
+		r1 = rf(cfgMode)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MultisigQuerier_ResolveAutoMode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveAutoMode'
+type MultisigQuerier_ResolveAutoMode_Call struct {
+	*mock.Call
+}
+
+// ResolveAutoMode is a helper method to define mock.On call
+//   - cfgMode types.AggsenderMode
+func (_e *MultisigQuerier_Expecter) ResolveAutoMode(cfgMode interface{}) *MultisigQuerier_ResolveAutoMode_Call {
+	return &MultisigQuerier_ResolveAutoMode_Call{Call: _e.mock.On("ResolveAutoMode", cfgMode)}
+}
+
+func (_c *MultisigQuerier_ResolveAutoMode_Call) Run(run func(cfgMode types.AggsenderMode)) *MultisigQuerier_ResolveAutoMode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(types.AggsenderMode))
+	})
+	return _c
+}
+
+func (_c *MultisigQuerier_ResolveAutoMode_Call) Return(_a0 types.AggsenderMode, _a1 error) *MultisigQuerier_ResolveAutoMode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MultisigQuerier_ResolveAutoMode_Call) RunAndReturn(run func(types.AggsenderMode) (types.AggsenderMode, error)) *MultisigQuerier_ResolveAutoMode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMultisigQuerier creates a new instance of MultisigQuerier. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMultisigQuerier(t interface {

--- a/aggsender/mocks/mock_multisig_querier.go
+++ b/aggsender/mocks/mock_multisig_querier.go
@@ -24,6 +24,61 @@ func (_m *MultisigQuerier) EXPECT() *MultisigQuerier_Expecter {
 	return &MultisigQuerier_Expecter{mock: &_m.Mock}
 }
 
+// ContractMode provides a mock function with no fields
+func (_m *MultisigQuerier) ContractMode() (types.AggsenderMode, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ContractMode")
+	}
+
+	var r0 types.AggsenderMode
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (types.AggsenderMode, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() types.AggsenderMode); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(types.AggsenderMode)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MultisigQuerier_ContractMode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ContractMode'
+type MultisigQuerier_ContractMode_Call struct {
+	*mock.Call
+}
+
+// ContractMode is a helper method to define mock.On call
+func (_e *MultisigQuerier_Expecter) ContractMode() *MultisigQuerier_ContractMode_Call {
+	return &MultisigQuerier_ContractMode_Call{Call: _e.mock.On("ContractMode")}
+}
+
+func (_c *MultisigQuerier_ContractMode_Call) Run(run func()) *MultisigQuerier_ContractMode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MultisigQuerier_ContractMode_Call) Return(_a0 types.AggsenderMode, _a1 error) *MultisigQuerier_ContractMode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MultisigQuerier_ContractMode_Call) RunAndReturn(run func() (types.AggsenderMode, error)) *MultisigQuerier_ContractMode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMultisigCommittee provides a mock function with given fields: ctx, blockNum
 func (_m *MultisigQuerier) GetMultisigCommittee(ctx context.Context, blockNum *big.Int) (*types.MultisigCommittee, error) {
 	ret := _m.Called(ctx, blockNum)

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -13,8 +13,10 @@ import (
 )
 
 var (
-	_ types.MultisigQuerier  = (*BaseMultisigCommitteeQuery)(nil)
-	_ types.MultisigContract = (*aggchainbase.Aggchainbase)(nil)
+	_                     types.MultisigQuerier  = (*BaseMultisigCommitteeQuery)(nil)
+	_                     types.MultisigContract = (*aggchainbase.Aggchainbase)(nil)
+	aggchainECDSAMultisig                        = [2]byte{0, 0}
+	aggchainFEP                                  = [2]byte{0, 1}
 )
 
 type BaseMultisigCommitteeQuery struct {
@@ -95,4 +97,31 @@ func (m *BaseMultisigCommitteeQuery) GetMultisigCommittee(
 	}
 
 	return types.NewMultisigCommittee(signerInfos, threshold)
+}
+
+// ContractMode returns the mode of the multisig contract (PP or FEP)
+func (m *BaseMultisigCommitteeQuery) ContractMode() (types.AggsenderMode, error) {
+	var none types.AggsenderMode
+	if m == nil {
+		return none, fmt.Errorf("object is nil")
+	}
+	consensusType, err := m.sovereignRollupAddrSC.CONSENSUSTYPE(&bind.CallOpts{})
+	if err != nil {
+		return none, fmt.Errorf("failed to get consensus type from contract: %w", err)
+	}
+	if consensusType != 1 {
+		return none, fmt.Errorf("consensus type must be 1 always: %d", consensusType)
+	}
+	aggchainType, err := m.sovereignRollupAddrSC.AGGCHAINTYPE(&bind.CallOpts{})
+	if err != nil {
+		return none, fmt.Errorf("failed to get aggchain type from contract: %w", err)
+	}
+	if aggchainType == aggchainECDSAMultisig {
+		return types.PessimisticProofMode, nil
+	}
+
+	if aggchainType == aggchainFEP { // aggchainFEP
+		return types.AggchainProofMode, nil
+	}
+	return none, fmt.Errorf("unsupported aggchain type: %v", aggchainType)
 }

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -119,8 +119,7 @@ func (m *BaseMultisigCommitteeQuery) ContractMode() (types.AggsenderMode, error)
 	if aggchainType == aggchainECDSAMultisig {
 		return types.PessimisticProofMode, nil
 	}
-
-	if aggchainType == aggchainFEP { // aggchainFEP
+	if aggchainType == aggchainFEP {
 		return types.AggchainProofMode, nil
 	}
 	return none, fmt.Errorf("unsupported aggchain type: %v", aggchainType)

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -125,3 +125,18 @@ func (m *BaseMultisigCommitteeQuery) ContractMode() (types.AggsenderMode, error)
 	}
 	return none, fmt.Errorf("unsupported aggchain type: %v", aggchainType)
 }
+
+func (m *BaseMultisigCommitteeQuery) ResolveAutoMode(cfgMode types.AggsenderMode) (types.AggsenderMode, error) {
+	switch cfgMode {
+	case types.PessimisticProofMode, types.AggchainProofMode:
+		return cfgMode, nil
+	case types.AutoMode:
+		mode, err := m.ContractMode()
+		if err != nil {
+			return mode, fmt.Errorf("aggsender mode is AUTO, but can't get contract mode from rollup contract: %w", err)
+		}
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unknown aggsender mode: %s", cfgMode)
+	}
+}

--- a/aggsender/query/multisig_committee_query.go
+++ b/aggsender/query/multisig_committee_query.go
@@ -19,10 +19,12 @@ var (
 	aggchainFEP                                  = [2]byte{0, 1}
 )
 
+const consensusTypeMultiECDSAAndSP1 = uint32(1)
+
 type BaseMultisigCommitteeQuery struct {
-	sovereignRollupAddrSC types.MultisigContract
-	sovereignRollupAddr   common.Address
-	overrideURL           *CommitteeOverride
+	sovereignRollupSC   types.MultisigContract
+	sovereignRollupAddr common.Address
+	overrideURL         *CommitteeOverride
 }
 
 // CommitteeOverride is used to override the URLs of the committee members
@@ -66,9 +68,9 @@ func NewBaseMultisigCommitteeQuery(sovereignRollupAddr common.Address,
 	}
 
 	return &BaseMultisigCommitteeQuery{
-		sovereignRollupAddrSC: sovereignRollupAddrSC,
-		sovereignRollupAddr:   sovereignRollupAddr,
-		overrideURL:           overrideURL,
+		sovereignRollupSC:   sovereignRollupAddrSC,
+		sovereignRollupAddr: sovereignRollupAddr,
+		overrideURL:         overrideURL,
 	}, nil
 }
 
@@ -76,13 +78,13 @@ func NewBaseMultisigCommitteeQuery(sovereignRollupAddr common.Address,
 func (m *BaseMultisigCommitteeQuery) GetMultisigCommittee(
 	ctx context.Context, blockNum *big.Int) (*types.MultisigCommittee, error) {
 	callOpts := &bind.CallOpts{Pending: false, BlockNumber: blockNum}
-	threshold, err := m.sovereignRollupAddrSC.Threshold(callOpts)
+	threshold, err := m.sovereignRollupSC.Threshold(callOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query the signatures threshold for block %d (rollupAddr %s): %w",
 			blockNum, m.sovereignRollupAddr.String(), err)
 	}
 
-	aggChainSigners, err := m.sovereignRollupAddrSC.GetAggchainSignerInfos(callOpts)
+	aggChainSigners, err := m.sovereignRollupSC.GetAggchainSignerInfos(callOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query the committee signers for block %d (rollupAddr %s): %w",
 			blockNum, m.sovereignRollupAddr.String(), err)
@@ -105,24 +107,25 @@ func (m *BaseMultisigCommitteeQuery) ContractMode() (types.AggsenderMode, error)
 	if m == nil {
 		return none, fmt.Errorf("object is nil")
 	}
-	consensusType, err := m.sovereignRollupAddrSC.CONSENSUSTYPE(&bind.CallOpts{})
+	consensusType, err := m.sovereignRollupSC.CONSENSUSTYPE(&bind.CallOpts{})
 	if err != nil {
 		return none, fmt.Errorf("failed to get consensus type from contract: %w", err)
 	}
-	if consensusType != 1 {
+	if consensusType != consensusTypeMultiECDSAAndSP1 {
 		return none, fmt.Errorf("consensus type must be 1 always: %d", consensusType)
 	}
-	aggchainType, err := m.sovereignRollupAddrSC.AGGCHAINTYPE(&bind.CallOpts{})
+	aggchainType, err := m.sovereignRollupSC.AGGCHAINTYPE(&bind.CallOpts{})
 	if err != nil {
 		return none, fmt.Errorf("failed to get aggchain type from contract: %w", err)
 	}
-	if aggchainType == aggchainECDSAMultisig {
+	switch aggchainType {
+	case aggchainECDSAMultisig:
 		return types.PessimisticProofMode, nil
-	}
-	if aggchainType == aggchainFEP {
+	case aggchainFEP:
 		return types.AggchainProofMode, nil
+	default:
+		return none, fmt.Errorf("unsupported aggchain type: %v", aggchainType)
 	}
-	return none, fmt.Errorf("unsupported aggchain type: %v", aggchainType)
 }
 
 func (m *BaseMultisigCommitteeQuery) ResolveAutoMode(cfgMode types.AggsenderMode) (types.AggsenderMode, error) {

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/aggchain-ecdsa-multisig/aggchainbase"
 	"github.com/agglayer/aggkit/aggsender/mocks"
+	"github.com/agglayer/aggkit/aggsender/types"
 	typesmocks "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
@@ -231,4 +232,75 @@ func Test_NewBaseMultisigCommitteeQuery(t *testing.T) {
 		require.Equal(t, rollupAddr, query.sovereignRollupAddr)
 		require.NotNil(t, query.sovereignRollupAddrSC)
 	})
+}
+
+func Test_ContractMode(t *testing.T) {
+	type testCase struct {
+		name                string
+		consensusTypeReturn uint32
+		consensusTypeErr    error
+		aggchainTypeReturn  [2]byte
+		aggchainTypeErr     error
+		expectedMode        types.AggsenderMode
+		expectedErr         string // if "" no error
+	}
+	errGeneric := errors.New("some error")
+	testCases := []testCase{
+		{
+			name:                "error CONSENSUSTYPE",
+			consensusTypeReturn: 0,
+			expectedErr:         "consensus type must be 1 always",
+		},
+		{
+			name:             "error getting CONSENSUSTYPE",
+			consensusTypeErr: errGeneric,
+			expectedErr:      "failed to get consensus type",
+		},
+		{
+			name:                "error getting AGGCHAINTYPE",
+			consensusTypeReturn: 1,
+			aggchainTypeErr:     errGeneric,
+			expectedErr:         "failed to get aggchain type",
+		},
+		{
+			name:                "return PessimisticProofMode",
+			consensusTypeReturn: 1,
+			aggchainTypeReturn:  aggchainECDSAMultisig,
+			expectedMode:        types.PessimisticProofMode,
+		},
+		{
+			name:                "return AggchainProofMode",
+			consensusTypeReturn: 1,
+			aggchainTypeReturn:  aggchainFEP,
+			expectedMode:        types.AggchainProofMode,
+		},
+		{
+			name:                "unknown AGGCHAINTYPE",
+			consensusTypeReturn: 1,
+			aggchainTypeReturn:  [2]byte{0xFF, 0xFF},
+			expectedErr:         "unsupported aggchain type",
+		},
+	}
+
+	for _, tc := range testCases {
+		mockSC := new(mocks.MultisigContract)
+		sut := &BaseMultisigCommitteeQuery{
+			sovereignRollupAddrSC: mockSC,
+			sovereignRollupAddr:   common.Address{},
+		}
+		mockSC.EXPECT().CONSENSUSTYPE(mock.Anything).
+			Return(tc.consensusTypeReturn, tc.consensusTypeErr).Maybe()
+		mockSC.EXPECT().AGGCHAINTYPE(mock.Anything).
+			Return(tc.aggchainTypeReturn, tc.aggchainTypeErr).Maybe()
+
+		mode, err := sut.ContractMode()
+		if tc.expectedErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErr)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMode, mode)
+		}
+		mockSC.AssertExpectations(t)
+	}
 }

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -93,9 +93,9 @@ func Test_ECDSAMultisigCommitteeQuery_GetMultisigCommittee(t *testing.T) {
 			}
 
 			q := &BaseMultisigCommitteeQuery{
-				sovereignRollupAddrSC: mockSC,
-				sovereignRollupAddr:   common.Address{},
-				overrideURL:           tc.overrideURL,
+				sovereignRollupSC:   mockSC,
+				sovereignRollupAddr: common.Address{},
+				overrideURL:         tc.overrideURL,
 			}
 
 			blockNum := big.NewInt(100)
@@ -230,7 +230,7 @@ func Test_NewBaseMultisigCommitteeQuery(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, query)
 		require.Equal(t, rollupAddr, query.sovereignRollupAddr)
-		require.NotNil(t, query.sovereignRollupAddrSC)
+		require.NotNil(t, query.sovereignRollupSC)
 	})
 }
 
@@ -285,8 +285,8 @@ func Test_ContractMode(t *testing.T) {
 	for _, tc := range testCases {
 		mockSC := new(mocks.MultisigContract)
 		sut := &BaseMultisigCommitteeQuery{
-			sovereignRollupAddrSC: mockSC,
-			sovereignRollupAddr:   common.Address{},
+			sovereignRollupSC:   mockSC,
+			sovereignRollupAddr: common.Address{},
 		}
 		mockSC.EXPECT().CONSENSUSTYPE(mock.Anything).
 			Return(tc.consensusTypeReturn, tc.consensusTypeErr).Maybe()

--- a/aggsender/query/multisig_committee_query_test.go
+++ b/aggsender/query/multisig_committee_query_test.go
@@ -258,49 +258,114 @@ func Test_ContractMode(t *testing.T) {
 		},
 		{
 			name:                "error getting AGGCHAINTYPE",
-			consensusTypeReturn: 1,
+			consensusTypeReturn: consensusTypeMultiECDSAAndSP1,
 			aggchainTypeErr:     errGeneric,
 			expectedErr:         "failed to get aggchain type",
 		},
 		{
 			name:                "return PessimisticProofMode",
-			consensusTypeReturn: 1,
+			consensusTypeReturn: consensusTypeMultiECDSAAndSP1,
 			aggchainTypeReturn:  aggchainECDSAMultisig,
 			expectedMode:        types.PessimisticProofMode,
 		},
 		{
 			name:                "return AggchainProofMode",
-			consensusTypeReturn: 1,
+			consensusTypeReturn: consensusTypeMultiECDSAAndSP1,
 			aggchainTypeReturn:  aggchainFEP,
 			expectedMode:        types.AggchainProofMode,
 		},
 		{
 			name:                "unknown AGGCHAINTYPE",
-			consensusTypeReturn: 1,
+			consensusTypeReturn: consensusTypeMultiECDSAAndSP1,
 			aggchainTypeReturn:  [2]byte{0xFF, 0xFF},
 			expectedErr:         "unsupported aggchain type",
 		},
 	}
 
 	for _, tc := range testCases {
-		mockSC := new(mocks.MultisigContract)
-		sut := &BaseMultisigCommitteeQuery{
-			sovereignRollupSC:   mockSC,
-			sovereignRollupAddr: common.Address{},
-		}
-		mockSC.EXPECT().CONSENSUSTYPE(mock.Anything).
-			Return(tc.consensusTypeReturn, tc.consensusTypeErr).Maybe()
-		mockSC.EXPECT().AGGCHAINTYPE(mock.Anything).
-			Return(tc.aggchainTypeReturn, tc.aggchainTypeErr).Maybe()
+		t.Run(tc.name, func(t *testing.T) {
+			mockSC := new(mocks.MultisigContract)
+			sut := &BaseMultisigCommitteeQuery{
+				sovereignRollupSC:   mockSC,
+				sovereignRollupAddr: common.Address{},
+			}
+			mockSC.EXPECT().CONSENSUSTYPE(mock.Anything).
+				Return(tc.consensusTypeReturn, tc.consensusTypeErr).Maybe()
+			mockSC.EXPECT().AGGCHAINTYPE(mock.Anything).
+				Return(tc.aggchainTypeReturn, tc.aggchainTypeErr).Maybe()
 
-		mode, err := sut.ContractMode()
-		if tc.expectedErr != "" {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
-		} else {
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedMode, mode)
-		}
-		mockSC.AssertExpectations(t)
+			mode, err := sut.ContractMode()
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedMode, mode)
+			}
+			mockSC.AssertExpectations(t)
+		})
+	}
+}
+
+func Test_ResolveAutoMode(t *testing.T) {
+	type testCase struct {
+		name               string
+		aggchainTypeReturn [2]byte
+		aggchainTypeErr    error
+		cfgMode            types.AggsenderMode
+		expectedMode       types.AggsenderMode
+		expectedErr        string // if "" no error
+	}
+	errGeneric := errors.New("some error")
+	testCases := []testCase{
+
+		{
+			name:            "error getting ContractMode",
+			aggchainTypeErr: errGeneric,
+			cfgMode:         types.AutoMode,
+			expectedErr:     "aggsender mode is AUTO, but can't get contract mode",
+		},
+		{
+			name:            "dont ask for ContractMode due cfg is not AUTO",
+			aggchainTypeErr: errGeneric,
+			cfgMode:         types.AggchainProofMode,
+			expectedMode:    types.AggchainProofMode,
+		},
+		{
+			name:               "return PessimisticProofMode",
+			aggchainTypeReturn: aggchainECDSAMultisig,
+			cfgMode:            types.AutoMode,
+			expectedMode:       types.PessimisticProofMode,
+		},
+		{
+			name:               "return AggchainProofMode",
+			aggchainTypeReturn: aggchainFEP,
+			cfgMode:            types.AutoMode,
+			expectedMode:       types.AggchainProofMode,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSC := new(mocks.MultisigContract)
+			sut := &BaseMultisigCommitteeQuery{
+				sovereignRollupSC:   mockSC,
+				sovereignRollupAddr: common.Address{},
+			}
+			mockSC.EXPECT().CONSENSUSTYPE(mock.Anything).
+				Return(consensusTypeMultiECDSAAndSP1, nil).Maybe()
+			mockSC.EXPECT().AGGCHAINTYPE(mock.Anything).
+				Return(tc.aggchainTypeReturn, tc.aggchainTypeErr).Maybe()
+
+			mode, err := sut.ResolveAutoMode(tc.cfgMode)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedMode, mode)
+			}
+			mockSC.AssertExpectations(t)
+		})
 	}
 }

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -275,6 +275,7 @@ type MultisigContract interface {
 type MultisigQuerier interface {
 	GetMultisigCommittee(ctx context.Context, blockNum *big.Int) (*MultisigCommittee, error)
 	ContractMode() (AggsenderMode, error)
+	ResolveAutoMode(cfgMode AggsenderMode) (AggsenderMode, error)
 }
 
 // ValidatorPoller is an interface defining functions that a ValidatorPoller should implement

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -267,11 +267,14 @@ type AggchainProofQuerier interface {
 type MultisigContract interface {
 	Threshold(opts *bind.CallOpts) (*big.Int, error)
 	GetAggchainSignerInfos(opts *bind.CallOpts) ([]aggchainbase.IAggchainSignersSignerInfo, error)
+	AGGCHAINTYPE(opts *bind.CallOpts) ([2]byte, error)
+	CONSENSUSTYPE(opts *bind.CallOpts) (uint32, error)
 }
 
 // MultisigQuerier is an abstraction for querying the multisig committee
 type MultisigQuerier interface {
 	GetMultisigCommittee(ctx context.Context, blockNum *big.Int) (*MultisigCommittee, error)
+	ContractMode() (AggsenderMode, error)
 }
 
 // ValidatorPoller is an interface defining functions that a ValidatorPoller should implement

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -54,6 +54,14 @@ func (c *AggsenderMode) Scan(value interface{}) error {
 	return nil
 }
 
+func (c *AggsenderMode) Validate() error {
+	if c == nil {
+		return fmt.Errorf("AggsenderMode: mode is nil")
+	}
+	_, err := NewAggsenderMode(c.String())
+	return err
+}
+
 func NewAggsenderMode(mode string) (AggsenderMode, error) {
 	modeUpper := strings.ToUpper(mode)
 	switch modeUpper {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -29,7 +29,7 @@ const (
 func (c *AggsenderMode) Scan(value interface{}) error {
 	str, ok := value.(string)
 	if !ok {
-		return fmt.Errorf("CertificateType: expected string, got %T", value)
+		return fmt.Errorf("AggsenderMode: expected string, got %T", value)
 	}
 	v, err := NewAggsenderMode(str)
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *AggsenderMode) Scan(value interface{}) error {
 
 func (c *AggsenderMode) Validate() error {
 	if c == nil {
-		return fmt.Errorf("AggsenderMode: mode is nil")
+		return fmt.Errorf("AggsenderMode is nil")
 	}
 	_, err := NewAggsenderMode(c.String())
 	return err

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 	"time"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
@@ -21,7 +22,51 @@ type AggsenderMode string
 const (
 	PessimisticProofMode AggsenderMode = "PessimisticProof"
 	AggchainProofMode    AggsenderMode = "AggchainProof"
+	AutoMode             AggsenderMode = "Auto"
 )
+
+func (c AggsenderMode) ResolveAutoMode(committeeQuerier MultisigQuerier) (AggsenderMode, error) {
+	switch c {
+	case PessimisticProofMode, AggchainProofMode:
+		return c, nil
+	case AutoMode:
+		mode, err := committeeQuerier.ContractMode()
+		if err != nil {
+			return mode, fmt.Errorf("aggsender mode is AUTO, but can't get contract mode from rollup contract: %w", err)
+		}
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unknown aggsender mode: %s", c)
+	}
+}
+
+// meddler support for store as string
+func (c *AggsenderMode) Scan(value interface{}) error {
+	str, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("CertificateType: expected string, got %T", value)
+	}
+	v, err := NewAggsenderMode(str)
+	if err != nil {
+		return fmt.Errorf("AggsenderMode.Scan(...): %w", err)
+	}
+	*c = v
+	return nil
+}
+
+func NewAggsenderMode(mode string) (AggsenderMode, error) {
+	modeUpper := strings.ToUpper(mode)
+	switch modeUpper {
+	case strings.ToUpper(PessimisticProofMode.String()):
+		return PessimisticProofMode, nil
+	case strings.ToUpper(AggchainProofMode.String()):
+		return AggchainProofMode, nil
+	case strings.ToUpper(AutoMode.String()):
+		return AutoMode, nil
+	default:
+		return "", fmt.Errorf("unknown AggsenderMode: %s", mode)
+	}
+}
 
 func (m AggsenderMode) String() string {
 	return string(m)

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -25,21 +25,6 @@ const (
 	AutoMode             AggsenderMode = "Auto"
 )
 
-func (c AggsenderMode) ResolveAutoMode(committeeQuerier MultisigQuerier) (AggsenderMode, error) {
-	switch c {
-	case PessimisticProofMode, AggchainProofMode:
-		return c, nil
-	case AutoMode:
-		mode, err := committeeQuerier.ContractMode()
-		if err != nil {
-			return mode, fmt.Errorf("aggsender mode is AUTO, but can't get contract mode from rollup contract: %w", err)
-		}
-		return mode, nil
-	default:
-		return "", fmt.Errorf("unknown aggsender mode: %s", c)
-	}
-}
-
 // meddler support for store as string
 func (c *AggsenderMode) Scan(value interface{}) error {
 	str, ok := value.(string)

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -314,7 +314,7 @@ func TestAggsenderMode_Validate(t *testing.T) {
 			name:    "NilAggsenderMode",
 			mode:    func() *AggsenderMode { return nil },
 			wantErr: true,
-			errMsg:  "mode is nil",
+			errMsg:  "AggsenderMode is nil",
 		},
 		{
 			name: "ValidPessimisticProofMode",

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -249,6 +249,7 @@ func TestCertificateHeader_ElapsedTimeSinceCreation(t *testing.T) {
 		require.GreaterOrEqual(t, int64(dur.Seconds()), int64(10))
 	})
 }
+
 func TestAggsenderMode_Scan(t *testing.T) {
 	tests := []struct {
 		input       interface{}
@@ -275,6 +276,7 @@ func TestAggsenderMode_Scan(t *testing.T) {
 		})
 	}
 }
+
 func TestNewAggsenderMode(t *testing.T) {
 	tests := []struct {
 		input       string
@@ -303,6 +305,7 @@ func TestNewAggsenderMode(t *testing.T) {
 		})
 	}
 }
+
 func TestAggsenderMode_Validate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -251,23 +251,23 @@ func TestCertificateHeader_ElapsedTimeSinceCreation(t *testing.T) {
 }
 func TestAggsenderMode_Scan(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		expected AggsenderMode
-		hasError bool
+		input       interface{}
+		expected    AggsenderMode
+		expectedErr string
 	}{
-		{"PessimisticProof", AggsenderMode("PessimisticProof"), false},
-		{"AggchainProof", AggsenderMode("AggchainProof"), false},
-		{"Auto", AggsenderMode("Auto"), false},
-		{"invalid", AggsenderMode(""), true},
-		{123, AggsenderMode(""), true}, // Non-string input
+		{"PessimisticProof", AggsenderMode("PessimisticProof"), ""},
+		{"AggchainProof", AggsenderMode("AggchainProof"), ""},
+		{"Auto", AggsenderMode("Auto"), ""},
+		{"invalid", AggsenderMode(""), "unknown AggsenderMode"},
+		{123, AggsenderMode(""), "expected string, got int"}, // Non-string input
 	}
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("AggsenderMode_Scan_%v", tt.input), func(t *testing.T) {
 			var mode AggsenderMode
 			err := mode.Scan(tt.input)
-			if tt.hasError {
-				require.Error(t, err)
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, mode)
@@ -277,25 +277,25 @@ func TestAggsenderMode_Scan(t *testing.T) {
 }
 func TestNewAggsenderMode(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected AggsenderMode
-		hasError bool
+		input       string
+		expected    AggsenderMode
+		expectedErr string
 	}{
-		{"PessimisticProof", PessimisticProofMode, false},
-		{"pessimisticproof", PessimisticProofMode, false},
-		{"AggchainProof", AggchainProofMode, false},
-		{"aggchainproof", AggchainProofMode, false},
-		{"Auto", AutoMode, false},
-		{"auto", AutoMode, false},
-		{"invalid", "", true},
-		{"", "", true},
+		{"PessimisticProof", PessimisticProofMode, ""},
+		{"pessimisticproof", PessimisticProofMode, ""},
+		{"AggchainProof", AggchainProofMode, ""},
+		{"aggchainproof", AggchainProofMode, ""},
+		{"Auto", AutoMode, ""},
+		{"auto", AutoMode, ""},
+		{"invalid", "", "unknown AggsenderMode"},
+		{"", "", "unknown AggsenderMode"},
 	}
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("NewAggsenderMode_%s", tt.input), func(t *testing.T) {
 			result, err := NewAggsenderMode(tt.input)
-			if tt.hasError {
-				require.Error(t, err)
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, result)

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -249,3 +249,109 @@ func TestCertificateHeader_ElapsedTimeSinceCreation(t *testing.T) {
 		require.GreaterOrEqual(t, int64(dur.Seconds()), int64(10))
 	})
 }
+func TestAggsenderMode_Scan(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected AggsenderMode
+		hasError bool
+	}{
+		{"PessimisticProof", AggsenderMode("PessimisticProof"), false},
+		{"AggchainProof", AggsenderMode("AggchainProof"), false},
+		{"Auto", AggsenderMode("Auto"), false},
+		{"invalid", AggsenderMode(""), true},
+		{123, AggsenderMode(""), true}, // Non-string input
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("AggsenderMode_Scan_%v", tt.input), func(t *testing.T) {
+			var mode AggsenderMode
+			err := mode.Scan(tt.input)
+			if tt.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, mode)
+			}
+		})
+	}
+}
+func TestNewAggsenderMode(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected AggsenderMode
+		hasError bool
+	}{
+		{"PessimisticProof", PessimisticProofMode, false},
+		{"pessimisticproof", PessimisticProofMode, false},
+		{"AggchainProof", AggchainProofMode, false},
+		{"aggchainproof", AggchainProofMode, false},
+		{"Auto", AutoMode, false},
+		{"auto", AutoMode, false},
+		{"invalid", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("NewAggsenderMode_%s", tt.input), func(t *testing.T) {
+			result, err := NewAggsenderMode(tt.input)
+			if tt.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+func TestAggsenderMode_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    func() *AggsenderMode
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "NilAggsenderMode",
+			mode:    func() *AggsenderMode { return nil },
+			wantErr: true,
+			errMsg:  "mode is nil",
+		},
+		{
+			name: "ValidPessimisticProofMode",
+			mode: func() *AggsenderMode {
+				m := PessimisticProofMode
+				return &m
+			},
+			wantErr: false,
+		},
+		{
+			name: "ValidAggchainProofMode",
+			mode: func() *AggsenderMode {
+				m := AggchainProofMode
+				return &m
+			},
+			wantErr: false,
+		},
+		{
+			name: "ValidAutoMode",
+			mode: func() *AggsenderMode {
+				m := AutoMode
+				return &m
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode := tt.mode()
+			err := mode.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -69,6 +69,11 @@ type LerQuerierConfig struct {
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
+	err := c.Mode.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid mode %s, must be one of PessimisticProof, AggchainProof, Auto: %w", c.Mode, err)
+	}
+
 	if c.Mode == aggsendertypes.AggchainProofMode {
 		if c.FEPConfig.SovereignRollupAddr == aggkitcommon.ZeroAddress {
 			return errInvalidSovereignRollupAddr

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	// AgglayerClient is the Agglayer gRPC client configuration
 	AgglayerClient agglayer.ClientConfig `mapstructure:"AgglayerClient"`
 	// Mode is the mode of the AggSender Validator (regular pessimistic proof mode or the aggchain proof mode)
-	ModeCfg aggsendertypes.AggsenderMode `jsonschema:"enum=PessimisticProof, enum=AggchainProof, enum=Auto" mapstructure:"Mode"`
+	Mode aggsendertypes.AggsenderMode `jsonschema:"enum=PessimisticProof, enum=AggchainProof, enum=Auto" mapstructure:"Mode"` //nolint:lll
 	// RequireCommitteeMembershipCheck indicates whether to check if the validator is part of the committee
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 }
@@ -69,7 +69,7 @@ type LerQuerierConfig struct {
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.ModeCfg == aggsendertypes.AggchainProofMode {
+	if c.Mode == aggsendertypes.AggchainProofMode {
 		if c.FEPConfig.SovereignRollupAddr == aggkitcommon.ZeroAddress {
 			return errInvalidSovereignRollupAddr
 		}

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	// AgglayerClient is the Agglayer gRPC client configuration
 	AgglayerClient agglayer.ClientConfig `mapstructure:"AgglayerClient"`
 	// Mode is the mode of the AggSender Validator (regular pessimistic proof mode or the aggchain proof mode)
-	Mode string `jsonschema:"enum=PessimisticProof, enum=AggchainProof" mapstructure:"Mode"`
+	ModeCfg aggsendertypes.AggsenderMode `jsonschema:"enum=PessimisticProof, enum=AggchainProof, enum=Auto" mapstructure:"Mode"`
 	// RequireCommitteeMembershipCheck indicates whether to check if the validator is part of the committee
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 }
@@ -69,15 +69,7 @@ type LerQuerierConfig struct {
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.Mode != aggsendertypes.PessimisticProofMode.String() &&
-		c.Mode != aggsendertypes.AggchainProofMode.String() {
-		return fmt.Errorf("invalid mode %s, must be one of %s or %s",
-			c.Mode,
-			aggsendertypes.PessimisticProofMode.String(),
-			aggsendertypes.AggchainProofMode.String())
-	}
-
-	if c.Mode == aggsendertypes.AggchainProofMode.String() {
+	if c.ModeCfg == aggsendertypes.AggchainProofMode {
 		if c.FEPConfig.SovereignRollupAddr == aggkitcommon.ZeroAddress {
 			return errInvalidSovereignRollupAddr
 		}

--- a/aggsender/validator/config_test.go
+++ b/aggsender/validator/config_test.go
@@ -23,7 +23,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Valid PessimisticProof mode",
 			config: Config{
-				Mode: aggsendertypes.PessimisticProofMode.String(),
+				ModeCfg: aggsendertypes.PessimisticProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -33,7 +33,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Valid AggchainProof mode",
 			config: Config{
-				Mode: aggsendertypes.AggchainProofMode.String(),
+				ModeCfg: aggsendertypes.AggchainProofMode,
 				FEPConfig: FEPConfig{
 					SovereignRollupAddr: common.HexToAddress("0x1"),
 				},
@@ -46,7 +46,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Invalid AggchainProof mode",
 			config: Config{
-				Mode: aggsendertypes.AggchainProofMode.String(),
+				ModeCfg: aggsendertypes.AggchainProofMode,
 				FEPConfig: FEPConfig{
 					SovereignRollupAddr: common.HexToAddress("0x0"), // Zero address
 				},
@@ -60,7 +60,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Invalid mode",
 			config: Config{
-				Mode: "invalid-mode",
+				ModeCfg: "invalid-mode",
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -71,7 +71,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Empty mode",
 			config: Config{
-				Mode: "",
+				ModeCfg: "",
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -82,7 +82,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Invalid AgglayerClient configuration",
 			config: Config{
-				Mode: aggsendertypes.PessimisticProofMode.String(),
+				ModeCfg: aggsendertypes.PessimisticProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL: "",
 				}},

--- a/aggsender/validator/config_test.go
+++ b/aggsender/validator/config_test.go
@@ -23,7 +23,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Valid PessimisticProof mode",
 			config: Config{
-				ModeCfg: aggsendertypes.PessimisticProofMode,
+				Mode: aggsendertypes.PessimisticProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -33,7 +33,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Valid AggchainProof mode",
 			config: Config{
-				ModeCfg: aggsendertypes.AggchainProofMode,
+				Mode: aggsendertypes.AggchainProofMode,
 				FEPConfig: FEPConfig{
 					SovereignRollupAddr: common.HexToAddress("0x1"),
 				},
@@ -46,7 +46,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Invalid AggchainProof mode",
 			config: Config{
-				ModeCfg: aggsendertypes.AggchainProofMode,
+				Mode: aggsendertypes.AggchainProofMode,
 				FEPConfig: FEPConfig{
 					SovereignRollupAddr: common.HexToAddress("0x0"), // Zero address
 				},
@@ -60,7 +60,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Invalid mode",
 			config: Config{
-				ModeCfg: "invalid-mode",
+				Mode: "invalid-mode",
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -71,7 +71,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Empty mode",
 			config: Config{
-				ModeCfg: "",
+				Mode: "",
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL:               "http://localhost:9090",
 					MinConnectTimeout: types.NewDuration(5 * time.Second),
@@ -82,7 +82,7 @@ func TestValidatorConfigValidate(t *testing.T) {
 		{
 			name: "Invalid AgglayerClient configuration",
 			config: Config{
-				ModeCfg: aggsendertypes.PessimisticProofMode,
+				Mode: aggsendertypes.PessimisticProofMode,
 				AgglayerClient: agglayer.ClientConfig{GRPC: &grpc.ClientConfig{
 					URL: "",
 				}},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -221,14 +221,14 @@ func createAggSenderValidator(ctx context.Context,
 	rollupDataQuerier *etherman.RollupDataQuerier,
 	committeeQuerier aggsendertypes.MultisigQuerier,
 ) (*aggsender.AggsenderValidator, error) {
-	mode, err := cfg.ModeCfg.ResolveAutoMode(committeeQuerier)
+	mode, err := cfg.Mode.ResolveAutoMode(committeeQuerier)
 	if err != nil {
 		return nil, err
 	}
 	// Override configuration with the resolved mode
-	if cfg.ModeCfg != mode {
-		log.Infof("aggsenderValidator mode from %s to %s", cfg.ModeCfg, mode)
-		cfg.ModeCfg = mode
+	if cfg.Mode != mode {
+		log.Infof("aggsenderValidator mode from %s to %s", cfg.Mode, mode)
+		cfg.Mode = mode
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -246,7 +246,7 @@ func createAggSenderValidator(ctx context.Context,
 		commonFlowComponents *flows.CommonFlowComponents
 	)
 
-	switch cfg.ModeCfg {
+	switch cfg.Mode {
 	case aggsendertypes.PessimisticProofMode:
 		commonFlowComponents, err = flows.CreateCommonFlowComponents(
 			ctx, logger,
@@ -304,12 +304,12 @@ func createAggSenderValidator(ctx context.Context,
 			nil, // we don't query the prover in validator mode
 		)
 	default:
-		return nil, fmt.Errorf("unsupported mode %s", cfg.ModeCfg)
+		return nil, fmt.Errorf("unsupported mode %s", cfg.Mode)
 	}
 
 	aggchainFEPQuerier, err := query.NewAggchainFEPQuerier(
 		logger,
-		cfg.ModeCfg,
+		cfg.Mode,
 		cfg.FEPConfig.SovereignRollupAddr,
 		l1Client,
 	)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -221,7 +221,7 @@ func createAggSenderValidator(ctx context.Context,
 	rollupDataQuerier *etherman.RollupDataQuerier,
 	committeeQuerier aggsendertypes.MultisigQuerier,
 ) (*aggsender.AggsenderValidator, error) {
-	mode, err := cfg.Mode.ResolveAutoMode(committeeQuerier)
+	mode, err := committeeQuerier.ResolveAutoMode(cfg.Mode)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -221,6 +221,16 @@ func createAggSenderValidator(ctx context.Context,
 	rollupDataQuerier *etherman.RollupDataQuerier,
 	committeeQuerier aggsendertypes.MultisigQuerier,
 ) (*aggsender.AggsenderValidator, error) {
+	mode, err := cfg.ModeCfg.ResolveAutoMode(committeeQuerier)
+	if err != nil {
+		return nil, err
+	}
+	// Override configuration with the resolved mode
+	if cfg.ModeCfg != mode {
+		log.Infof("aggsenderValidator mode from %s to %s", cfg.ModeCfg, mode)
+		cfg.ModeCfg = mode
+	}
+
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid aggsender validator config: %w", err)
 	}
@@ -236,8 +246,8 @@ func createAggSenderValidator(ctx context.Context,
 		commonFlowComponents *flows.CommonFlowComponents
 	)
 
-	switch cfg.Mode {
-	case aggsendertypes.PessimisticProofMode.String():
+	switch cfg.ModeCfg {
+	case aggsendertypes.PessimisticProofMode:
 		commonFlowComponents, err = flows.CreateCommonFlowComponents(
 			ctx, logger,
 			nil, // storage is not used in validator,
@@ -260,7 +270,7 @@ func createAggSenderValidator(ctx context.Context,
 			cfg.PPConfig.RequireOneBridgeInPPCertificate,
 			cfg.MaxL2BlockNumber,
 		)
-	case aggsendertypes.AggchainProofMode.String():
+	case aggsendertypes.AggchainProofMode:
 		commonFlowComponents, err = flows.CreateCommonFlowComponents(
 			ctx, logger,
 			nil, // storage is not used in validator,
@@ -294,12 +304,12 @@ func createAggSenderValidator(ctx context.Context,
 			nil, // we don't query the prover in validator mode
 		)
 	default:
-		return nil, fmt.Errorf("unsupported mode %s", cfg.Mode)
+		return nil, fmt.Errorf("unsupported mode %s", cfg.ModeCfg)
 	}
 
 	aggchainFEPQuerier, err := query.NewAggchainFEPQuerier(
 		logger,
-		aggsendertypes.AggsenderMode(cfg.Mode),
+		cfg.ModeCfg,
 		cfg.FEPConfig.SovereignRollupAddr,
 		l1Client,
 	)

--- a/config.toml.example
+++ b/config.toml.example
@@ -126,9 +126,9 @@ EnableAggOracleCommittee = false
 #
 [AggSender]
 # ------------------------------------------------------------------------------
-# Set to "AggchainProof" when enabling FEP. Possible values - "PessimisticProof", "AggchainProof"
+# Set to "AggchainProof" when enabling FEP. Possible values - "PessimisticProof", "AggchainProof", "Auto"
 # ------------------------------------------------------------------------------
-Mode = "PessimisticProof"
+# Mode = "Auto"
 #
 # [Prometheus]
 # Enabled = true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	aggsendertypes "github.com/agglayer/aggkit/aggsender/types"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/config/types"
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,8 @@ func TestLoadDefaultConfig(t *testing.T) {
 	require.Equal(t, cfg.Validator.AgglayerClient.GRPC.MinConnectTimeout, cfg.AggSender.AgglayerClient.GRPC.MinConnectTimeout)
 	require.Equal(t, cfg.Validator.AgglayerClient.GRPC.Retry.MaxAttempts, cfg.AggSender.AgglayerClient.GRPC.Retry.MaxAttempts)
 	require.Equal(t, cfg.AggSender.RollupManagerAddr, cfg.Validator.LerQuerier.RollupManagerAddr)
+	require.Equal(t, aggsendertypes.AutoMode, cfg.AggSender.Mode)
+	require.Equal(t, aggsendertypes.AutoMode, cfg.Validator.Mode)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -190,8 +190,8 @@ KeepCertificatesHistory = true
 MaxCertSize = 8388608
 DryRun = false
 EnableRPC = true
-# PessimisticProof or AggchainProof
-Mode = "PessimisticProof"
+# PessimisticProof, AggchainProof or Auto
+Mode = "Auto"
 CheckStatusCertificateInterval = "5m"
 RetryCertAfterInError = false
 GlobalExitRootL2 = "{{L2Config.GlobalExitRootAddr}}"
@@ -275,8 +275,8 @@ Signer = {{AggsenderPrivateKey}}
 MaxCertSize = "{{AggSender.MaxCertSize}}"
 MaxL2BlockNumber = "{{AggSender.MaxL2BlockNumber}}"
 DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
-# PessimisticProof or AggchainProof
-Mode = "PessimisticProof"
+# PessimisticProof, AggchainProof or Auto
+Mode = "{{AggSender.Mode}}"
 RequireCommitteeMembershipCheck = {{AggSender.RequireCommitteeMembershipCheck}}
 [Validator.ServerConfig]
 	Host = "0.0.0.0"

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -134,7 +134,7 @@ func (d *downloaderSovereign) buildAppender(
 		l1InfoTreeLeaf, err := d.l1InfoTreeSync.GetInfoByGlobalExitRoot(insertGEREvent.NewGlobalExitRoot)
 		if err != nil {
 			log.Fatalf("GER %s received from L2 is not present in L1InfoTreeSync: %v",
-				insertGEREvent.NewGlobalExitRoot, err)
+				common.Hash(insertGEREvent.NewGlobalExitRoot).String(), err)
 		}
 
 		b.Events = []any{

--- a/test/config/fep-config.toml.template
+++ b/test/config/fep-config.toml.template
@@ -172,7 +172,7 @@ AggSenderPrivateKey = {Path = "{{.zkevm_l2_sequencer_keystore_file_path}}", Pass
 # ------------------------------------------------------------------------------
 #BlockFinality = "LatestBlock"
 
-Mode = "AggchainProof"
+Mode = "Auto"
 CheckStatusCertificateInterval = "1s"
 
 [AggSender.OptimisticModeConfig]

--- a/test/config/pp-config.toml.template
+++ b/test/config/pp-config.toml.template
@@ -165,7 +165,7 @@ Port = "{{.aggkit_node_rest_api_port}}"
 # ------------------------------------------------------------------------------
 AggSenderPrivateKey = {Path = "{{.zkevm_l2_sequencer_keystore_file_path}}", Password = "{{.zkevm_l2_keystore_password}}"}
 
-Mode = "PessimisticProof"
+Mode = "Auto"
 CheckStatusCertificateInterval = "1s"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## 🔄 Changes Summary
- `Aggsender-proposer` and `aggsender-validator` can be configured with `Mode = "Auto"` that request to the rollup contract what is the expected mode 


## 📋 Config Updates
- 🧾 **Diff/Config snippet**: 
```
[AggSender]
Mode = "Auto"
[Validator]
Mode = "Auto"
```
## 🐞 Issues
- Closes #948


