### PR TITLE
refactor: change log level

### DIFF
--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -705,7 +705,7 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 	}
 
 	if err != nil {
-		b.logger.Errorf(
+		b.logger.Debugf(
 			"failed to get L1 info tree index (network id=%d, deposit count=%d): %v",
 			networkID,
 			depositCount,

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -784,7 +784,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 	}
 
 	if err != nil {
-		b.logger.Errorf("failed to get L1 info tree leaf (network id=%d, leaf index=%d): %v", networkID, l1InfoTreeIndex, err)
+		b.logger.Debugf("failed to get L1 info tree leaf (network id=%d, leaf index=%d): %v", networkID, l1InfoTreeIndex, err)
 		c.JSON(http.StatusInternalServerError,
 			gin.H{"error": fmt.Sprintf("failed to get L1 info tree leaf (network id=%d, leaf index=%d), error: %s",
 				networkID, l1InfoTreeIndex, err)})


### PR DESCRIPTION
## 🔄 Changes Summary
- Adjust log level from `error` to `debug` to prevent excessive logging in Datadog

## 🐞 Issues
- Closes #1112


