### PR TITLE
chore: bump agglayer protobuf dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/agglayer/aggkit
 go 1.25.0
 
 require (
-	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250929081700-7218132f14eb.2
-	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.9-20250929081700-7218132f14eb.1
-	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.9-20250923143526-220bf697ba47.1
+	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20251003171624-441244f9c27c.2
+	buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.10-20251003171624-441244f9c27c.1
+	buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.10-20250923143526-220bf697ba47.1
 	buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250520163122-7efa0a2f81a8.2
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.9-20250520163122-7efa0a2f81a8.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.10
@@ -44,7 +44,7 @@ require (
 	golang.org/x/sync v0.17.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7
 	google.golang.org/grpc v1.75.1
-	google.golang.org/protobuf v1.36.9
+	google.golang.org/protobuf v1.36.10
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250929081700-7218132f14eb.2 h1:5AwyzNpIa8d1sjBL0LQqIpFaAtIWZBCnQWqJzgI/4n4=
-buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20250929081700-7218132f14eb.2/go.mod h1:k8hEWzxx3mWeDIsSH78Bwo2zbXwGn3X9TUr5h+I3QZg=
-buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.9-20250929081700-7218132f14eb.1 h1:m/gdZfaS6wijCWHi4D4CYhNoLocMKoDMgzCFFMRFyWY=
-buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.9-20250929081700-7218132f14eb.1/go.mod h1:Gtw/vUDOWKymf9VknO4nw5gZgOqVsMVn/nGdawEdUmU=
-buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.9-20250923143526-220bf697ba47.1 h1:gsWI9qik/Qh6QDrA20l4FbE8elgzwd0Xgwk4M1l9nUQ=
-buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.9-20250923143526-220bf697ba47.1/go.mod h1:WRALePvnRLfzL7umxHa8KFSbdQeXxJ7hmbHQogdCqhQ=
+buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20251003171624-441244f9c27c.2 h1:23CS9MxO55S+gDXVpwVoa4hwKat+d8T1NPgzLTfXYpU=
+buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20251003171624-441244f9c27c.2/go.mod h1:rp+z1JBVbnfL6GxedjchGBRkkNR0JyIrgxej27KKx60=
+buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.10-20251003171624-441244f9c27c.1 h1:a5KZLl8exodMB2arDu0Z01GyUzGZgzCtYObFWD5IkBk=
+buf.build/gen/go/agglayer/agglayer/protocolbuffers/go v1.36.10-20251003171624-441244f9c27c.1/go.mod h1:/HWm/smObsOmsOsLxM5r3Py0tqUvi6mAP/m2pX6Ldqk=
+buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.10-20250923143526-220bf697ba47.1 h1:T6T0F/TU9tq+8UDVb5U9oZRiE6V0RN6HBREDwYKqdIQ=
+buf.build/gen/go/agglayer/interop/protocolbuffers/go v1.36.10-20250923143526-220bf697ba47.1/go.mod h1:j8EqojEdmnuL9uVgWyb3w9LBRebDCHk1pZW9pygiiao=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250520163122-7efa0a2f81a8.2 h1:gV+6xXfMHDXA4XI5jCpJmMITl6A51SUaoECeRO4/GAY=
 buf.build/gen/go/agglayer/provers/grpc/go v1.5.1-20250520163122-7efa0a2f81a8.2/go.mod h1:NJnqmcfr760oCyvQ8MC6H8HsXRTHtzqAkzhEj+ms0uU=
 buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.9-20250520163122-7efa0a2f81a8.1 h1:60giwJ9yVmC8b4WYqDfGrZUJW9TSs7NYOfCOCUUEioQ=
@@ -704,8 +704,8 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
-google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
+google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=


### PR DESCRIPTION
## 🔄 Changes Summary
Bump the agglayer protobuf bindings (agglayer `v0.4.0-rc15`):
- [agglayer](https://buf.build/agglayer/agglayer/commits/commit/441244f9c27c4b59ad23d6814d23620c)
- [interop](https://buf.build/agglayer/interop/commits/commit/220bf697ba4749a8a40e87389cd7dbdb)

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
N/A

## 📝 Notes
N/A
