### PR TITLE
feat: cherry-pick: check always last cert using the initial check  (#1262)

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -263,8 +263,12 @@ func (a *AggSender) sendCertificates(ctx context.Context, returnAfterNIterations
 			iteration++
 			a.log.Debugf("Checking perodical certificates status (%s)",
 				a.cfg.CheckCertConfigBriefString())
-			checkResult := a.certStatusChecker.CheckPendingCertificatesStatus(ctx)
-			if !checkResult.ExistPendingCerts && checkResult.ExistNewInErrorCert {
+
+			checkResult, err := a.certStatusChecker.CheckPeriodicallyStatus(ctx)
+			if err != nil {
+				a.status.SetLastError(err)
+				a.log.Errorf("error checking last certificate from agglayer: %v", err)
+			} else if !checkResult.ExistPendingCerts && checkResult.ExistNewInErrorCert {
 				if a.cfg.RetryCertAfterInError {
 					a.log.Infof("An InError cert exists. Sending a new one (%s)", a.cfg.CheckCertConfigBriefString())
 					_, err := a.sendCertificate(ctx)
@@ -277,6 +281,7 @@ func (a *AggSender) sendCertificates(ctx context.Context, returnAfterNIterations
 					a.log.Infof("An InError cert exists but skipping send cert because RetryCertAfterInError is false")
 				}
 			}
+
 			if returnAfterNIterations > 0 && iteration >= returnAfterNIterations {
 				a.log.Warnf("reached number of iterations, so we are going to return")
 				return
@@ -284,20 +289,25 @@ func (a *AggSender) sendCertificates(ctx context.Context, returnAfterNIterations
 		case epoch := <-chEpoch:
 			iteration++
 			a.log.Infof("Epoch received: %s", epoch.String())
-			checkResult := a.certStatusChecker.CheckPendingCertificatesStatus(ctx)
-			if !checkResult.ExistPendingCerts {
-				_, err := a.sendCertificateWithRetries(ctx)
-				if err != nil {
-					a.log.Errorf("error sending certificate: %v", err)
-					a.status.SetLastError(err)
-				}
+			checkResult, err := a.certStatusChecker.CheckPeriodicallyStatus(ctx)
+			if err != nil {
+				a.log.Errorf("Epoch trigger: error checking certificate status: %v", err)
+				a.status.SetLastError(err)
 			} else {
-				a.log.Infof("Skipping epoch %s because there are pending certificates",
-					epoch.String())
+				if !checkResult.ExistPendingCerts {
+					_, err := a.sendCertificateWithRetries(ctx)
+					if err != nil {
+						a.log.Errorf("Epoch trigger: error sending certificate: %v", err)
+						a.status.SetLastError(err)
+					}
+				} else {
+					a.log.Infof("Epoch trigger: Skipping epoch %s because there are pending certificates",
+						epoch.String())
+				}
 			}
 
 			if returnAfterNIterations > 0 && iteration >= returnAfterNIterations {
-				a.log.Warnf("reached number of iterations, so we are going to return")
+				a.log.Warnf("Epoch trigger: reached number of iterations, so we are going to return")
 				return
 			}
 		case <-ctx.Done():

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -557,7 +557,7 @@ func TestAggSenderStartFailsCompatibilityChecker(t *testing.T) {
 	}, "Expected panic when starting AggSender")
 }
 
-func TestSendCertificatesRetry(t *testing.T) {
+func TestRetrySendCertificates(t *testing.T) {
 	mockCertStatusChecker := mocks.NewCertificateStatusChecker(t)
 	mockEpochNotifier := mocks.NewEpochNotifier(t)
 	mockStorage := mocks.NewAggSenderStorage(t)
@@ -589,10 +589,10 @@ func TestSendCertificatesRetry(t *testing.T) {
 	chEpoch := make(chan aggsendertypes.EpochEvent)
 	mockEpochNotifier.EXPECT().Subscribe("aggsender").Return(chEpoch).Once()
 	expectedNumAttempts := 4
-	mockCertStatusChecker.EXPECT().CheckPendingCertificatesStatus(mock.Anything).Return(aggsendertypes.CertStatus{
+	mockCertStatusChecker.EXPECT().CheckPeriodicallyStatus(mock.Anything).Return(aggsendertypes.CertStatus{
 		ExistPendingCerts:   false,
 		ExistNewInErrorCert: false,
-	}).Times(2)
+	}, nil).Times(2)
 	mockEpochNotifier.EXPECT().GetEpochStatus().Return(aggsendertypes.EpochStatus{
 		Epoch:        123,
 		PercentEpoch: 0.2,
@@ -613,56 +613,71 @@ func TestSendCertificates(t *testing.T) {
 
 	tests := []struct {
 		name                    string
-		mockFn                  func(*mocks.CertificateStatusChecker, *mocks.EpochNotifier, *mocks.AggSenderStorage, *mocks.AggsenderBuilderFlow)
+		mockFn                  func(context.Context, *mocks.CertificateStatusChecker, *mocks.EpochNotifier, *mocks.AggSenderStorage, *mocks.AggsenderBuilderFlow)
 		returnAfterNIterations  int
 		certStatusCheckInterval time.Duration
+		needTimeoutCancel       bool
 	}{
 		{
+			name: "fails CheckPeriodicallyStatus",
+			mockFn: func(ctx context.Context, mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
+				chEpoch := make(chan aggsendertypes.EpochEvent, 1)
+				chEpoch <- aggsendertypes.EpochEvent{Epoch: 1}
+				mockEpochNotifier.EXPECT().Subscribe("aggsender").Return(chEpoch).Once()
+				mockCertStatusChecker.EXPECT().CheckPeriodicallyStatus(ctx).Return(aggsendertypes.CertStatus{}, errors.New("some error")).Once()
+			},
+			returnAfterNIterations: 1,
+		},
+		{
 			name: "context canceled",
-			mockFn: func(mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
+			mockFn: func(ctx context.Context, mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
 				mockEpochNotifier.EXPECT().Subscribe("aggsender").Return(make(chan aggsendertypes.EpochEvent)).Once()
 			},
 			returnAfterNIterations: 0,
+			needTimeoutCancel:      true,
 		},
 		{
 			name: "retry certificate after in-error",
-			mockFn: func(mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
-				mockCertStatusChecker.EXPECT().CheckPendingCertificatesStatus(mock.Anything).Return(aggsendertypes.CertStatus{
+			mockFn: func(ctx context.Context, mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
+				mockCertStatusChecker.EXPECT().CheckPeriodicallyStatus(mock.Anything).Return(aggsendertypes.CertStatus{
 					ExistPendingCerts:   false,
 					ExistNewInErrorCert: true,
-				}).Once()
+				}, nil).Once()
 				mockEpochNotifier.EXPECT().Subscribe("aggsender").Return(make(chan aggsendertypes.EpochEvent)).Once()
 				mockEpochNotifier.EXPECT().GetEpochStatus().Return(aggsendertypes.EpochStatus{}).Once()
 				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(nil, nil).Once()
 			},
 			returnAfterNIterations:  1,
 			certStatusCheckInterval: 100 * time.Millisecond,
+			needTimeoutCancel:       true,
 		},
 		{
 			name: "epoch received with no pending certificates",
-			mockFn: func(mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
+			mockFn: func(ctx context.Context, mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
 				chEpoch := make(chan aggsendertypes.EpochEvent, 1)
 				chEpoch <- aggsendertypes.EpochEvent{Epoch: 1}
 				mockEpochNotifier.EXPECT().Subscribe("aggsender").Return(chEpoch).Once()
 				mockEpochNotifier.EXPECT().GetEpochStatus().Return(aggsendertypes.EpochStatus{}).Once()
-				mockCertStatusChecker.EXPECT().CheckPendingCertificatesStatus(mock.Anything).Return(aggsendertypes.CertStatus{
+				mockCertStatusChecker.EXPECT().CheckPeriodicallyStatus(mock.Anything).Return(aggsendertypes.CertStatus{
 					ExistPendingCerts: false,
-				}).Once()
+				}, nil).Once()
 				mockFlow.EXPECT().GetCertificateBuildParams(mock.Anything).Return(nil, nil).Once()
 			},
 			returnAfterNIterations: 1,
+			needTimeoutCancel:      true,
 		},
 		{
 			name: "epoch received with pending certificates",
-			mockFn: func(mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
+			mockFn: func(ctx context.Context, mockCertStatusChecker *mocks.CertificateStatusChecker, mockEpochNotifier *mocks.EpochNotifier, mockStorage *mocks.AggSenderStorage, mockFlow *mocks.AggsenderBuilderFlow) {
 				chEpoch := make(chan aggsendertypes.EpochEvent, 1)
 				chEpoch <- aggsendertypes.EpochEvent{Epoch: 1}
 				mockEpochNotifier.EXPECT().Subscribe("aggsender").Return(chEpoch).Once()
-				mockCertStatusChecker.EXPECT().CheckPendingCertificatesStatus(mock.Anything).Return(aggsendertypes.CertStatus{
+				mockCertStatusChecker.EXPECT().CheckPeriodicallyStatus(mock.Anything).Return(aggsendertypes.CertStatus{
 					ExistPendingCerts: true,
-				}).Once()
+				}, nil).Once()
 			},
 			returnAfterNIterations: 1,
+			needTimeoutCancel:      true,
 		},
 	}
 
@@ -676,8 +691,6 @@ func TestSendCertificates(t *testing.T) {
 			mockEpochNotifier := mocks.NewEpochNotifier(t)
 			mockStorage := mocks.NewAggSenderStorage(t)
 			mockFlow := mocks.NewAggsenderBuilderFlow(t)
-
-			tt.mockFn(mockCertStatusChecker, mockEpochNotifier, mockStorage, mockFlow)
 
 			logger := log.WithFields("aggsender-test", tt.name)
 			aggSender := &AggSender{
@@ -695,11 +708,13 @@ func TestSendCertificates(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-
-			go func() {
-				time.Sleep(300 * time.Millisecond)
-				cancel()
-			}()
+			tt.mockFn(ctx, mockCertStatusChecker, mockEpochNotifier, mockStorage, mockFlow)
+			if tt.needTimeoutCancel {
+				go func() {
+					time.Sleep(300 * time.Millisecond)
+					cancel()
+				}()
+			}
 
 			aggSender.sendCertificates(ctx, tt.returnAfterNIterations)
 

--- a/aggsender/mocks/mock_certificate_status_checker.go
+++ b/aggsender/mocks/mock_certificate_status_checker.go
@@ -59,48 +59,58 @@ func (_c *CertificateStatusChecker_CheckInitialStatus_Call) RunAndReturn(run fun
 	return _c
 }
 
-// CheckPendingCertificatesStatus provides a mock function with given fields: ctx
-func (_m *CertificateStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) types.CertStatus {
+// CheckPeriodicallyStatus provides a mock function with given fields: ctx
+func (_m *CertificateStatusChecker) CheckPeriodicallyStatus(ctx context.Context) (types.CertStatus, error) {
 	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CheckPendingCertificatesStatus")
+		panic("no return value specified for CheckPeriodicallyStatus")
 	}
 
 	var r0 types.CertStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (types.CertStatus, error)); ok {
+		return rf(ctx)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context) types.CertStatus); ok {
 		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(types.CertStatus)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// CertificateStatusChecker_CheckPendingCertificatesStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckPendingCertificatesStatus'
-type CertificateStatusChecker_CheckPendingCertificatesStatus_Call struct {
+// CertificateStatusChecker_CheckPeriodicallyStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckPeriodicallyStatus'
+type CertificateStatusChecker_CheckPeriodicallyStatus_Call struct {
 	*mock.Call
 }
 
-// CheckPendingCertificatesStatus is a helper method to define mock.On call
+// CheckPeriodicallyStatus is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *CertificateStatusChecker_Expecter) CheckPendingCertificatesStatus(ctx interface{}) *CertificateStatusChecker_CheckPendingCertificatesStatus_Call {
-	return &CertificateStatusChecker_CheckPendingCertificatesStatus_Call{Call: _e.mock.On("CheckPendingCertificatesStatus", ctx)}
+func (_e *CertificateStatusChecker_Expecter) CheckPeriodicallyStatus(ctx interface{}) *CertificateStatusChecker_CheckPeriodicallyStatus_Call {
+	return &CertificateStatusChecker_CheckPeriodicallyStatus_Call{Call: _e.mock.On("CheckPeriodicallyStatus", ctx)}
 }
 
-func (_c *CertificateStatusChecker_CheckPendingCertificatesStatus_Call) Run(run func(ctx context.Context)) *CertificateStatusChecker_CheckPendingCertificatesStatus_Call {
+func (_c *CertificateStatusChecker_CheckPeriodicallyStatus_Call) Run(run func(ctx context.Context)) *CertificateStatusChecker_CheckPeriodicallyStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context))
 	})
 	return _c
 }
 
-func (_c *CertificateStatusChecker_CheckPendingCertificatesStatus_Call) Return(_a0 types.CertStatus) *CertificateStatusChecker_CheckPendingCertificatesStatus_Call {
-	_c.Call.Return(_a0)
+func (_c *CertificateStatusChecker_CheckPeriodicallyStatus_Call) Return(_a0 types.CertStatus, _a1 error) *CertificateStatusChecker_CheckPeriodicallyStatus_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *CertificateStatusChecker_CheckPendingCertificatesStatus_Call) RunAndReturn(run func(context.Context) types.CertStatus) *CertificateStatusChecker_CheckPendingCertificatesStatus_Call {
+func (_c *CertificateStatusChecker_CheckPeriodicallyStatus_Call) RunAndReturn(run func(context.Context) (types.CertStatus, error)) *CertificateStatusChecker_CheckPeriodicallyStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/statuschecker/cert_status_checker.go
+++ b/aggsender/statuschecker/cert_status_checker.go
@@ -83,7 +83,7 @@ func (c *certStatusChecker) CheckInitialStatus(
 	defer ticker.Stop()
 
 	for {
-		c.CheckPendingCertificatesStatus(ctx)
+		c.checkPendingCertificatesStatus(ctx)
 		err := c.checkLastCertificateFromAgglayer(ctx)
 		aggsenderStatus.SetLastError(err)
 		if err != nil {
@@ -100,11 +100,22 @@ func (c *certStatusChecker) CheckInitialStatus(
 	}
 }
 
-// CheckPendingCertificatesStatus checks the status of pending certificates
+// CheckPeriodicallyStatus checks the status of pending certificates
+// and the last certificate from the aggregation layer.
+// It returns the status of pending certificates and any error encountered
+// while checking the last certificate from the aggregation layer.
+func (c *certStatusChecker) CheckPeriodicallyStatus(
+	ctx context.Context,
+) (types.CertStatus, error) {
+	err := c.checkLastCertificateFromAgglayer(ctx)
+	return c.checkPendingCertificatesStatus(ctx), err
+}
+
+// checkPendingCertificatesStatus checks the status of pending certificates
 // and updates in the storage if it changed on agglayer
 // It returns:
 // bool -> if there are pending certificates
-func (c *certStatusChecker) CheckPendingCertificatesStatus(ctx context.Context) types.CertStatus {
+func (c *certStatusChecker) checkPendingCertificatesStatus(ctx context.Context) types.CertStatus {
 	pendingCertificates, err := c.storage.GetCertificateHeadersByStatus(agglayertypes.NonSettledStatuses)
 	if err != nil {
 		c.log.Errorf("error getting pending certificates: %w", err)

--- a/aggsender/statuschecker/cert_status_checker_test.go
+++ b/aggsender/statuschecker/cert_status_checker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/agglayer/aggkit/agglayer"
 	agglayermocks "github.com/agglayer/aggkit/agglayer/mocks"
@@ -117,10 +118,11 @@ func TestCheckIfCertificatesAreSettled(t *testing.T) {
 				mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			}
 
-			certStatusChecker := NewCertStatusChecker(mockLogger, mockStorage, mockAggLayerClient, nil, 1)
-
+			sut := NewCertStatusChecker(mockLogger, mockStorage, mockAggLayerClient, nil, 1)
+			certStatusChecker, ok := sut.(*certStatusChecker)
+			require.True(t, ok)
 			ctx := context.TODO()
-			checkResult := certStatusChecker.CheckPendingCertificatesStatus(ctx)
+			checkResult := certStatusChecker.checkPendingCertificatesStatus(ctx)
 			require.Equal(t, tt.expectedError, checkResult.ExistPendingCerts)
 			mockAggLayerClient.AssertExpectations(t)
 			mockStorage.AssertExpectations(t)
@@ -516,4 +518,102 @@ func TestCheckLastCertificateFromAgglayer(t *testing.T) {
 			mockAggLayerClient.AssertExpectations(t)
 		})
 	}
+}
+
+func TestCheckPeriodicallyStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		newInitialErr  error
+		processErr     error
+		action         *initialStatusResult
+		localCert      *types.CertificateHeader
+		agglayerCert   *agglayertypes.CertificateHeader
+		mockFn         func(m *mocks.AggSenderStorage)
+		expectedError  string
+		expectedStatus types.CertStatus
+	}{
+
+		{
+			name: "cert local InError, agglayer Settled",
+			localCert: &types.CertificateHeader{
+				CertificateID: common.HexToHash("0x1"),
+				Status:        agglayertypes.InError,
+			},
+			agglayerCert: &agglayertypes.CertificateHeader{
+				CertificateID: common.HexToHash("0x1"),
+				Status:        agglayertypes.Settled,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			mockLogger := log.WithFields("test", "unittest")
+			mockStorage := mocks.NewAggSenderStorage(t)
+			mockAggLayerClient := agglayermocks.NewAgglayerClientMock(t)
+			mockInitialStatus := &initialStatus{
+				log:                     mockLogger,
+				LocalLastCert:           tt.localCert,
+				AgglayerLastSettledCert: tt.agglayerCert,
+			}
+			newInitialStatusFn = func(_ context.Context,
+				_ types.Logger, _ uint32,
+				_ db.AggSenderStorage,
+				_ agglayer.AggLayerClientRecoveryQuerier) (*initialStatus, error) {
+				return mockInitialStatus, tt.newInitialErr
+			}
+
+			certStatusChecker := &certStatusChecker{
+				log:            mockLogger,
+				storage:        mockStorage,
+				agglayerClient: mockAggLayerClient,
+			}
+			mockStorage.EXPECT().GetCertificateHeadersByStatus(mock.Anything).Return(
+				[]*types.CertificateHeader{tt.localCert}, nil)
+			mockAggLayerClient.EXPECT().GetCertificateHeader(mock.Anything,
+				mock.Anything).Return(tt.agglayerCert, nil)
+			mockStorage.EXPECT().UpdateCertificateStatus(mock.Anything,
+				tt.localCert.CertificateID,
+				tt.agglayerCert.Status,
+				mock.Anything).Return(nil)
+			status, err := certStatusChecker.CheckPeriodicallyStatus(ctx)
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedStatus, status)
+			}
+
+			mockStorage.AssertExpectations(t)
+			mockAggLayerClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCheckInitialStatus(t *testing.T) {
+	ctx := t.Context()
+	mockLogger := log.WithFields("test", "unittest")
+	mockStorage := mocks.NewAggSenderStorage(t)
+	mockAggLayerClient := agglayermocks.NewAgglayerClientMock(t)
+
+	newInitialStatusFn = func(_ context.Context,
+		_ types.Logger, _ uint32,
+		_ db.AggSenderStorage,
+		_ agglayer.AggLayerClientRecoveryQuerier) (*initialStatus, error) {
+		return nil, fmt.Errorf("error")
+	}
+
+	certStatusChecker := &certStatusChecker{
+		log:            mockLogger,
+		storage:        mockStorage,
+		agglayerClient: mockAggLayerClient,
+	}
+	mockStorage.EXPECT().GetCertificateHeadersByStatus(mock.Anything).Return(
+		nil, fmt.Errorf("error"))
+	aggsenderStatus := &types.AggsenderStatus{}
+	ctx, cancel := context.WithTimeout(ctx, time.Millisecond*10)
+	defer cancel()
+	certStatusChecker.CheckInitialStatus(ctx, time.Millisecond, aggsenderStatus)
+	require.Equal(t, "recovery: error retrieving initial status: error", aggsenderStatus.LastError)
 }

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -174,7 +174,7 @@ type Logger interface {
 
 // CertificateStatusChecker is an interface defining functions that a CertificateStatusChecker should implement
 type CertificateStatusChecker interface {
-	CheckPendingCertificatesStatus(ctx context.Context) CertStatus
+	CheckPeriodicallyStatus(ctx context.Context) (CertStatus, error)
 	CheckInitialStatus(
 		ctx context.Context,
 		delayBetweenRetries time.Duration,


### PR DESCRIPTION
cherry-pick: #1262
## 🔄 Changes Summary
**Aggsender** test execute the same align code that at startup periodically to be aligned with **Agglayer**
This will allow to support the case that the last certificate `InError` is promoted manually to `Settled`

## 🐞 Issues
- Closes #1215

---------

## 🔄 Changes Summary
- [Brief description of what was added, fixed, or changed in this PR]

## ⚠️ Breaking Changes
- 🛠️ **Config**: [Optional: Changes to TOML config]
- 🔌 **API/CLI**: [Optional: Breaking interface changes]
- 🗑️ **Deprecated Features**: [Optional: Removed features]

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: [Optional: Enumerate config changes/provide snippet of changes]

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- #1262

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
