### PR TITLE
fix: adapt aggkit (optimistic mode) to aggchainFEP contract

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -154,11 +154,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@d000ca0a0bfcfa15db77468621f561763f1403ef
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+      agglayer-e2e-ref: d000ca0a0bfcfa15db77468621f561763f1403ef
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -180,12 +180,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@d000ca0a0bfcfa15db77468621f561763f1403ef
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+      agglayer-e2e-ref: d000ca0a0bfcfa15db77468621f561763f1403ef
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-global-index-pp-old-contracts }}
       test-name: "test-single-l2-network-fork12-global-index-pp-old-contracts"
@@ -208,11 +208,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@c4b28f648b98b1a55fc14d5f5310d58fc5f3add2
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+      agglayer-e2e-ref: c4b28f648b98b1a55fc14d5f5310d58fc5f3add2
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       test-name: "test-single-l2-network-op-succinct"
@@ -233,12 +233,12 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@d000ca0a0bfcfa15db77468621f561763f1403ef
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+      agglayer-e2e-ref: d000ca0a0bfcfa15db77468621f561763f1403ef
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -261,11 +261,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@d000ca0a0bfcfa15db77468621f561763f1403ef
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+      agglayer-e2e-ref: d000ca0a0bfcfa15db77468621f561763f1403ef
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -287,12 +287,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@d000ca0a0bfcfa15db77468621f561763f1403ef
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: f39a4e6a47bab2f35f0455a59e1a72d86cb97640
+      agglayer-e2e-ref: d000ca0a0bfcfa15db77468621f561763f1403ef
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/aggsender/optimistic/interfaces.go
+++ b/aggsender/optimistic/interfaces.go
@@ -19,7 +19,6 @@ type FEPContractQuerier interface {
 	LatestBlockNumber(opts *bind.CallOpts) (*big.Int, error)
 	GetAggchainSigners(opts *bind.CallOpts) ([]common.Address, error)
 	OptimisticMode(opts *bind.CallOpts) (bool, error)
-
 	SelectedOpSuccinctConfigName(opts *bind.CallOpts) ([32]byte, error)
 	OpSuccinctConfigs(opts *bind.CallOpts, arg0 [32]byte) (struct {
 		AggregationVkey     [32]byte

--- a/aggsender/optimistic/interfaces.go
+++ b/aggsender/optimistic/interfaces.go
@@ -18,9 +18,14 @@ type FEPContractQuerier interface {
 	StartingBlockNumber(opts *bind.CallOpts) (*big.Int, error)
 	LatestBlockNumber(opts *bind.CallOpts) (*big.Int, error)
 	GetAggchainSigners(opts *bind.CallOpts) ([]common.Address, error)
-	RollupConfigHash(opts *bind.CallOpts) ([32]byte, error)
-	RangeVkeyCommitment(opts *bind.CallOpts) ([32]byte, error)
 	OptimisticMode(opts *bind.CallOpts) (bool, error)
+
+	SelectedOpSuccinctConfigName(opts *bind.CallOpts) ([32]byte, error)
+	OpSuccinctConfigs(opts *bind.CallOpts, arg0 [32]byte) (struct {
+		AggregationVkey     [32]byte
+		RangeVkeyCommitment [32]byte
+		RollupConfigHash    [32]byte
+	}, error)
 }
 
 // OptimisticAggregationProofPublicValuesQuerier defines an interface for

--- a/aggsender/optimistic/mocks/mock_fep_contract_querier.go
+++ b/aggsender/optimistic/mocks/mock_fep_contract_querier.go
@@ -140,6 +140,91 @@ func (_c *FEPContractQuerier_LatestBlockNumber_Call) RunAndReturn(run func(*bind
 	return _c
 }
 
+// OpSuccinctConfigs provides a mock function with given fields: opts, arg0
+func (_m *FEPContractQuerier) OpSuccinctConfigs(opts *bind.CallOpts, arg0 [32]byte) (struct {
+	AggregationVkey     [32]byte
+	RangeVkeyCommitment [32]byte
+	RollupConfigHash    [32]byte
+}, error) {
+	ret := _m.Called(opts, arg0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OpSuccinctConfigs")
+	}
+
+	var r0 struct {
+		AggregationVkey     [32]byte
+		RangeVkeyCommitment [32]byte
+		RollupConfigHash    [32]byte
+	}
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*bind.CallOpts, [32]byte) (struct {
+		AggregationVkey     [32]byte
+		RangeVkeyCommitment [32]byte
+		RollupConfigHash    [32]byte
+	}, error)); ok {
+		return rf(opts, arg0)
+	}
+	if rf, ok := ret.Get(0).(func(*bind.CallOpts, [32]byte) struct {
+		AggregationVkey     [32]byte
+		RangeVkeyCommitment [32]byte
+		RollupConfigHash    [32]byte
+	}); ok {
+		r0 = rf(opts, arg0)
+	} else {
+		r0 = ret.Get(0).(struct {
+			AggregationVkey     [32]byte
+			RangeVkeyCommitment [32]byte
+			RollupConfigHash    [32]byte
+		})
+	}
+
+	if rf, ok := ret.Get(1).(func(*bind.CallOpts, [32]byte) error); ok {
+		r1 = rf(opts, arg0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// FEPContractQuerier_OpSuccinctConfigs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OpSuccinctConfigs'
+type FEPContractQuerier_OpSuccinctConfigs_Call struct {
+	*mock.Call
+}
+
+// OpSuccinctConfigs is a helper method to define mock.On call
+//   - opts *bind.CallOpts
+//   - arg0 [32]byte
+func (_e *FEPContractQuerier_Expecter) OpSuccinctConfigs(opts interface{}, arg0 interface{}) *FEPContractQuerier_OpSuccinctConfigs_Call {
+	return &FEPContractQuerier_OpSuccinctConfigs_Call{Call: _e.mock.On("OpSuccinctConfigs", opts, arg0)}
+}
+
+func (_c *FEPContractQuerier_OpSuccinctConfigs_Call) Run(run func(opts *bind.CallOpts, arg0 [32]byte)) *FEPContractQuerier_OpSuccinctConfigs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*bind.CallOpts), args[1].([32]byte))
+	})
+	return _c
+}
+
+func (_c *FEPContractQuerier_OpSuccinctConfigs_Call) Return(_a0 struct {
+	AggregationVkey     [32]byte
+	RangeVkeyCommitment [32]byte
+	RollupConfigHash    [32]byte
+}, _a1 error) *FEPContractQuerier_OpSuccinctConfigs_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *FEPContractQuerier_OpSuccinctConfigs_Call) RunAndReturn(run func(*bind.CallOpts, [32]byte) (struct {
+	AggregationVkey     [32]byte
+	RangeVkeyCommitment [32]byte
+	RollupConfigHash    [32]byte
+}, error)) *FEPContractQuerier_OpSuccinctConfigs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OptimisticMode provides a mock function with given fields: opts
 func (_m *FEPContractQuerier) OptimisticMode(opts *bind.CallOpts) (bool, error) {
 	ret := _m.Called(opts)
@@ -196,12 +281,12 @@ func (_c *FEPContractQuerier_OptimisticMode_Call) RunAndReturn(run func(*bind.Ca
 	return _c
 }
 
-// RangeVkeyCommitment provides a mock function with given fields: opts
-func (_m *FEPContractQuerier) RangeVkeyCommitment(opts *bind.CallOpts) ([32]byte, error) {
+// SelectedOpSuccinctConfigName provides a mock function with given fields: opts
+func (_m *FEPContractQuerier) SelectedOpSuccinctConfigName(opts *bind.CallOpts) ([32]byte, error) {
 	ret := _m.Called(opts)
 
 	if len(ret) == 0 {
-		panic("no return value specified for RangeVkeyCommitment")
+		panic("no return value specified for SelectedOpSuccinctConfigName")
 	}
 
 	var r0 [32]byte
@@ -226,88 +311,30 @@ func (_m *FEPContractQuerier) RangeVkeyCommitment(opts *bind.CallOpts) ([32]byte
 	return r0, r1
 }
 
-// FEPContractQuerier_RangeVkeyCommitment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RangeVkeyCommitment'
-type FEPContractQuerier_RangeVkeyCommitment_Call struct {
+// FEPContractQuerier_SelectedOpSuccinctConfigName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SelectedOpSuccinctConfigName'
+type FEPContractQuerier_SelectedOpSuccinctConfigName_Call struct {
 	*mock.Call
 }
 
-// RangeVkeyCommitment is a helper method to define mock.On call
+// SelectedOpSuccinctConfigName is a helper method to define mock.On call
 //   - opts *bind.CallOpts
-func (_e *FEPContractQuerier_Expecter) RangeVkeyCommitment(opts interface{}) *FEPContractQuerier_RangeVkeyCommitment_Call {
-	return &FEPContractQuerier_RangeVkeyCommitment_Call{Call: _e.mock.On("RangeVkeyCommitment", opts)}
+func (_e *FEPContractQuerier_Expecter) SelectedOpSuccinctConfigName(opts interface{}) *FEPContractQuerier_SelectedOpSuccinctConfigName_Call {
+	return &FEPContractQuerier_SelectedOpSuccinctConfigName_Call{Call: _e.mock.On("SelectedOpSuccinctConfigName", opts)}
 }
 
-func (_c *FEPContractQuerier_RangeVkeyCommitment_Call) Run(run func(opts *bind.CallOpts)) *FEPContractQuerier_RangeVkeyCommitment_Call {
+func (_c *FEPContractQuerier_SelectedOpSuccinctConfigName_Call) Run(run func(opts *bind.CallOpts)) *FEPContractQuerier_SelectedOpSuccinctConfigName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(*bind.CallOpts))
 	})
 	return _c
 }
 
-func (_c *FEPContractQuerier_RangeVkeyCommitment_Call) Return(_a0 [32]byte, _a1 error) *FEPContractQuerier_RangeVkeyCommitment_Call {
+func (_c *FEPContractQuerier_SelectedOpSuccinctConfigName_Call) Return(_a0 [32]byte, _a1 error) *FEPContractQuerier_SelectedOpSuccinctConfigName_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *FEPContractQuerier_RangeVkeyCommitment_Call) RunAndReturn(run func(*bind.CallOpts) ([32]byte, error)) *FEPContractQuerier_RangeVkeyCommitment_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RollupConfigHash provides a mock function with given fields: opts
-func (_m *FEPContractQuerier) RollupConfigHash(opts *bind.CallOpts) ([32]byte, error) {
-	ret := _m.Called(opts)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RollupConfigHash")
-	}
-
-	var r0 [32]byte
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*bind.CallOpts) ([32]byte, error)); ok {
-		return rf(opts)
-	}
-	if rf, ok := ret.Get(0).(func(*bind.CallOpts) [32]byte); ok {
-		r0 = rf(opts)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([32]byte)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*bind.CallOpts) error); ok {
-		r1 = rf(opts)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// FEPContractQuerier_RollupConfigHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RollupConfigHash'
-type FEPContractQuerier_RollupConfigHash_Call struct {
-	*mock.Call
-}
-
-// RollupConfigHash is a helper method to define mock.On call
-//   - opts *bind.CallOpts
-func (_e *FEPContractQuerier_Expecter) RollupConfigHash(opts interface{}) *FEPContractQuerier_RollupConfigHash_Call {
-	return &FEPContractQuerier_RollupConfigHash_Call{Call: _e.mock.On("RollupConfigHash", opts)}
-}
-
-func (_c *FEPContractQuerier_RollupConfigHash_Call) Run(run func(opts *bind.CallOpts)) *FEPContractQuerier_RollupConfigHash_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*bind.CallOpts))
-	})
-	return _c
-}
-
-func (_c *FEPContractQuerier_RollupConfigHash_Call) Return(_a0 [32]byte, _a1 error) *FEPContractQuerier_RollupConfigHash_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *FEPContractQuerier_RollupConfigHash_Call) RunAndReturn(run func(*bind.CallOpts) ([32]byte, error)) *FEPContractQuerier_RollupConfigHash_Call {
+func (_c *FEPContractQuerier_SelectedOpSuccinctConfigName_Call) RunAndReturn(run func(*bind.CallOpts) ([32]byte, error)) *FEPContractQuerier_SelectedOpSuccinctConfigName_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/optimistic/optimistic_aggegation_proof_public_values_query.go
+++ b/aggsender/optimistic/optimistic_aggegation_proof_public_values_query.go
@@ -54,24 +54,20 @@ func (o *OptimisticAggregationProofPublicValuesQuery) GetAggregationProofPublicV
 		return nil, fmt.Errorf("optimisticModeSignQuery. claimRoot opNodeClient.OutputAtBlockRoot(%d). Err: %w",
 			requestedEndBlock, err)
 	}
