### PR TITLE
fix: rate_limit object in case no sleep required

### DIFF
--- a/common/rate_limit.go
+++ b/common/rate_limit.go
@@ -66,24 +66,27 @@ func (r *RateLimit) Call(msg string, allowToSleep bool) *time.Duration {
 	if r == nil || !r.cfg.Enabled() {
 		return nil
 	}
-	var sleepTime time.Duration
+	var returnSleepTime *time.Duration
 	now := TimeProvider()
 	r.cleanOutdatedCalls(now)
 
 	// Rate limit check BEFORE adding the current call
 	if len(r.calls) >= r.cfg.NumRequests {
-		sleepTime = r.cfg.Interval.Duration - now.Sub(r.calls[0])
+		sleepTime := r.cfg.Interval.Duration - now.Sub(r.calls[0])
 		if allowToSleep {
 			if msg != "" {
 				log.Infof("Rate limit reached, sleeping for %s for %s", sleepTime, msg)
 			}
 			time.Sleep(sleepTime)
+		} else {
+			// If no sleep, we return the time
+			returnSleepTime = &sleepTime
 		}
 	}
 
 	// Add the current call to the tracking
 	r.calls = append(r.calls, now)
-	return &sleepTime
+	return returnSleepTime
 }
 
 func (r *RateLimit) cleanOutdatedCalls(now time.Time) {

--- a/common/rate_limit_test.go
+++ b/common/rate_limit_test.go
@@ -56,8 +56,8 @@ func TestRateLimitSleepTime(t *testing.T) {
 	elapsed := time.Since(start)
 	require.Nil(t, sleepTime)
 	// The call should have slept for approximately 5 seconds
-	require.True(t, elapsed >= time.Second*1, "Expected to sleep for at least 1 seconds (1min- 59sec), but slept for %v", elapsed)
-	require.True(t, elapsed <= time.Second*2, "Expected to sleep for at most 1  seconds (error margin of 1sec), but slept for %v", elapsed)
+	require.True(t, elapsed >= time.Second*1, "Expected to sleep for at least 1 seconds (1minute - 59 seconds), but slept for %v", elapsed)
+	require.True(t, elapsed <= time.Second*2, "Expected to sleep for at most 2 seconds (error margin of 1 second), but slept for %v", elapsed)
 }
 
 func TestRateLimitDisabled(t *testing.T) {

--- a/common/rate_limit_test.go
+++ b/common/rate_limit_test.go
@@ -14,13 +14,11 @@ func TestRateLimit(t *testing.T) {
 		return now
 	}
 	sut := common.NewRateLimit(common.NewRateLimitConfig(2, time.Second))
-
-	// First two calls should succeed without rate limiting
-	sut.Call("test", false)
-	sut.Call("test", false)
-
-	// Third call should trigger rate limiting (but we don't sleep since allowToSleep=false)
-	sut.Call("test", false)
+	require.Nil(t, sut.Call("test", false))
+	require.Nil(t, sut.Call("test", false))
+	sleepTime := sut.Call("test", false)
+	require.NotNil(t, sleepTime)
+	require.Equal(t, time.Second, *sleepTime)
 
 	// Advance time by 2 seconds to reset the rate limit window
 	common.TimeProvider = func() time.Time {
@@ -39,26 +37,27 @@ func TestRateLimitSleepTime(t *testing.T) {
 	}
 	sut := common.NewRateLimit(common.NewRateLimitConfig(2, time.Minute))
 
-	// First call should succeed
-	sut.Call("test", false)
+	require.Nil(t, sut.Call("test", false))
 
 	// Advance time by 55 seconds
 	common.TimeProvider = func() time.Time {
 		return now.Add(time.Second * 55)
 	}
 
-	// Second call should succeed (within the 1-minute window)
-	sut.Call("test", false)
-
-	// Third call should trigger rate limiting and sleep for 5 seconds
-	// (since we're 55 seconds into a 60-second window, we need to wait 5 more seconds)
+	require.Nil(t, sut.Call("test", false))
+	sleepTime := sut.Call("test", false)
+	require.NotNil(t, sleepTime)
+	require.Equal(t, time.Second*5, *sleepTime)
+	common.TimeProvider = func() time.Time {
+		return now.Add(time.Second * 59)
+	}
 	start := time.Now()
-	sut.Call("test", true)
+	sleepTime = sut.Call("test", true)
 	elapsed := time.Since(start)
-
+	require.Nil(t, sleepTime)
 	// The call should have slept for approximately 5 seconds
-	require.True(t, elapsed >= time.Second*4, "Expected to sleep for at least 4 seconds, but slept for %v", elapsed)
-	require.True(t, elapsed <= time.Second*6, "Expected to sleep for at most 6 seconds, but slept for %v", elapsed)
+	require.True(t, elapsed >= time.Second*1, "Expected to sleep for at least 1 seconds (1min- 59sec), but slept for %v", elapsed)
+	require.True(t, elapsed <= time.Second*2, "Expected to sleep for at most 1  seconds (error margin of 1sec), but slept for %v", elapsed)
 }
 
 func TestRateLimitDisabled(t *testing.T) {


### PR DESCRIPTION
## 🔄 Changes Summary
- Fix false warning each time a certificate is submitted.
The object `RateLimit` was changed in a way that no longer response with a `nil` if no sleep required


## 🐞 Issues
- Closes #1033

## 🔗 Related PRs
- #824


