### PR TITLE
feat: remove caller address from claims

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@1dcc532c36997d2309930d268545309e1f0eb412
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
+      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@1dcc532c36997d2309930d268545309e1f0eb412
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412 # main
+      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@1dcc532c36997d2309930d268545309e1f0eb412
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
+      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@1dcc532c36997d2309930d268545309e1f0eb412
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
+      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@1dcc532c36997d2309930d268545309e1f0eb412
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
+      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@11d0a2722753c11b925d8c333373f789122651af
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@14122c958a3176212052e776830ab4a88a31e765
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
+      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@11d0a2722753c11b925d8c333373f789122651af
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@14122c958a3176212052e776830ab4a88a31e765
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af # main
+      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@11d0a2722753c11b925d8c333373f789122651af
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@14122c958a3176212052e776830ab4a88a31e765
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
+      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@11d0a2722753c11b925d8c333373f789122651af
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@14122c958a3176212052e776830ab4a88a31e765
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
+      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@11d0a2722753c11b925d8c333373f789122651af
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@14122c958a3176212052e776830ab4a88a31e765
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
+      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@11d0a2722753c11b925d8c333373f789122651af
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@11d0a2722753c11b925d8c333373f789122651af
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d # main
+      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@11d0a2722753c11b925d8c333373f789122651af
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@11d0a2722753c11b925d8c333373f789122651af
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@11d0a2722753c11b925d8c333373f789122651af
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
+      agglayer-e2e-ref: 11d0a2722753c11b925d8c333373f789122651af
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
+      agglayer-e2e-ref: e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6 # main
+      agglayer-e2e-ref: e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
+      agglayer-e2e-ref: e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
+      agglayer-e2e-ref: e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
+      agglayer-e2e-ref: e7d0c983e3db8e64ed23b4902d2f4a2567f0fa80
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="5bcd88d0695ee976cfb2bd059f08463f0a95cf9c"
+            COMMIT="065241eab7a30c615147a9b262343d27e6f4cb3b"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: ae92165db92fcda4dd6bab323ab2b7b8fe579d82 # main
+      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: ae92165db92fcda4dd6bab323ab2b7b8fe579d82
+      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@14122c958a3176212052e776830ab4a88a31e765
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@1dcc532c36997d2309930d268545309e1f0eb412
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
+      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@14122c958a3176212052e776830ab4a88a31e765
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@1dcc532c36997d2309930d268545309e1f0eb412
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765 # main
+      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@14122c958a3176212052e776830ab4a88a31e765
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@1dcc532c36997d2309930d268545309e1f0eb412
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
+      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@14122c958a3176212052e776830ab4a88a31e765
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@1dcc532c36997d2309930d268545309e1f0eb412
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
+      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@14122c958a3176212052e776830ab4a88a31e765
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@1dcc532c36997d2309930d268545309e1f0eb412
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 14122c958a3176212052e776830ab4a88a31e765
+      agglayer-e2e-ref: 1dcc532c36997d2309930d268545309e1f0eb412
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
+      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127 # main
+      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
+      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
+      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@bd3bb998afbd45ec12564d742691239b4d875ab6
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
+      agglayer-e2e-ref: bd3bb998afbd45ec12564d742691239b4d875ab6
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
+      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5 # main
+      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
+      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
+      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@817a3149311ad9144447a176d596f5ae2a11d3c5
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 817a3149311ad9144447a176d596f5ae2a11d3c5
+      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
+      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65 # main
+      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127 # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
+      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
+      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@06d0f106002d2d4c490360b4ee43eb9f35297c65
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@618235ab4cd00e6a6842019d04dfb91f0ead9127
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: 06d0f106002d2d4c490360b4ee43eb9f35297c65
+      agglayer-e2e-ref: 618235ab4cd00e6a6842019d04dfb91f0ead9127
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,11 +176,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
+      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-pessimistic }}
       test-name: "test-single-l2-network-op-pessimistic"
@@ -203,11 +203,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302 # main
+      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d # main
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct }}
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
@@ -230,12 +230,12 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-single-chain.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
     if: always() && github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
+      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
       kurtosis-cdk-enclave-name: op
       kurtosis-cdk-args: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-single-op-succinct-aggoracle-committee }}
       test-name: "test-single-l2-network-op-succinct-aggoracle-committee"
@@ -259,11 +259,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
+      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
       kurtosis-cdk-enclave-name: op
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-1 }}
@@ -285,11 +285,11 @@ jobs:
       - build-tools
       - read-aggkit-args
       - get-kurtosis-cdk-commit
-    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@b54c9393ac8f5820aab45c3edeb40a9495758302
+    uses: agglayer/e2e/.github/workflows/aggkit-e2e-multi-chains.yml@18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
     secrets: inherit
     with:
       kurtosis-cdk-ref: ${{ needs.get-kurtosis-cdk-commit.outputs.kurtosis-commit }}
-      agglayer-e2e-ref: b54c9393ac8f5820aab45c3edeb40a9495758302
+      agglayer-e2e-ref: 18c7017dfc38bf3bc9d72138e6d603ead2e50f9d
       kurtosis-cdk-enclave-name: aggkit
       aggsender-find-imported-bridge-artifact: aggsender_find_imported_bridge
       kurtosis-cdk-args-1: ${{ needs.read-aggkit-args.outputs.kurtosis-cdk-args-3 }}

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -345,7 +345,6 @@ func (b *BridgeService) GetBridgesHandler(c *gin.Context) {
 		count   int
 	)
 
