### PR TITLE
feat: Add L1 contract fallback check for missing GERs during L2GERSync

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -177,6 +177,7 @@ DBPath = "{{PathRWData}}/l2gersync.sqlite"
 BlockFinality = "LatestBlock"
 InitialBlockNum = 0
 GlobalExitRootL2Addr = "{{L2Config.GlobalExitRootAddr}}"
+GlobalExitRootL1Addr = "{{L1NetworkConfig.GlobalExitRootManagerAddr}}"
 SyncBlockChunkSize = 100
 RetryAfterErrorPeriod = "1s"
 MaxRetryAttemptsAfterError = -1

--- a/l2gersync/config.go
+++ b/l2gersync/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	InitialBlockNum uint64 `mapstructure:"InitialBlockNum"`
 	// GlobalExitRootL2Addr is the address of the GER smart contract on L2
 	GlobalExitRootL2Addr common.Address `mapstructure:"GlobalExitRootL2Addr"`
+	// GlobalExitRootL1Addr is the address of the GER smart contract on L1
+	GlobalExitRootL1Addr common.Address `mapstructure:"GlobalExitRootL1Addr"`
 	// SyncBlockChunkSize is the maximum block range downloaded at once
 	SyncBlockChunkSize uint64 `mapstructure:"SyncBlockChunkSize"`
 	// RetryAfterErrorPeriod is the time that will be waited when an unexpected error happens before retry

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -159,7 +159,7 @@ func (d *downloaderSovereign) buildAppender(
 				gerHash := common.Hash(insertGEREvent.NewGlobalExitRoot)
 				timestamp, err := d.l1GERManager.GlobalExitRootMap(&bind.CallOpts{Pending: false}, gerHash)
 				if err != nil {
-					log.Errorf("L1InfoTreeSync is up to date, GER lookup for %s failed in L1InfoTreeSync, and L1 contract check also failed: %v",
+					log.Errorf("GER lookup for %s failed in L1 contract: %v",
 						gerHash.Hex(), err)
 				}
 

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -150,17 +150,17 @@ func (d *downloaderSovereign) buildAppender(
 			log.Errorf("failed to fetch l1 info tree for global exit root %s: %v",
 				common.Hash(insertGEREvent.NewGlobalExitRoot).Hex(), err)
 			ctx := context.Background()
-			isUpToDate, err := d.l1InfoTreeSync.IsUpToDate(ctx, d.l1Client)
-			if err != nil {
-				log.Warnf("Failed to check if L1InfoTreeSync is up to date: %v", err)
+			isUpToDate, upToDateErr := d.l1InfoTreeSync.IsUpToDate(ctx, d.l1Client)
+			if upToDateErr != nil {
+				log.Errorf("Failed to check if L1InfoTreeSync is up to date: %v", upToDateErr)
 			}
 			if isUpToDate {
 				// Check L1 contract directly before failing
 				gerHash := common.Hash(insertGEREvent.NewGlobalExitRoot)
-				timestamp, err := d.l1GERManager.GlobalExitRootMap(&bind.CallOpts{Pending: false}, gerHash)
-				if err != nil {
+				timestamp, contractErr := d.l1GERManager.GlobalExitRootMap(&bind.CallOpts{Pending: false}, gerHash)
+				if contractErr != nil {
 					log.Errorf("GER lookup for %s failed in L1 contract: %v",
-						gerHash.Hex(), err)
+						gerHash.Hex(), contractErr)
 				}
 
 				if timestamp.Cmp(common.Big0) == 0 {

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerger"
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayergerl2"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
 	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -28,6 +30,8 @@ type downloaderSovereign struct {
 	l2GERAddr          common.Address
 	l1InfoTreeSync     L1InfoTreeQuerier
 	l1Client           aggkittypes.BaseEthereumClienter
+	l1GERManager       *agglayerger.Agglayerger
+	l1GERAddr          common.Address
 	rh                 *sync.RetryHandler
 	syncBlockChunkSize uint64
 }
@@ -37,6 +41,7 @@ func newDownloaderSovereign(
 	l2GERAddr common.Address,
 	l1InfoTreeSync L1InfoTreeQuerier,
 	l1Client aggkittypes.BaseEthereumClienter,
+	l1GERAddr common.Address,
 	rh *sync.RetryHandler,
 	blockFinality aggkittypes.BlockNumberFinality,
 	waitForNewBlocksPeriod time.Duration,
@@ -47,11 +52,19 @@ func newDownloaderSovereign(
 		return nil, fmt.Errorf("failed to initialize L2 GER manager contract: %w", err)
 	}
 
+	l1GERManager, err := agglayerger.NewAgglayerger(
+		l1GERAddr, l1Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize L1 GER manager contract: %w", err)
+	}
+
 	d := &downloaderSovereign{
 		l2GERManager:       l2GERManager,
 		l2GERAddr:          l2GERAddr,
 		l1InfoTreeSync:     l1InfoTreeSync,
 		l1Client:           l1Client,
+		l1GERManager:       l1GERManager,
+		l1GERAddr:          l1GERAddr,
 		rh:                 rh,
 		syncBlockChunkSize: syncBlockChunkSize,
 	}
@@ -142,8 +155,19 @@ func (d *downloaderSovereign) buildAppender(
 				log.Warnf("Failed to check if L1InfoTreeSync is up to date: %v", err)
 			}
 			if isUpToDate {
-				log.Fatal("L1InfoTreeSync is to date, GER lookup for %s failed: %v",
-					common.Hash(insertGEREvent.NewGlobalExitRoot).Hex(), err)
+				// Check L1 contract directly before failing
+				gerHash := common.Hash(insertGEREvent.NewGlobalExitRoot)
+				timestamp, err := d.l1GERManager.GlobalExitRootMap(&bind.CallOpts{Pending: false}, gerHash)
+				if err != nil {
+					log.Errorf("L1InfoTreeSync is up to date, GER lookup for %s failed in L1InfoTreeSync, and L1 contract check also failed: %v",
+						gerHash.Hex(), err)
+				}
+
+				if timestamp.Cmp(common.Big0) == 0 {
+					log.Fatalf("GER %s not found in L1 contract globalExitRootMap", gerHash.Hex())
+				} else {
+					log.Infof("GER %s exists in L1 contract", gerHash.Hex())
+				}
 			}
 
 			return fmt.Errorf("failed to fetch l1 info tree for global exit root %s: %w",

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -170,7 +170,8 @@ func (d *downloaderSovereign) buildAppender(
 				}
 			}
 
-			return err
+			return fmt.Errorf("failed to fetch l1 info tree for global exit root %s: %w",
+				common.Hash(insertGEREvent.NewGlobalExitRoot).Hex(), err)
 		}
 
 		b.Events = []any{

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -31,7 +31,6 @@ type downloaderSovereign struct {
 	l1InfoTreeSync     L1InfoTreeQuerier
 	l1Client           aggkittypes.BaseEthereumClienter
 	l1GERManager       *agglayerger.Agglayerger
-	l1GERAddr          common.Address
 	rh                 *sync.RetryHandler
 	syncBlockChunkSize uint64
 }
@@ -64,7 +63,6 @@ func newDownloaderSovereign(
 		l1InfoTreeSync:     l1InfoTreeSync,
 		l1Client:           l1Client,
 		l1GERManager:       l1GERManager,
-		l1GERAddr:          l1GERAddr,
 		rh:                 rh,
 		syncBlockChunkSize: syncBlockChunkSize,
 	}
@@ -149,6 +147,8 @@ func (d *downloaderSovereign) buildAppender(
 
 		l1InfoTreeLeaf, err := d.l1InfoTreeSync.GetInfoByGlobalExitRoot(insertGEREvent.NewGlobalExitRoot)
 		if err != nil {
+			log.Errorf("failed to fetch l1 info tree for global exit root %s: %v",
+				common.Hash(insertGEREvent.NewGlobalExitRoot).Hex(), err)
 			ctx := context.Background()
 			isUpToDate, err := d.l1InfoTreeSync.IsUpToDate(ctx, d.l1Client)
 			if err != nil {
@@ -170,8 +170,7 @@ func (d *downloaderSovereign) buildAppender(
 				}
 			}
 
-			return fmt.Errorf("failed to fetch l1 info tree for global exit root %s: %w",
-				common.Hash(insertGEREvent.NewGlobalExitRoot).Hex(), err)
+			return err
 		}
 
 		b.Events = []any{

--- a/l2gersync/evm_downloader_sovereign_test.go
+++ b/l2gersync/evm_downloader_sovereign_test.go
@@ -94,6 +94,7 @@ func TestDownloaderSovereign_Download(t *testing.T) {
 		l2GERAddr,
 		mockL1InfoTreeSync,
 		mockL1Client,
+		common.HexToAddress("0x0000000000000000000000000000000000000001"), // l1GERAddr
 		rh,
 		aggkittypes.LatestBlock,
 		time.Millisecond*10, // waitForNewBlocksPeriod
@@ -179,6 +180,7 @@ func TestIsL1InfoTreeQuerierUpToDate(t *testing.T) {
 				common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
 				mockL1InfoTreeSync,
 				mockL1Client,
+				common.HexToAddress("0x0000000000000000000000000000000000000001"), // l1GERAddr
 				rh,
 				aggkittypes.LatestBlock,
 				time.Millisecond*10,
@@ -297,6 +299,7 @@ func TestDownloaderSovereign_GetInfoByGlobalExitRootErrorHandlingInAppender(t *t
 				l2GERAddr,
 				mockL1InfoTreeSync,
 				mockL1Client,
+				common.HexToAddress("0x0000000000000000000000000000000000000001"), // l1GERAddr
 				rh,
 				aggkittypes.LatestBlock,
 				time.Millisecond*10,

--- a/l2gersync/evm_downloader_sovereign_test.go
+++ b/l2gersync/evm_downloader_sovereign_test.go
@@ -240,6 +240,8 @@ func TestDownloaderSovereign_GetInfoByGlobalExitRootErrorHandlingInAppender(t *t
 		getInfoByGERError    error
 		isUpToDateResult     bool
 		isUpToDateError      error
+		l1ContractTimestamp  *big.Int
+		l1ContractError      error
 		expectError          bool
 		expectedErrorMessage string
 	}{
@@ -256,6 +258,28 @@ func TestDownloaderSovereign_GetInfoByGlobalExitRootErrorHandlingInAppender(t *t
 			getInfoByGERError:    fmt.Errorf("GER lookup failed"),
 			isUpToDateResult:     false,
 			isUpToDateError:      nil,
+			expectError:          true,
+			expectedErrorMessage: "failed to fetch l1 info tree for global exit root",
+		},
+		{
+			name:                 "GetInfoByGlobalExitRoot_fails_IsUpToDate_true_L1Contract_GER_exists",
+			getInfoByGERError:    fmt.Errorf("GER lookup failed"),
+			isUpToDateResult:     true,
+			isUpToDateError:      nil,
+			l1ContractTimestamp:  big.NewInt(1234567890), // timestamp > 0 means GER exists
+			l1ContractError:      nil,
+			expectError:          true,
+			expectedErrorMessage: "failed to fetch l1 info tree for global exit root",
+		},
+		// Note: Skipping the case where log.Fatalf is called as it would terminate the test process
+		// The case where L1 contract returns timestamp=0 is covered by integration tests
+		{
+			name:                 "GetInfoByGlobalExitRoot_fails_IsUpToDate_false_skips_L1Contract_call",
+			getInfoByGERError:    fmt.Errorf("GER lookup failed"),
+			isUpToDateResult:     false, // Set to false to avoid L1 contract call path
+			isUpToDateError:      nil,
+			l1ContractTimestamp:  nil,
+			l1ContractError:      nil,
 			expectError:          true,
 			expectedErrorMessage: "failed to fetch l1 info tree for global exit root",
 		},
@@ -292,6 +316,15 @@ func TestDownloaderSovereign_GetInfoByGlobalExitRootErrorHandlingInAppender(t *t
 			mockL1InfoTreeSync.EXPECT().GetInfoByGlobalExitRoot(testGER).Return(nil, tt.getInfoByGERError).Maybe()
 			mockL1InfoTreeSync.EXPECT().IsUpToDate(mock.Anything, mock.Anything).Return(tt.isUpToDateResult, tt.isUpToDateError).Maybe()
 
+			// Mock L1 client contract calls for test cases where isUpToDate is true
+			if tt.isUpToDateResult {
+				if tt.l1ContractTimestamp != nil {
+					callResult := make([]byte, 32)
+					tt.l1ContractTimestamp.FillBytes(callResult)
+					mockL1Client.EXPECT().CallContract(mock.Anything, mock.Anything, mock.Anything).Return(callResult, tt.l1ContractError).Maybe()
+				}
+			}
+
 			mockL2Client.EXPECT().FilterLogs(mock.Anything, mock.Anything).Return(testLogs, nil).Maybe()
 
 			downloader, err := newDownloaderSovereign(
@@ -324,6 +357,7 @@ func TestDownloaderSovereign_GetInfoByGlobalExitRootErrorHandlingInAppender(t *t
 			require.Contains(t, err.Error(), tt.expectedErrorMessage)
 
 			mockL2Client.AssertExpectations(t)
+			mockL1Client.AssertExpectations(t)
 			mockL1InfoTreeSync.AssertExpectations(t)
 		})
 	}

--- a/l2gersync/l2_ger_syncer.go
+++ b/l2gersync/l2_ger_syncer.go
@@ -84,7 +84,7 @@ func New(
 	case SovereignChain:
 		downloader, err = newDownloaderSovereign(
 			l2Client, cfg.GlobalExitRootL2Addr,
-			l1InfoTreeSync, l1Client,
+			l1InfoTreeSync, l1Client, cfg.GlobalExitRootL1Addr,
 			rh, cfg.BlockFinality, cfg.WaitForNewBlocksPeriod.Duration,
 			cfg.SyncBlockChunkSize,
 		)


### PR DESCRIPTION
## 🔄 Changes Summary
- While syncing L2GERSync, if a GER is not found in L1InfoTreeSync despite it being up to date, verify on the L1 contract whether the GER exists and treat it as a fatal error if the GER is also missing from the L1 contract

## 📋 Config Updates
- 🧾 Added `GlobalExitRootL1Addr` in `[L2GERSync]`

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

