### PR TITLE
feat: cherry-pick Removed Common.NetworkID field (#1165)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -136,7 +136,7 @@ func start(cliCtx *cli.Context) error {
 	if hasBridgeComponent && (l1BridgeSync != nil || l2BridgeSync != nil) {
 		b := createBridgeService(
 			cfg.REST,
-			cfg.Common.NetworkID,
+			rollupDataQuerier.RollupID,
 			l1InfoTreeSync,
 			l2GERSync,
 			l1BridgeSync,

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ const (
 	requireValidatorCallDeprecatedHint     = "RequireValidatorCall is deprecated, remove it from configuration"
 	maxSubmitCertificateRateDeprecatedHint = "AggSender.MaxSubmitCertificateRate is deprecated, " +
 		"remove it from configuration, instead use AggSender.AgglayerClient.APIRateLimits"
+	networkIDDeprecatedHint = "Common.NetworkID is deprecated, remove it from configuration"
 )
 
 type DeprecatedFieldsError struct {
@@ -221,6 +222,10 @@ var (
 		{
 			FieldNamePattern: "AggSender.KeepCertificatesHistory",
 			Reason:           "field moved to AggSender.StorageRetainCertificatesPolicy.KeepCertificatesHistory",
+		},
+		{
+			FieldNamePattern: "Common.NetworkID",
+			Reason:           networkIDDeprecatedHint,
 		},
 	}
 )

--- a/config/default.go
+++ b/config/default.go
@@ -11,7 +11,6 @@ OpNodeURL = ""
 AggLayerURL = "https://agglayer-dev.polygon.technology"
 AggchainProofURL = "http://localhost:5576"
 
-NetworkID = 1
 SequencerPrivateKeyPath = "/etc/aggkit/sequencer.keystore"
 SequencerPrivateKeyPassword = "test"
 
@@ -62,7 +61,6 @@ Level = "info"
 Outputs = ["stderr"]
 
 [Common]
-NetworkID = {{NetworkID}}
 L2RPC = {{L2RPC}}
 
 [L1NetworkConfig]

--- a/config/network.go
+++ b/config/network.go
@@ -18,8 +18,6 @@ var (
 
 // Config holds the common configuration for the Aggkit services
 type CommonConfig struct {
-	// NetworkID is the networkID of the Aggkit being run
-	NetworkID uint32 `mapstructure:"NetworkID"`
 	// L2URL is the URL of the L2 node
 	L2RPC L2RPCClientConfig `mapstructure:"L2RPC"`
 }


### PR DESCRIPTION
**Cherrypick**: #1165
- Remove config entry `Common.NetworkID` in favour of get `NetworkID` from contracts
- 🛠️ **Config**:
- Removed `Common.NetworkID` and `NetworkID`:
```
NetworkID = 1
[Common]
NetworkID = {{NetworkID}}
```
- Closes #1164

## 🔄 Changes Summary
- [Brief description of what was added, fixed, or changed in this PR]

## ⚠️ Breaking Changes
- 🛠️ **Config**: [Optional: Changes to TOML config]
- 🔌 **API/CLI**: [Optional: Breaking interface changes]
- 🗑️ **Deprecated Features**: [Optional: Removed features]

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: [Optional: Enumerate config changes/provide snippet of changes]

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
