### PR TITLE
fix: [cherry-pick] populate version metadata in Docker image (#1163)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.25.0-alpine AS builder
 
 # Install build dependencies
-RUN apk add --no-cache gcc musl-dev make sqlite-dev
+RUN apk add --no-cache gcc musl-dev make sqlite-dev git
 
 WORKDIR /app
 


### PR DESCRIPTION
## 🔄 Changes Summary
The issue was that when running build of Docker image, the build container didn't have the git installed and therefore git commands that are run in the linking time, during binary building, were silently failing.

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: CI checks
- 🖱️ **Manual**:
1. Run `make build-docker`
2. Run `docker run aggkit:local version`
3. Note that all the version metadata fields are populated (namely are not empty strings)
