### PR TITLE
feat: turn off `meddler` debug

### DIFF
--- a/db/meddler.go
+++ b/db/meddler.go
@@ -16,6 +16,7 @@ import (
 // init registers tags to be used to read/write from SQL DBs using meddler
 func init() {
 	meddler.Default = meddler.SQLite
+	meddler.Debug = false
 	meddler.Register("bigint", BigIntMeddler{})
 	meddler.Register("merkleproof", MerkleProofMeddler{})
 	meddler.Register("hash", HashMeddler{})


### PR DESCRIPTION
## 🔄 Changes Summary
This PR turns off `meddler` `Debug` flag which is used only to log stuff like:
```
if Debug {
	log.Printf("meddler.Targets: column [%s] not found in struct", name)
}

// not destination, so throw this away
if Debug {
	log.Printf("meddler.WriteTargets: column [%s] not found in struct", name)
}
```

Basically, this is only logged when for example, we use `CertificateHeader` struct to read a row from certificates table, without using the entire `Certificate` struct (which contains, `aggchain_proof`, `signed_certificate`, etc.). In this case, `meddler` will log that it can not load `aggchain_proof` field for example, because `CertificateHeader` does not have that field, which is fine in our case, but it is logging this on networks with `datadog`, or other `logging` platforms, which can be anoying and confusing for someone that is looking at the logs.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI

