### PR TITLE
feat: pick fixes from zkevm_migration_support-0_7_X

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -192,6 +192,10 @@ func (a *AggSender) Info() types.AggsenderInfo {
 	return res
 }
 
+func (a *AggSender) ForceTriggerCertitificate() {
+	a.epochNotifier.ForcePublishEpochEvent()
+}
+
 // GetRPCServices returns the list of services that the RPC provider exposes
 func (a *AggSender) GetRPCServices() []jRPC.Service {
 	if !a.cfg.EnableRPC {

--- a/aggsender/epoch_notifier_per_block.go
+++ b/aggsender/epoch_notifier_per_block.go
@@ -123,6 +123,16 @@ func (e *EpochNotifierPerBlock) GetEpochStatus() types.EpochStatus {
 	}
 }
 
+func (e *EpochNotifierPerBlock) ForcePublishEpochEvent() {
+	currentBlock := e.blockNotifier.GetCurrentBlockNumber()
+	info := e.infoEpoch(currentBlock, e.epochNumber(currentBlock))
+	event := &types.EpochEvent{
+		Epoch:     e.epochNumber(currentBlock),
+		ExtraInfo: info,
+	}
+	e.Publish(*event)
+}
+
 func (e *EpochNotifierPerBlock) startInternal(ctx context.Context, eventNewBlockChannel <-chan types.EventNewBlock) {
 	status := internalStatus{
 		lastBlockSeen:   e.Config.StartingEpochBlock,

--- a/aggsender/epoch_notifier_per_block_test.go
+++ b/aggsender/epoch_notifier_per_block_test.go
@@ -205,6 +205,18 @@ func TestBlockBeforeEpoch(t *testing.T) {
 	require.Equal(t, uint64(114), newStatus.lastBlockSeen)
 }
 
+func TestForcePublishEpochEvent(t *testing.T) {
+	testData := newNotifierPerBlockTestData(t, nil)
+	ch := testData.sut.Subscribe("test")
+	testData.blockNotifierMock.EXPECT().GetCurrentBlockNumber().Return(uint64(145))
+	testData.blockNotifierMock.EXPECT().Subscribe(mock.Anything).Return(make(chan types.EventNewBlock))
+	testData.sut.StartAsync(testData.ctx)
+	testData.sut.ForcePublishEpochEvent()
+	epochEvent := <-ch
+	require.Equal(t, uint64(15), epochEvent.Epoch)
+	testData.ctx.Done()
+}
+
 func TestGetEpochStatus(t *testing.T) {
 	testData := newNotifierPerBlockTestData(t, nil)
 	testData.blockNotifierMock.EXPECT().GetCurrentBlockNumber().Return(uint64(105))

--- a/aggsender/mocks/mock_aggsender_interface.go
+++ b/aggsender/mocks/mock_aggsender_interface.go
@@ -20,6 +20,38 @@ func (_m *AggsenderInterface) EXPECT() *AggsenderInterface_Expecter {
 	return &AggsenderInterface_Expecter{mock: &_m.Mock}
 }
 
+// ForceTriggerCertitificate provides a mock function with no fields
+func (_m *AggsenderInterface) ForceTriggerCertitificate() {
+	_m.Called()
+}
+
+// AggsenderInterface_ForceTriggerCertitificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForceTriggerCertitificate'
+type AggsenderInterface_ForceTriggerCertitificate_Call struct {
+	*mock.Call
+}
+
+// ForceTriggerCertitificate is a helper method to define mock.On call
+func (_e *AggsenderInterface_Expecter) ForceTriggerCertitificate() *AggsenderInterface_ForceTriggerCertitificate_Call {
+	return &AggsenderInterface_ForceTriggerCertitificate_Call{Call: _e.mock.On("ForceTriggerCertitificate")}
+}
+
+func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) Run(run func()) *AggsenderInterface_ForceTriggerCertitificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) Return() *AggsenderInterface_ForceTriggerCertitificate_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) RunAndReturn(run func()) *AggsenderInterface_ForceTriggerCertitificate_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Info provides a mock function with no fields
 func (_m *AggsenderInterface) Info() types.AggsenderInfo {
 	ret := _m.Called()

--- a/aggsender/mocks/mock_epoch_notifier.go
+++ b/aggsender/mocks/mock_epoch_notifier.go
@@ -22,6 +22,38 @@ func (_m *EpochNotifier) EXPECT() *EpochNotifier_Expecter {
 	return &EpochNotifier_Expecter{mock: &_m.Mock}
 }
 
+// ForcePublishEpochEvent provides a mock function with no fields
+func (_m *EpochNotifier) ForcePublishEpochEvent() {
+	_m.Called()
+}
+
+// EpochNotifier_ForcePublishEpochEvent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForcePublishEpochEvent'
+type EpochNotifier_ForcePublishEpochEvent_Call struct {
+	*mock.Call
+}
+
+// ForcePublishEpochEvent is a helper method to define mock.On call
+func (_e *EpochNotifier_Expecter) ForcePublishEpochEvent() *EpochNotifier_ForcePublishEpochEvent_Call {
+	return &EpochNotifier_ForcePublishEpochEvent_Call{Call: _e.mock.On("ForcePublishEpochEvent")}
+}
+
+func (_c *EpochNotifier_ForcePublishEpochEvent_Call) Run(run func()) *EpochNotifier_ForcePublishEpochEvent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EpochNotifier_ForcePublishEpochEvent_Call) Return() *EpochNotifier_ForcePublishEpochEvent_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *EpochNotifier_ForcePublishEpochEvent_Call) RunAndReturn(run func()) *EpochNotifier_ForcePublishEpochEvent_Call {
+	_c.Run(run)
+	return _c
+}
+
 // GetEpochStatus provides a mock function with no fields
 func (_m *EpochNotifier) GetEpochStatus() types.EpochStatus {
 	ret := _m.Called()

--- a/aggsender/rpc/aggsender_rpc.go
+++ b/aggsender/rpc/aggsender_rpc.go
@@ -15,6 +15,7 @@ type AggsenderStorer interface {
 
 type AggsenderInterface interface {
 	Info() types.AggsenderInfo
+	ForceTriggerCertitificate()
 }
 
 // AggsenderRPC is the RPC interface for the aggsender
@@ -42,6 +43,14 @@ func NewAggsenderRPC(
 func (b *AggsenderRPC) Status() (interface{}, rpc.Error) {
 	info := b.aggsender.Info()
 	return info, nil
+}
+
+// TriggerCertitificate forces the publication of an epoch event
+// curl -X POST http://localhost:5576/ "Content-Type: application/json" \
+// -d '{"method":"aggsender_triggerCertitificate", "params":[], "id":1}'
+func (b *AggsenderRPC) TriggerCertitificate() (interface{}, rpc.Error) {
+	b.aggsender.ForceTriggerCertitificate()
+	return nil, nil
 }
 
 // GetCertificateHeaderPerHeight returns the certificate header for the given height

--- a/aggsender/rpc/aggsender_rpc.go
+++ b/aggsender/rpc/aggsender_rpc.go
@@ -45,7 +45,7 @@ func (b *AggsenderRPC) Status() (interface{}, rpc.Error) {
 	return info, nil
 }
 
-// TriggerCertitificate forces the publication of an epoch event
+// TriggerCertitificate forces the publication of an epoch event to trigger certificate creation
 // curl -X POST http://localhost:5576/ "Content-Type: application/json" \
 // -d '{"method":"aggsender_triggerCertitificate", "params":[], "id":1}'
 func (b *AggsenderRPC) TriggerCertitificate() (interface{}, rpc.Error) {

--- a/aggsender/rpc/aggsender_rpc_test.go
+++ b/aggsender/rpc/aggsender_rpc_test.go
@@ -16,6 +16,13 @@ func TestAggsenderRPCStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
+func TestAggsenderRPCTriggerCertitificate(t *testing.T) {
+	testData := newAggsenderData(t)
+	testData.mockAggsender.EXPECT().ForceTriggerCertitificate().Return()
+	res, err := testData.sut.TriggerCertitificate()
+	require.NoError(t, err)
+	require.Nil(t, res)
+}
 
 func TestAggsenderRPCGetCertificateHeaderPerHeight(t *testing.T) {
 	testData := newAggsenderData(t)

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -150,17 +150,8 @@ func (c *CertificateBuildParams) EstimatedSize() uint {
 	if c == nil {
 		return 0
 	}
-	sizeBridges := float64(0)
-	for _, bridge := range c.Bridges {
-		sizeBridges += agglayertypes.EstimatedBridgeExitSize
-		sizeBridges += float64(len(bridge.Metadata))
-	}
-
-	sizeClaims := float64(0)
-	for _, claim := range c.Claims {
-		sizeClaims += agglayertypes.EstimatedImportedBridgeExitSize
-		sizeClaims += float64(len(claim.Metadata))
-	}
+	sizeBridges := (agglayertypes.EstimatedBridgeExitSize + common.HashLength) * float64(len(c.Bridges))
+	sizeClaims := (agglayertypes.EstimatedImportedBridgeExitSize + common.HashLength) * float64(len(c.Claims))
 
 	sizeAggchainData := float64(0)
 	switch c.CertificateType {

--- a/aggsender/types/certificate_build_params_test.go
+++ b/aggsender/types/certificate_build_params_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,4 +61,17 @@ func TestNumberOfBlocks(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestEstimateSize(t *testing.T) {
+	sut := &CertificateBuildParams{
+		FromBlock: 100,
+		ToBlock:   200,
+		Bridges:   make([]bridgesync.Bridge, 50),
+		Claims:    make([]bridgesync.Claim, 150),
+	}
+
+	estimatedSize := sut.EstimatedSize()
+
+	require.Equal(t, uint(0x6bb47), estimatedSize, "Estimated size should match expected size")
 }

--- a/aggsender/types/epoch_notifier.go
+++ b/aggsender/types/epoch_notifier.go
@@ -35,4 +35,5 @@ type EpochNotifier interface {
 	// GetEpochStatus returns the current status of the epoch
 	GetEpochStatus() EpochStatus
 	String() string
+	ForcePublishEpochEvent()
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- Fix estimatedSize that must consided metadata as a Hash, not the length of bytes
- Add a new RPC end-point for aggsender `aggsender_triggerCertitificate` to force a trigger certificate:
This is a useful feature for testing or event can be used in production to don't wait a epoch to force a trigger
```
curl -X POST http://localhost:5576/ "Content-Type: application/json"   -d '{"method":"aggsender_triggerCertitificate", "params":[], "id":1}'
```




## 🔗 Related PRs
- #1296

