### PR TITLE
chore: simplify syncer constructor functions

### DIFF
--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -66,6 +66,7 @@ func NewEVMChainGERSender(
 	logger *log.Logger,
 	cfg EVMConfig,
 	l2Client aggkittypes.BaseEthereumClienter,
+	l2GERManager types.L2GERManagerContract,
 	ethTxMan types.EthTxManager,
 	enableAggOracleCommittee bool,
 ) (*EVMChainGERSender, error) {
@@ -75,14 +76,6 @@ func NewEVMChainGERSender(
 		mode = AggOracleCommitteeMode
 	}
 	logger.Infof("EVMChainGERSender initialized in %s mode", mode)
-
-	// Always initialize L2 GER Manager (needed for checking if GER is injected)
-	l2GERManager, err := globalexitrootmanagerl2sovereignchain.NewGlobalexitrootmanagerl2sovereignchain(
-		cfg.GlobalExitRootL2Addr, l2Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create binding for GER L2 manager (SC address: %s): %w",
-			cfg.GlobalExitRootL2Addr, err)
-	}
 
 	l2GERAbi, err := globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainMetaData.GetAbi()
 	if err != nil {

--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -64,26 +64,24 @@ type EVMChainGERSender struct {
 
 func NewEVMChainGERSender(
 	logger *log.Logger,
-	l2GERManagerAddr common.Address,
-	aggOracleCommitteeAddr common.Address,
+	cfg EVMConfig,
 	l2Client aggkittypes.BaseEthereumClienter,
 	ethTxMan types.EthTxManager,
-	gasOffset uint64,
-	waitPeriodMonitorTx time.Duration,
 	enableAggOracleCommittee bool,
 ) (*EVMChainGERSender, error) {
 	// Determine mode based on configuration
 	mode := DirectInjectionMode
-	if enableAggOracleCommittee && aggOracleCommitteeAddr != aggkitcommon.ZeroAddress {
+	if enableAggOracleCommittee && cfg.AggOracleCommitteeAddr != aggkitcommon.ZeroAddress {
 		mode = AggOracleCommitteeMode
 	}
 	logger.Infof("EVMChainGERSender initialized in %s mode", mode)
 
 	// Always initialize L2 GER Manager (needed for checking if GER is injected)
 	l2GERManager, err := globalexitrootmanagerl2sovereignchain.NewGlobalexitrootmanagerl2sovereignchain(
-		l2GERManagerAddr, l2Client)
+		cfg.GlobalExitRootL2Addr, l2Client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create binding for GER L2 manager (SC address: %s): %w", l2GERManagerAddr, err)
+		return nil, fmt.Errorf("failed to create binding for GER L2 manager (SC address: %s): %w",
+			cfg.GlobalExitRootL2Addr, err)
 	}
 
 	l2GERAbi, err := globalexitrootmanagerl2sovereignchain.Globalexitrootmanagerl2sovereignchainMetaData.GetAbi()
@@ -95,13 +93,13 @@ func NewEVMChainGERSender(
 		logger:                 logger,
 		mode:                   mode,
 		l2GERManager:           l2GERManager,
-		l2GERManagerAddr:       l2GERManagerAddr,
+		l2GERManagerAddr:       cfg.GlobalExitRootL2Addr,
 		l2GERManagerAbi:        l2GERAbi,
-		aggOracleCommitteeAddr: aggOracleCommitteeAddr,
+		aggOracleCommitteeAddr: cfg.AggOracleCommitteeAddr,
 		l2Client:               l2Client,
 		ethTxMan:               ethTxMan,
-		gasOffset:              gasOffset,
-		waitPeriodMonitorTx:    waitPeriodMonitorTx,
+		gasOffset:              cfg.GasOffset,
+		waitPeriodMonitorTx:    cfg.WaitPeriodMonitorTx.Duration,
 	}
 
 	// Initialize and validate mode-specific components

--- a/aggoracle/chaingersender/evm_test.go
+++ b/aggoracle/chaingersender/evm_test.go
@@ -18,6 +18,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNEWEVMChainGERSender_DirectMode(t *testing.T) {
+	txManagerMock := mocks.NewEthTxManager(t)
+	txManagerMock.EXPECT().From().Return(common.HexToAddress("0x123")).Once()
+
+	l2GERManagerMock := mocks.NewL2GERManagerContract(t)
+	l2GERManagerMock.EXPECT().GlobalExitRootUpdater(mock.Anything).Return(common.HexToAddress("0x123"), nil).Once()
+
+	gerSender, err := NewEVMChainGERSender(log.GetDefaultLogger(), EVMConfig{}, nil, l2GERManagerMock, txManagerMock, false)
+	require.NoError(t, err)
+	require.NotNil(t, gerSender)
+	require.Equal(t, DirectInjectionMode, gerSender.mode)
+}
+
 func TestEVMChainGERSender_InitializeAndValidateMode(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/aggsender/validator/validate_db_test.go
+++ b/aggsender/validator/validate_db_test.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"context"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -16,7 +15,7 @@ import (
 	"github.com/agglayer/aggkit/log"
 	mocksethclient "github.com/agglayer/aggkit/types/mocks"
 	"github.com/agglayer/go_signer/signer"
-	signerTypes "github.com/agglayer/go_signer/signer/types"
+	signertypes "github.com/agglayer/go_signer/signer/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
@@ -27,7 +26,7 @@ func TestValidateFullAggsenderDB(t *testing.T) {
 	// Test real db verification
 	testDataPath := getTestDataPath(t)
 	logger := log.WithFields("test", "TestValidateFullAggsenderDB")
-	ctx := context.TODO()
+	ctx := t.Context()
 	dbQueryTimeout := 30 * time.Second
 	mockL2EthClient := mocksethclient.NewEthClienter(t)
 	mockL2EthClient.EXPECT().BlockByNumber(ctx, mock.Anything).Return(&types.Block{}, nil).Maybe()
@@ -56,8 +55,8 @@ func TestValidateFullAggsenderDB(t *testing.T) {
 	lerQuerier, err := query.NewLERDataQuerier(common.Address{}, 1, mockRollupDataQuerier)
 	require.NoError(t, err)
 	chainID := uint64(1)
-	signer, err := signer.NewSigner(ctx, chainID, signerTypes.SignerConfig{
-		Method: signerTypes.MethodMock,
+	signer, err := signer.NewSigner(ctx, chainID, signertypes.SignerConfig{
+		Method: signertypes.MethodMock,
 	}, "test", logger)
 	require.NoError(t, err)
 

--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
+	cfgtypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/test/contracts/proxy"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	ethereum "github.com/ethereum/go-ethereum"
@@ -105,8 +106,19 @@ func TestBridgeCallData(t *testing.T) {
 
 	dbQueryTimeout := 30 * time.Second
 
-	bridgeSync, err := NewL1(ctx, dbPathBridgeSyncL1, bridgeProxyAddr, 1, aggkittypes.FinalizedBlock, client,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, dbQueryTimeout)
+	bridgeSyncCfg := Config{
+		DBPath:                             dbPathBridgeSyncL1,
+		BlockFinality:                      aggkittypes.FinalizedBlock,
+		BridgeAddr:                         bridgeProxyAddr,
+		SyncBlockChunkSize:                 1,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryPeriod),
+		MaxRetryAttemptsAfterError:         retriesCount,
+		RequireStorageContentCompatibility: false,
+		DBQueryTimeout:                     cfgtypes.NewDuration(dbQueryTimeout),
+	}
+	bridgeSync, err := NewL1(ctx, bridgeSyncCfg, aggkittypes.FinalizedBlock, client, originNetwork, false)
 	require.NoError(t, err)
 	go bridgeSync.Start(ctx)
 

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -72,37 +72,21 @@ type noOpReorgDetectorWrapper struct {
 // NewL1 creates a bridge syncer that synchronizes the mainnet exit tree
 func NewL1(
 	ctx context.Context,
-	dbPath string,
-	bridge common.Address,
-	syncBlockChunkSize uint64,
+	cfg Config,
 	blockFinalityType aggkittypes.BlockNumberFinality,
 	ethClient aggkittypes.EthClienter,
-	initialBlock uint64,
-	waitForNewBlocksPeriod time.Duration,
-	retryAfterErrorPeriod time.Duration,
-	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
-	requireStorageContentCompatibility bool,
-	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
+		cfg,
 		blockFinalityType,
 		&noOpReorgDetectorWrapper{*reorgdetector.NewNoOpReorgDetector()},
 		ethClient,
-		initialBlock,
 		L1BridgeSyncer,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		syncFullClaims,
-		requireStorageContentCompatibility,
-		dbQueryTimeout,
 	)
 }
 
@@ -127,74 +111,49 @@ func NewL2ReadOnly(
 // NewL2 creates a bridge syncer that synchronizes the local exit tree
 func NewL2(
 	ctx context.Context,
-	dbPath string,
-	bridge common.Address,
-	syncBlockChunkSize uint64,
-	blockFinalityType aggkittypes.BlockNumberFinality,
+	cfg Config,
 	rd ReorgDetector,
 	ethClient aggkittypes.EthClienter,
-	initialBlock uint64,
-	waitForNewBlocksPeriod time.Duration,
-	retryAfterErrorPeriod time.Duration,
-	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
-	requireStorageContentCompatibility bool,
-	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
-		blockFinalityType,
+		cfg,
+		cfg.BlockFinality,
 		rd,
 		ethClient,
-		initialBlock,
 		L2BridgeSyncer,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		syncFullClaims,
-		requireStorageContentCompatibility,
-		dbQueryTimeout,
 	)
 }
 
 func newBridgeSync(
 	ctx context.Context,
-	dbPath string,
-	bridge common.Address,
-	syncBlockChunkSize uint64,
+	cfg Config,
 	blockFinalityType aggkittypes.BlockNumberFinality,
 	rd ReorgDetector,
 	ethClient aggkittypes.EthClienter,
-	initialBlock uint64,
 	syncerID BridgeSyncerType,
-	waitForNewBlocksPeriod time.Duration,
-	retryAfterErrorPeriod time.Duration,
-	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
-	requireStorageContentCompatibility bool,
-	dbQueryTimeout time.Duration,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
 
-	bridgeContractV2, err := polygonzkevmbridgev2.NewPolygonzkevmbridgev2(bridge, ethClient)
+	bridgeContractV2, err := polygonzkevmbridgev2.NewPolygonzkevmbridgev2(cfg.BridgeAddr, ethClient)
 	if err != nil {
 		return nil, err
 	}
 
-	err = sanityCheckContract(logger, bridge, bridgeContractV2)
+	err = sanityCheckContract(logger, cfg.BridgeAddr, bridgeContractV2)
 	if err != nil {
-		logger.Errorf("sanityCheckContract(bridge:%s) fails sanity check. Err: %w",
-			bridge.String(), err)
+		logger.Errorf("sanityCheckContract(bridge: %s) fails sanity check. Err: %w",
+			cfg.BridgeAddr.String(), err)
 		return nil, err
 	}
 
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, dbQueryTimeout)
+	processor, err := newProcessor(cfg.DBPath, "bridge_sync_"+syncerID.String(), logger, cfg.DBQueryTimeout.Duration)
 	if err != nil {
 		return nil, err
 	}
@@ -204,14 +163,14 @@ func newBridgeSync(
 		return nil, err
 	}
 
-	if lastProcessedBlock < initialBlock {
-		block, err := ethClient.BlockByNumber(ctx, new(big.Int).SetUint64(initialBlock))
+	if lastProcessedBlock < cfg.InitialBlockNum {
+		block, err := ethClient.BlockByNumber(ctx, new(big.Int).SetUint64(cfg.InitialBlockNum))
 		if err != nil {
-			return nil, fmt.Errorf("failed to get initial block %d: %w", initialBlock, err)
+			return nil, fmt.Errorf("failed to get initial block %d: %w", cfg.InitialBlockNum, err)
 		}
 
 		err = processor.ProcessBlock(ctx, sync.Block{
-			Num:  initialBlock,
+			Num:  cfg.InitialBlockNum,
 			Hash: block.Hash(),
 		})
 		if err != nil {
@@ -219,22 +178,22 @@ func newBridgeSync(
 		}
 	}
 	rh := &sync.RetryHandler{
-		MaxRetryAttemptsAfterError: maxRetryAttemptsAfterError,
-		RetryAfterErrorPeriod:      retryAfterErrorPeriod,
+		MaxRetryAttemptsAfterError: cfg.MaxRetryAttemptsAfterError,
+		RetryAfterErrorPeriod:      cfg.RetryAfterErrorPeriod.Duration,
 	}
 
-	appender, err := buildAppender(ethClient, bridge, syncFullClaims, bridgeContractV2, logger)
+	appender, err := buildAppender(ethClient, cfg.BridgeAddr, syncFullClaims, bridgeContractV2, logger)
 	if err != nil {
 		return nil, err
 	}
 	downloader, err := sync.NewEVMDownloader(
 		syncerID.String(),
 		ethClient,
-		syncBlockChunkSize,
-		blockFinalityType,
-		waitForNewBlocksPeriod,
+		cfg.SyncBlockChunkSize,
+		cfg.BlockFinality,
+		cfg.WaitForNewBlocksPeriod.Duration,
 		appender,
-		[]common.Address{bridge},
+		[]common.Address{cfg.BridgeAddr},
 		rh,
 		rd.GetFinalizedBlockType(),
 	)
@@ -242,7 +201,7 @@ func newBridgeSync(
 		return nil, err
 	}
 	compatibilityChecker := compatibility.NewCompatibilityCheck(
-		requireStorageContentCompatibility,
+		cfg.RequireStorageContentCompatibility,
 		func(ctx context.Context) (BridgeSyncRuntimeData, error) {
 			tmp, err := downloader.RuntimeData(ctx)
 			if err != nil {
@@ -275,15 +234,15 @@ func newBridgeSync(
 			"  ReorgDetector: %s\n"+
 			"  waitForNewBlocksPeriod: %s",
 		syncerID,
-		dbPath,
-		initialBlock,
-		bridge.String(),
+		cfg.DBPath,
+		cfg.InitialBlockNum,
+		cfg.BridgeAddr.String(),
 		syncFullClaims,
-		maxRetryAttemptsAfterError,
-		retryAfterErrorPeriod.String(),
-		syncBlockChunkSize,
+		cfg.MaxRetryAttemptsAfterError,
+		cfg.RetryAfterErrorPeriod.String(),
+		cfg.SyncBlockChunkSize,
 		rd.String(),
-		waitForNewBlocksPeriod.String(),
+		cfg.WaitForNewBlocksPeriod.String(),
 	)
 
 	return &BridgeSync{

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	mocksbridgesync "github.com/agglayer/aggkit/bridgesync/mocks"
+	cfgtypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/agglayer/aggkit/sync"
@@ -56,21 +57,25 @@ func TestNewLx(t *testing.T) {
 
 	dbQueryTimeout := 30 * time.Second
 
+	bridgeSyncL1Cfg := Config{
+		DBPath:                             dbPath,
+		BridgeAddr:                         bridge,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		RequireStorageContentCompatibility: true,
+		DBQueryTimeout:                     cfgtypes.NewDuration(dbQueryTimeout),
+	}
 	l1BridgeSync, err := NewL1(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
+		bridgeSyncL1Cfg,
 		blockFinalityType,
 		mockEthClient,
-		initialBlock,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		true,
-		dbQueryTimeout,
 	)
 
 	require.NoError(t, err)
@@ -78,22 +83,25 @@ func TestNewLx(t *testing.T) {
 	require.Equal(t, originNetwork, l1BridgeSync.OriginNetwork())
 	require.Equal(t, blockFinalityType, l1BridgeSync.BlockFinality())
 
+	bridgeSyncL2Cfg := Config{
+		DBPath:                             dbPath,
+		BridgeAddr:                         bridge,
+		BlockFinality:                      aggkittypes.SafeBlock,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		RequireStorageContentCompatibility: true,
+		DBQueryTimeout:                     cfgtypes.NewDuration(dbQueryTimeout),
+	}
 	l2BridgdeSync, err := NewL2(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
-		blockFinalityType,
+		bridgeSyncL2Cfg,
 		mockReorgDetector,
 		mockEthClient,
-		initialBlock,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		true,
-		dbQueryTimeout,
 	)
 
 	require.NoError(t, err)
@@ -105,26 +113,18 @@ func TestNewLx(t *testing.T) {
 	mockEthClient = mocksethclient.NewEthClienter(t)
 	mockEthClient.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once()
 	mockEthClient.EXPECT().CodeAt(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once()
-	l2BridgdeSyncErr, err := NewL2(
+
+	l2BridgeSyncer, err := NewL2(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
-		blockFinalityType,
+		bridgeSyncL2Cfg,
 		mockReorgDetector,
 		mockEthClient,
-		initialBlock,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		true,
-		dbQueryTimeout,
 	)
 	t.Log(err)
 	require.Error(t, err)
-	require.Nil(t, l2BridgdeSyncErr)
+	require.Nil(t, l2BridgeSyncer)
 }
 
 func TestGetLastProcessedBlock(t *testing.T) {
@@ -216,22 +216,25 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 
 	dbQueryTimeout := 30 * time.Second
 
+	bridgeSyncCfg := Config{
+		DBPath:                             dbPath,
+		BridgeAddr:                         bridge,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		RequireStorageContentCompatibility: false,
+		DBQueryTimeout:                     cfgtypes.NewDuration(dbQueryTimeout),
+	}
 	s, err := NewL2(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
-		blockFinalityType,
+		bridgeSyncCfg,
 		mockReorgDetector,
 		mockEthClient,
-		initialBlock,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		false,
-		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 
@@ -374,22 +377,25 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 
 	dbQueryTimeout := 30 * time.Second
 
+	bridgeSyncCfg := Config{
+		DBPath:                             dbPath,
+		BridgeAddr:                         bridge,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		RequireStorageContentCompatibility: false,
+		DBQueryTimeout:                     cfgtypes.NewDuration(dbQueryTimeout),
+	}
 	s, err := NewL2(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
-		blockFinalityType,
+		bridgeSyncCfg,
 		mockReorgDetector,
 		mockEthClient,
-		initialBlock,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		false,
-		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 
@@ -558,22 +564,25 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 
 	dbQueryTimeout := 30 * time.Second
 
+	bridgeSyncCfg := Config{
+		DBPath:                             dbPath,
+		BridgeAddr:                         bridge,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		RequireStorageContentCompatibility: false,
+		DBQueryTimeout:                     cfgtypes.NewDuration(dbQueryTimeout),
+	}
 	s, err := NewL2(
 		ctx,
-		dbPath,
-		bridge,
-		syncBlockChunkSize,
-		blockFinalityType,
+		bridgeSyncCfg,
 		mockReorgDetector,
 		mockEthClient,
-		initialBlock,
-		waitForNewBlocksPeriod,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
-		false,
-		dbQueryTimeout,
 	)
 	require.NoError(t, err)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -484,19 +484,11 @@ func runL1InfoTreeSyncerIfNeeded(
 	}
 	l1InfoTreeSync, err := l1infotreesync.New(
 		ctx,
-		cfg.L1InfoTreeSync.DBPath,
-		cfg.L1InfoTreeSync.GlobalExitRootAddr,
-		cfg.L1InfoTreeSync.RollupManagerAddr,
-		cfg.L1InfoTreeSync.SyncBlockChunkSize,
+		cfg.L1InfoTreeSync,
 		aggkittypes.FinalizedBlock,
 		l1Client,
-		cfg.L1InfoTreeSync.WaitForNewBlocksPeriod.Duration,
-		cfg.L1InfoTreeSync.InitialBlock,
-		cfg.L1InfoTreeSync.RetryAfterErrorPeriod.Duration,
-		cfg.L1InfoTreeSync.MaxRetryAttemptsAfterError,
 		l1infotreesync.FlagNone,
 		aggkittypes.FinalizedBlock,
-		cfg.L1InfoTreeSync.RequireStorageContentCompatibility,
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -589,18 +589,10 @@ func runL2GERSyncIfNeeded(
 	}
 	l2GERSync, err := l2gersync.New(
 		ctx,
-		cfg.DBPath,
+		cfg,
 		reorgDetectorL2,
 		l2Client,
-		cfg.GlobalExitRootL2Addr,
 		l1InfoTreeSync,
-		cfg.SyncBlockChunkSize,
-		cfg.RetryAfterErrorPeriod.Duration,
-		cfg.MaxRetryAttemptsAfterError,
-		cfg.BlockFinality,
-		cfg.WaitForNewBlocksPeriod.Duration,
-		cfg.DownloadBufferSize,
-		cfg.RequireStorageContentCompatibility,
 	)
 	if err != nil {
 		log.Fatalf("error creating l2GERSync: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -624,19 +624,11 @@ func runBridgeSyncL1IfNeeded(
 
 	bridgeSyncL1, err := bridgesync.NewL1(
 		ctx,
-		cfg.DBPath,
-		cfg.BridgeAddr,
-		cfg.SyncBlockChunkSize,
+		cfg,
 		aggkittypes.FinalizedBlock,
 		l1Client,
-		cfg.InitialBlockNum,
-		cfg.WaitForNewBlocksPeriod.Duration,
-		cfg.RetryAfterErrorPeriod.Duration,
-		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
 		true,
-		cfg.RequireStorageContentCompatibility,
-		cfg.DBQueryTimeout.Duration,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -665,20 +657,11 @@ func runBridgeSyncL2IfNeeded(
 
 	bridgeSyncL2, err := bridgesync.NewL2(
 		ctx,
-		cfg.DBPath,
-		cfg.BridgeAddr,
-		cfg.SyncBlockChunkSize,
-		cfg.BlockFinality,
+		cfg,
 		reorgDetectorL2,
 		l2Client,
-		cfg.InitialBlockNum,
-		cfg.WaitForNewBlocksPeriod.Duration,
-		cfg.RetryAfterErrorPeriod.Duration,
-		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
 		true,
-		cfg.RequireStorageContentCompatibility,
-		cfg.DBQueryTimeout.Duration,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"slices"
 	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonrollupmanager"
@@ -457,10 +458,8 @@ func newReorgDetector(
 
 func isNeeded(casesWhereNeeded, actualCases []string) bool {
 	for _, actualCase := range actualCases {
-		for _, caseWhereNeeded := range casesWhereNeeded {
-			if actualCase == caseWhereNeeded {
-				return true
-			}
+		if slices.Contains(casesWhereNeeded, actualCase) {
+			return true
 		}
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonrollupmanager"
 	jRPC "github.com/0xPolygon/cdk-rpc/rpc"
 	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
@@ -379,15 +380,25 @@ func createAggoracle(
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		l2GERManagerAddr := cfg.AggOracle.EVMSender.GlobalExitRootL2Addr
 		logger.Infof("AggOracle sender address: %s | GER contract address on L2: %s",
 			ethTxManager.From().Hex(),
-			cfg.AggOracle.EVMSender.GlobalExitRootL2Addr.Hex(),
+			l2GERManagerAddr.Hex(),
 		)
 		go ethTxManager.Start()
+
+		l2GERManager, err := globalexitrootmanagerl2sovereignchain.NewGlobalexitrootmanagerl2sovereignchain(
+			l2GERManagerAddr, l2Client)
+		if err != nil {
+			log.Fatalf("failed to create binding for GER L2 manager (SC address: %s): %w", l2GERManagerAddr, err)
+		}
+
 		sender, err = chaingersender.NewEVMChainGERSender(
 			logger,
 			cfg.AggOracle.EVMSender,
 			l2Client,
+			l2GERManager,
 			ethTxManager,
 			cfg.AggOracle.EnableAggOracleCommittee,
 		)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -385,12 +385,9 @@ func createAggoracle(
 		go ethTxManager.Start()
 		sender, err = chaingersender.NewEVMChainGERSender(
 			logger,
-			cfg.AggOracle.EVMSender.GlobalExitRootL2Addr,
-			cfg.AggOracle.EVMSender.AggOracleCommitteeAddr,
+			cfg.AggOracle.EVMSender,
 			l2Client,
 			ethTxManager,
-			cfg.AggOracle.EVMSender.GasOffset,
-			cfg.AggOracle.EVMSender.WaitPeriodMonitorTx.Duration,
 			cfg.AggOracle.EnableAggOracleCommittee,
 		)
 		if err != nil {

--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
+	cfgtypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/test/contracts/verifybatchesmock"
 	"github.com/agglayer/aggkit/test/helpers"
@@ -65,8 +66,19 @@ func TestE2E(t *testing.T) {
 	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestE2E.sqlite")
 
 	client, auth, gerAddr, verifyAddr, gerSc, _ := newSimulatedClient(t)
-	syncer, err := l1infotreesync.New(ctx, dbPath, gerAddr, verifyAddr, 10, aggkittypes.LatestBlock, client.Client(), time.Millisecond, 0, 100*time.Millisecond, 25,
-		l1infotreesync.FlagAllowWrongContractsAddrs, aggkittypes.SafeBlock, true)
+	cfg := l1infotreesync.Config{
+		DBPath:                             dbPath,
+		InitialBlock:                       0,
+		SyncBlockChunkSize:                 10,
+		GlobalExitRootAddr:                 gerAddr,
+		RollupManagerAddr:                  verifyAddr,
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(time.Millisecond * 100),
+		MaxRetryAttemptsAfterError:         25,
+		RequireStorageContentCompatibility: true,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(time.Millisecond),
+	}
+	syncer, err := l1infotreesync.New(ctx, cfg, aggkittypes.LatestBlock, client.Client(),
+		l1infotreesync.FlagAllowWrongContractsAddrs, aggkittypes.SafeBlock)
 	require.NoError(t, err)
 
 	go syncer.Start(ctx)
@@ -113,8 +125,19 @@ func TestStress(t *testing.T) {
 
 	client, auth, gerAddr, verifyAddr, gerSc, verifySC := newSimulatedClient(t)
 
-	syncer, err := l1infotreesync.New(ctx, dbPathSyncer, gerAddr, verifyAddr, 10, aggkittypes.LatestBlock, client.Client(), time.Millisecond, 0, time.Second, 100,
-		l1infotreesync.FlagAllowWrongContractsAddrs, aggkittypes.SafeBlock, true)
+	cfg := l1infotreesync.Config{
+		DBPath:                             dbPathSyncer,
+		InitialBlock:                       0,
+		SyncBlockChunkSize:                 10,
+		GlobalExitRootAddr:                 gerAddr,
+		RollupManagerAddr:                  verifyAddr,
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(time.Millisecond * 100),
+		MaxRetryAttemptsAfterError:         100,
+		RequireStorageContentCompatibility: true,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(time.Millisecond),
+	}
+	syncer, err := l1infotreesync.New(ctx, cfg, aggkittypes.LatestBlock, client.Client(),
+		l1infotreesync.FlagAllowWrongContractsAddrs, aggkittypes.SafeBlock)
 	require.NoError(t, err)
 	go syncer.Start(ctx)
 

--- a/l1infotreesync/l1infotreesync.go
+++ b/l1infotreesync/l1infotreesync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/db/compatibility"
@@ -52,24 +51,16 @@ func NewReadOnly(
 	}, nil
 }
 
-// New creates a L1 Info tree syncer that syncs the L1 info tree
-// and the rollup exit tree
+// New creates a L1 Info tree syncer that syncs the L1 info tree and the rollup exit tree
 func New(
 	ctx context.Context,
-	dbPath string,
-	globalExitRoot, rollupManager common.Address,
-	syncBlockChunkSize uint64,
+	cfg Config,
 	blockFinalityType aggkittypes.BlockNumberFinality,
 	l1Client aggkittypes.BaseEthereumClienter,
-	waitForNewBlocksPeriod time.Duration,
-	initialBlock uint64,
-	retryAfterErrorPeriod time.Duration,
-	maxRetryAttemptsAfterError int,
 	flags CreationFlags,
 	finalizedBlockType aggkittypes.BlockNumberFinality,
-	requireStorageContentCompatibility bool,
 ) (*L1InfoTreeSync, error) {
-	processor, err := newProcessor(dbPath)
+	processor, err := newProcessor(cfg.DBPath)
 	if err != nil {
 		return nil, err
 	}
@@ -78,14 +69,16 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	if initialBlock > 0 && lastProcessedBlock < initialBlock-1 {
-		block, err := l1Client.BlockByNumber(ctx, new(big.Int).SetUint64(initialBlock-1))
+
+	parentBlockNumber := cfg.InitialBlock - 1
+	if cfg.InitialBlock > 0 && lastProcessedBlock < parentBlockNumber {
+		block, err := l1Client.BlockByNumber(ctx, new(big.Int).SetUint64(parentBlockNumber))
 		if err != nil {
-			return nil, fmt.Errorf("failed to get initial block %d: %w", initialBlock-1, err)
+			return nil, fmt.Errorf("failed to get initial block %d: %w", parentBlockNumber, err)
 		}
 
 		err = processor.ProcessBlock(ctx, sync.Block{
-			Num:  initialBlock - 1,
+			Num:  parentBlockNumber,
 			Hash: block.Hash(),
 		})
 		if err != nil {
@@ -93,22 +86,22 @@ func New(
 		}
 	}
 	rh := &sync.RetryHandler{
-		RetryAfterErrorPeriod:      retryAfterErrorPeriod,
-		MaxRetryAttemptsAfterError: maxRetryAttemptsAfterError,
+		RetryAfterErrorPeriod:      cfg.RetryAfterErrorPeriod.Duration,
+		MaxRetryAttemptsAfterError: cfg.MaxRetryAttemptsAfterError,
 	}
 
-	appender, err := buildAppender(l1Client, globalExitRoot, rollupManager, flags)
+	appender, err := buildAppender(l1Client, cfg.GlobalExitRootAddr, cfg.RollupManagerAddr, flags)
 	if err != nil {
 		return nil, err
 	}
 	downloader, err := sync.NewEVMDownloader(
 		"l1infotreesync",
 		l1Client,
-		syncBlockChunkSize,
+		cfg.SyncBlockChunkSize,
 		blockFinalityType,
-		waitForNewBlocksPeriod,
+		cfg.WaitForNewBlocksPeriod.Duration,
 		appender,
-		[]common.Address{globalExitRoot, rollupManager},
+		[]common.Address{cfg.GlobalExitRootAddr, cfg.RollupManagerAddr},
 		rh,
 		finalizedBlockType,
 	)
@@ -116,7 +109,7 @@ func New(
 		return nil, err
 	}
 	compatibilityChecker := compatibility.NewCompatibilityCheck(
-		requireStorageContentCompatibility,
+		cfg.RequireStorageContentCompatibility,
 		downloader.RuntimeData,
 		processor)
 

--- a/l2gersync/e2e_test.go
+++ b/l2gersync/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	cfgtypes "github.com/agglayer/aggkit/config/types"
 	"github.com/agglayer/aggkit/l2gersync"
 	"github.com/agglayer/aggkit/test/helpers"
 	aggkittypes "github.com/agglayer/aggkit/types"
@@ -28,29 +29,27 @@ const (
 
 func TestL2GERSyncE2E(t *testing.T) {
 	t.Parallel()
+
 	t.Skip("Skipping E2E test, this test is broken and needs a PR to be fixed. The lastProcessedBlock doesn't take in account empty blocks")
 
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Minute)
+	defer cancel()
 
 	l1Setup, l2Setup := helpers.NewSimulatedEVMEnvironment(t, helpers.DefaultEnvironmentConfig(helpers.SovereignChainL2GERContract))
-
 	dbPathSyncer := path.Join(t.TempDir(), "l2GERSyncTestE2E.sqlite")
 
-	syncer, err := l2gersync.New(
-		ctx,
-		dbPathSyncer,
-		l2Setup.ReorgDetector,
-		l2Setup.SimBackend.Client(),
-		l2Setup.GERAddr,
-		l1Setup.InfoTreeSync,
-		syncBlockChunkSize,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
-		aggkittypes.LatestBlock,
-		waitForNewBlocksPeriod,
-		10, // downloadBufferSize
-		true,
-	)
+	l2SyncerCfg := l2gersync.Config{
+		DBPath:                             dbPathSyncer,
+		GlobalExitRootL2Addr:               l2Setup.GERAddr,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		DownloadBufferSize:                 10,
+		RequireStorageContentCompatibility: true,
+	}
+	syncer, err := l2gersync.New(ctx, l2SyncerCfg, l2Setup.ReorgDetector, l2Setup.SimBackend.Client(), l1Setup.InfoTreeSync)
 	require.NoError(t, err)
 
 	go syncer.Start(ctx)
@@ -64,38 +63,37 @@ func TestL2GERSyncE2E(t *testing.T) {
 
 func TestL2GERSync_GERRemoval(t *testing.T) {
 	t.Parallel()
+
 	t.Skip("Skipping E2E test, this test is broken and needs a PR to be fixed. The lastProcessedBlock doesn't take in account empty blocks")
 
 	ctx := t.Context()
-	l1Environment, l2Environment := helpers.NewSimulatedEVMEnvironment(t, helpers.DefaultEnvironmentConfig(helpers.SovereignChainL2GERContract))
+	l1Setup, l2Setup := helpers.NewSimulatedEVMEnvironment(t, helpers.DefaultEnvironmentConfig(helpers.SovereignChainL2GERContract))
 
 	dbPathSyncer := path.Join(t.TempDir(), "l2GERSyncTestE2E.sqlite")
 
-	syncer, err := l2gersync.New(
-		ctx,
-		dbPathSyncer,
-		l2Environment.ReorgDetector,
-		l2Environment.SimBackend.Client(),
-		l2Environment.GERAddr,
-		l1Environment.InfoTreeSync,
-		syncBlockChunkSize,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
-		aggkittypes.LatestBlock,
-		waitForNewBlocksPeriod,
-		10, // downloadBufferSize
-		true,
-	)
+	l2SyncerCfg := l2gersync.Config{
+		DBPath:                             dbPathSyncer,
+		GlobalExitRootL2Addr:               l2Setup.GERAddr,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		DownloadBufferSize:                 10,
+		RequireStorageContentCompatibility: true,
+	}
+	syncer, err := l2gersync.New(ctx, l2SyncerCfg, l2Setup.ReorgDetector,
+		l2Setup.SimBackend.Client(), l1Setup.InfoTreeSync)
 	require.NoError(t, err)
 
 	go syncer.Start(ctx)
 
 	updatedGERs := make([]common.Hash, 0, testIterations)
 	for i := range testIterations {
-		ger := updateL1GlobalExitRoot(t, l1Environment, i)
+		ger := updateL1GlobalExitRoot(t, l1Setup, i)
 		updatedGERs = append(updatedGERs, ger)
 		time.Sleep(syncDelay)
-		testGERSyncer(t, ctx, l1Environment, l2Environment, syncer, i)
+		testGERSyncer(t, ctx, l1Setup, l2Setup, syncer, i)
 	}
 
 	removeGERsUntilIdx := testIterations / 2
@@ -104,24 +102,24 @@ func TestL2GERSync_GERRemoval(t *testing.T) {
 		gersToRemove = append(gersToRemove, ger)
 	}
 
-	_, err = l2Environment.GERManagerSovereignSC.RemoveGlobalExitRoots(
-		l2Environment.Auth, gersToRemove)
+	_, err = l2Setup.GERManagerSovereignSC.RemoveGlobalExitRoots(
+		l2Setup.Auth, gersToRemove)
 	require.NoError(t, err)
-	l2Environment.SimBackend.Commit()
+	l2Setup.SimBackend.Commit()
 
 	// wait for the GER removal events to be processed
-	lb, err := l2Environment.SimBackend.Client().BlockNumber(ctx)
+	lb, err := l2Setup.SimBackend.Client().BlockNumber(ctx)
 	require.NoError(t, err)
-	helpers.RequireProcessorUpdated(t, syncer, lb, l2Environment.SimBackend.Client())
+	helpers.RequireProcessorUpdated(t, syncer, lb, l2Setup.SimBackend.Client())
 
 	for _, removedGER := range gersToRemove {
-		isInjected, err := l2Environment.AggoracleSender.IsGERInjected(removedGER)
+		isInjected, err := l2Setup.AggoracleSender.IsGERInjected(removedGER)
 		require.NoError(t, err)
 		require.False(t, isInjected)
 	}
 
 	for _, updatedGER := range updatedGERs[removeGERsUntilIdx:] {
-		isInjected, err := l2Environment.AggoracleSender.IsGERInjected(updatedGER)
+		isInjected, err := l2Setup.AggoracleSender.IsGERInjected(updatedGER)
 		require.NoError(t, err)
 		require.True(t, isInjected)
 	}
@@ -129,27 +127,29 @@ func TestL2GERSync_GERRemoval(t *testing.T) {
 
 func TestL2GERSync_IndexLegacyGERManagerSC(t *testing.T) {
 	t.Parallel()
-	t.Skip("Skipping E2E test, this test is broken and needs a PR to be fixed. The lastProcessedBlock doesn't take in account empty blocks")
 
 	ctx := context.Background()
 	l1Setup, l2Setup := helpers.NewSimulatedEVMEnvironment(t, helpers.DefaultEnvironmentConfig(helpers.LegacyL2GERContract))
 
 	dbPathSyncer := path.Join(t.TempDir(), "l2GERSyncTestE2E.sqlite")
 
+	l2SyncerCfg := l2gersync.Config{
+		DBPath:                             dbPathSyncer,
+		GlobalExitRootL2Addr:               l2Setup.GERAddr,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryAfterErrorPeriod),
+		MaxRetryAttemptsAfterError:         maxRetryAttemptsAfterError,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		DownloadBufferSize:                 10,
+		RequireStorageContentCompatibility: true,
+	}
 	l2GERSyncer, err := l2gersync.New(
 		ctx,
-		dbPathSyncer,
+		l2SyncerCfg,
 		l2Setup.ReorgDetector,
 		l2Setup.SimBackend.Client(),
-		l2Setup.GERAddr,
 		l1Setup.InfoTreeSync,
-		syncBlockChunkSize,
-		retryAfterErrorPeriod,
-		maxRetryAttemptsAfterError,
-		aggkittypes.LatestBlock,
-		waitForNewBlocksPeriod,
-		10, // downloadBufferSize
-		true,
 	)
 	require.NoError(t, err)
 

--- a/l2gersync/l2_ger_syncer.go
+++ b/l2gersync/l2_ger_syncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/globalexitrootmanagerl2sovereignchain"
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmglobalexitrootv2"
@@ -46,34 +45,26 @@ type L2GERSync struct {
 // New initializes and returns a new instance of L2GERSync
 func New(
 	ctx context.Context,
-	dbPath string,
+	cfg Config,
 	rdL2 sync.ReorgDetector,
 	l2Client aggkittypes.BaseEthereumClienter,
-	l2GERManagerAddr common.Address,
 	l1InfoTreeSync L1InfoTreeQuerier,
-	syncBlockChunkSize uint64,
-	retryAfterErrorPeriod time.Duration,
-	maxRetryAttemptsAfterError int,
-	blockFinality aggkittypes.BlockNumberFinality,
-	waitForNewBlocksPeriod time.Duration,
-	downloadBufferSize int,
-	requireStorageContentCompatibility bool,
 ) (*L2GERSync, error) {
-	if syncBlockChunkSize == 0 {
+	if cfg.SyncBlockChunkSize == 0 {
 		return nil, fmt.Errorf("syncBlockChunkSize must be greater than 0")
 	}
 
-	processor, err := newProcessor(dbPath)
+	processor, err := newProcessor(cfg.DBPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processor: %w", err)
 	}
 
 	rh := &sync.RetryHandler{
-		RetryAfterErrorPeriod:      retryAfterErrorPeriod,
-		MaxRetryAttemptsAfterError: maxRetryAttemptsAfterError,
+		RetryAfterErrorPeriod:      cfg.RetryAfterErrorPeriod.Duration,
+		MaxRetryAttemptsAfterError: cfg.MaxRetryAttemptsAfterError,
 	}
 
-	syncMode, err := resolveSyncMode(ctx, l2GERManagerAddr, l2Client)
+	syncMode, err := resolveSyncMode(ctx, cfg.GlobalExitRootL2Addr, l2Client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve l2 ger syncer sync mode: %w", err)
 	}
@@ -83,17 +74,17 @@ func New(
 	switch syncMode {
 	case Legacy:
 		downloader, err = newDownloaderLegacy(
-			l2Client, l2GERManagerAddr,
+			l2Client, cfg.GlobalExitRootL2Addr,
 			l1InfoTreeSync, processor,
-			rh, blockFinality, waitForNewBlocksPeriod,
+			rh, cfg.BlockFinality, cfg.WaitForNewBlocksPeriod.Duration,
 		)
 
 	case SovereignChain:
 		downloader, err = newDownloaderSovereign(
-			l2Client, l2GERManagerAddr,
+			l2Client, cfg.GlobalExitRootL2Addr,
 			l1InfoTreeSync,
-			rh, blockFinality, waitForNewBlocksPeriod,
-			syncBlockChunkSize,
+			rh, cfg.BlockFinality, cfg.WaitForNewBlocksPeriod.Duration,
+			cfg.SyncBlockChunkSize,
 		)
 
 	default:
@@ -104,11 +95,11 @@ func New(
 		return nil, err
 	}
 	compatibilityChecker := compatibility.NewCompatibilityCheck(
-		requireStorageContentCompatibility,
+		cfg.RequireStorageContentCompatibility,
 		downloader.RuntimeData,
 		processor)
 	driver, err := sync.NewEVMDriver(rdL2, processor, downloader, reorgDetectorID,
-		downloadBufferSize, rh, compatibilityChecker)
+		cfg.DownloadBufferSize, rh, compatibilityChecker)
 	if err != nil {
 		return nil, err
 	}

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -126,15 +126,24 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 		l1InfoTreeSyncerRetryFreq = time.Millisecond * 100
 	)
 
+	syncerCfg := l1infotreesync.Config{
+		DBPath:                             dbPathL1InfoTreeSync,
+		InitialBlock:                       0,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		GlobalExitRootAddr:                 gerL1Addr,
+		RollupManagerAddr:                  common.Address{},
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(l1InfoTreeSyncerRetryFreq),
+		MaxRetryAttemptsAfterError:         l1InfoTreeSyncerRetries,
+		RequireStorageContentCompatibility: true,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(time.Millisecond),
+	}
 	l1InfoTreeSync, err := l1infotreesync.New(
-		ctx, dbPathL1InfoTreeSync,
-		gerL1Addr, common.Address{},
-		syncBlockChunkSize, aggkittypes.LatestBlock,
+		ctx,
+		syncerCfg,
+		aggkittypes.LatestBlock,
 		l1Client.Client(),
-		time.Millisecond, 0, l1InfoTreeSyncerRetryFreq,
-		l1InfoTreeSyncerRetries, l1infotreesync.FlagAllowWrongContractsAddrs,
+		l1infotreesync.FlagAllowWrongContractsAddrs,
 		aggkittypes.SafeBlock,
-		true,
 	)
 	require.NoError(t, err)
 

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -126,7 +126,7 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 		l1InfoTreeSyncerRetryFreq = time.Millisecond * 100
 	)
 
-	syncerCfg := l1infotreesync.Config{
+	l1InfoTreeSyncCfg := l1infotreesync.Config{
 		DBPath:                             dbPathL1InfoTreeSync,
 		InitialBlock:                       0,
 		SyncBlockChunkSize:                 syncBlockChunkSize,
@@ -139,7 +139,7 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 	}
 	l1InfoTreeSync, err := l1infotreesync.New(
 		ctx,
-		syncerCfg,
+		l1InfoTreeSyncCfg,
 		aggkittypes.LatestBlock,
 		l1Client.Client(),
 		l1infotreesync.FlagAllowWrongContractsAddrs,
@@ -161,11 +161,18 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 	testClient := NewTestClient(l1Client.Client(), WithRPCClienter(cfg.L1RPCClient))
 	dbPathBridgeSyncL1 := path.Join(t.TempDir(), "BridgeSyncL1.sqlite")
 
-	bridgeL1Sync, err := bridgesync.NewL1(
-		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
-		syncBlockChunkSize, aggkittypes.LatestBlock, testClient,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true, defaultDBQueryTimeout)
+	bridgeSyncCfg := bridgesync.Config{
+		DBPath:                             dbPathBridgeSyncL1,
+		BridgeAddr:                         bridgeL1Addr,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryPeriod),
+		MaxRetryAttemptsAfterError:         retriesCount,
+		RequireStorageContentCompatibility: true,
+		DBQueryTimeout:                     cfgtypes.NewDuration(defaultDBQueryTimeout),
+	}
+	bridgeL1Sync, err := bridgesync.NewL1(ctx, bridgeSyncCfg, aggkittypes.LatestBlock, testClient, originNetwork, false)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -262,7 +269,7 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 	go rdL2.Start(ctx) //nolint:errcheck
 
 	// Bridge sync
-	dbPathL2BridgeSync := path.Join(t.TempDir(), "BridgeSyncL2.sqlite")
+	dbPathBridgeSyncL2 := path.Join(t.TempDir(), "BridgeSyncL2.sqlite")
 	testClient := NewTestClient(l2Client.Client(), WithRPCClienter(cfg.L2RPCClient))
 
 	const (
@@ -273,11 +280,19 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 		retriesCount           = 100
 	)
 
-	bridgeL2Sync, err := bridgesync.NewL2(
-		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,
-		aggkittypes.LatestBlock, rdL2, testClient,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true, defaultDBQueryTimeout)
+	bridgeSyncCfg := bridgesync.Config{
+		DBPath:                             dbPathBridgeSyncL2,
+		BridgeAddr:                         bridgeL2Addr,
+		BlockFinality:                      aggkittypes.LatestBlock,
+		SyncBlockChunkSize:                 syncBlockChunkSize,
+		InitialBlockNum:                    initialBlock,
+		WaitForNewBlocksPeriod:             cfgtypes.NewDuration(waitForNewBlocksPeriod),
+		RetryAfterErrorPeriod:              cfgtypes.NewDuration(retryPeriod),
+		MaxRetryAttemptsAfterError:         retriesCount,
+		RequireStorageContentCompatibility: true,
+		DBQueryTimeout:                     cfgtypes.NewDuration(defaultDBQueryTimeout),
+	}
+	bridgeL2Sync, err := bridgesync.NewL2(ctx, bridgeSyncCfg, rdL2, testClient, originNetwork, false)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -30,10 +30,9 @@ import (
 )
 
 const (
-	rollupID                = uint32(1)
-	aggOracleCommitteeNonce = 4
-	syncBlockChunkSize      = 10
-	defaultDBQueryTimeout   = 30 * time.Second
+	rollupID              = uint32(1)
+	syncBlockChunkSize    = 10
+	defaultDBQueryTimeout = 30 * time.Second
 )
 
 type L2GERManagerContractType int
@@ -241,9 +240,14 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 			gerInjectionFrequency = time.Millisecond * 20
 		)
 
+		evmSenderCfg := chaingersender.EVMConfig{
+			GlobalExitRootL2Addr:   gerL2Addr,
+			AggOracleCommitteeAddr: aggOracleCommitteeAddr,
+			WaitPeriodMonitorTx:    cfgtypes.NewDuration(gerCheckFrequency),
+		}
 		sender, err = chaingersender.NewEVMChainGERSender(
-			log.GetDefaultLogger(), gerL2Addr, aggOracleCommitteeAddr,
-			l2Client.Client(), ethTxManagerMock, 0, gerCheckFrequency, cfg.AggOracleCommitteeCfg.EnableAggOracleCommittee,
+			log.GetDefaultLogger(), evmSenderCfg, l2Client.Client(),
+			ethTxManagerMock, cfg.AggOracleCommitteeCfg.EnableAggOracleCommittee,
 		)
 		require.NoError(t, err)
 

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -245,8 +245,13 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 			AggOracleCommitteeAddr: aggOracleCommitteeAddr,
 			WaitPeriodMonitorTx:    cfgtypes.NewDuration(gerCheckFrequency),
 		}
+		l2GERManager, err := globalexitrootmanagerl2sovereignchain.NewGlobalexitrootmanagerl2sovereignchain(
+			gerL2Addr, l2Client.Client())
+		if err != nil {
+			log.Fatalf("failed to create binding for GER L2 manager (SC address: %s): %w", gerL2Addr, err)
+		}
 		sender, err = chaingersender.NewEVMChainGERSender(
-			log.GetDefaultLogger(), evmSenderCfg, l2Client.Client(),
+			log.GetDefaultLogger(), evmSenderCfg, l2Client.Client(), l2GERManager,
 			ethTxManagerMock, cfg.AggOracleCommitteeCfg.EnableAggOracleCommittee,
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
## 🔄 Changes Summary
For syncers' constructor functions, we can provide the configuration, instead of spreading the huge amount of parameters (even 9-10 for l1 info tree syncer).

## ⚠️ Breaking Changes
- 🛠️ **Config**: N/A
- 🔌 **API/CLI**: N/A
- 🗑️ **Deprecated Features**: N/A

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: N/A

## ✅ Testing
- 🤖 **Automatic**: CI checks
- 🖱️ **Manual**: N/A

## 🐞 Issues
- Closes #1041
