### PR TITLE
feat: cherry-pick unify all e2e to latest commitid in e2e main branch (#1105)

### DIFF
--- a/.github/test_e2e_cdk_erigon_args_base.json
+++ b/.github/test_e2e_cdk_erigon_args_base.json
@@ -13,6 +13,7 @@
     "binary_name": "aggkit",
     "aggkit_components": "aggsender",
     "aggkit_image": "aggkit:local",
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.18",
     "agglayer_contracts_image": "jhkimqd/agglayer-contracts:v0.0.0-rc.0.fix.1.create.genesis-fork.12",
     "agglayer_prover_primary_prover": "mock-prover",
     "zkevm_use_real_verifier": false,

--- a/.github/test_e2e_op_args_base.json
+++ b/.github/test_e2e_op_args_base.json
@@ -10,6 +10,7 @@
     "l1_seconds_per_slot": 2,
     "verbosity": "debug",
     "aggkit_image": "aggkit:local",
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.18",
     "additional_services": [],
     "binary_name": "aggkit",
     "aggkit_components": "aggsender,aggoracle",

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -171,11 +171,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -196,11 +196,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eb195bccd8bddbb5e2eba26b6274664f1417d44d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: eb195bccd8bddbb5e2eba26b6274664f1417d44d # main <- feat/fix_e2e_multisig 
+      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       test-name: "test-single-l2-network-op-succinct"
@@ -221,11 +221,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -247,11 +247,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -273,11 +273,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 25ece31a112cc6f48f2dada8fdaf69350eedb8dc
+      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/config/default.go
+++ b/config/default.go
@@ -217,8 +217,8 @@ RequireCommitteeMembershipCheck = false
 		[[AggSender.AgglayerClient.APIRateLimits]]
 			MethodName = "SendCertificate"
 			[AggSender.AgglayerClient.APIRateLimits.RateLimit]
-				NumRequests = 1800 # up to 1800 requests per hour (avg ~1 request every 2s)
-				Interval = "1h"
+				NumRequests = 15 # up to 15 requests per minute (avg ~1 request every 4s)
+				Interval = "1m"
 		[AggSender.AgglayerClient.ConfigurationCache]
 			TTL = "5m"
 			Capacity = 100

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -164,7 +164,7 @@ if [ "$E2E_REPO_PATH" != "-" ]; then
     log_info "Running BATS E2E tests..."
     case "$TEST_TYPE" in
     single-l2-network-op-succinct)
-        bats  ./tests/aggkit/bridge-e2e.bats || exit 1 
+        bats --jobs 5 ./tests/aggkit/bridge-e2e.bats || exit 1 
         bats  ./tests/op/optimistic-mode.bats || exit 1
         bats  ./tests/aggkit/e2e-pp.bats || exit 1
         bats  ./tests/aggkit/bridge-sovereign-chain-e2e.bats || exit 1


### PR DESCRIPTION
## 🔄 Changes Summary
- Cherry pick #1105:  Fix all aggkit e2e tests to work with the changes in
    `aggkit_bridge_service.bash`