-	rollupConfigHash, err := o.aggchainFEPContract.RollupConfigHash(nil)
-	if err != nil {
-		return nil, fmt.Errorf("optimisticModeSignQuery. rollupConfigHash from contract %s. Err: %w",
-			o.aggchainFEPAddr, err)
-	}
-	multiBlockVKey, err := o.aggchainFEPContract.RangeVkeyCommitment(nil)
-	if err != nil {
-		return nil, fmt.Errorf("optimisticModeSignQuery. multiBlockVKey(AggregationVkey) from contract %s. Err: %w",
-			o.aggchainFEPAddr, err)
-	}
+	configName, err := o.aggchainFEPContract.SelectedOpSuccinctConfigName(nil)
 
+	opConfig, err := o.aggchainFEPContract.OpSuccinctConfigs(nil, configName)
+	if err != nil {
+		return nil, fmt.Errorf("optimisticModeSignQuery. OpSuccinctConfigs from contract %s. Err: %w",
+			o.aggchainFEPAddr, err)
+	}
 	return &optimistichash.AggregationProofPublicValues{
 		L1Head:           l1InfoTreeLeafHash,
 		L2PreRoot:        l2PreRoot,
 		ClaimRoot:        claimRoot,
 		L2BlockNumber:    requestedEndBlock,
-		RollupConfigHash: rollupConfigHash,
-		MultiBlockVKey:   multiBlockVKey,
+		RollupConfigHash: opConfig.RollupConfigHash,
+		MultiBlockVKey:   opConfig.RangeVkeyCommitment,
 		ProverAddress:    o.proverAddress,
 	}, nil
 }