-	//nolint:dupl
 	switch networkID {
 	case mainnetNetworkID:
 		if b.bridgeL1 == nil {
@@ -407,7 +406,6 @@ func (b *BridgeService) GetBridgesHandler(c *gin.Context) {
 // @Param page_number query uint32 false "Page number (default 1)"
 // @Param page_size query uint32 false "Page size (default 100)"
 // @Param network_ids query []uint32 false "Filter by one or more source network IDs (maximum 5 allowed)"
-// @Param from_address query string false "Filter by from address"
 // @Param include_all_fields query bool false "Whether to include full response fields (default false)"
 // @Param global_index query uint32 false "Filter by global index"
 // @Produce json
@@ -442,8 +440,6 @@ func (b *BridgeService) GetClaimsHandler(c *gin.Context) {
 		c.JSON(statusCode, gin.H{"error": fmt.Sprintf("invalid %s parameter: %s", networkIDsParam, err)})
 		return
 	}
-
-	fromAddress := c.Query(fromAddressParam)
 
 	// Parse include_all_fields parameter (default to false)
 	includeAllFieldsFlag := false
@@ -484,15 +480,14 @@ func (b *BridgeService) GetClaimsHandler(c *gin.Context) {
 
 	b.logger.Debugf(
 		"fetching claims (network id=%d, page=%d, size=%d, "+
-			"network_ids=%v, from_address=%s, include_all_fields=%t, global_index=%d)",
-		networkID, pageNumber, pageSize, networkIDs, fromAddress, includeAllFieldsFlag, globalIndex)
+			"network_ids=%v, include_all_fields=%t, global_index=%d)",
+		networkID, pageNumber, pageSize, networkIDs, includeAllFieldsFlag, globalIndex)
 
 	var (
 		claims []*bridgesync.Claim
 		count  int
 	)
 
-	//nolint:dupl
 	switch networkID {
 	case mainnetNetworkID:
 		if b.bridgeL1 == nil {
@@ -502,7 +497,7 @@ func (b *BridgeService) GetClaimsHandler(c *gin.Context) {
 			return
 		}
 
-		claims, count, err = b.bridgeL1.GetClaimsPaged(ctx, pageNumber, pageSize, networkIDs, fromAddress, globalIndex)
+		claims, count, err = b.bridgeL1.GetClaimsPaged(ctx, pageNumber, pageSize, networkIDs, globalIndex)
 		if err != nil {
 			b.logger.Warnf("failed to get claims for L1 network: %v", err)
 			statusCode = http.StatusInternalServerError
@@ -518,7 +513,7 @@ func (b *BridgeService) GetClaimsHandler(c *gin.Context) {
 			return
 		}
 
-		claims, count, err = b.bridgeL2.GetClaimsPaged(ctx, pageNumber, pageSize, networkIDs, fromAddress, globalIndex)
+		claims, count, err = b.bridgeL2.GetClaimsPaged(ctx, pageNumber, pageSize, networkIDs, globalIndex)
 		if err != nil {
 			b.logger.Warnf("failed to get claims for L2 network (ID=%d): %v", networkID, err)
 			statusCode = http.StatusInternalServerError

--- a/bridgeservice/bridge_interfaces.go
+++ b/bridgeservice/bridge_interfaces.go
@@ -22,7 +22,7 @@ type Bridger interface {
 	GetLegacyTokenMigrations(ctx context.Context,
 		pageNumber, pageSize uint32) ([]*bridgesync.LegacyTokenMigration, int, error)
 	GetClaimsPaged(ctx context.Context, page, pageSize uint32,
-		networkIDs []uint32, fromAddress string, globalIndex *big.Int) ([]*bridgesync.Claim, int, error)
+		networkIDs []uint32, globalIndex *big.Int) ([]*bridgesync.Claim, int, error)
 	GetLastReorgEvent(ctx context.Context) (*bridgesync.LastReorg, error)
 	GetContractDepositCount(ctx context.Context) (uint32, error)
 	GetLastProcessedBlock(ctx context.Context) (uint64, error)

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -775,7 +775,7 @@ func TestGetClaimsHandler(t *testing.T) {
 		})
 
 		bridgeMocks.bridgeL1.EXPECT().
-			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
 
 		queryParams := url.Values{
@@ -818,7 +818,7 @@ func TestGetClaimsHandler(t *testing.T) {
 
 		bridgeMocks.bridge.networkID = 10
 		bridgeMocks.bridgeL2.EXPECT().
-			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
 
 		query := url.Values{}
@@ -851,7 +851,7 @@ func TestGetClaimsHandler(t *testing.T) {
 	t.Run("GetClaims for L1 network failed", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 		bridgeMocks.bridgeL1.EXPECT().
-			GetClaimsPaged(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, 0, errors.New(fooErrMsg))
 
 		query := url.Values{}
@@ -867,7 +867,7 @@ func TestGetClaimsHandler(t *testing.T) {
 	t.Run("GetClaims for L2 network failed", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 		bridgeMocks.bridgeL2.EXPECT().
-			GetClaimsPaged(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, 0, errors.New(barErrMsg))
 
 		query := url.Values{}
@@ -970,7 +970,7 @@ func TestGetClaimsHandler(t *testing.T) {
 		})
 
 		bridgeMocks.bridgeL1.EXPECT().
-			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
 
 		queryParams := url.Values{
@@ -1043,7 +1043,7 @@ func TestGetClaimsHandler(t *testing.T) {
 
 		bridgeMocks.bridge.networkID = 10
 		bridgeMocks.bridgeL2.EXPECT().
-			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
 
 		query := url.Values{}
@@ -1114,7 +1114,7 @@ func TestGetClaimsHandler(t *testing.T) {
 		})
 
 		bridgeMocks.bridgeL1.EXPECT().
-			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything, mock.Anything).
+			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
 
 		queryParams := url.Values{

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -219,12 +219,6 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "string",
-                        "description": "Filter by from address",
-                        "name": "from_address",
-                        "in": "query"
-                    },
-                    {
                         "type": "boolean",
                         "description": "Whether to include full response fields (default false)",
                         "name": "include_all_fields",

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -212,12 +212,6 @@
                         "in": "query"
                     },
                     {
-                        "type": "string",
-                        "description": "Filter by from address",
-                        "name": "from_address",
-                        "in": "query"
-                    },
-                    {
                         "type": "boolean",
                         "description": "Whether to include full response fields (default false)",
                         "name": "include_all_fields",

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -548,10 +548,6 @@ paths:
           type: integer
         name: network_ids
         type: array
-      - description: Filter by from address
-        in: query
-        name: from_address
-        type: string
       - description: Whether to include full response fields (default false)
         in: query
         name: include_all_fields

--- a/bridgeservice/mocks/mock_bridger.go
+++ b/bridgeservice/mocks/mock_bridger.go
@@ -99,9 +99,9 @@ func (_c *Bridger_GetBridgesPaged_Call) RunAndReturn(run func(context.Context, u
 	return _c
 }
 
-// GetClaimsPaged provides a mock function with given fields: ctx, page, pageSize, networkIDs, fromAddress, globalIndex
-func (_m *Bridger) GetClaimsPaged(ctx context.Context, page uint32, pageSize uint32, networkIDs []uint32, fromAddress string, globalIndex *big.Int) ([]*bridgesync.Claim, int, error) {
-	ret := _m.Called(ctx, page, pageSize, networkIDs, fromAddress, globalIndex)
+// GetClaimsPaged provides a mock function with given fields: ctx, page, pageSize, networkIDs, globalIndex
+func (_m *Bridger) GetClaimsPaged(ctx context.Context, page uint32, pageSize uint32, networkIDs []uint32, globalIndex *big.Int) ([]*bridgesync.Claim, int, error) {
+	ret := _m.Called(ctx, page, pageSize, networkIDs, globalIndex)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetClaimsPaged")
@@ -110,25 +110,25 @@ func (_m *Bridger) GetClaimsPaged(ctx context.Context, page uint32, pageSize uin
 	var r0 []*bridgesync.Claim
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, []uint32, string, *big.Int) ([]*bridgesync.Claim, int, error)); ok {
-		return rf(ctx, page, pageSize, networkIDs, fromAddress, globalIndex)
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, []uint32, *big.Int) ([]*bridgesync.Claim, int, error)); ok {
+		return rf(ctx, page, pageSize, networkIDs, globalIndex)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, []uint32, string, *big.Int) []*bridgesync.Claim); ok {
-		r0 = rf(ctx, page, pageSize, networkIDs, fromAddress, globalIndex)
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, []uint32, *big.Int) []*bridgesync.Claim); ok {
+		r0 = rf(ctx, page, pageSize, networkIDs, globalIndex)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*bridgesync.Claim)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32, []uint32, string, *big.Int) int); ok {
-		r1 = rf(ctx, page, pageSize, networkIDs, fromAddress, globalIndex)
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32, []uint32, *big.Int) int); ok {
+		r1 = rf(ctx, page, pageSize, networkIDs, globalIndex)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, uint32, uint32, []uint32, string, *big.Int) error); ok {
-		r2 = rf(ctx, page, pageSize, networkIDs, fromAddress, globalIndex)
+	if rf, ok := ret.Get(2).(func(context.Context, uint32, uint32, []uint32, *big.Int) error); ok {
+		r2 = rf(ctx, page, pageSize, networkIDs, globalIndex)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -146,15 +146,14 @@ type Bridger_GetClaimsPaged_Call struct {
 //   - page uint32
 //   - pageSize uint32
 //   - networkIDs []uint32
-//   - fromAddress string
 //   - globalIndex *big.Int
-func (_e *Bridger_Expecter) GetClaimsPaged(ctx interface{}, page interface{}, pageSize interface{}, networkIDs interface{}, fromAddress interface{}, globalIndex interface{}) *Bridger_GetClaimsPaged_Call {
-	return &Bridger_GetClaimsPaged_Call{Call: _e.mock.On("GetClaimsPaged", ctx, page, pageSize, networkIDs, fromAddress, globalIndex)}
+func (_e *Bridger_Expecter) GetClaimsPaged(ctx interface{}, page interface{}, pageSize interface{}, networkIDs interface{}, globalIndex interface{}) *Bridger_GetClaimsPaged_Call {
+	return &Bridger_GetClaimsPaged_Call{Call: _e.mock.On("GetClaimsPaged", ctx, page, pageSize, networkIDs, globalIndex)}
 }
 
-func (_c *Bridger_GetClaimsPaged_Call) Run(run func(ctx context.Context, page uint32, pageSize uint32, networkIDs []uint32, fromAddress string, globalIndex *big.Int)) *Bridger_GetClaimsPaged_Call {
+func (_c *Bridger_GetClaimsPaged_Call) Run(run func(ctx context.Context, page uint32, pageSize uint32, networkIDs []uint32, globalIndex *big.Int)) *Bridger_GetClaimsPaged_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint32), args[2].(uint32), args[3].([]uint32), args[4].(string), args[5].(*big.Int))
+		run(args[0].(context.Context), args[1].(uint32), args[2].(uint32), args[3].([]uint32), args[4].(*big.Int))
 	})
 	return _c
 }
@@ -164,7 +163,7 @@ func (_c *Bridger_GetClaimsPaged_Call) Return(_a0 []*bridgesync.Claim, _a1 int, 
 	return _c
 }
 
-func (_c *Bridger_GetClaimsPaged_Call) RunAndReturn(run func(context.Context, uint32, uint32, []uint32, string, *big.Int) ([]*bridgesync.Claim, int, error)) *Bridger_GetClaimsPaged_Call {
+func (_c *Bridger_GetClaimsPaged_Call) RunAndReturn(run func(context.Context, uint32, uint32, []uint32, *big.Int) ([]*bridgesync.Claim, int, error)) *Bridger_GetClaimsPaged_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/bridgeservice/utils.go
+++ b/bridgeservice/utils.go
@@ -144,7 +144,6 @@ func NewClaimResponse(claim *bridgesync.Claim, populateProofs bool) *bridgetypes
 		TxHash:             bridgetypes.Hash(claim.TxHash.Hex()),
 		Amount:             bridgetypes.BigIntString(claim.Amount.String()),
 		BlockNum:           claim.BlockNum,
-		FromAddress:        bridgetypes.Address(claim.FromAddress.Hex()),
 		DestinationAddress: bridgetypes.Address(claim.DestinationAddress.Hex()),
 		OriginAddress:      bridgetypes.Address(claim.OriginAddress.Hex()),
 		OriginNetwork:      claim.OriginNetwork,

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -68,14 +68,13 @@ func TestBackfillTxnSender(t *testing.T) {
 			block_num, block_pos, global_index, origin_network, origin_address,
 			destination_address, amount, proof_local_exit_root, proof_rollup_exit_root,
 			mainnet_exit_root, rollup_exit_root, global_exit_root, destination_network,
-			metadata, is_message, block_timestamp, tx_hash, from_address
+			metadata, is_message, block_timestamp, tx_hash
 		) VALUES (
 			1, 1, '1', 1, '0x1234567890123456789012345678901234567890',
 			'0x0987654321098765432109876543210987654321', '1000000000000000000',
 			'', '', '', '', '', 2,
 			'', false, 1234567890,
-			'0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			'0x2222222222222222222222222222222222222222'
+			'0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
 		)
 	`)
 	require.NoError(t, err)

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -320,12 +320,12 @@ func (s *BridgeSync) GetBridgesPaged(
 
 func (s *BridgeSync) GetClaimsPaged(
 	ctx context.Context,
-	page, pageSize uint32, networkIDs []uint32, fromAddress string, globalIndex *big.Int) ([]*Claim, int, error) {
+	page, pageSize uint32, networkIDs []uint32, globalIndex *big.Int) ([]*Claim, int, error) {
 	if s.processor.isHalted() {
 		s.processor.log.Error("processor is halted, cannot get claims")
 		return nil, 0, sync.ErrInconsistentState
 	}
-	return s.processor.GetClaimsPaged(ctx, page, pageSize, networkIDs, fromAddress, globalIndex)
+	return s.processor.GetClaimsPaged(ctx, page, pageSize, networkIDs, globalIndex)
 }
 
 func (s *BridgeSync) GetLastProcessedBlock(ctx context.Context) (uint64, error) {

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -607,7 +607,7 @@ func TestGetClaimPaged(t *testing.T) {
 		halted: true,
 		log:    log.WithFields("module", "L2BridgeSyncer"),
 	}}
-	_, _, err := s.GetClaimsPaged(context.Background(), 0, 0, nil, "", nil)
+	_, _, err := s.GetClaimsPaged(context.Background(), 0, 0, nil, nil)
 	require.ErrorIs(t, err, sync.ErrInconsistentState)
 }
 

--- a/bridgesync/claimcalldata_test.go
+++ b/bridgesync/claimcalldata_test.go
@@ -36,7 +36,7 @@ func TestClaimCalldata(t *testing.T) {
 	require.NoError(t, err)
 	claimCallerAddr, _, claimCaller, err := claimmockcaller.DeployClaimmockcaller(auth, client, bridgeAddr)
 	require.NoError(t, err)
-	claimTestAddr, _, claimTest, err := claimmocktest.DeployClaimmocktest(auth, client, bridgeAddr, claimCallerAddr)
+	_, _, claimTest, err := claimmocktest.DeployClaimmocktest(auth, client, bridgeAddr, claimCallerAddr)
 	require.NoError(t, err)
 
 	proofLocal := [tree.DefaultHeight][common.HashLength]byte{}
@@ -59,7 +59,6 @@ func TestClaimCalldata(t *testing.T) {
 		DestinationNetwork:  0,
 		Metadata:            []byte{},
 		GlobalExitRoot:      crypto.Keccak256Hash(common.HexToHash("5ca1e").Bytes(), common.HexToHash("dead").Bytes()),
-		FromAddress:         auth.From,
 	}
 	expectedClaim2 := Claim{
 		OriginNetwork:       87,
@@ -73,7 +72,6 @@ func TestClaimCalldata(t *testing.T) {
 		DestinationNetwork:  0,
 		Metadata:            []byte{},
 		GlobalExitRoot:      crypto.Keccak256Hash(common.HexToHash("5ca1e").Bytes(), common.HexToHash("dead").Bytes()),
-		FromAddress:         auth.From,
 	}
 	expectedClaim3 := Claim{
 		OriginNetwork:       69,
@@ -87,7 +85,6 @@ func TestClaimCalldata(t *testing.T) {
 		DestinationNetwork:  0,
 		Metadata:            []byte{},
 		GlobalExitRoot:      crypto.Keccak256Hash(common.HexToHash("5ca1e").Bytes(), common.HexToHash("dead").Bytes()),
-		FromAddress:         auth.From,
 	}
 	auth.GasLimit = 999999 // for some reason gas estimation fails :(
 
@@ -125,7 +122,6 @@ func TestClaimCalldata(t *testing.T) {
 	// indirect call claim asset
 	expectedClaim.IsMessage = false
 	expectedClaim.GlobalIndex = big.NewInt(422)
-	expectedClaim.FromAddress = claimCallerAddr
 	tx, err = claimCaller.ClaimAsset(
 		auth,
 		proofLocal,
@@ -176,7 +172,6 @@ func TestClaimCalldata(t *testing.T) {
 	// direct call claim message
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(424)
-	expectedClaim.FromAddress = auth.From
 	tx, err = bridgeContract.ClaimMessage(
 		auth,
 		proofLocal,
@@ -205,7 +200,6 @@ func TestClaimCalldata(t *testing.T) {
 	// indirect call claim message
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(425)
-	expectedClaim.FromAddress = claimCallerAddr
 	tx, err = claimCaller.ClaimMessage(
 		auth,
 		proofLocal,
@@ -272,7 +266,6 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
-	expectedClaim2.FromAddress = claimCallerAddr
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err := encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -678,7 +671,6 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim2.GlobalIndex = big.NewInt(427)
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
-	expectedClaim3.FromAddress = claimCallerAddr
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -720,10 +712,8 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
-	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
-	expectedClaim3.FromAddress = claimCallerAddr
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
 	require.NoError(t, err)
 	expectedClaimBytes2, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim2, proofLocal, proofRollup)
@@ -767,7 +757,6 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
-	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -848,7 +837,6 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(428)
-	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(429)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -888,7 +876,6 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
-	expectedClaim2.FromAddress = claimCallerAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -965,10 +952,8 @@ func TestClaimCalldata(t *testing.T) {
 	// 1 ok 1 ok 1 ko (indirectx2, indirect, indirectx2) call claim message (same global index)
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(427)
-	expectedClaim.FromAddress = claimTestAddr
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
-	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -1039,7 +1024,6 @@ func TestClaimCalldata(t *testing.T) {
 	// 1 ok 2 ko (indirectx2, indirect, indirectx2) call claim message (same global index)
 	expectedClaim.IsMessage = true
 	expectedClaim.GlobalIndex = big.NewInt(427)
-	expectedClaim.FromAddress = claimCallerAddr
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
 	expectedClaim3.IsMessage = true
@@ -1075,7 +1059,6 @@ func TestClaimCalldata(t *testing.T) {
 	expectedClaim.GlobalIndex = big.NewInt(427)
 	expectedClaim2.IsMessage = true
 	expectedClaim2.GlobalIndex = big.NewInt(427)
-	expectedClaim2.FromAddress = claimTestAddr
 	expectedClaim3.IsMessage = true
 	expectedClaim3.GlobalIndex = big.NewInt(427)
 	expectedClaimBytes, err = encodeClaimCalldata(abi, "claimMessage", expectedClaim, proofLocal, proofRollup)
@@ -1123,7 +1106,6 @@ func TestClaimCalldata(t *testing.T) {
 			err = actualClaim.setClaimCalldataFromRoot(rootCall, bridgeAddr, logger)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedClaim, actualClaim)
-			require.Equal(t, tc.expectedClaim.FromAddress, actualClaim.FromAddress)
 		})
 	}
 }

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -467,7 +467,7 @@ func (c *Claim) setClaimCalldataFromRoot(
 			if call.Err != nil {
 				return false, nil
 			}
-			return c.tryDecodeClaimCalldata(call.From, call.Input, logger)
+			return c.tryDecodeClaimCalldata(call.Input, logger)
 		}, logger)
 
 	return err
@@ -477,7 +477,7 @@ func (c *Claim) setClaimCalldataFromRoot(
 // It checks if the method ID corresponds to either the claim asset or claim message methods.
 // If a match is found, it decodes the calldata using the ABI of the bridge contract and updates the claim object.
 // Returns true if the calldata is successfully decoded and matches the expected format, otherwise returns false.
-func (c *Claim) tryDecodeClaimCalldata(senderAddr common.Address, input []byte, logger *logger.Logger) (bool, error) {
+func (c *Claim) tryDecodeClaimCalldata(input []byte, logger *logger.Logger) (bool, error) {
 	if len(input) < methodIDLength {
 		return false, fmt.Errorf("input too short: %d bytes", len(input))
 	}
@@ -501,7 +501,7 @@ func (c *Claim) tryDecodeClaimCalldata(senderAddr common.Address, input []byte, 
 			return false, err
 		}
 
-		found, err := c.decodeEtrogCalldata(senderAddr, data)
+		found, err := c.decodeEtrogCalldata(data)
 		if err != nil {
 			return false, err
 		}
@@ -531,7 +531,7 @@ func (c *Claim) tryDecodeClaimCalldata(senderAddr common.Address, input []byte, 
 			return false, err
 		}
 
-		found, err := c.decodePreEtrogCalldata(senderAddr, data)
+		found, err := c.decodePreEtrogCalldata(data)
 		if err != nil {
 			return false, err
 		}

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -474,11 +474,10 @@ func TestFindCallWithOnlyUnrecognizedMethods(t *testing.T) {
 
 func TestTryDecodeClaimCalldata(t *testing.T) {
 	c := &Claim{}
-	fromAddr := common.HexToAddress("0x20")
 	logger := logger.WithFields("module", "test")
 
 	// Short input should return false, error
-	found, err := c.tryDecodeClaimCalldata(fromAddr, []byte{0x01, 0x02, 0x03}, logger)
+	found, err := c.tryDecodeClaimCalldata([]byte{0x01, 0x02, 0x03}, logger)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "input too short: 3 bytes")
 	require.False(t, found)
@@ -486,20 +485,20 @@ func TestTryDecodeClaimCalldata(t *testing.T) {
 	// Unknown method ID should return false, nil (not error anymore)
 	input := make([]byte, methodIDLength)
 	copy(input, []byte{0xaa, 0xbb, 0xcc, 0xdd})
-	found, err = c.tryDecodeClaimCalldata(fromAddr, input, logger)
+	found, err = c.tryDecodeClaimCalldata(input, logger)
 	require.NoError(t, err) // Should not return error anymore
 	require.False(t, found)
 
 	// Test getProxiedTokensManager method ID (38b8fbbb)
 	getProxiedTokensManagerID := []byte{0x38, 0xb8, 0xfb, 0xbb}
-	found, err = c.tryDecodeClaimCalldata(fromAddr, getProxiedTokensManagerID, logger)
+	found, err = c.tryDecodeClaimCalldata(getProxiedTokensManagerID, logger)
 	require.NoError(t, err) // Should not return error
 	require.False(t, found) // Should return false (not a claim method)
 
 	// Valid method ID (simulate claimAssetEtrogMethodID)
 	copy(input, claimAssetEtrogMethodID)
 	// The rest of the input is not valid ABI, so it will error on unpack
-	found, err = c.tryDecodeClaimCalldata(fromAddr, input, logger)
+	found, err = c.tryDecodeClaimCalldata(input, logger)
 	require.Error(t, err)
 	require.False(t, found)
 }

--- a/bridgesync/migrations/bridgesync0010.sql
+++ b/bridgesync/migrations/bridgesync0010.sql
@@ -1,5 +1,5 @@
 -- +migrate Down
-ALTER TABLE bridge ADD COLUMN from_address VARCHAR;
+ALTER TABLE claim ADD COLUMN from_address VARCHAR;
 
 -- +migrate Up
 ALTER TABLE claim DROP COLUMN from_address;

--- a/bridgesync/migrations/bridgesync0010.sql
+++ b/bridgesync/migrations/bridgesync0010.sql
@@ -1,0 +1,5 @@
+-- +migrate Down
+ALTER TABLE bridge ADD COLUMN from_address VARCHAR;
+
+-- +migrate Up
+ALTER TABLE claim DROP COLUMN from_address;

--- a/bridgesync/migrations/migrations.go
+++ b/bridgesync/migrations/migrations.go
@@ -35,6 +35,9 @@ var mig0008 string
 //go:embed bridgesync0009.sql
 var mig0009 string
 
+//go:embed bridgesync0010.sql
+var mig0010 string
+
 func RunMigrations(dbPath string) error {
 	migrations := []types.Migration{
 		{
@@ -72,6 +75,10 @@ func RunMigrations(dbPath string) error {
 		{
 			ID:  "bridgesync0009",
 			SQL: mig0009,
+		},
+		{
+			ID:  "bridgesync0010",
+			SQL: mig0010,
 		},
 	}
 	migrations = append(migrations, treeMigrations.Migrations...)

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -124,9 +124,8 @@ func TestMigration0002(t *testing.T) {
 			metadata,
 			is_message,
 			block_timestamp,
-			tx_hash,
-			from_address
-		) VALUES (1, 0, 0, 0, '0x3', '0x0000', 0, 0, NULL, FALSE, 1739270804, '0xabcd', '0x123');
+			tx_hash
+		) VALUES (1, 0, 0, 0, '0x3', '0x0000', 0, 0, NULL, FALSE, 1739270804, '0xabcd');
 	`)
 	require.NoError(t, err)
 	err = tx.Commit()
@@ -194,7 +193,6 @@ func TestMigration0002(t *testing.T) {
 		IsMessage          bool     `meddler:"is_message"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
-		FromAddress        string   `meddler:"from_address"`
 	}
 
 	err = meddler.QueryRow(db, &claim,
@@ -202,7 +200,6 @@ func TestMigration0002(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, claim)
 	require.Equal(t, uint64(1739270804), claim.BlockTimestamp)
-	require.Equal(t, "0x123", claim.FromAddress)
 }
 
 func TestMigrations0003(t *testing.T) {

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -576,9 +576,9 @@ func (p *processor) GetClaimsPaged(
 }
 
 // buildClaimsFilterClause builds the WHERE clause for the claims table
-// based on the provided networkIDs, fromAddress and globalIndex
+// based on the provided networkIDs and globalIndex
 func (p *processor) buildClaimsFilterClause(networkIDs []uint32, globalIndex *big.Int) string {
-	const clauseCapacity = 3
+	const clauseCapacity = 2
 	clauses := make([]string, 0, clauseCapacity)
 	if len(networkIDs) > 0 {
 		clauses = append(clauses, buildNetworkIDsFilter(networkIDs, "origin_network"))

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -111,7 +111,6 @@ func (b *Bridge) Hash() common.Hash {
 type Claim struct {
 	BlockNum            uint64         `meddler:"block_num"`
 	BlockPos            uint64         `meddler:"block_pos"`
-	FromAddress         common.Address `meddler:"from_address,address"`
 	TxHash              common.Hash    `meddler:"tx_hash,hash"`
 	GlobalIndex         *big.Int       `meddler:"global_index,bigint"`
 	OriginNetwork       uint32         `meddler:"origin_network"`
@@ -130,7 +129,7 @@ type Claim struct {
 }
 
 // decodeEtrogCalldata decodes claim calldata for Etrog fork
-func (c *Claim) decodeEtrogCalldata(senderAddr common.Address, data []any) (bool, error) {
+func (c *Claim) decodeEtrogCalldata(data []any) (bool, error) {
 	// Unpack method inputs. Note that both claimAsset and claimMessage have the same interface
 	// for the relevant parts
 	// claimAsset/claimMessage(
@@ -190,13 +189,12 @@ func (c *Claim) decodeEtrogCalldata(senderAddr common.Address, data []any) (bool
 	}
 
 	c.GlobalExitRoot = crypto.Keccak256Hash(c.MainnetExitRoot.Bytes(), c.RollupExitRoot.Bytes())
-	c.FromAddress = senderAddr
 
 	return true, nil
 }
 
 // decodePreEtrogCalldata decodes the claim calldata for pre-Etrog forks
-func (c *Claim) decodePreEtrogCalldata(senderAddr common.Address, data []any) (bool, error) {
+func (c *Claim) decodePreEtrogCalldata(data []any) (bool, error) {
 	// claimMessage/claimAsset(
 	// 	0: bytes32[32] smtProof,
 	// 	1: uint32 index,
@@ -247,7 +245,6 @@ func (c *Claim) decodePreEtrogCalldata(senderAddr common.Address, data []any) (b
 	}
 
 	c.GlobalExitRoot = crypto.Keccak256Hash(c.MainnetExitRoot.Bytes(), c.RollupExitRoot.Bytes())
-	c.FromAddress = senderAddr
 
 	return true, nil
 }
@@ -534,9 +531,9 @@ func (p *processor) buildBridgesFilterClause(depositCount *uint64, networkIDs []
 
 func (p *processor) GetClaimsPaged(
 	ctx context.Context, pageNumber, pageSize uint32,
-	networkIDs []uint32, fromAddress string, globalIndex *big.Int,
+	networkIDs []uint32, globalIndex *big.Int,
 ) ([]*Claim, int, error) {
-	whereClause := p.buildClaimsFilterClause(networkIDs, fromAddress, globalIndex)
+	whereClause := p.buildClaimsFilterClause(networkIDs, globalIndex)
 	claimsCount, err := p.GetTotalNumberOfRecords(ctx, claimTableName, whereClause)
 	if err != nil {
 		return nil, 0, err
@@ -580,15 +577,11 @@ func (p *processor) GetClaimsPaged(
 
 // buildClaimsFilterClause builds the WHERE clause for the claims table
 // based on the provided networkIDs, fromAddress and globalIndex
-func (p *processor) buildClaimsFilterClause(networkIDs []uint32, fromAddress string, globalIndex *big.Int) string {
+func (p *processor) buildClaimsFilterClause(networkIDs []uint32, globalIndex *big.Int) string {
 	const clauseCapacity = 3
 	clauses := make([]string, 0, clauseCapacity)
 	if len(networkIDs) > 0 {
 		clauses = append(clauses, buildNetworkIDsFilter(networkIDs, "origin_network"))
-	}
-
-	if fromAddress != "" && common.IsHexAddress(fromAddress) {
-		clauses = append(clauses, fmt.Sprintf("UPPER(from_address) LIKE '%s'", fromAddress))
 	}
 
 	if globalIndex != nil {

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1246,12 +1246,12 @@ func TestGetClaimsPaged(t *testing.T) {
 	num2.SetString("18446744073709551618", 10)
 
 	claims := []*Claim{
-		{BlockNum: 1, GlobalIndex: num2, Amount: big.NewInt(1), OriginNetwork: 1, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970"), MainnetExitRoot: common.Hash{}},
-		{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1), OriginNetwork: 1, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970"), MainnetExitRoot: common.Hash{}},
-		{BlockNum: 3, GlobalIndex: uint64Max, Amount: big.NewInt(1), OriginNetwork: 2, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970"), MainnetExitRoot: common.Hash{}},
-		{BlockNum: 4, GlobalIndex: num1, Amount: big.NewInt(1), OriginNetwork: 2, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970"), MainnetExitRoot: common.Hash{}},
-		{BlockNum: 5, GlobalIndex: big.NewInt(5), Amount: big.NewInt(1), OriginNetwork: 3, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970"), MainnetExitRoot: common.Hash{}},
-		{BlockNum: 6, GlobalIndex: uint256Max, Amount: big.NewInt(1), OriginNetwork: 4, FromAddress: common.HexToAddress("0xd34aaF64b29273B7D567FCFc40544c014EEe9970"), MainnetExitRoot: common.Hash{}},
+		{BlockNum: 1, GlobalIndex: num2, Amount: big.NewInt(1), OriginNetwork: 1, MainnetExitRoot: common.Hash{}},
+		{BlockNum: 2, GlobalIndex: big.NewInt(2), Amount: big.NewInt(1), OriginNetwork: 1, MainnetExitRoot: common.Hash{}},
+		{BlockNum: 3, GlobalIndex: uint64Max, Amount: big.NewInt(1), OriginNetwork: 2, MainnetExitRoot: common.Hash{}},
+		{BlockNum: 4, GlobalIndex: num1, Amount: big.NewInt(1), OriginNetwork: 2, MainnetExitRoot: common.Hash{}},
+		{BlockNum: 5, GlobalIndex: big.NewInt(5), Amount: big.NewInt(1), OriginNetwork: 3, MainnetExitRoot: common.Hash{}},
+		{BlockNum: 6, GlobalIndex: uint256Max, Amount: big.NewInt(1), OriginNetwork: 4, MainnetExitRoot: common.Hash{}},
 	}
 
 	path := path.Join(t.TempDir(), "bridgesyncGetClaimsPaged.sqlite")
@@ -1278,7 +1278,6 @@ func TestGetClaimsPaged(t *testing.T) {
 		pageSize       uint32
 		page           uint32
 		networkIDs     []uint32
-		fromAddress    string
 		globalIndex    *big.Int
 		expectedCount  int
 		expectedClaims []*Claim
@@ -1339,19 +1338,8 @@ func TestGetClaimsPaged(t *testing.T) {
 			pageSize:       3,
 			page:           1,
 			networkIDs:     []uint32{claims[0].OriginNetwork, claims[4].OriginNetwork},
-			fromAddress:    claims[0].FromAddress.String(),
 			expectedCount:  3,
 			expectedClaims: []*Claim{claims[4], claims[1], claims[0]},
-			expectedError:  "",
-		},
-		{
-			name:           "filter by network ids (all results within the same page) and from address case insensitive",
-			pageSize:       3,
-			page:           1,
-			networkIDs:     []uint32{claims[0].OriginNetwork, claims[4].OriginNetwork},
-			fromAddress:    "0xd34aaF64b29273B7D567FCFc40544c014EEe9970",
-			expectedCount:  0,
-			expectedClaims: []*Claim{},
 			expectedError:  "",
 		},
 		{
@@ -1381,7 +1369,7 @@ func TestGetClaimsPaged(t *testing.T) {
 
 			ctx := context.Background()
 			claims, count, err := p.GetClaimsPaged(ctx, tc.page, tc.pageSize,
-				tc.networkIDs, tc.fromAddress, tc.globalIndex)
+				tc.networkIDs, tc.globalIndex)
 
 			if tc.expectedError != "" {
 				require.ErrorContains(t, err, tc.expectedError)
@@ -1597,7 +1585,6 @@ func TestDecodePreEtrogCalldata_Valid(t *testing.T) {
 	originAddress := common.HexToAddress("0x0a0a")
 	amount := big.NewInt(150)
 	destinationAddr := common.HexToAddress("0x0b0b")
-	zeroAddr := common.HexToAddress("0x0")
 
 	proof := types.Proof{}
 	for i := range types.DefaultHeight {
@@ -1640,7 +1627,7 @@ func TestDecodePreEtrogCalldata_Valid(t *testing.T) {
 	claimAssetData, err := method.Inputs.Unpack(claimAssetInput[4:])
 	require.NoError(t, err)
 
-	isFound, err := actualClaim.decodePreEtrogCalldata(zeroAddr, claimAssetData)
+	isFound, err := actualClaim.decodePreEtrogCalldata(claimAssetData)
 	require.NoError(t, err)
 	require.True(t, isFound)
 
@@ -1681,7 +1668,6 @@ func TestDecodePreEtrogCalldata(t *testing.T) {
 		metadata               = []byte("mock metadata")
 		destinationNetwork     = uint32(1)
 		invalidTypePlaceholder = "invalidType"
-		zeroAddr               = common.HexToAddress("0x0")
 	)
 
 	tests := []struct {
@@ -1838,7 +1824,7 @@ func TestDecodePreEtrogCalldata(t *testing.T) {
 				Metadata:           nil,
 			}
 
-			match, err := claim.decodePreEtrogCalldata(zeroAddr, tt.data)
+			match, err := claim.decodePreEtrogCalldata(tt.data)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -1859,7 +1845,6 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 		metadata               = []byte("mock metadata")
 		destinationNetwork     = uint32(1)
 		invalidTypePlaceholder = "invalidType"
-		zeroAddr               = common.HexToAddress("0x0")
 	)
 
 	tests := []struct {
@@ -2036,7 +2021,7 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			claim := &Claim{GlobalIndex: globalIndex}
 
-			isDecoded, err := claim.decodeEtrogCalldata(zeroAddr, tt.data)
+			isDecoded, err := claim.decodeEtrogCalldata(tt.data)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -2489,12 +2474,12 @@ func TestProcessor_ErrorPathLogging(t *testing.T) {
 		require.NoError(t, p.ProcessBlock(context.Background(), testBlock))
 
 		// Test invalid page number (page 10 with only 1 record and page size 5)
-		_, _, err := p.GetClaimsPaged(context.Background(), 10, 5, nil, "", nil)
+		_, _, err := p.GetClaimsPaged(context.Background(), 10, 5, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid page number")
 
 		// Test successful case with valid page
-		claims, count, err := p.GetClaimsPaged(context.Background(), 1, 5, nil, "", nil)
+		claims, count, err := p.GetClaimsPaged(context.Background(), 1, 5, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, claims, 1)
 		require.Equal(t, 1, count)
@@ -2665,7 +2650,6 @@ func createTestClaim(blockNum uint64, blockPos int) *Claim {
 		BlockPos:            uint64(blockPos),
 		BlockTimestamp:      1234567890,
 		TxHash:              common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		FromAddress:         common.HexToAddress("0x1234567890123456789012345678901234567890"),
 		GlobalIndex:         big.NewInt(1000000000000000000),
 		OriginNetwork:       1,
 		OriginAddress:       common.HexToAddress("0x1234567890123456789012345678901234567890"),

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -212,12 +212,6 @@
                         "in": "query"
                     },
                     {
-                        "type": "string",
-                        "description": "Filter by from address",
-                        "name": "from_address",
-                        "in": "query"
-                    },
-                    {
                         "type": "boolean",
                         "description": "Whether to include full response fields (default false)",
                         "name": "include_all_fields",


### PR DESCRIPTION
## 🔄 Changes Summary
The `claim.from_address` is not used by the bridge hub and since this value is not provided by the [DetailedClaimEvent](https://github.com/agglayer/agglayer-contracts/blob/9f75ee58719f35111990b17bc4b6fcaf084a5edd/contracts/sovereignChains/AgglayerBridgeL2.sol#L237-L249), we decided to drop this column.

## ⚠️ Breaking Changes
- 🗑️ **Deprecated Features**: Removed filtering claims by caller address (`from_address`) field

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #1295 

## 🔗 Related PRs
https://github.com/agglayer/e2e/pull/211
#1263