### PR TITLE
fix: handle reorg detection edgecase

### DIFF
--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -183,8 +183,6 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 			headers := hdrs.getSorted()
 			for _, hdr := range headers {
 				// Get the actual header from the network or from the cache
-				var err error
-
 				currentHeader, err := rd.client.HeaderByNumber(ctx, new(big.Int).SetUint64(hdr.Num))
 				if err != nil {
 					return fmt.Errorf("failed to get the header %d: %w", hdr.Num, err)

--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -184,13 +184,13 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 			for _, hdr := range headers {
 				// Get the actual header from the network or from the cache
 				var err error
-				rd.headersCacheLock.Lock()
 
 				currentHeader, err := rd.client.HeaderByNumber(ctx, new(big.Int).SetUint64(hdr.Num))
 				if err != nil {
 					return fmt.Errorf("failed to get the header %d: %w", hdr.Num, err)
 				}
 
+				rd.headersCacheLock.Lock()
 				oldHeader, ok := rd.headersCache[hdr.Num]
 				if !ok || oldHeader == nil {
 					rd.headersCache[hdr.Num] = currentHeader
@@ -218,8 +218,8 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 					FromBlock:    hdr.Num,
 					ToBlock:      headers[len(headers)-1].Num,
 					SubscriberID: id,
-					CurrentHash:  hdr.Hash,
-					TrackedHash:  currentHeader.Hash(),
+					CurrentHash:  currentHeader.Hash(),
+					TrackedHash:  hdr.Hash,
 				}
 				if err := rd.insertReorgEvent(event); err != nil {
 					return fmt.Errorf("failed to insert reorg event: %w", err)

--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -167,8 +167,6 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 	subscriberIDs := rd.getSubscriberIDs()
 	startTime := time.Now()
 	for _, id := range subscriberIDs {
-		id := id
-
 		// This is done like this because of a possible deadlock
 		// between AddBlocksToTrack and detectReorgInTrackedList
 		rd.trackedBlocksLock.RLock()
@@ -187,18 +185,21 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 				// Get the actual header from the network or from the cache
 				var err error
 				rd.headersCacheLock.Lock()
-				currentHeader, ok := rd.headersCache[hdr.Num]
-				if !ok || currentHeader == nil {
-					if currentHeader, err = rd.client.HeaderByNumber(ctx, new(big.Int).SetUint64(hdr.Num)); err != nil {
-						rd.headersCacheLock.Unlock()
-						return fmt.Errorf("failed to get the header %d: %w", hdr.Num, err)
-					}
+
+				currentHeader, err := rd.client.HeaderByNumber(ctx, new(big.Int).SetUint64(hdr.Num))
+				if err != nil {
+					return fmt.Errorf("failed to get the header %d: %w", hdr.Num, err)
+				}
+
+				oldHeader, ok := rd.headersCache[hdr.Num]
+				if !ok || oldHeader == nil {
 					rd.headersCache[hdr.Num] = currentHeader
+					oldHeader = currentHeader
 				}
 				rd.headersCacheLock.Unlock()
 
 				// Check if the block hash matches with the actual block hash
-				if hdr.Hash == currentHeader.Hash() {
+				if hdr.Hash == oldHeader.Hash() && currentHeader.Hash() == hdr.Hash {
 					// Delete block from the tracked blocks list if it is less than or equal to the last finalized block
 					// and hashes matches. If higher than finalized block, we assume a reorg still might happen.
 					if hdr.Num <= lastFinalizedBlock.Number.Uint64() {
@@ -217,8 +218,8 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 					FromBlock:    hdr.Num,
 					ToBlock:      headers[len(headers)-1].Num,
 					SubscriberID: id,
-					CurrentHash:  currentHeader.Hash(),
-					TrackedHash:  hdr.Hash,
+					CurrentHash:  hdr.Hash,
+					TrackedHash:  currentHeader.Hash(),
 				}
 				if err := rd.insertReorgEvent(event); err != nil {
 					return fmt.Errorf("failed to insert reorg event: %w", err)


### PR DESCRIPTION
## 🔄 Changes Summary
- Handle an edgecase when we are not able to track previous block reorgs and we are on the current block. When polling new block, the blockhash changes after the last ticker, then we are not able to track the block hash of previous block and new block is added. Now we are always comparing the latest block header in reorg detection as well