### PR TITLE
fix: op-succinct e2e tests

### DIFF
--- a/.github/test_e2e_cdk_args_base.json
+++ b/.github/test_e2e_cdk_args_base.json
@@ -7,7 +7,6 @@
   "args": {
     "verbosity": "debug",
     "aggkit_image": "aggkit:local",
-    "consensus_contract_type": "pessimistic",
     "additional_services": [],
     "erigon_strict_mode": false,
     "enable_normalcy": true,

--- a/.github/test_e2e_cdk_args_base.json
+++ b/.github/test_e2e_cdk_args_base.json
@@ -7,6 +7,7 @@
   "args": {
     "verbosity": "debug",
     "aggkit_image": "aggkit:local",
+    "consensus_contract_type": "pessimistic",
     "additional_services": [],
     "erigon_strict_mode": false,
     "enable_normalcy": true,

--- a/.github/test_e2e_cdk_args_base.json
+++ b/.github/test_e2e_cdk_args_base.json
@@ -7,9 +7,6 @@
   "args": {
     "verbosity": "debug",
     "aggkit_image": "aggkit:local",
-    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",
-    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.2.0",
-    "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
     "consensus_contract_type": "pessimistic",
     "additional_services": [],
     "erigon_strict_mode": false,

--- a/.github/test_e2e_cdk_args_base.json
+++ b/.github/test_e2e_cdk_args_base.json
@@ -7,6 +7,9 @@
   "args": {
     "verbosity": "debug",
     "aggkit_image": "aggkit:local",
+    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",
+    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.2.0",
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
     "consensus_contract_type": "pessimistic",
     "additional_services": [],
     "erigon_strict_mode": false,

--- a/.github/test_e2e_single_chain_op_succinct_args.json
+++ b/.github/test_e2e_single_chain_op_succinct_args.json
@@ -5,9 +5,6 @@
   "args": {
     "consensus_contract_type": "fep",
     "aggkit_image": "aggkit:local",
-    "op_geth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101602.3",
-    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7",
-    "geth_image": "ethereum/client-go:v1.16.3",
     "op_succinct_mock": true,
     "op_succinct_agglayer": true,
     "op_succinct_agg_proof_mode": "compressed",
@@ -23,7 +20,7 @@
       {
         "participants": [
           {
-            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7"
+            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5"
           }
         ],
         "proposer_params": {

--- a/.github/test_e2e_single_chain_op_succinct_args.json
+++ b/.github/test_e2e_single_chain_op_succinct_args.json
@@ -3,8 +3,6 @@
     "deploy_op_succinct": true
   },
   "args": {
-    "verbosity": "debug",
-    "aggkit_image": "aggkit:local",
     "consensus_contract_type": "fep",
     "op_succinct_mock": true,
     "op_succinct_agglayer": true,
@@ -13,9 +11,9 @@
     "op_succinct_max_concurrent_proof_requests": "1",
     "op_succinct_max_concurrent_witness_gen": "1",
     "op_succinct_range_proof_interval": "60",
-    "additional_services": [
-      "bridge_spammer"
-    ]
+    "aggkit_image": "aggkit:local",
+    "l1_seconds_per_slot": 2,
+    "aggkit_components": "aggoracle,aggsender,bridge"
   },
   "optimism_package": {
     "chains": [

--- a/.github/test_e2e_single_chain_op_succinct_args.json
+++ b/.github/test_e2e_single_chain_op_succinct_args.json
@@ -1,8 +1,10 @@
 {
   "deployment_stages": {
-    "deploy_op_succinct": true
+    "deploy_op_succinct": true,
+    "deploy_cdk_bridge_infra": false
   },
   "args": {
+    "verbosity": "debug",
     "consensus_contract_type": "fep",
     "aggkit_image": "aggkit:local",
     "op_succinct_mock": true,
@@ -13,29 +15,11 @@
     "op_succinct_max_concurrent_witness_gen": "1",
     "op_succinct_range_proof_interval": "60",
     "l1_seconds_per_slot": 2,
-    "aggkit_components": "aggoracle,aggsender,bridge"
+    "additional_services": [
+      "bridge_spammer"
+    ]
   },
   "optimism_package": {
-    "chains": [
-      {
-        "participants": [
-          {
-            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5"
-          }
-        ],
-        "proposer_params": {
-          "enabled": false
-        },
-        "challenger_params": {
-          "enabled": false
-        },
-        "network_params": {
-          "name": "001",
-          "network_id": "2151908",
-          "seconds_per_slot": 1
-        }
-      }
-    ],
     "observability": {
       "enabled": false
     }

--- a/.github/test_e2e_single_chain_op_succinct_args.json
+++ b/.github/test_e2e_single_chain_op_succinct_args.json
@@ -5,10 +5,6 @@
   "args": {
     "consensus_contract_type": "fep",
     "aggkit_image": "aggkit:local",
-    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",
-    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.2.0",
-    "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
-    "op_succinct_proposer_image": "ghcr.io/agglayer/op-succinct/op-succinct:v2.3.3-agglayer",
     "op_geth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101602.3",
     "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7",
     "geth_image": "ethereum/client-go:v1.16.3",

--- a/.github/test_e2e_single_chain_op_succinct_args.json
+++ b/.github/test_e2e_single_chain_op_succinct_args.json
@@ -4,6 +4,14 @@
   },
   "args": {
     "consensus_contract_type": "fep",
+    "aggkit_image": "aggkit:local",
+    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",
+    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.2.0",
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
+    "op_succinct_proposer_image": "ghcr.io/agglayer/op-succinct/op-succinct:v2.3.3-agglayer",
+    "op_geth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101602.3",
+    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7",
+    "geth_image": "ethereum/client-go:v1.16.3",
     "op_succinct_mock": true,
     "op_succinct_agglayer": true,
     "op_succinct_agg_proof_mode": "compressed",
@@ -11,7 +19,6 @@
     "op_succinct_max_concurrent_proof_requests": "1",
     "op_succinct_max_concurrent_witness_gen": "1",
     "op_succinct_range_proof_interval": "60",
-    "aggkit_image": "aggkit:local",
     "l1_seconds_per_slot": 2,
     "aggkit_components": "aggoracle,aggsender,bridge"
   },
@@ -20,7 +27,7 @@
       {
         "participants": [
           {
-            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5"
+            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7"
           }
         ],
         "proposer_params": {

--- a/.github/test_e2e_single_chain_op_succinct_args.json
+++ b/.github/test_e2e_single_chain_op_succinct_args.json
@@ -1,7 +1,6 @@
 {
   "deployment_stages": {
-    "deploy_op_succinct": true,
-    "deploy_cdk_bridge_infra": false
+    "deploy_op_succinct": true
   },
   "args": {
     "verbosity": "debug",
@@ -19,6 +18,26 @@
     ]
   },
   "optimism_package": {
+    "chains": [
+      {
+        "participants": [
+          {
+            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5"
+          }
+        ],
+        "proposer_params": {
+          "enabled": false
+        },
+        "challenger_params": {
+          "enabled": false
+        },
+        "network_params": {
+          "name": "001",
+          "network_id": "2151908",
+          "seconds_per_slot": 1
+        }
+      }
+    ],
     "observability": {
       "enabled": false
     }

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="37089c19f9ad1470ec4eb0d65c183c0c58ea93d6"
+            COMMIT="c5309bd43c15094baa4427d8c04bf441f59edca7"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="4ec31fc2fc984a4de46c9868b9f4a8df47dbc4f1"
+            COMMIT="37089c19f9ad1470ec4eb0d65c183c0c58ea93d6"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="c5309bd43c15094baa4427d8c04bf441f59edca7"
+            COMMIT="e83a60092925aaa2c0aad92dbc8e416034a24803"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="1956b69d3821dd0895acab35e01b6e62a718ce6f"
+            COMMIT="4ec31fc2fc984a4de46c9868b9f4a8df47dbc4f1"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -143,11 +143,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@51c24d9b67881e43a851afbe40abb323598920a0
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 51c24d9b67881e43a851afbe40abb323598920a0
+      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
       test-name: "test-single-l2-network-fork12-pessimistic"
@@ -169,12 +169,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@51c24d9b67881e43a851afbe40abb323598920a0
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 51c24d9b67881e43a851afbe40abb323598920a0
+      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-global-index-pp-old-contracts }}
       test-name: "test-single-l2-network-fork12-global-index-pp-old-contracts"
@@ -197,11 +197,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@51c24d9b67881e43a851afbe40abb323598920a0
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 51c24d9b67881e43a851afbe40abb323598920a0
+      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       test-name: "test-single-l2-network-op-succinct"
@@ -222,12 +222,12 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@51c24d9b67881e43a851afbe40abb323598920a0
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 51c24d9b67881e43a851afbe40abb323598920a0
+      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -250,11 +250,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@51c24d9b67881e43a851afbe40abb323598920a0
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 51c24d9b67881e43a851afbe40abb323598920a0
+      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -276,12 +276,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@51c24d9b67881e43a851afbe40abb323598920a0
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 51c24d9b67881e43a851afbe40abb323598920a0
+      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -143,11 +143,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@9dda27f0c3960133f35872675822f6851881bb8c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
+      agglayer-e2e-ref: 9dda27f0c3960133f35872675822f6851881bb8c
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-pessimistic }}
       test-name: "test-single-l2-network-fork12-pessimistic"
@@ -169,12 +169,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@9dda27f0c3960133f35872675822f6851881bb8c
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
+      agglayer-e2e-ref: 9dda27f0c3960133f35872675822f6851881bb8c
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-fork12-global-index-pp-old-contracts }}
       test-name: "test-single-l2-network-fork12-global-index-pp-old-contracts"
@@ -197,11 +197,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@9dda27f0c3960133f35872675822f6851881bb8c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
+      agglayer-e2e-ref: 9dda27f0c3960133f35872675822f6851881bb8c
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       test-name: "test-single-l2-network-op-succinct"
@@ -222,12 +222,12 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@9dda27f0c3960133f35872675822f6851881bb8c
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
+      agglayer-e2e-ref: 9dda27f0c3960133f35872675822f6851881bb8c
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -250,11 +250,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@9dda27f0c3960133f35872675822f6851881bb8c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
+      agglayer-e2e-ref: 9dda27f0c3960133f35872675822f6851881bb8c
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -276,12 +276,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@66e6efbe3097143f3a45ffe9724062e81b0a3b31
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@9dda27f0c3960133f35872675822f6851881bb8c
     secrets: inherit
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 66e6efbe3097143f3a45ffe9724062e81b0a3b31
+      agglayer-e2e-ref: 9dda27f0c3960133f35872675822f6851881bb8c
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="e83a60092925aaa2c0aad92dbc8e416034a24803"
+            COMMIT="1956b69d3821dd0895acab35e01b6e62a718ce6f"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🔄 Changes Summary
Fix op-succinct E2E tests by adding the disk cleanup step before starting up the op-succinct stack.
Note: the changes on the e2e repo would not be merged to the `main`, as it would break the pre-multisig setup execution (the tests have been slightly adapted to a new deployment) and we are expecting the #860 to be merged any time soon.

E2E repo [branch](https://github.com/agglayer/e2e/fix/op-succinct-tests-free-up-disk-space).

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: ci checks are successfully executed

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
