### PR TITLE
fix: add cleanup step in single chain e2e workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -171,11 +171,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
+      agglayer-e2e-ref: 5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -196,11 +196,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c # main
+      agglayer-e2e-ref: 5a2c4d0a776da7bf877c1717ec5965e9cb92c79a # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       test-name: "test-single-l2-network-op-succinct"
@@ -221,11 +221,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
+      agglayer-e2e-ref: 5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -247,11 +247,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
+      agglayer-e2e-ref: 5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -273,11 +273,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
+      agglayer-e2e-ref: 5a2c4d0a776da7bf877c1717ec5965e9cb92c79a
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -171,11 +171,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
+      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
       kurtosis-cdk-enclave-name: aggkit
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -196,11 +196,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053 # main
+      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       test-name: "test-single-l2-network-op-succinct"
@@ -221,11 +221,11 @@ jobs:
       - build-aggkit-image
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
+      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -247,11 +247,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
+      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -273,11 +273,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@eebf6f10aacd189dca250e11da9dbfdbc1e14053
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@644c72b9d38810b1eee8004d5bd06980420a9d5c
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: eebf6f10aacd189dca250e11da9dbfdbc1e14053
+      agglayer-e2e-ref: 644c72b9d38810b1eee8004d5bd06980420a9d5c
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}


### PR DESCRIPTION
## 🔄 Changes Summary
The op-succinct e2e tests are [failing](https://github.com/agglayer/aggkit/actions/runs/18546294585/job/52864960096) in the nightly executions, because we are running low on the disk space, which as a consequence has that L1 and L2 Geth container gracefully shut down.

### Log excerpt

```json
{"t":"2025-10-16T02:10:39.825820786Z","lvl":"error","msg":"Low disk space. Gracefully shutting down Geth to prevent database corruption.","available":"505.62 MiB","path":"/data/geth/execution-data/geth"}
```

The https://github.com/agglayer/e2e/pull/189 adds a cleanup step, before starting the kurtosis deployment. This action is used in the [kurtosis cdk](https://github.com/0xPolygon/kurtosis-cdk/blob/1d26548a5917f24282fc97ecb25594238c2a4104/.github/workflows/test.yml#L249-L258), since the devtools team also detected the same issue.

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: E2E tests execution
- 🖱️ **Manual**: N/A

## 🐞 Issues
- Closes #1127

## 🔗 Related PRs
https://github.com/agglayer/e2e/pull/189

## 📝 Notes
N/A
