### PR TITLE
fix: FEP cert validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ build-docker-ci: ## Builds a docker image with the aggkit binary for CI (include
 
 .PHONY: build-docker-nc
 build-docker-nc: ## Builds a docker image with the aggkit binary - but without build cache
-	docker build --no-cache=true -t aggkit -f ./Dockerfile .
+	docker build --no-cache=true -t aggkit:local -f ./Dockerfile .
 
 .PHONY: test-unit
 test-unit: ## Runs the unit tests

--- a/aggsender/flows/flow_aggchain_prover.go
+++ b/aggsender/flows/flow_aggchain_prover.go
@@ -148,12 +148,12 @@ func (a *AggchainProverFlow) getCertificateTypeToGenerate() (types.CertificateTy
 func (a *AggchainProverFlow) GenerateBuildParams(ctx context.Context,
 	preParams *types.CertificatePreBuildParams) (*types.CertificateBuildParams, error) {
 	if preParams == nil {
-		return nil, fmt.Errorf("ppFlow - preParams is nil")
+		return nil, fmt.Errorf("aggchainProverFlow - preParams is nil")
 	}
 
 	params, err := a.baseFlow.GenerateBuildParams(ctx, *preParams)
 	if err != nil {
-		return nil, fmt.Errorf("ppFlow - error generating build params: %w", err)
+		return nil, fmt.Errorf("aggchainProverFlow - error generating build params: %w", err)
 	}
 
 	// we do not limit the size of the certificate in FEP flow,

--- a/aggsender/flows/flow_aggchain_prover_test.go
+++ b/aggsender/flows/flow_aggchain_prover_test.go
@@ -794,7 +794,7 @@ func Test_AggchainProverFlow_GenerateBuildParams(t *testing.T) {
 		{
 			name:          "preParams is nil",
 			preParams:     nil,
-			expectedError: "ppFlow - preParams is nil",
+			expectedError: "aggchainProverFlow - preParams is nil",
 		},
 		{
 			name: "error generating build params from baseFlow",
@@ -806,7 +806,7 @@ func Test_AggchainProverFlow_GenerateBuildParams(t *testing.T) {
 					BlockRange: types.NewBlockRange(1, 10),
 				}).Return(nil, errors.New("base flow error")).Once()
 			},
-			expectedError: "ppFlow - error generating build params: base flow error",
+			expectedError: "aggchainProverFlow - error generating build params: base flow error",
 		},
 		{
 			name: "success generating build params",

--- a/aggsender/validator/compare_certs.go
+++ b/aggsender/validator/compare_certs.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"bytes"
 	"fmt"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
@@ -37,11 +36,6 @@ func DiffsCertificate(
 	if validatingCertificate.NewLocalExitRoot != expectedCertificate.NewLocalExitRoot {
 		diffs = append(diffs, fmt.Sprintf("NewLocalExitRoot mismatch. Expected: %s, Certificate: %s",
 			expectedCertificate.NewLocalExitRoot.Hex(), validatingCertificate.NewLocalExitRoot.Hex()))
-	}
-
-	if !bytes.Equal(validatingCertificate.CustomChainData, expectedCertificate.CustomChainData) {
-		diffs = append(diffs, fmt.Sprintf("CustomChainData mismatch. Expected: %x, Certificate: %x",
-			expectedCertificate.CustomChainData, validatingCertificate.CustomChainData))
 	}
 
 	if validatingCertificate.L1InfoTreeLeafCount != expectedCertificate.L1InfoTreeLeafCount {

--- a/aggsender/validator/compare_certs_test.go
+++ b/aggsender/validator/compare_certs_test.go
@@ -36,12 +36,6 @@ func TestDiffsCertificates(t *testing.T) {
 		&agglayertypes.Certificate{}))
 
 	require.Equal(t, []string{
-		"CustomChainData mismatch. Expected: 0102, Certificate: ",
-	}, DiffsCertificate(
-		&agglayertypes.Certificate{CustomChainData: []byte{0x1, 0x2}},
-		&agglayertypes.Certificate{}))
-
-	require.Equal(t, []string{
 		"L1InfoTreeLeafCount mismatch. Expected: 123, Certificate: 0",
 	}, DiffsCertificate(
 		&agglayertypes.Certificate{L1InfoTreeLeafCount: 123},

--- a/test/config/fep-config.toml.template
+++ b/test/config/fep-config.toml.template
@@ -180,7 +180,8 @@ SovereignRollupAddr = "{{.sovereign_rollup_addr}}"
 TrustedSequencerKey = {Path = "{{.zkevm_l2_sequencer_keystore_file_path}}", Password = "{{.zkevm_l2_keystore_password}}"}
 OpNodeURL = "{{.op_cl_rpc_url}}"
 RequireKeyMatchTrustedSequencer = true
-
+[AggSender.CommitteeOverride]
+    URLMapping = {{.aggsender_committee_override_urls}}
 
 
 


### PR DESCRIPTION
## 🔄 Changes Summary
- The validator doesn't generate the aggchain proof, so the field `CustomChainData` is not possible to be compare

## 🐞 Issues
- Closes #1025


