### PR TITLE
fix: record timestamp after sleep and recheck in wrapper

### DIFF
--- a/agglayer/rate_limit_wrapper.go
+++ b/agglayer/rate_limit_wrapper.go
@@ -61,6 +61,16 @@ func (r *RateLimitWrapper) applyRateLimit(methodName string) {
 			methodName,
 			rateLimitSleepTime.String(), rateLimiter.String())
 		time.Sleep(*rateLimitSleepTime)
+		// After sleeping externally, re-check and record the call. Loop to be safe under concurrency.
+		for {
+			r.mu.Lock()
+			rateLimitSleepTime = rateLimiter.Call(methodName, true)
+			r.mu.Unlock()
+			if rateLimitSleepTime == nil {
+				break
+			}
+			time.Sleep(*rateLimitSleepTime)
+		}
 	}
 }
 

--- a/common/rate_limit.go
+++ b/common/rate_limit.go
@@ -66,27 +66,35 @@ func (r *RateLimit) Call(msg string, allowToSleep bool) *time.Duration {
 	if r == nil || !r.cfg.Enabled() {
 		return nil
 	}
-	var returnSleepTime *time.Duration
 	now := TimeProvider()
 	r.cleanOutdatedCalls(now)
 
 	// Rate limit check BEFORE adding the current call
 	if len(r.calls) >= r.cfg.NumRequests {
 		sleepTime := r.cfg.Interval.Duration - now.Sub(r.calls[0])
+		// If the computed sleep time is non-positive, proceed without sleeping and record now
+		if sleepTime <= 0 {
+			r.calls = append(r.calls, now)
+			return nil
+		}
 		if allowToSleep {
 			if msg != "" {
 				log.Infof("Rate limit reached, sleeping for %s for %s", sleepTime, msg)
 			}
 			time.Sleep(sleepTime)
-		} else {
-			// If no sleep, we return the time
-			returnSleepTime = &sleepTime
+			// After sleeping, recompute now and cleanup before recording the call
+			now = TimeProvider()
+			r.cleanOutdatedCalls(now)
+			r.calls = append(r.calls, now)
+			return nil
 		}
+		// Non-blocking path: return the sleep time, do NOT record the call yet
+		return &sleepTime
 	}
 
 	// Add the current call to the tracking
 	r.calls = append(r.calls, now)
-	return returnSleepTime
+	return nil
 }
 
 func (r *RateLimit) cleanOutdatedCalls(now time.Time) {


### PR DESCRIPTION
Problem:
- RateLimit.Call() was appending a pre-sleep timestamp both in internal- and external-sleep flows.
- This mis-accounted requests and tightened the effective sliding window, causing unnecessarily strict throughput.
- The agglayer wrapper slept externally but the timestamp had already been recorded before the sleep.

Changes:
- In common/rate_limit.go, record the timestamp only when the request is actually allowed to proceed "now":
  * For blocking calls: sleep first, then recompute now, cleanup, and append.
  * For non-blocking calls: return the sleep duration without appending.
- In agglayer/rate_limit_wrapper.go, after external sleep, re-check and record using a loop to remain correct under concurrency.

Why:
- Aligns with the documented behavior: the system waits until the next interval before allowing more requests.
- Ensures precise sliding-window accounting and stable throughput, especially under concurrent load.