### PR TITLE
feat: introduce aggoracle metrics

### DIFF
--- a/aggoracle/metrics/metrics.go
+++ b/aggoracle/metrics/metrics.go
@@ -1,0 +1,5 @@
+package metrics
+
+func Register() {
+
+}

--- a/aggoracle/metrics/metrics.go
+++ b/aggoracle/metrics/metrics.go
@@ -1,5 +1,51 @@
 package metrics
 
-func Register() {
+import (
+	"time"
 
+	"github.com/agglayer/aggkit/prometheus"
+	prometheusclient "github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prefix                = "aggoracle_"
+	gerProcessDuration    = prefix + "ger_processing_duration_seconds"
+	gerProcessCount       = prefix + "ger_processing_trigger_total"
+	gerProcessErrorsCount = prefix + "ger_processing_errors_total"
+)
+
+// Register the metrics for the aggoracle package
+func Register() {
+	gerProcessingDuration := prometheusclient.HistogramOpts{
+		Name: gerProcessDuration,
+		Help: "[AGGORACLE] Duration in seconds for processing a Global Exit Root.",
+	}
+
+	gerProcessTriggerCount := prometheusclient.CounterOpts{
+		Name: gerProcessCount,
+		Help: "[AGGORACLE] Total number of GER processing triggers.",
+	}
+
+	gerProcessErrorCount := prometheusclient.CounterOpts{
+		Name: gerProcessErrorsCount,
+		Help: "[AGGORACLE] Total number of GER processing errors, labeled by error type.",
+	}
+
+	prometheus.RegisterHistograms(gerProcessingDuration)
+	prometheus.RegisterCounters(gerProcessTriggerCount, gerProcessErrorCount)
+}
+
+// IncGERProcessCount increments the GER processing trigger counter
+func IncGERProcessCount() {
+	prometheus.CounterInc(gerProcessCount)
+}
+
+// IncGERProcessCount increments the GER processing error counter
+func IncGERProcessErrCount() {
+	prometheus.CounterInc(gerProcessErrorsCount)
+}
+
+// ObserveGERProcessDuration records the duration taken to process a GER
+func ObserveGERProcessDuration(d time.Duration) {
+	prometheus.HistogramObserve(gerProcessDuration, d.Seconds())
 }

--- a/aggoracle/metrics/metrics.go
+++ b/aggoracle/metrics/metrics.go
@@ -8,27 +8,30 @@ import (
 )
 
 const (
-	prefix                = "aggoracle_"
-	gerProcessDuration    = prefix + "ger_processing_duration_seconds"
-	gerProcessCount       = prefix + "ger_processing_trigger_total"
-	gerProcessErrorsCount = prefix + "ger_processing_errors_total"
+	namespace             = "aggoracle"
+	gerProcessDuration    = "ger_processing_duration_seconds"
+	gerProcessCount       = "ger_processing_trigger_total"
+	gerProcessErrorsCount = "ger_processing_errors_total"
 )
 
 // Register the metrics for the aggoracle package
 func Register() {
 	gerProcessingDuration := prometheusclient.HistogramOpts{
-		Name: gerProcessDuration,
-		Help: "[AGGORACLE] Duration in seconds for processing a Global Exit Root.",
+		Namespace: namespace,
+		Name:      gerProcessDuration,
+		Help:      "Duration in seconds for processing a Global Exit Root.",
 	}
 
 	gerProcessTriggerCount := prometheusclient.CounterOpts{
-		Name: gerProcessCount,
-		Help: "[AGGORACLE] Total number of GER processing triggers.",
+		Namespace: namespace,
+		Name:      gerProcessCount,
+		Help:      "Total number of GER processing triggers.",
 	}
 
 	gerProcessErrorCount := prometheusclient.CounterOpts{
-		Name: gerProcessErrorsCount,
-		Help: "[AGGORACLE] Total number of GER processing errors, labeled by error type.",
+		Namespace: namespace,
+		Name:      gerProcessErrorsCount,
+		Help:      "Total number of GER processing errors.",
 	}
 
 	prometheus.RegisterHistograms(gerProcessingDuration)

--- a/aggoracle/oracle.go
+++ b/aggoracle/oracle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/agglayer/aggkit/aggoracle/metrics"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum"
@@ -52,6 +53,8 @@ func New(
 
 // Start starts the AggOracle process that checks for new GERs and injects them if not already injected
 func (a *AggOracle) Start(ctx context.Context) {
+	// Register metrics
+	metrics.Register()
 	for {
 		if err := a.processLatestGER(ctx); err != nil {
 			a.handleGERProcessingError(err)

--- a/aggoracle/oracle.go
+++ b/aggoracle/oracle.go
@@ -73,9 +73,11 @@ func (a *AggOracle) Start(ctx context.Context) {
 // processLatestGER fetches the latest finalized GER, checks if it is already injected and injects it if not
 func (a *AggOracle) processLatestGER(ctx context.Context) error {
 	a.logger.Debugf("checking for new GERs...")
+	metrics.IncGERProcessCount()
 	// Fetch the latest GER
 	latestL1InfoLeaf, err := a.l1Info.GetLatestL1InfoLeaf(ctx)
 	if err != nil {
+		metrics.IncGERProcessErrCount()
 		return err
 	}
 
@@ -84,8 +86,11 @@ func (a *AggOracle) processLatestGER(ctx context.Context) error {
 	latestGER := latestL1InfoLeaf.GlobalExitRoot
 
 	go func() {
+		start := time.Now()
 		err := a.chainSender.ProcessGER(ctx, latestGER)
+		metrics.ObserveGERProcessDuration(time.Since(start))
 		if err != nil {
+			metrics.IncGERProcessErrCount()
 			a.logger.Error(err)
 		}
 	}()

--- a/aggoracle/oracle.go
+++ b/aggoracle/oracle.go
@@ -55,6 +55,7 @@ func New(
 func (a *AggOracle) Start(ctx context.Context) {
 	// Register metrics
 	metrics.Register()
+
 	for {
 		if err := a.processLatestGER(ctx); err != nil {
 			a.handleGERProcessingError(err)

--- a/docs/aggoracle.md
+++ b/docs/aggoracle.md
@@ -280,6 +280,17 @@ AggOracle:
 
 ---
 
+## 📊 Aggoracle Metrics
+
+The **Aggoracle** service exposes Prometheus metrics to track Global Exit Root (GER) processing activity, latency, and error rates.
+All metrics are registered under the namespace: `aggoracle`
+
+| Metric | Type | Description | Unit |
+|---------|------|--------------|------|
+| `aggoracle_ger_processing_trigger_total` | Counter | Total number of GER processing triggers. | count |
+| `aggoracle_ger_processing_errors_total` | Counter | Total number of GER processing errors. | count |
+| `aggoracle_ger_processing_duration_seconds` | Histogram | Time taken to process a single Global Exit Root from start to finish. | seconds |
+
 ## Summary
 
 The **AggOracle** component automates the propagation of GERs from L1 to L2, enabling bridging across networks. It supports two operational modes:


### PR DESCRIPTION
## 🔄 Changes Summary
This PR introduces the following Prometheus metrics to the `aggoracle`.

| Metric | Type | Description | Unit |
|---------|------|--------------|------|
| `aggoracle_ger_processing_trigger_total` | Counter | Total number of GER processing triggers. | count |
| `aggoracle_ger_processing_errors_total` | Counter | Total number of GER processing errors. | count |
| `aggoracle_ger_processing_duration_seconds` | Histogram | Time taken to process a single Global Exit Root from start to finish. | seconds |

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #1153 

## 🔗 Related PRs
N/A

## 📝 Notes
N/A
