### PR TITLE
feat: pick fixes from zkevm_migration_support-0_7_X (#1304)

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -232,6 +232,10 @@ func (a *AggSender) Info() types.AggsenderInfo {
 	return res
 }
 
+func (a *AggSender) ForceTriggerCertitificate() {
+	a.epochNotifier.ForcePublishEpochEvent()
+}
+
 // GetRPCServices returns the list of services that the RPC provider exposes
 func (a *AggSender) GetRPCServices() []jRPC.Service {
 	if !a.cfg.EnableRPC {

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -233,7 +233,7 @@ func (a *AggSender) Info() types.AggsenderInfo {
 }
 
 func (a *AggSender) ForceTriggerCertitificate() {
-	a.epochNotifier.ForcePublishEpochEvent()
+	a.certificateSendTrigger.ForceTriggerEvent()
 }
 
 // GetRPCServices returns the list of services that the RPC provider exposes

--- a/aggsender/certificate_send_trigger.go
+++ b/aggsender/certificate_send_trigger.go
@@ -3,13 +3,14 @@ package aggsender
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/agglayer/aggkit/agglayer"
 	"github.com/agglayer/aggkit/aggsender/config"
 	"github.com/agglayer/aggkit/aggsender/types"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
-	"github.com/agglayer/aggkit/sync"
+	aggkitsync "github.com/agglayer/aggkit/sync"
 	aggkittypes "github.com/agglayer/aggkit/types"
 )
 
@@ -150,6 +151,7 @@ func (r *epochBasedTrigger) ForceTriggerEvent() {
 type preconfTrigger struct {
 	log          aggkitcommon.Logger
 	l2BridgeSync types.L2BridgeSyncer
+	mutex        sync.Mutex
 	ch           chan types.CertificateTriggerEvent
 }
 
@@ -188,16 +190,24 @@ func (r *preconfTrigger) Setup(ctx context.Context) {
 // notifications. Each value is a sync.Block (which implements CertificateTriggerEvent).
 // The returned channel will be closed when the provided context is canceled.
 func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.CertificateTriggerEvent {
+	syncSub := r.l2BridgeSync.SubscribeToSync("aggsender")
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	ch := make(chan types.CertificateTriggerEvent)
 	r.ch = ch
-	syncSub := r.l2BridgeSync.SubscribeToSync("aggsender")
+
 	go func() {
 		for {
 			select {
 			case <-ctx.Done():
+				r.mutex.Lock()
+				defer r.mutex.Unlock()
+				r.ch = nil
 				close(ch)
 				return
 			case epochEvent := <-syncSub:
+				r.mutex.Lock()
+				defer r.mutex.Unlock()
 				ch <- epochEvent
 			}
 		}
@@ -213,5 +223,7 @@ func (r *preconfTrigger) ForceTriggerEvent() {
 		r.log.Errorf("ForceTriggerEvent: Failed to get last processed block: %v", err)
 		return
 	}
-	r.ch <- sync.Block{Num: blockNumber}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.ch <- aggkitsync.Block{Num: blockNumber}
 }

--- a/aggsender/certificate_send_trigger.go
+++ b/aggsender/certificate_send_trigger.go
@@ -191,28 +191,26 @@ func (r *preconfTrigger) Setup(ctx context.Context) {
 // The returned channel will be closed when the provided context is canceled.
 func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.CertificateTriggerEvent {
 	syncSub := r.l2BridgeSync.SubscribeToSync("aggsender")
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	ch := make(chan types.CertificateTriggerEvent)
-	r.ch = ch
 
+	ch := make(chan types.CertificateTriggerEvent)
 	go func() {
 		for {
 			select {
 			case <-ctx.Done():
 				r.mutex.Lock()
 				r.ch = nil
-				close(ch)
 				r.mutex.Unlock()
+				close(ch)
+
 				return
 			case epochEvent := <-syncSub:
-				r.mutex.Lock()
 				ch <- epochEvent
-				r.mutex.Unlock()
 			}
 		}
 	}()
-
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.ch = ch
 	return ch
 }
 
@@ -225,5 +223,8 @@ func (r *preconfTrigger) ForceTriggerEvent() {
 	}
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+	if r.ch == nil {
+		return
+	}
 	r.ch <- aggkitsync.Block{Num: blockNumber}
 }

--- a/aggsender/certificate_send_trigger.go
+++ b/aggsender/certificate_send_trigger.go
@@ -3,7 +3,6 @@ package aggsender
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/agglayer/aggkit/agglayer"
 	"github.com/agglayer/aggkit/aggsender/config"
@@ -151,7 +150,6 @@ func (r *epochBasedTrigger) ForceTriggerEvent() {
 type preconfTrigger struct {
 	log          aggkitcommon.Logger
 	l2BridgeSync types.L2BridgeSyncer
-	mutex        sync.Mutex
 	ch           chan types.CertificateTriggerEvent
 }
 
@@ -193,13 +191,13 @@ func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.Certificate
 	syncSub := r.l2BridgeSync.SubscribeToSync("aggsender")
 
 	ch := make(chan types.CertificateTriggerEvent)
+	r.ch = ch
+
 	go func() {
 		for {
 			select {
 			case <-ctx.Done():
-				r.mutex.Lock()
 				r.ch = nil
-				r.mutex.Unlock()
 				close(ch)
 
 				return
@@ -208,9 +206,7 @@ func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.Certificate
 			}
 		}
 	}()
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	r.ch = ch
+
 	return ch
 }
 
@@ -221,8 +217,6 @@ func (r *preconfTrigger) ForceTriggerEvent() {
 		r.log.Errorf("ForceTriggerEvent: Failed to get last processed block: %v", err)
 		return
 	}
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
 	if r.ch == nil {
 		return
 	}

--- a/aggsender/certificate_send_trigger.go
+++ b/aggsender/certificate_send_trigger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/types"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
+	"github.com/agglayer/aggkit/sync"
 	aggkittypes "github.com/agglayer/aggkit/types"
 )
 
@@ -139,11 +140,17 @@ func (r *epochBasedTrigger) Setup(ctx context.Context) {
 	go r.epochNotifier.Start(ctx)
 }
 
+// ForceTriggerEvent forces the epoch notifier to publish an epoch event immediately.
+func (r *epochBasedTrigger) ForceTriggerEvent() {
+	r.epochNotifier.ForcePublishEpochEvent()
+}
+
 // preconfTrigger handles preconfirmation operations by listening to L2 bridge synchronization
 // and maintaining subscription state to the synchronized L2 bridge events.
 type preconfTrigger struct {
 	log          aggkitcommon.Logger
 	l2BridgeSync types.L2BridgeSyncer
+	ch           chan types.CertificateTriggerEvent
 }
 
 // newPreconfTrigger creates and initializes a new preconfTrigger instance.
@@ -182,6 +189,7 @@ func (r *preconfTrigger) Setup(ctx context.Context) {
 // The returned channel will be closed when the provided context is canceled.
 func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.CertificateTriggerEvent {
 	ch := make(chan types.CertificateTriggerEvent)
+	r.ch = ch
 	syncSub := r.l2BridgeSync.SubscribeToSync("aggsender")
 	go func() {
 		for {
@@ -196,4 +204,14 @@ func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.Certificate
 	}()
 
 	return ch
+}
+
+// ForceTriggerEvent forces the preconf trigger to emit a synchronization event.
+func (r *preconfTrigger) ForceTriggerEvent() {
+	blockNumber, err := r.l2BridgeSync.GetLastProcessedBlock(context.Background())
+	if err != nil {
+		r.log.Errorf("ForceTriggerEvent: Failed to get last processed block: %v", err)
+		return
+	}
+	r.ch <- sync.Block{Num: blockNumber}
 }

--- a/aggsender/certificate_send_trigger.go
+++ b/aggsender/certificate_send_trigger.go
@@ -201,14 +201,14 @@ func (r *preconfTrigger) TriggerCh(ctx context.Context) <-chan types.Certificate
 			select {
 			case <-ctx.Done():
 				r.mutex.Lock()
-				defer r.mutex.Unlock()
 				r.ch = nil
 				close(ch)
+				r.mutex.Unlock()
 				return
 			case epochEvent := <-syncSub:
 				r.mutex.Lock()
-				defer r.mutex.Unlock()
 				ch <- epochEvent
+				r.mutex.Unlock()
 			}
 		}
 	}()

--- a/aggsender/certificate_send_trigger_test.go
+++ b/aggsender/certificate_send_trigger_test.go
@@ -314,6 +314,7 @@ func TestPreconfRunner_TriggerCh(t *testing.T) {
 		mockEvent3 := sync.Block{Num: 126, Events: []any{}, Hash: common.HexToHash("0x4")}
 
 		// Send multiple events
+
 		syncCh <- mockEvent1
 		syncCh <- mockEvent2
 		syncCh <- mockEvent3

--- a/aggsender/certificate_send_trigger_test.go
+++ b/aggsender/certificate_send_trigger_test.go
@@ -446,45 +446,69 @@ func TestEpochBasedRunner_TriggerCh(t *testing.T) {
 	})
 }
 
-func TestForceTriggerEvent(t *testing.T) {
-	t.Run("epochBasedTrigger calls ForcePublishEpochEvent", func(t *testing.T) {
+func TestEpochBasedTriggerForceTriggerEvent(t *testing.T) {
+	mockBlockNotifier := mocks.NewBlockNotifier(t)
+	logger := log.WithFields("test", "test")
+	mockEpochNotifier, err := NewEpochNotifierPerBlock(
+		mockBlockNotifier,
+		logger,
+		ConfigEpochNotifierPerBlock{
+			StartingEpochBlock:          1000,
+			NumBlockPerEpoch:            100,
+			EpochNotificationPercentage: 80.0,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	runner := &epochBasedTrigger{
+		epochNotifier: mockEpochNotifier,
+		blockNotifier: mockBlockNotifier,
+	}
 
-		mockBlockNotifier := mocks.NewBlockNotifier(t)
-		logger := log.WithFields("test", "test")
-		mockEpochNotifier, err := NewEpochNotifierPerBlock(
-			mockBlockNotifier,
-			logger,
-			ConfigEpochNotifierPerBlock{
-				StartingEpochBlock:          1000,
-				NumBlockPerEpoch:            100,
-				EpochNotificationPercentage: 80.0,
-			},
-			nil,
-		)
-		require.NoError(t, err)
-		runner := &epochBasedTrigger{
-			epochNotifier: mockEpochNotifier,
-			blockNotifier: mockBlockNotifier,
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	triggerCh := runner.TriggerCh(ctx)
+	mockBlockNotifier.EXPECT().GetCurrentBlockNumber().Return(uint64(1100)).Times(1)
+	runner.ForceTriggerEvent()
+
+	// Verify all events are forwarded
+	receivedEvents := make([]types.CertificateTriggerEvent, 0, 1)
+	for i := 0; i < 1; i++ {
+		select {
+		case event := <-triggerCh:
+			receivedEvents = append(receivedEvents, event)
+		case <-time.After(1 * time.Second):
+			t.Fatalf("Expected event was not received after 1 sec")
 		}
+	}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	require.Len(t, receivedEvents, 1)
+}
 
-		triggerCh := runner.TriggerCh(ctx)
-		mockBlockNotifier.EXPECT().GetCurrentBlockNumber().Return(uint64(1100)).Times(1)
-		runner.ForceTriggerEvent()
+func TestPreconfTriggerForceTriggerEvent(t *testing.T) {
+	logger := log.WithFields("test", "test")
+	mockL2BridgeSync := mocks.NewL2BridgeSyncer(t)
 
-		// Verify all events are forwarded
-		receivedEvents := make([]types.CertificateTriggerEvent, 0, 1)
-		for i := 0; i < 1; i++ {
-			select {
-			case event := <-triggerCh:
-				receivedEvents = append(receivedEvents, event)
-			case <-time.After(1 * time.Second):
-				t.Fatalf("Expected event was not received after 1 sec")
-			}
-		}
+	// Create a mock subscription channel
+	syncCh := make(chan sync.Block, 3)
+	mockL2BridgeSync.EXPECT().SubscribeToSync("aggsender").Return(syncCh)
+	mockL2BridgeSync.EXPECT().GetLastProcessedBlock(mock.Anything).Return(uint64(12345), nil).Once()
+	sut := newPreconfTrigger(
+		logger,
+		mockL2BridgeSync,
+	)
 
-		require.Len(t, receivedEvents, 1)
-	})
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	triggerCh := sut.TriggerCh(ctx)
+	go sut.ForceTriggerEvent()
+
+	select {
+	case event := <-triggerCh:
+		t.Logf("Received event: %+v", event)
+		break
+	case <-ctx.Done():
+		t.Fatalf("Expected event was not received after 1 sec")
+	}
 }

--- a/aggsender/certificate_send_trigger_test.go
+++ b/aggsender/certificate_send_trigger_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/config"
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
+	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
 	ethmanmocks "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
@@ -442,5 +443,48 @@ func TestEpochBasedRunner_TriggerCh(t *testing.T) {
 		require.Equal(t, mockEvent1, receivedEvents[0])
 		require.Equal(t, mockEvent2, receivedEvents[1])
 		require.Equal(t, mockEvent3, receivedEvents[2])
+	})
+}
+
+func TestForceTriggerEvent(t *testing.T) {
+	t.Run("epochBasedTrigger calls ForcePublishEpochEvent", func(t *testing.T) {
+
+		mockBlockNotifier := mocks.NewBlockNotifier(t)
+		logger := log.WithFields("test", "test")
+		mockEpochNotifier, err := NewEpochNotifierPerBlock(
+			mockBlockNotifier,
+			logger,
+			ConfigEpochNotifierPerBlock{
+				StartingEpochBlock:          1000,
+				NumBlockPerEpoch:            100,
+				EpochNotificationPercentage: 80.0,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		runner := &epochBasedTrigger{
+			epochNotifier: mockEpochNotifier,
+			blockNotifier: mockBlockNotifier,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		triggerCh := runner.TriggerCh(ctx)
+		mockBlockNotifier.EXPECT().GetCurrentBlockNumber().Return(uint64(1100)).Times(1)
+		runner.ForceTriggerEvent()
+
+		// Verify all events are forwarded
+		receivedEvents := make([]types.CertificateTriggerEvent, 0, 1)
+		for i := 0; i < 1; i++ {
+			select {
+			case event := <-triggerCh:
+				receivedEvents = append(receivedEvents, event)
+			case <-time.After(1 * time.Second):
+				t.Fatalf("Expected event was not received after 1 sec")
+			}
+		}
+
+		require.Len(t, receivedEvents, 1)
 	})
 }

--- a/aggsender/epoch_notifier_per_block.go
+++ b/aggsender/epoch_notifier_per_block.go
@@ -123,6 +123,16 @@ func (e *EpochNotifierPerBlock) GetEpochStatus() types.EpochStatus {
 	}
 }
 
+func (e *EpochNotifierPerBlock) ForcePublishEpochEvent() {
+	currentBlock := e.blockNotifier.GetCurrentBlockNumber()
+	info := e.infoEpoch(currentBlock, e.epochNumber(currentBlock))
+	event := &types.EpochEvent{
+		Epoch:     e.epochNumber(currentBlock),
+		ExtraInfo: info,
+	}
+	e.Publish(*event)
+}
+
 func (e *EpochNotifierPerBlock) startInternal(ctx context.Context, eventNewBlockChannel <-chan types.EventNewBlock) {
 	status := internalStatus{
 		lastBlockSeen:   e.Config.StartingEpochBlock,

--- a/aggsender/epoch_notifier_per_block_test.go
+++ b/aggsender/epoch_notifier_per_block_test.go
@@ -205,6 +205,18 @@ func TestBlockBeforeEpoch(t *testing.T) {
 	require.Equal(t, uint64(114), newStatus.lastBlockSeen)
 }
 
+func TestForcePublishEpochEvent(t *testing.T) {
+	testData := newNotifierPerBlockTestData(t, nil)
+	ch := testData.sut.Subscribe("test")
+	testData.blockNotifierMock.EXPECT().GetCurrentBlockNumber().Return(uint64(145))
+	testData.blockNotifierMock.EXPECT().Subscribe(mock.Anything).Return(make(chan types.EventNewBlock))
+	testData.sut.StartAsync(testData.ctx)
+	testData.sut.ForcePublishEpochEvent()
+	epochEvent := <-ch
+	require.Equal(t, uint64(15), epochEvent.Epoch)
+	testData.ctx.Done()
+}
+
 func TestGetEpochStatus(t *testing.T) {
 	testData := newNotifierPerBlockTestData(t, nil)
 	testData.blockNotifierMock.EXPECT().GetCurrentBlockNumber().Return(uint64(105))

--- a/aggsender/mocks/mock_aggsender_interface.go
+++ b/aggsender/mocks/mock_aggsender_interface.go
@@ -20,6 +20,38 @@ func (_m *AggsenderInterface) EXPECT() *AggsenderInterface_Expecter {
 	return &AggsenderInterface_Expecter{mock: &_m.Mock}
 }
 
+// ForceTriggerCertitificate provides a mock function with no fields
+func (_m *AggsenderInterface) ForceTriggerCertitificate() {
+	_m.Called()
+}
+
+// AggsenderInterface_ForceTriggerCertitificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForceTriggerCertitificate'
+type AggsenderInterface_ForceTriggerCertitificate_Call struct {
+	*mock.Call
+}
+
+// ForceTriggerCertitificate is a helper method to define mock.On call
+func (_e *AggsenderInterface_Expecter) ForceTriggerCertitificate() *AggsenderInterface_ForceTriggerCertitificate_Call {
+	return &AggsenderInterface_ForceTriggerCertitificate_Call{Call: _e.mock.On("ForceTriggerCertitificate")}
+}
+
+func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) Run(run func()) *AggsenderInterface_ForceTriggerCertitificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) Return() *AggsenderInterface_ForceTriggerCertitificate_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) RunAndReturn(run func()) *AggsenderInterface_ForceTriggerCertitificate_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Info provides a mock function with no fields
 func (_m *AggsenderInterface) Info() types.AggsenderInfo {
 	ret := _m.Called()

--- a/aggsender/mocks/mock_certificate_send_trigger.go
+++ b/aggsender/mocks/mock_certificate_send_trigger.go
@@ -22,6 +22,38 @@ func (_m *CertificateSendTrigger) EXPECT() *CertificateSendTrigger_Expecter {
 	return &CertificateSendTrigger_Expecter{mock: &_m.Mock}
 }
 
+// ForceTriggerEvent provides a mock function with no fields
+func (_m *CertificateSendTrigger) ForceTriggerEvent() {
+	_m.Called()
+}
+
+// CertificateSendTrigger_ForceTriggerEvent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForceTriggerEvent'
+type CertificateSendTrigger_ForceTriggerEvent_Call struct {
+	*mock.Call
+}
+
+// ForceTriggerEvent is a helper method to define mock.On call
+func (_e *CertificateSendTrigger_Expecter) ForceTriggerEvent() *CertificateSendTrigger_ForceTriggerEvent_Call {
+	return &CertificateSendTrigger_ForceTriggerEvent_Call{Call: _e.mock.On("ForceTriggerEvent")}
+}
+
+func (_c *CertificateSendTrigger_ForceTriggerEvent_Call) Run(run func()) *CertificateSendTrigger_ForceTriggerEvent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CertificateSendTrigger_ForceTriggerEvent_Call) Return() *CertificateSendTrigger_ForceTriggerEvent_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *CertificateSendTrigger_ForceTriggerEvent_Call) RunAndReturn(run func()) *CertificateSendTrigger_ForceTriggerEvent_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Setup provides a mock function with given fields: ctx
 func (_m *CertificateSendTrigger) Setup(ctx context.Context) {
 	_m.Called(ctx)

--- a/aggsender/mocks/mock_epoch_notifier.go
+++ b/aggsender/mocks/mock_epoch_notifier.go
@@ -22,6 +22,38 @@ func (_m *EpochNotifier) EXPECT() *EpochNotifier_Expecter {
 	return &EpochNotifier_Expecter{mock: &_m.Mock}
 }
 
+// ForcePublishEpochEvent provides a mock function with no fields
+func (_m *EpochNotifier) ForcePublishEpochEvent() {
+	_m.Called()
+}
+
+// EpochNotifier_ForcePublishEpochEvent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForcePublishEpochEvent'
+type EpochNotifier_ForcePublishEpochEvent_Call struct {
+	*mock.Call
+}
+
+// ForcePublishEpochEvent is a helper method to define mock.On call
+func (_e *EpochNotifier_Expecter) ForcePublishEpochEvent() *EpochNotifier_ForcePublishEpochEvent_Call {
+	return &EpochNotifier_ForcePublishEpochEvent_Call{Call: _e.mock.On("ForcePublishEpochEvent")}
+}
+
+func (_c *EpochNotifier_ForcePublishEpochEvent_Call) Run(run func()) *EpochNotifier_ForcePublishEpochEvent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EpochNotifier_ForcePublishEpochEvent_Call) Return() *EpochNotifier_ForcePublishEpochEvent_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *EpochNotifier_ForcePublishEpochEvent_Call) RunAndReturn(run func()) *EpochNotifier_ForcePublishEpochEvent_Call {
+	_c.Run(run)
+	return _c
+}
+
 // GetEpochStatus provides a mock function with no fields
 func (_m *EpochNotifier) GetEpochStatus() types.EpochStatus {
 	ret := _m.Called()

--- a/aggsender/rpc/aggsender_rpc.go
+++ b/aggsender/rpc/aggsender_rpc.go
@@ -15,6 +15,7 @@ type AggsenderStorer interface {
 
 type AggsenderInterface interface {
 	Info() types.AggsenderInfo
+	ForceTriggerCertitificate()
 }
 
 // AggsenderRPC is the RPC interface for the aggsender
@@ -42,6 +43,14 @@ func NewAggsenderRPC(
 func (b *AggsenderRPC) Status() (interface{}, rpc.Error) {
 	info := b.aggsender.Info()
 	return info, nil
+}
+
+// TriggerCertitificate forces the publication of an epoch event to trigger certificate creation
+// curl -X POST http://localhost:5576/ "Content-Type: application/json" \
+// -d '{"method":"aggsender_triggerCertitificate", "params":[], "id":1}'
+func (b *AggsenderRPC) TriggerCertitificate() (interface{}, rpc.Error) {
+	b.aggsender.ForceTriggerCertitificate()
+	return nil, nil
 }
 
 // GetCertificateHeaderPerHeight returns the certificate header for the given height

--- a/aggsender/rpc/aggsender_rpc_test.go
+++ b/aggsender/rpc/aggsender_rpc_test.go
@@ -16,6 +16,13 @@ func TestAggsenderRPCStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
+func TestAggsenderRPCTriggerCertitificate(t *testing.T) {
+	testData := newAggsenderData(t)
+	testData.mockAggsender.EXPECT().ForceTriggerCertitificate().Return()
+	res, err := testData.sut.TriggerCertitificate()
+	require.NoError(t, err)
+	require.Nil(t, res)
+}
 
 func TestAggsenderRPCGetCertificateHeaderPerHeight(t *testing.T) {
 	testData := newAggsenderData(t)

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -172,6 +172,7 @@ func (c *CertificateBuildParams) EstimatedSize() uint {
 	if c == nil {
 		return 0
 	}
+	// common.HashLength represents the size of a metadata hash in bytes
 	sizeBridges := (agglayertypes.EstimatedBridgeExitSize + common.HashLength) * float64(len(c.Bridges))
 	sizeClaims := (agglayertypes.EstimatedImportedBridgeExitSize + common.HashLength) * float64(len(c.Claims))
 

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -172,17 +172,8 @@ func (c *CertificateBuildParams) EstimatedSize() uint {
 	if c == nil {
 		return 0
 	}
-	sizeBridges := float64(0)
-	for _, bridge := range c.Bridges {
-		sizeBridges += agglayertypes.EstimatedBridgeExitSize
-		sizeBridges += float64(len(bridge.Metadata))
-	}
-
-	sizeClaims := float64(0)
-	for _, claim := range c.Claims {
-		sizeClaims += agglayertypes.EstimatedImportedBridgeExitSize
-		sizeClaims += float64(len(claim.Metadata))
-	}
+	sizeBridges := (agglayertypes.EstimatedBridgeExitSize + common.HashLength) * float64(len(c.Bridges))
+	sizeClaims := (agglayertypes.EstimatedImportedBridgeExitSize + common.HashLength) * float64(len(c.Claims))
 
 	sizeAggchainData := float64(0)
 	switch c.CertificateType {

--- a/aggsender/types/certificate_build_params_test.go
+++ b/aggsender/types/certificate_build_params_test.go
@@ -334,3 +334,16 @@ func TestAdjustToBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestEstimateSize(t *testing.T) {
+	sut := &CertificateBuildParams{
+		FromBlock: 100,
+		ToBlock:   200,
+		Bridges:   make([]bridgesync.Bridge, 50),
+		Claims:    make([]bridgesync.Claim, 150),
+	}
+
+	estimatedSize := sut.EstimatedSize()
+
+	require.Equal(t, uint(0x6bb47), estimatedSize, "Estimated size should match expected size")
+}

--- a/aggsender/types/epoch_notifier.go
+++ b/aggsender/types/epoch_notifier.go
@@ -35,4 +35,5 @@ type EpochNotifier interface {
 	// GetEpochStatus returns the current status of the epoch
 	GetEpochStatus() EpochStatus
 	String() string
+	ForcePublishEpochEvent()
 }

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -386,4 +386,5 @@ type CertificateSendTrigger interface {
 	Setup(ctx context.Context)
 	Status() string
 	TriggerCh(ctx context.Context) <-chan CertificateTriggerEvent
+	ForceTriggerEvent()
 }


### PR DESCRIPTION
- Fix estimatedSize that must consided metadata as a Hash, not the length of bytes
- Add a new RPC end-point for aggsender `aggsender_triggerCertitificate` to force a trigger certificate:
This is a useful feature for testing or event can be used in production to don't wait a epoch to force a trigger
```
curl -X POST http://localhost:5576/ "Content-Type: application/json"   -d '{"method":"aggsender_triggerCertitificate", "params":[], "id":1}'
```
- #1296


## 🔗 Related PRs
- #1304

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
