### PR TITLE
fix: build and push both prod and dev images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,8 @@ jobs:
           - linux/arm64
         variant:
           - { suffix: "", include_shell: "false", description: "production" }
-          - {
-              suffix: "-dev",
-              include_shell: "true",
-              description: "development",
-            }
+          - { suffix: "-dev", include_shell: "true", description: "development" }
+
     outputs:
       IMAGE_NAME_PROD: ${{ steps.image_builder_prod.outputs.IMAGE }}
       IMAGE_NAME_DEV: ${{ steps.image_builder_dev.outputs.IMAGE }}
@@ -102,19 +99,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push by digest
+      - name: Build and push ${{ matrix.variant.description }} image by digest
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
           platforms: ${{ matrix.platform }}
-          labels: ${{ (matrix.variant.suffix == '') && steps.meta_prod.outputs.labels || steps.meta_dev.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          push: false
+          cache-from: type=gha,scope=${{ matrix.variant.description }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant.description }}
           build-args: |
             INCLUDE_SHELL=${{ matrix.variant.include_shell }}
-          outputs: type=image,name=${{ (matrix.variant.suffix == '') && steps.image_builder_prod.outputs.IMAGE || steps.image_builder_dev.outputs.IMAGE }},push-by-digest=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true
 
       - name: Export digest
         run: |


### PR DESCRIPTION
## 🔄 Changes Summary
During build and push Docker image, we haven't been handing the development image (that includes shell), so this PR fixes it.

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: N/A
- 🖱️ **Manual**: Create new release and make sure that both prod Docker image (without suffix) and the `development`
 (with dev suffix) are built.

## 🐞 Issues
- Closes #[issue-number]