--- a/aggsender/optimistic/optimistic_aggegation_proof_public_values_query.go
+++ b/aggsender/optimistic/optimistic_aggegation_proof_public_values_query.go
@@ -55,7 +55,10 @@ func (o *OptimisticAggregationProofPublicValuesQuery) GetAggregationProofPublicV
 			requestedEndBlock, err)
 	}
 	configName, err := o.aggchainFEPContract.SelectedOpSuccinctConfigName(nil)
-
+	if err != nil {
+		return nil, fmt.Errorf("optimisticModeSignQuery. SelectedOpSuccinctConfigName from contract %s. Err: %w",
+			o.aggchainFEPAddr, err)
+	}
 	opConfig, err := o.aggchainFEPContract.OpSuccinctConfigs(nil, configName)
 	if err != nil {
 		return nil, fmt.Errorf("optimisticModeSignQuery. OpSuccinctConfigs from contract %s. Err: %w",

--- a/aggsender/optimistic/optimistic_aggegation_proof_public_values_query.go
+++ b/aggsender/optimistic/optimistic_aggegation_proof_public_values_query.go
@@ -56,12 +56,12 @@ func (o *OptimisticAggregationProofPublicValuesQuery) GetAggregationProofPublicV
 	}
 	configName, err := o.aggchainFEPContract.SelectedOpSuccinctConfigName(nil)
 	if err != nil {
-		return nil, fmt.Errorf("optimisticModeSignQuery. SelectedOpSuccinctConfigName from contract %s. Err: %w",
+		return nil, fmt.Errorf("optimisticModeSignQuery. contract.SelectedOpSuccinctConfigName from contract %s. Err: %w",
 			o.aggchainFEPAddr, err)
 	}
 	opConfig, err := o.aggchainFEPContract.OpSuccinctConfigs(nil, configName)
 	if err != nil {
-		return nil, fmt.Errorf("optimisticModeSignQuery. OpSuccinctConfigs from contract %s. Err: %w",
+		return nil, fmt.Errorf("optimisticModeSignQuery. contract.OpSuccinctConfigs from contract %s. Err: %w",
 			o.aggchainFEPAddr, err)
 	}
 	return &optimistichash.AggregationProofPublicValues{

--- a/aggsender/optimistic/optimistic_aggegation_proof_public_values_query_test.go
+++ b/aggsender/optimistic/optimistic_aggegation_proof_public_values_query_test.go
@@ -54,22 +54,70 @@ func TestGetAggregationProofPublicValuesData_Success(t *testing.T) {
 }
 
 func TestGetAggregationProofPublicValuesData_Failure(t *testing.T) {
-	mockFEPContract := mocks.NewFEPContractQuerier(t)
-	mockOPNodeClient := mocks.NewOpNodeClienter(t)
 
 	contractAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	proverAddress := common.HexToAddress("0x0987654321098765432109876543210987654321")
-	sut := NewOptimisticAggregationProofPublicValuesQuery(mockFEPContract, contractAddr, mockOPNodeClient, proverAddress)
 
 	lastProvenBlock := uint64(1)
 	requestedEndBlock := uint64(2)
 	l1InfoTreeLeafHash := common.HexToHash("0xbeef")
+	t.Run("opNodeClient.OutputAtBlockRoot error on l2PreRoot", func(t *testing.T) {
+		mockFEPContract := mocks.NewFEPContractQuerier(t)
+		mockOPNodeClient := mocks.NewOpNodeClienter(t)
+		sut := NewOptimisticAggregationProofPublicValuesQuery(mockFEPContract, contractAddr, mockOPNodeClient, proverAddress)
 
-	mockOPNodeClient.On("OutputAtBlockRoot", lastProvenBlock).Return(common.Hash{}, errors.New("mock error"))
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(lastProvenBlock).Return(common.Hash{}, errors.New("mock error")).Once()
 
-	result, err := sut.GetAggregationProofPublicValuesData(lastProvenBlock, requestedEndBlock, l1InfoTreeLeafHash)
+		result, err := sut.GetAggregationProofPublicValuesData(lastProvenBlock, requestedEndBlock, l1InfoTreeLeafHash)
 
-	assert.Error(t, err)
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "l2PreRoot")
+		assert.ErrorContains(t, err, "l2PreRoot")
+		assert.Nil(t, result)
+	})
+	t.Run("opNodeClient.OutputAtBlockRoot error on claimRoot", func(t *testing.T) {
+		mockFEPContract := mocks.NewFEPContractQuerier(t)
+		mockOPNodeClient := mocks.NewOpNodeClienter(t)
+		sut := NewOptimisticAggregationProofPublicValuesQuery(mockFEPContract, contractAddr, mockOPNodeClient, proverAddress)
+
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(lastProvenBlock).Return(common.Hash{}, nil)
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(requestedEndBlock).Return(common.Hash{}, errors.New("mock error"))
+
+		result, err := sut.GetAggregationProofPublicValuesData(lastProvenBlock, requestedEndBlock, l1InfoTreeLeafHash)
+
+		assert.ErrorContains(t, err, "claimRoot")
+		assert.Nil(t, result)
+	})
+
+	t.Run("opNodeClient.OutputAtBlockRoot error on contract.SelectedOpSuccinctConfigName", func(t *testing.T) {
+		mockFEPContract := mocks.NewFEPContractQuerier(t)
+		mockOPNodeClient := mocks.NewOpNodeClienter(t)
+		sut := NewOptimisticAggregationProofPublicValuesQuery(mockFEPContract, contractAddr, mockOPNodeClient, proverAddress)
+
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(lastProvenBlock).Return(common.Hash{}, nil)
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(requestedEndBlock).Return(common.Hash{}, nil)
+		mockFEPContract.EXPECT().SelectedOpSuccinctConfigName((*bind.CallOpts)(nil)).Return([32]byte{0x00}, errors.New("mock error")).Once()
+
+		result, err := sut.GetAggregationProofPublicValuesData(lastProvenBlock, requestedEndBlock, l1InfoTreeLeafHash)
+
+		assert.ErrorContains(t, err, "SelectedOpSuccinctConfigName")
+		assert.Nil(t, result)
+	})
+
+	t.Run("opNodeClient.OutputAtBlockRoot error on contract.OpSuccinctConfigs", func(t *testing.T) {
+		mockFEPContract := mocks.NewFEPContractQuerier(t)
+		mockOPNodeClient := mocks.NewOpNodeClienter(t)
+		sut := NewOptimisticAggregationProofPublicValuesQuery(mockFEPContract, contractAddr, mockOPNodeClient, proverAddress)
+
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(lastProvenBlock).Return(common.Hash{}, nil)
+		mockOPNodeClient.EXPECT().OutputAtBlockRoot(requestedEndBlock).Return(common.Hash{}, nil)
+		mockFEPContract.EXPECT().SelectedOpSuccinctConfigName((*bind.CallOpts)(nil)).Return([32]byte{0x00}, nil).Once()
+		mockFEPContract.EXPECT().OpSuccinctConfigs((*bind.CallOpts)(nil), [32]byte{0x00}).Return(struct {
+			AggregationVkey     [32]byte
+			RangeVkeyCommitment [32]byte
+			RollupConfigHash    [32]byte
+		}{}, errors.New("mock error")).Once()
+		result, err := sut.GetAggregationProofPublicValuesData(lastProvenBlock, requestedEndBlock, l1InfoTreeLeafHash)
+
+		assert.ErrorContains(t, err, "OpSuccinctConfigs")
+		assert.Nil(t, result)
+	})
 }

--- a/aggsender/optimistic/optimistic_aggegation_proof_public_values_query_test.go
+++ b/aggsender/optimistic/optimistic_aggegation_proof_public_values_query_test.go
@@ -54,7 +54,6 @@ func TestGetAggregationProofPublicValuesData_Success(t *testing.T) {
 }
 
 func TestGetAggregationProofPublicValuesData_Failure(t *testing.T) {
-
 	contractAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	proverAddress := common.HexToAddress("0x0987654321098765432109876543210987654321")
 

--- a/aggsender/optimistic/optimistic_aggegation_proof_public_values_query_test.go
+++ b/aggsender/optimistic/optimistic_aggegation_proof_public_values_query_test.go
@@ -27,10 +27,18 @@ func TestGetAggregationProofPublicValuesData_Success(t *testing.T) {
 	expectedRollupConfigHash := [32]byte{0x01}
 	expectedMultiBlockVKey := [32]byte{0x02}
 
-	mockOPNodeClient.On("OutputAtBlockRoot", lastProvenBlock).Return(expectedL2PreRoot, nil)
-	mockOPNodeClient.On("OutputAtBlockRoot", requestedEndBlock).Return(expectedClaimRoot, nil)
-	mockFEPContract.On("RollupConfigHash", (*bind.CallOpts)(nil)).Return(expectedRollupConfigHash, nil)
-	mockFEPContract.On("RangeVkeyCommitment", (*bind.CallOpts)(nil)).Return(expectedMultiBlockVKey, nil)
+	mockOPNodeClient.EXPECT().OutputAtBlockRoot(lastProvenBlock).Return(expectedL2PreRoot, nil)
+	mockOPNodeClient.EXPECT().OutputAtBlockRoot(requestedEndBlock).Return(expectedClaimRoot, nil)
+	mockFEPContract.EXPECT().SelectedOpSuccinctConfigName((*bind.CallOpts)(nil)).Return([32]byte{0x00}, nil).Once()
+	mockFEPContract.EXPECT().OpSuccinctConfigs((*bind.CallOpts)(nil), [32]byte{0x00}).Return(struct {
+		AggregationVkey     [32]byte
+		RangeVkeyCommitment [32]byte
+		RollupConfigHash    [32]byte
+	}{
+		AggregationVkey:     [32]byte{},
+		RangeVkeyCommitment: expectedMultiBlockVKey,
+		RollupConfigHash:    expectedRollupConfigHash,
+	}, nil).Once()
 
 	result, err := sut.GetAggregationProofPublicValuesData(lastProvenBlock, requestedEndBlock, l1InfoTreeLeafHash)
 

--- a/aggsender/query/aggchain_fep_rollup_query_test.go
+++ b/aggsender/query/aggchain_fep_rollup_query_test.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/agglayer/aggkit/aggsender/mocks"
+	optimisticmocks "github.com/agglayer/aggkit/aggsender/optimistic/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
@@ -54,8 +54,7 @@ func TestAggchainFEPRollupQuerier(t *testing.T) {
 
 	t.Run("aggchain FEP caller returns error", func(t *testing.T) {
 		t.Parallel()
-
-		mockCaller := mocks.NewAggchainFEPCaller(t)
+		mockCaller := optimisticmocks.NewFEPContractQuerier(t)
 		mockCaller.EXPECT().StartingBlockNumber((*bind.CallOpts)(nil)).Return(nil, errors.New("mock error")).Once()
 
 		_, err := newAggchainFEPQuerier(
@@ -70,7 +69,7 @@ func TestAggchainFEPRollupQuerier(t *testing.T) {
 	t.Run("aggchain FEP caller returns valid starting block", func(t *testing.T) {
 		t.Parallel()
 
-		mockCaller := mocks.NewAggchainFEPCaller(t)
+		mockCaller := optimisticmocks.NewFEPContractQuerier(t)
 		startingBlock := big.NewInt(1000)
 		mockCaller.EXPECT().StartingBlockNumber((*bind.CallOpts)(nil)).Return(startingBlock, nil).Once()
 
@@ -88,7 +87,7 @@ func TestAggchainFEPRollupQuerier(t *testing.T) {
 	t.Run("aggchain FEP caller returns error on last settled block", func(t *testing.T) {
 		t.Parallel()
 
-		mockCaller := mocks.NewAggchainFEPCaller(t)
+		mockCaller := optimisticmocks.NewFEPContractQuerier(t)
 		mockCaller.EXPECT().StartingBlockNumber((*bind.CallOpts)(nil)).Return(big.NewInt(1000), nil).Once()
 		mockCaller.EXPECT().LatestBlockNumber((*bind.CallOpts)(nil)).Return(nil, errors.New("mock error")).Once()
 
@@ -108,7 +107,7 @@ func TestAggchainFEPRollupQuerier(t *testing.T) {
 	t.Run("aggchain FEP caller returns valid last settled block", func(t *testing.T) {
 		t.Parallel()
 
-		mockCaller := mocks.NewAggchainFEPCaller(t)
+		mockCaller := optimisticmocks.NewFEPContractQuerier(t)
 		startingBlock := big.NewInt(1000)
 		lastSettledBlock := big.NewInt(2000)
 

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -135,7 +135,7 @@ func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) 
 		}
 
 		if !certificateLocal.IsClosed() {
-			c.log.Infof("certificate %s is still pending, elapsed time:%s ",
+			c.log.Debugf("certificate %s is still pending, elapsed time:%s ",
 				certificateHeader.ID(), certificateLocal.ElapsedTimeSinceCreationString())
 			thereArePendingCerts = true
 		}


### PR DESCRIPTION
## 🔄 Changes Summary
- Use aggsanderContract.OpSuccinctConfigs to get `RangeVkeyCommitment` and `RollupConfigHash`

## 🐞 Issues
- Closes #1070

