### PR TITLE
fix: `imported-bridge-exit` commitment hash in optimistic mode

### DIFF
--- a/aggsender/converters/imported_bridge_exit_converter.go
+++ b/aggsender/converters/imported_bridge_exit_converter.go
@@ -19,23 +19,7 @@ import (
 // ImportedBridgeExit or an error if the global index cannot be decoded.
 func ConvertToImportedBridgeExitWithoutClaimData(
 	claim bridgesync.Claim) (*agglayertypes.ImportedBridgeExit, error) {
-	leafType := agglayertypes.LeafTypeAsset
-	if claim.IsMessage {
-		leafType = agglayertypes.LeafTypeMessage
-	}
-	metaData := convertBridgeMetadata(claim.Metadata)
-
-	bridgeExit := &agglayertypes.BridgeExit{
-		LeafType: leafType,
-		TokenInfo: &agglayertypes.TokenInfo{
-			OriginNetwork:      claim.OriginNetwork,
-			OriginTokenAddress: claim.OriginAddress,
-		},
-		DestinationNetwork: claim.DestinationNetwork,
-		DestinationAddress: claim.DestinationAddress,
-		Amount:             claim.Amount,
-		Metadata:           metaData,
-	}
+	bridgeExit := ConvertBridgeExitFromClaim(claim)
 
 	mainnetFlag, rollupIndex, leafIndex, err := bridgesync.DecodeGlobalIndex(claim.GlobalIndex)
 	if err != nil {
@@ -64,7 +48,7 @@ func ConvertToImportedBridgeExitWithoutClaimData(
 //
 // Returns:
 //   - *agglayertypes.BridgeExit: The constructed bridge exit object with core claim data.
-func ConvertBridgeExitFromClaim(claim *bridgesync.Claim) *agglayertypes.BridgeExit {
+func ConvertBridgeExitFromClaim(claim bridgesync.Claim) *agglayertypes.BridgeExit {
 	leafType := agglayertypes.LeafTypeAsset
 	if claim.IsMessage {
 		leafType = agglayertypes.LeafTypeMessage

--- a/aggsender/converters/imported_bridge_exit_converter.go
+++ b/aggsender/converters/imported_bridge_exit_converter.go
@@ -52,6 +52,38 @@ func ConvertToImportedBridgeExitWithoutClaimData(
 	}, nil
 }
 
+// ConvertBridgeExitFromClaim converts a bridgesync.Claim into an agglayertypes.BridgeExit.
+// It extracts the core bridge exit information from the claim, including the leaf type
+// (asset or message), token information, destination network and address, transfer amount,
+// and metadata. This is a simplified conversion that does not include global index data
+// or claim-specific proofs, making it suitable for scenarios where only the bridge exit
+// data is needed without the full imported bridge exit context.
+//
+// Parameters:
+//   - claim: bridgesync.Claim containing the claim data to convert.
+//
+// Returns:
+//   - *agglayertypes.BridgeExit: The constructed bridge exit object with core claim data.
+func ConvertBridgeExitFromClaim(claim *bridgesync.Claim) *agglayertypes.BridgeExit {
+	leafType := agglayertypes.LeafTypeAsset
+	if claim.IsMessage {
+		leafType = agglayertypes.LeafTypeMessage
+	}
+	metaData := convertBridgeMetadata(claim.Metadata)
+
+	return &agglayertypes.BridgeExit{
+		LeafType: leafType,
+		TokenInfo: &agglayertypes.TokenInfo{
+			OriginNetwork:      claim.OriginNetwork,
+			OriginTokenAddress: claim.OriginAddress,
+		},
+		DestinationNetwork: claim.DestinationNetwork,
+		DestinationAddress: claim.DestinationAddress,
+		Amount:             claim.Amount,
+		Metadata:           metaData,
+	}
+}
+
 // ConvertToImportedBridgeExit converts a bridgesync.Claim into an agglayertypes.ImportedBridgeExit.
 // It determines the leaf type based on the claim, constructs the bridge exit data, decodes the global index,
 // and retrieves the necessary Merkle proofs for the claim. Depending on whether the claim is from mainnet or rollup,

--- a/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges.go
+++ b/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges.go
@@ -3,7 +3,7 @@ package optimistichash
 import (
 	"math/big"
 
-	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggsender/converters"
 	"github.com/agglayer/aggkit/bridgesync"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/ethereum/go-ethereum/common"
@@ -51,21 +51,6 @@ func (o *optimisticCommitImportedBrigesData) hash() common.Hash {
 }
 
 func (o *optimisticCommitImportedBrigeData) setBridgeExitHash(claim *bridgesync.Claim) {
-	leafType := agglayertypes.LeafTypeAsset
-	if claim.IsMessage {
-		leafType = agglayertypes.LeafTypeMessage
-	}
-
-	be := agglayertypes.BridgeExit{
-		LeafType: leafType,
-		TokenInfo: &agglayertypes.TokenInfo{
-			OriginNetwork:      claim.OriginNetwork,
-			OriginTokenAddress: claim.OriginAddress,
-		},
-		DestinationNetwork: claim.DestinationNetwork,
-		DestinationAddress: claim.DestinationAddress,
-		Amount:             claim.Amount,
-		Metadata:           claim.Metadata,
-	}
+	be := converters.ConvertBridgeExitFromClaim(claim)
 	o.bridgeExitHash = be.Hash()
 }

--- a/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges.go
+++ b/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges.go
@@ -51,6 +51,6 @@ func (o *optimisticCommitImportedBrigesData) hash() common.Hash {
 }
 
 func (o *optimisticCommitImportedBrigeData) setBridgeExitHash(claim *bridgesync.Claim) {
-	be := converters.ConvertBridgeExitFromClaim(claim)
+	be := converters.ConvertBridgeExitFromClaim(*claim)
 	o.bridgeExitHash = be.Hash()
 }

--- a/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges_test.go
+++ b/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/agglayer/aggkit/aggsender/converters"
 	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -68,6 +68,7 @@ func TestNewCommitImportedBrigesData(t *testing.T) {
 		require.NotNil(t, data.bridges[i].bridgeExitHash, "BridgeExitHash should not be nil")
 	}
 }
+
 func TestSetBridgeExitHash(t *testing.T) {
 	claim := &bridgesync.Claim{
 		GlobalIndex:        big.NewInt(12345),
@@ -85,22 +86,7 @@ func TestSetBridgeExitHash(t *testing.T) {
 
 	require.NotNil(t, data.bridgeExitHash, "BridgeExitHash should not be nil")
 
-	leafType := agglayertypes.LeafTypeAsset
-	if claim.IsMessage {
-		leafType = agglayertypes.LeafTypeMessage
-	}
-
-	expectedBridgeExit := agglayertypes.BridgeExit{
-		LeafType: leafType,
-		TokenInfo: &agglayertypes.TokenInfo{
-			OriginNetwork:      claim.OriginNetwork,
-			OriginTokenAddress: claim.OriginAddress,
-		},
-		DestinationNetwork: claim.DestinationNetwork,
-		DestinationAddress: claim.DestinationAddress,
-		Amount:             claim.Amount,
-		Metadata:           claim.Metadata,
-	}
+	expectedBridgeExit := converters.ConvertBridgeExitFromClaim(claim)
 
 	expectedHash := expectedBridgeExit.Hash()
 	require.Equal(t, expectedHash, data.bridgeExitHash, "BridgeExitHash should match the expected hash")

--- a/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges_test.go
+++ b/aggsender/optimistic/optimistichash/calculate_hash_commit_imported_bridges_test.go
@@ -86,7 +86,7 @@ func TestSetBridgeExitHash(t *testing.T) {
 
 	require.NotNil(t, data.bridgeExitHash, "BridgeExitHash should not be nil")
 
-	expectedBridgeExit := converters.ConvertBridgeExitFromClaim(claim)
+	expectedBridgeExit := converters.ConvertBridgeExitFromClaim(*claim)
 
 	expectedHash := expectedBridgeExit.Hash()
 	require.Equal(t, expectedHash, data.bridgeExitHash, "BridgeExitHash should match the expected hash")


### PR DESCRIPTION
## 🔄 Changes Summary
This PR fixes the `imported bridge exit` commitment hash calculation in the `optimistic` mode.

`imported bridge exits` are consisted of `bridge exit` part, `global index` and `claim data`. When creating the `bridge exit` part from the `Claim` event, we need to do `keccak256` on the `Metadata` field of the `Claim`, like it is done for the certificates, and in `interop` repo [here](https://github.com/agglayer/interop/blob/6f892711bb533dfb9d4bc6b3717db77ad06c9634/crates/unified-bridge/src/bridge_exit.rs#L66).

While calculating the hash of the `imported bridge exits` commitment in the `optimistic` mode, when we recreated `bridge exit` part from the `Claim`, we did not do `keccak256` on the `Metadata` field, like we do for certificates.

This PR fixes this, and makes the conversion of the `bridge exit` part of the `Claim` use the same code as we do when building certificates. This fixes the hash calculation on the `optimistic` mode.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI
