### PR TITLE
fix: nightly e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,8 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            # branch: feat/fix_e2e_fep_v2
-            COMMIT="94b3f2e7b2085a37d134424440d39e4d9e4d543d"
+            COMMIT="28b4886797dc1aad90bf565e9eb8798de619a332"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -55,7 +55,7 @@ jobs:
           else
             # For push/workflow_dispatch, use the fixed commit
             # branch: feat/fix_e2e_fep_v2
-            COMMIT="ef69dcb659ff67fa8ecfd6773eb00c5ec385e28c"
+            COMMIT="94b3f2e7b2085a37d134424440d39e4d9e4d543d"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🔄 Changes Summary
The aggkit bridge service `rest` port was not exposed in the kurtosis. It was fixed through https://github.com/0xPolygon/kurtosis-cdk/pull/794 and this PR bumps the Kurtosis CDK version where it was fixed.

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: E2E tests are passing
- 🖱️ **Manual**: N/A

## 🐞 Issues
- Closes #1110

## 🔗 Related PRs
https://github.com/0xPolygon/kurtosis-cdk/pull/794