### PR TITLE
feat: categorize aggsender metrics to namespaces

### DIFF
--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -45,7 +45,7 @@ func Register() {
 		{
 			Namespace: namespace,
 			Name:      numberOfCertificatesSettled,
-			Help:      "number of certificates settled",
+			Help:      "Number of certificates settled",
 		},
 		{
 			Namespace: namespace,

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -13,7 +13,7 @@ const (
 	numberOfCertificatesSent    = "number_of_certificates_sent"
 	numberOfCertificatesInError = "number_of_certificates_in_error"
 	numberOfSendingRetries      = "number_of_sending_retries"
-	numberOfCertificatesSettled = "number_of_sending_settled"
+	numberOfCertificatesSettled = "number_of_certificates_settled"
 	certificateBuildTime        = "certificate_build_time"
 	proverTime                  = "prover_time"
 	numberOfProverErrors        = "number_of_prover_errors"
@@ -26,7 +26,7 @@ const (
 
 // Register the metrics for the aggsender package
 func Register() {
-	gauges := []prometheusClient.GaugeOpts{
+	counters := []prometheusClient.CounterOpts{
 		{
 			Namespace: namespace,
 			Name:      numberOfCertificatesSent,
@@ -58,7 +58,7 @@ func Register() {
 			Help:      "Number of times multisig threshold was not reached",
 		},
 	}
-	prometheus.RegisterGauges(gauges...)
+	prometheus.RegisterCounters(counters...)
 
 	counterVecs := []prometheus.CounterVecOpts{
 		{
@@ -112,44 +112,44 @@ func Register() {
 	log.Info("Registered prometheus aggsender metrics")
 }
 
-// CertificateSent increments the gauge for the number of certificates sent
+// CertificateSent increments the counter for the number of certificates sent
 func CertificateSent() {
-	prometheus.GaugeInc(numberOfCertificatesSent)
+	prometheus.CounterInc(numberOfCertificatesSent)
 }
 
-// InError increments the gauge for the number of certificates in error
+// InError increments the counter for the number of certificates in error
 func InError() {
-	prometheus.GaugeInc(numberOfCertificatesInError)
+	prometheus.CounterInc(numberOfCertificatesInError)
 }
 
-// SendingRetry increments the gauge for the number of sending retries
+// SendingRetry increments the counter for the number of sending retries
 func SendingRetry() {
-	prometheus.GaugeInc(numberOfSendingRetries)
+	prometheus.CounterInc(numberOfSendingRetries)
 }
 
-// Settled increments the gauge for the number of certificates settled
+// Settled increments the counter for the number of certificates settled
 func Settled() {
-	prometheus.GaugeInc(numberOfCertificatesSettled)
+	prometheus.CounterInc(numberOfCertificatesSettled)
 }
 
-// CertificateBuildTime sets the gauge for the certificate build time
+// CertificateBuildTime sets the counter for the certificate build time
 func CertificateBuildTime(value float64) {
 	prometheus.HistogramObserve(certificateBuildTime, value)
 }
 
-// ProverTime sets the gauge for the prover time
+// ProverTime provides a histogram for the prover time
 func ProverTime(value float64) {
 	prometheus.HistogramObserve(proverTime, value)
 }
 
-// CertificateSettlementTime sets the gauge for the certificate settlement time
+// CertificateSettlementTime provides a histogram for the certificate settlement time
 func CertificateSettlementTime(value float64) {
 	prometheus.HistogramObserve(certificateSettlementTime, value)
 }
 
-// ProverError increments the gauge for the number of prover errors
+// ProverError increments the counter for the number of prover errors
 func ProverError() {
-	prometheus.GaugeInc(numberOfProverErrors)
+	prometheus.CounterInc(numberOfProverErrors)
 }
 
 // ValidatorError increments the counter for the number of validator errors, labeled by validator address
@@ -163,13 +163,13 @@ func ValidatorInvalidSignature(validator common.Address) {
 	prometheus.CounterVecInc(validatorInvalidSignature, validator.String())
 }
 
-// ValidateTime sets the gauge for the time taken to validate a certificate
+// ValidateTime provides a histogram for the time taken to validate a certificate
 func ValidateTime(value float64) {
 	prometheus.HistogramObserve(validateTime, value)
 }
 
-// MultiSigThresholdNotReached increments the gauge for the number of times
+// MultiSigThresholdNotReached increments the counter for the number of times
 // the multisig threshold was not reached
 func MultiSigThresholdNotReached() {
-	prometheus.GaugeInc(multiSigThresholdNotReached)
+	prometheus.CounterInc(multiSigThresholdNotReached)
 }

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -8,48 +8,54 @@ import (
 )
 
 const (
-	prefix                      = "aggsender_"
-	aggsenderValidator          = "aggsender_validator"
-	numberOfCertificatesSent    = prefix + "number_of_certificates_sent"
-	numberOfCertificatesInError = prefix + "number_of_certificates_in_error"
-	numberOfSendingRetries      = prefix + "number_of_sending_retries"
-	numberOfCertificatesSettled = prefix + "number_of_sending_settled"
-	certificateBuildTime        = prefix + "certificate_build_time"
-	proverTime                  = prefix + "prover_time"
-	numberOfProverErrors        = prefix + "number_of_prover_errors"
-	validatorErrorNumber        = prefix + "validator_errors_total"
-	validatorInvalidSignature   = prefix + "validator_invalid_signature_total"
-	validateTime                = prefix + "validate_time"
-	multiSigThresholdNotReached = prefix + "multisig_threshold_not_reached"
-	certificateSettlementTime   = prefix + "certificate_settlement_time"
+	namespace                   = "aggsender"
+	aggsenderValidatorLabel     = "aggsender_validator"
+	numberOfCertificatesSent    = "number_of_certificates_sent"
+	numberOfCertificatesInError = "number_of_certificates_in_error"
+	numberOfSendingRetries      = "number_of_sending_retries"
+	numberOfCertificatesSettled = "number_of_sending_settled"
+	certificateBuildTime        = "certificate_build_time"
+	proverTime                  = "prover_time"
+	numberOfProverErrors        = "number_of_prover_errors"
+	validatorErrorNumber        = "validator_errors_total"
+	validatorInvalidSignature   = "validator_invalid_signature_total"
+	validateTime                = "validate_time"
+	multiSigThresholdNotReached = "multisig_threshold_not_reached"
+	certificateSettlementTime   = "certificate_settlement_time"
 )
 
 // Register the metrics for the aggsender package
 func Register() {
 	gauges := []prometheusClient.GaugeOpts{
 		{
-			Name: numberOfCertificatesSent,
-			Help: "[AGGSENDER] number of certificates sent",
+			Namespace: namespace,
+			Name:      numberOfCertificatesSent,
+			Help:      "Number of certificates sent",
 		},
 		{
-			Name: numberOfCertificatesInError,
-			Help: "[AGGSENDER] number of certificates in error",
+			Namespace: namespace,
+			Name:      numberOfCertificatesInError,
+			Help:      "Number of certificates in error",
 		},
 		{
-			Name: numberOfSendingRetries,
-			Help: "[AGGSENDER] number of sending retries",
+			Namespace: namespace,
+			Name:      numberOfSendingRetries,
+			Help:      "Number of sending retries",
 		},
 		{
-			Name: numberOfCertificatesSettled,
-			Help: "[AGGSENDER] number of certificates settled",
+			Namespace: namespace,
+			Name:      numberOfCertificatesSettled,
+			Help:      "number of certificates settled",
 		},
 		{
-			Name: numberOfProverErrors,
-			Help: "[AGGSENDER] number of prover errors",
+			Namespace: namespace,
+			Name:      numberOfProverErrors,
+			Help:      "Number of prover errors",
 		},
 		{
-			Name: multiSigThresholdNotReached,
-			Help: "[AGGSENDER] number of times multisig threshold was not reached",
+			Namespace: namespace,
+			Name:      multiSigThresholdNotReached,
+			Help:      "Number of times multisig threshold was not reached",
 		},
 	}
 	prometheus.RegisterGauges(gauges...)
@@ -57,41 +63,47 @@ func Register() {
 	counterVecs := []prometheus.CounterVecOpts{
 		{
 			CounterOpts: prometheusClient.CounterOpts{
-				Name: validatorErrorNumber,
-				Help: "[AGGSENDER] total number of errors returned by a validator over time",
+				Namespace: namespace,
+				Name:      validatorErrorNumber,
+				Help:      "Total number of errors returned by a validator over time",
 			},
-			Labels: []string{aggsenderValidator},
+			Labels: []string{aggsenderValidatorLabel},
 		},
 		{
 			CounterOpts: prometheusClient.CounterOpts{
-				Name: validatorInvalidSignature,
-				Help: "[AGGSENDER] number of times a validator returned an invalid signature",
+				Namespace: namespace,
+				Name:      validatorInvalidSignature,
+				Help:      "Number of times a validator returned an invalid signature",
 			},
-			Labels: []string{aggsenderValidator},
+			Labels: []string{aggsenderValidatorLabel},
 		},
 	}
 	prometheus.RegisterCounterVecs(counterVecs...)
 
 	histograms := []prometheusClient.HistogramOpts{
 		{
-			Name:    validateTime,
-			Help:    "[AGGSENDER] time taken to validate a certificate",
-			Buckets: prometheusClient.DefBuckets,
+			Namespace: namespace,
+			Name:      validateTime,
+			Help:      "Time taken to validate a certificate",
+			Buckets:   prometheusClient.DefBuckets,
 		},
 		{
-			Name:    proverTime,
-			Help:    "[AGGSENDER] time taken by the prover",
-			Buckets: prometheusClient.DefBuckets,
+			Namespace: namespace,
+			Name:      proverTime,
+			Help:      "Time taken by the prover",
+			Buckets:   prometheusClient.DefBuckets,
 		},
 		{
-			Name:    certificateSettlementTime,
-			Help:    "[AGGSENDER] time taken to settle a certificate",
-			Buckets: prometheusClient.DefBuckets,
+			Namespace: namespace,
+			Name:      certificateSettlementTime,
+			Help:      "Time taken to settle a certificate",
+			Buckets:   prometheusClient.DefBuckets,
 		},
 		{
-			Name:    certificateBuildTime,
-			Help:    "[AGGSENDER] time taken to build a certificate",
-			Buckets: prometheusClient.DefBuckets,
+			Namespace: namespace,
+			Name:      certificateBuildTime,
+			Help:      "Time taken to build a certificate",
+			Buckets:   prometheusClient.DefBuckets,
 		},
 	}
 

--- a/aggsender/metrics/metrics.go
+++ b/aggsender/metrics/metrics.go
@@ -132,7 +132,7 @@ func Settled() {
 	prometheus.CounterInc(numberOfCertificatesSettled)
 }
 
-// CertificateBuildTime sets the counter for the certificate build time
+// CertificateBuildTime provides a histogram for the certificate build time
 func CertificateBuildTime(value float64) {
 	prometheus.HistogramObserve(certificateBuildTime, value)
 }

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -277,12 +277,12 @@ If enabled in the configuration, Aggsender exposes the following Prometheus metr
 
 | **Metric Name**                               | **Type**                                   | **Description**                                           |
 | --------------------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
-| `aggsender_number_of_certificates_sent`       | Gauge                                      | Number of certificates sent                               |
-| `aggsender_number_of_certificates_in_error`   | Gauge                                      | Number of certificates in error                           |
-| `aggsender_number_of_sending_retries`         | Gauge                                      | Number of sending retries                                 |
-| `aggsender_number_of_sending_settled`         | Gauge                                      | Number of certificates settled                            |
-| `aggsender_number_of_prover_errors`           | Gauge                                      | Number of prover errors                                   |
-| `aggsender_multisig_threshold_not_reached`    | Gauge                                      | Number of times multisig threshold was not reached        |
+| `aggsender_number_of_certificates_sent`       | Counter                                      | Number of certificates sent                               |
+| `aggsender_number_of_certificates_in_error`   | Counter                                      | Number of certificates in error                           |
+| `aggsender_number_of_sending_retries`         | Counter                                      | Number of sending retries                                 |
+| `aggsender_number_of_certificates_settled`         | Counter                                      | Number of certificates settled                            |
+| `aggsender_number_of_prover_errors`           | Counter                                      | Number of prover errors                                   |
+| `aggsender_multisig_threshold_not_reached`    | Counter                                      | Number of times multisig threshold was not reached        |
 | `aggsender_validator_errors_total`            | Counter (labeled by `aggsender_validator`) | Total number of errors returned by a validator over time  |
 | `aggsender_validator_invalid_signature_total` | Counter (labeled by `aggsender_validator`) | Number of times a validator returned an invalid signature |
 | `aggsender_validate_time`                     | Histogram                                  | Time taken to validate a certificate (seconds)            |


### PR DESCRIPTION
## 🔄 Changes Summary
- Categorize aggsender metrics into the `aggsender` namespace
- Convert gauges into counters, as it is more appropriate (as the values are monotonic increasing during the time)
- Update docs

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #1239 
- Closes #1236
