### PR TITLE
feat: removed Common.NetworkID field

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -136,7 +136,7 @@ func start(cliCtx *cli.Context) error {
 	if hasBridgeComponent && (l1BridgeSync != nil || l2BridgeSync != nil) {
 		b := createBridgeService(
 			cfg.REST,
-			cfg.Common.NetworkID,
+			rollupDataQuerier.RollupID,
 			rollupDataQuerier,
 			l1InfoTreeSync,
 			l2GERSync,

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ const (
 	requireValidatorCallDeprecatedHint     = "RequireValidatorCall is deprecated, remove it from configuration"
 	maxSubmitCertificateRateDeprecatedHint = "AggSender.MaxSubmitCertificateRate is deprecated, " +
 		"remove it from configuration, instead use AggSender.AgglayerClient.APIRateLimits"
+	networkIDDeprecatedHint = "Common.NetworkID is deprecated, remove it from configuration"
 )
 
 type DeprecatedFieldsError struct {
@@ -221,6 +222,10 @@ var (
 		{
 			FieldNamePattern: "AggSender.KeepCertificatesHistory",
 			Reason:           "field moved to AggSender.StorageRetainCertificatesPolicy.KeepCertificatesHistory",
+		},
+		{
+			FieldNamePattern: "Common.NetworkID",
+			Reason:           networkIDDeprecatedHint,
 		},
 	}
 )

--- a/config/default.go
+++ b/config/default.go
@@ -11,7 +11,6 @@ OpNodeURL = ""
 AggLayerURL = "https://agglayer-dev.polygon.technology"
 AggchainProofURL = "http://localhost:5576"
 
-NetworkID = 1
 SequencerPrivateKeyPath = "/etc/aggkit/sequencer.keystore"
 SequencerPrivateKeyPassword = "test"
 
@@ -64,7 +63,6 @@ Level = "info"
 Outputs = ["stderr"]
 
 [Common]
-NetworkID = {{NetworkID}}
 L2RPC = {{L2RPC}}
 
 [L1NetworkConfig]

--- a/config/network.go
+++ b/config/network.go
@@ -20,8 +20,6 @@ var (
 
 // Config holds the common configuration for the Aggkit services
 type CommonConfig struct {
-	// NetworkID is the networkID of the Aggkit being run
-	NetworkID uint32 `mapstructure:"NetworkID"`
 	// L2URL is the URL of the L2 node
 	L2RPC L2RPCClientConfig `mapstructure:"L2RPC"`
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- Remove config entry `Common.NetworkID` in favour of get `NetworkID` from contracts

## ⚠️ Breaking Changes
- 🛠️ **Config**: 
- Removed `Common.NetworkID` and `NetworkID`:
```
NetworkID = 1
[Common]
NetworkID = {{NetworkID}}
```

## 🐞 Issues
- Closes #1164
