### PR TITLE
feat: disable temporaly aggchain params check

### DIFF
--- a/.github/test_e2e_op_args_base.json
+++ b/.github/test_e2e_op_args_base.json
@@ -4,9 +4,9 @@
   },
   "args": {
     "consensus_contract_type": "ecdsa_multisig",
-    "use_agg_sender_validator": false,
-    "agg_sender_multisig_threshold": 1,
-    "agg_sender_validator_total_number": 0,
+    "use_agg_sender_validator": true,
+    "agg_sender_multisig_threshold": 2,
+    "agg_sender_validator_total_number": 3,
     "l1_seconds_per_slot": 2,
     "verbosity": "debug",
     "aggkit_image": "aggkit:local",

--- a/aggsender/flows/verifier_flow_aggchain_prover.go
+++ b/aggsender/flows/verifier_flow_aggchain_prover.go
@@ -2,7 +2,6 @@ package flows
 
 import (
 	"context"
-	"fmt"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggsender/types"
@@ -35,46 +34,46 @@ func (a *AggchainProverVerifierFlow) VerifyCertificate(
 	cert *agglayertypes.Certificate,
 	lastBlockInCert uint64,
 	lastSettledBlock uint64) error {
-	if cert.AggchainData == nil {
-		return fmt.Errorf("aggchainProverFlow: certificate AggchainData is nil")
-	}
+	// Temporary disabled aggchainParams checks
+	// if cert.AggchainData == nil {
+	// 	return fmt.Errorf("aggchainProverFlow: certificate AggchainData is nil")
+	// }
+	// var aggchainDataProof *agglayertypes.AggchainDataProof
+	// switch v := cert.AggchainData.(type) {
+	// case *agglayertypes.AggchainDataProof:
+	// 	aggchainDataProof = v
+	// case *agglayertypes.AggchainDataMultisigWithProof:
+	// 	aggchainDataProof = v.AggchainProof
+	// default:
+	// 	return fmt.Errorf("aggchainProverFlow: certificate AggchainData is of unknown type %T", cert.AggchainData)
+	// }
 
-	var aggchainDataProof *agglayertypes.AggchainDataProof
-	switch v := cert.AggchainData.(type) {
-	case *agglayertypes.AggchainDataProof:
-		aggchainDataProof = v
-	case *agglayertypes.AggchainDataMultisigWithProof:
-		aggchainDataProof = v.AggchainProof
-	default:
-		return fmt.Errorf("aggchainProverFlow: certificate AggchainData is of unknown type %T", cert.AggchainData)
-	}
+	// // we need to reconstruct the AggchainParams field using what proposer provided,
+	// // plus, the current data from the L1 and L2 networks (what was last settled)
+	// l1InfoLeaf, err := a.l1InfoTreeDataQuerier.GetInfoByIndex(ctx, cert.L1InfoTreeLeafCount-1)
+	// if err != nil {
+	// 	return fmt.Errorf("aggchainProverFlow - error getting L1InfoLeaf by index %d: %w",
+	// 		cert.L1InfoTreeLeafCount-1, err)
+	// }
 
-	// we need to reconstruct the AggchainParams field using what proposer provided,
-	// plus, the current data from the L1 and L2 networks (what was last settled)
-	l1InfoLeaf, err := a.l1InfoTreeDataQuerier.GetInfoByIndex(ctx, cert.L1InfoTreeLeafCount-1)
-	if err != nil {
-		return fmt.Errorf("aggchainProverFlow - error getting L1InfoLeaf by index %d: %w",
-			cert.L1InfoTreeLeafCount-1, err)
-	}
+	// expectedAggchainProofPublicValues, err := a.aggProofPublicValuesQuery.GetAggregationProofPublicValuesData(
+	// 	lastSettledBlock,
+	// 	lastBlockInCert,
+	// 	l1InfoLeaf.Hash,
+	// )
+	// if err != nil {
+	// 	return fmt.Errorf("aggchainProverFlow - error getting expected aggchain proof public values: %w", err)
+	// }
 
-	expectedAggchainProofPublicValues, err := a.aggProofPublicValuesQuery.GetAggregationProofPublicValuesData(
-		lastSettledBlock,
-		lastBlockInCert,
-		l1InfoLeaf.Hash,
-	)
-	if err != nil {
-		return fmt.Errorf("aggchainProverFlow - error getting expected aggchain proof public values: %w", err)
-	}
+	// expectedAggchainParams, err := expectedAggchainProofPublicValues.Hash()
+	// if err != nil {
+	// 	return fmt.Errorf("aggchainProverFlow - error calculating expected aggchain params hash: %w", err)
+	// }
 
-	expectedAggchainParams, err := expectedAggchainProofPublicValues.Hash()
-	if err != nil {
-		return fmt.Errorf("aggchainProverFlow - error calculating expected aggchain params hash: %w", err)
-	}
-
-	if aggchainDataProof.AggchainParams != expectedAggchainParams {
-		return fmt.Errorf("aggchainProverFlow - aggchain params do not match: expected %s, got %s",
-			expectedAggchainParams, aggchainDataProof.AggchainParams)
-	}
+	// if aggchainDataProof.AggchainParams != expectedAggchainParams {
+	// 	return fmt.Errorf("aggchainProverFlow - aggchain params do not match: expected %s, got %s",
+	// 		expectedAggchainParams, aggchainDataProof.AggchainParams)
+	// }
 
 	return nil
 }

--- a/aggsender/flows/verifier_flow_aggchain_prover_test.go
+++ b/aggsender/flows/verifier_flow_aggchain_prover_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO: remove this test when aggchain params proof have been re-enabled
+func Test_AggchainProverFlow_NoVerifyCertificate(t *testing.T) {
+	flow := &AggchainProverVerifierFlow{}
+	require.NoError(t, flow.VerifyCertificate(t.Context(), &agglayertypes.Certificate{}, 0, 0))
+}
+
 func Test_AggchainProverFlow_VerifyCertificate(t *testing.T) {
 	t.Skip("aggchain params proof have been disabled temporalily as a workarround to issue #1099")
 	t.Parallel()

--- a/aggsender/flows/verifier_flow_aggchain_prover_test.go
+++ b/aggsender/flows/verifier_flow_aggchain_prover_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_AggchainProverFlow_VerifyCertificate(t *testing.T) {
+	t.Skip("aggchain params proof have been disabled temporalily as a workarround to issue #1099")
 	t.Parallel()
 
 	ctx := context.Background()


### PR DESCRIPTION
## 🔄 Changes Summary
- Disable aggchain param proof until the issue #1099 it's fixed. 
- This check is not mandatory, just a sanity check, Agglayer before accepting the certificate validate this data and also verify the sp1 proof.


## 🐞 Issues
- workarround for:  #1099


