### PR TITLE
fix: docker arm image

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: amd-runner-2204
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'arm-runner-2204' || 'amd-runner-2204' }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,18 +69,15 @@ jobs:
             echo "FULL_IMAGE_DEV=$FULL_IMAGE" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push ${{ matrix.variant.description }} image by digest
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: amd-runner-2204
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'arm-runner-2204' || 'amd-runner-2204' }}
     strategy:
       fail-fast: false
       matrix:
@@ -91,9 +91,6 @@ jobs:
         run: |
           IMAGE=$(jq -ecr '.tags | map(select(match("${{ env.REGEX_IMAGE }}-dev", "i"))) | first| sub(":.*$";"")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           echo "IMAGE=$IMAGE" >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # STAGE 1: Build binary
 # ================================
-FROM --platform=${BUILDPLATFORM} golang:1.25.0-alpine AS builder
+FROM golang:1.25.0-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache gcc musl-dev make sqlite-dev


### PR DESCRIPTION
## 🔄 Changes Summary
### Context
- `amd-runner-2204` (**x86_64**) builds for both `linux/amd64` and `linux/arm64`
- The `FROM` instruction is pinned to the native platform of the builder by using `--platform=${BUILDPLATFORM}` in the Dockerfile ([ref](https://docs.docker.com/build/building/multi-platform/#cross-compilation))
- Additionally, `ARCH := $(shell arch)` in the Makefile returns **x86_64**, not the target platform architecture

```
$ docker run --rm -it ghcr.io/agglayer/aggkit:0.7.1-rc1@sha256:77bbffc1e944ae0979a99a38978bf77d31f7ced53569f4098cc163ad86f2137c
rosetta error: failed to open elf at /lib/ld-musl-x86_64.so.1
```

### Approach
- Build native images using `amd-runner-2204` and `arm-runner-2204`


## ⚠️ Breaking Changes
- NA
## 📋 Config Updates
- NA

## ✅ Testing
- Manually triggered the [Build and Push Docker Image](https://github.com/agglayer/aggkit/actions/runs/18760171063) workflow

```
docker run --rm -it ghcr.io/agglayer/aggkit:tnobayashi-docker-arm_2025_10_23_19_57_9f47c74@sha256:0f7e54e1ceacc876c20c07f79d2f4ac1a59c679c613cb0611b25750f282e1db7
NAME:
   aggkit - A new cli application

USAGE:
   aggkit [global options] command [command options]

COMMANDS:
   version  Application version and build
   run      Run the aggkit client
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h  show help
```

