### PR TITLE
feat: insert corrected claims and track invalid ones

### DIFF
--- a/bridgesync/migrations/bridgesync0010.sql
+++ b/bridgesync/migrations/bridgesync0010.sql
@@ -1,6 +1,7 @@
 -- +migrate Down
 DROP TABLE IF EXISTS set_claim;
 DROP TABLE IF EXISTS unset_claim;
+DROP TABLE IF EXISTS invalid_claim;
 
 ALTER TABLE claim ADD COLUMN from_address VARCHAR;
 
@@ -22,6 +23,28 @@ CREATE TABLE set_claim (
 	global_index            TEXT NOT NULL,
 	created_at              INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
 	PRIMARY KEY (block_num, block_pos)
+);
+
+CREATE TABLE invalid_claim (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_num               INTEGER NOT NULL,
+    block_pos               INTEGER NOT NULL,
+    global_index            TEXT NOT NULL,
+    origin_network          INTEGER NOT NULL,
+    origin_address          VARCHAR NOT NULL,
+    destination_address     VARCHAR NOT NULL,
+    amount                  TEXT NOT NULL,
+    proof_local_exit_root   VARCHAR,
+    proof_rollup_exit_root  VARCHAR,
+    mainnet_exit_root       VARCHAR,
+    rollup_exit_root        VARCHAR,
+    global_exit_root        VARCHAR,
+    destination_network     INTEGER NOT NULL,
+    metadata                BLOB,
+    is_message              BOOLEAN,
+    block_timestamp         INTEGER,
+    created_at              INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    reason                  VARCHAR NOT NULL
 );
 
 ALTER TABLE claim DROP COLUMN from_address;

--- a/bridgesync/migrations/bridgesync0010.sql
+++ b/bridgesync/migrations/bridgesync0010.sql
@@ -26,7 +26,6 @@ CREATE TABLE set_claim (
 );
 
 CREATE TABLE invalid_claim (
-    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
     block_num               INTEGER NOT NULL,
     block_pos               INTEGER NOT NULL,
     global_index            TEXT NOT NULL,
@@ -45,7 +44,8 @@ CREATE TABLE invalid_claim (
     block_timestamp         INTEGER,
     tx_hash                 VARCHAR NOT NULL,
     created_at              INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
-    reason                  VARCHAR NOT NULL
+    reason                  VARCHAR NOT NULL,
+    PRIMARY KEY (block_num, block_pos)
 );
 
 ALTER TABLE claim DROP COLUMN from_address;

--- a/bridgesync/migrations/bridgesync0010.sql
+++ b/bridgesync/migrations/bridgesync0010.sql
@@ -43,6 +43,7 @@ CREATE TABLE invalid_claim (
     metadata                BLOB,
     is_message              BOOLEAN,
     block_timestamp         INTEGER,
+    tx_hash                 VARCHAR NOT NULL,
     created_at              INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
     reason                  VARCHAR NOT NULL
 );

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -299,13 +299,13 @@ type InvalidClaim struct {
 	IsMessage           bool           `meddler:"is_message"`
 	BlockTimestamp      uint64         `meddler:"block_timestamp"`
 	// additional fields
-	Reason    string    `meddler:"reason"`
-	CreatedAt time.Time `meddler:"created_at"`
+	Reason    string `meddler:"reason"`
+	CreatedAt uint64 `meddler:"created_at"`
 }
 
 // NewInvalidClaim creates a new InvalidClaim from a Claim and a reason
-func NewInvalidClaim(c *Claim, reason string) *InvalidClaim {
-	return &InvalidClaim{
+func NewInvalidClaim(c *Claim, id int64, reason string) *InvalidClaim {
+	ic := &InvalidClaim{
 		BlockNum:            c.BlockNum,
 		BlockPos:            c.BlockPos,
 		TxHash:              c.TxHash,
@@ -324,8 +324,12 @@ func NewInvalidClaim(c *Claim, reason string) *InvalidClaim {
 		IsMessage:           c.IsMessage,
 		BlockTimestamp:      c.BlockTimestamp,
 		Reason:              reason,
-		CreatedAt:           time.Now().UTC(),
+		CreatedAt:           uint64(time.Now().UTC().Unix()),
 	}
+	if id != -1 {
+		ic.ID = id
+	}
+	return ic
 }
 
 // TokenMapping representation of a NewWrappedToken event, that is emitted by the bridge contract
@@ -1017,10 +1021,12 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 						return err
 					}
 
-					invalidClaim := NewInvalidClaim(event.Claim, InvalidGERClaimCorrect.String())
-					if err = meddler.Insert(tx, invalidClaimTableName, invalidClaim); err != nil {
-						p.log.Errorf("failed to insert invalid claim for global index %d: %v", globalIndex, err)
-						return err
+					for _, existingClaim := range existingClaims {
+						invalidClaim := NewInvalidClaim(&existingClaim, -1, InvalidGERClaimCorrect.String())
+						if err = meddler.Insert(tx, invalidClaimTableName, invalidClaim); err != nil {
+							p.log.Errorf("failed to insert invalid claim for global index %d: %v", globalIndex, err)
+							return err
+						}
 					}
 				}
 			}
@@ -1082,6 +1088,20 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	}
 
 	return nil
+}
+
+// getInvalidClaimsByGlobalIndex returns invalid claims by global index
+func (p *processor) getInvalidClaimsByGlobalIndex(globalIndex *big.Int) ([]*InvalidClaim, error) {
+	var results []*InvalidClaim
+	if err := meddler.QueryAll(p.db, &results, fmt.Sprintf(`
+		SELECT * FROM %s
+		WHERE global_index = $1
+		ORDER BY block_num ASC, block_pos ASC;
+	`, invalidClaimTableName), globalIndex.String()); err != nil {
+		return nil, fmt.Errorf("failed to query invalid claims by global index: %s: %w", globalIndex.String(), err)
+	}
+
+	return results, nil
 }
 
 // GetTotalNumberOfRecords returns the total number of records in the given table

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -613,16 +613,16 @@ func (p *processor) GetUnsetClaimsPaged(
 	globalIndex *big.Int,
 ) ([]*UnsetClaim, int, error) {
 	whereClause := p.buildUnsetClaimsFilterClause(globalIndex)
-	claimsCount, err := p.GetTotalNumberOfRecords(ctx, unsetClaimTableName, whereClause)
+	unclaimsCount, err := p.GetTotalNumberOfRecords(ctx, unsetClaimTableName, whereClause)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	if claimsCount == 0 {
+	if unclaimsCount == 0 {
 		return []*UnsetClaim{}, 0, nil
 	}
 
-	offset, err := p.calculateOffset(pageNumber, pageSize, claimsCount, unsetClaimTableName)
+	offset, err := p.calculateOffset(pageNumber, pageSize, unclaimsCount, unsetClaimTableName)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -632,7 +632,7 @@ func (p *processor) GetUnsetClaimsPaged(
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no unset claims were found for provided parameters (pageNumber=%d, pageSize=%d)",
 				pageNumber, pageSize)
-			return nil, claimsCount, nil
+			return nil, unclaimsCount, nil
 		}
 		p.log.Errorf("GetUnsetClaimsPaged: queryPaged failed for pageNumber=%d, pageSize=%d: %v", pageNumber, pageSize, err)
 		return nil, 0, err
@@ -650,25 +650,16 @@ func (p *processor) GetUnsetClaimsPaged(
 		return nil, 0, err
 	}
 
-	return unsetClaims, claimsCount, nil
+	return unsetClaims, unclaimsCount, nil
 }
 
 // buildUnsetClaimsFilterClause builds the WHERE clause for the unset_claim table
-// based on the provided globalIndex (networkIDs not applicable for unset claims)
+// based on the provided globalIndex
 func (p *processor) buildUnsetClaimsFilterClause(globalIndex *big.Int) string {
-	const clauseCapacity = 1
-	clauses := make([]string, 0, clauseCapacity)
-
-	// Note: networkIDs filtering is not applicable for unset claims as they don't have network fields
-	// Unset claims only have global_index, block info, and hash chain
-
 	if globalIndex != nil {
-		clauses = append(clauses, fmt.Sprintf("global_index = '%s'", globalIndex.String()))
+		return " WHERE " + fmt.Sprintf("global_index = '%s'", globalIndex.String())
 	}
 
-	if len(clauses) > 0 {
-		return " WHERE " + strings.Join(clauses, " AND ")
-	}
 	return ""
 }
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -943,15 +943,27 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			}
 
 			if unsetCount == 0 {
-				if err = meddler.Save(tx, claimTableName, event.Claim); err != nil {
-					p.log.Errorf("failed to upsert claim event at block %d: %v", block.Num, err)
+				claims, err := p.GetClaimsByGlobalIndex(ctx, event.Claim.GlobalIndex)
+				if err != nil {
+					p.log.Errorf("failed to get claims for global index %d at block %d: %v",
+						event.Claim.GlobalIndex, block.Num, err)
 					return err
 				}
-			} else {
-				if err = meddler.Insert(tx, claimTableName, event.Claim); err != nil {
-					p.log.Errorf("failed to insert claim event at block %d: %v", block.Num, err)
-					return err
+
+				if len(claims) > 0 {
+					// TODO: figure out if we need to keep those claims for history
+					_, err = tx.Exec(`DELETE FROM claim WHERE global_index = ?`, event.Claim.GlobalIndex.String())
+					if err != nil {
+						p.log.Errorf("failed to delete claims for global index %d: %v",
+							event.Claim.GlobalIndex, err)
+						return err
+					}
 				}
+			}
+
+			if err = meddler.Insert(tx, claimTableName, event.Claim); err != nil {
+				p.log.Errorf("failed to insert claim event at block %d: %v", block.Num, err)
+				return err
 			}
 		}
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -935,9 +935,23 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 
 		if event.Claim != nil {
-			if err = meddler.Insert(tx, claimTableName, event.Claim); err != nil {
-				p.log.Errorf("failed to insert claim event at block %d: %v", block.Num, err)
+			_, unsetCount, err := p.GetUnsetClaimsPaged(ctx, 1, 1, event.Claim.GlobalIndex)
+			if err != nil {
+				p.log.Errorf("failed to get unset claims for global index %s at block %d: %v",
+					event.Claim.GlobalIndex.String(), block.Num, err)
 				return err
+			}
+
+			if unsetCount == 0 {
+				if err = meddler.Save(tx, claimTableName, event.Claim); err != nil {
+					p.log.Errorf("failed to upsert claim event at block %d: %v", block.Num, err)
+					return err
+				}
+			} else {
+				if err = meddler.Insert(tx, claimTableName, event.Claim); err != nil {
+					p.log.Errorf("failed to insert claim event at block %d: %v", block.Num, err)
+					return err
+				}
 			}
 		}
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -58,12 +58,15 @@ type DeleteClaimReason int
 
 const (
 	InvalidGERClaimCorrect DeleteClaimReason = iota
+	InvalidGERClaimIncorrect
 )
 
 func (d DeleteClaimReason) String() string {
 	switch d {
 	case InvalidGERClaimCorrect:
 		return "invalid_ger_claim_correct"
+	case InvalidGERClaimIncorrect:
+		return "invalid_ger_claim_incorrect"
 	default:
 		return "unknown"
 	}
@@ -304,8 +307,8 @@ type InvalidClaim struct {
 }
 
 // NewInvalidClaim creates a new InvalidClaim from a Claim and a reason
-func NewInvalidClaim(c *Claim, id int64, reason string) *InvalidClaim {
-	ic := &InvalidClaim{
+func NewInvalidClaim(c *Claim, reason string) *InvalidClaim {
+	return &InvalidClaim{
 		BlockNum:            c.BlockNum,
 		BlockPos:            c.BlockPos,
 		TxHash:              c.TxHash,
@@ -326,10 +329,6 @@ func NewInvalidClaim(c *Claim, id int64, reason string) *InvalidClaim {
 		Reason:              reason,
 		CreatedAt:           uint64(time.Now().UTC().Unix()),
 	}
-	if id != -1 {
-		ic.ID = id
-	}
-	return ic
 }
 
 // TokenMapping representation of a NewWrappedToken event, that is emitted by the bridge contract
@@ -1022,7 +1021,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 					}
 
 					for _, existingClaim := range existingClaims {
-						invalidClaim := NewInvalidClaim(&existingClaim, -1, InvalidGERClaimCorrect.String())
+						invalidClaim := NewInvalidClaim(&existingClaim, InvalidGERClaimCorrect.String())
 						if err = meddler.Insert(tx, invalidClaimTableName, invalidClaim); err != nil {
 							p.log.Errorf("failed to insert invalid claim for global index %d: %v", globalIndex, err)
 							return err
@@ -1060,6 +1059,20 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 
 		if event.UnsetClaim != nil {
+			existingClaims, err := p.GetClaimsByGlobalIndex(ctx, event.UnsetClaim.GlobalIndex)
+			if err != nil {
+				p.log.Errorf("failed to retrieve existing claims for unsetted claim global index %s at block %d: %v",
+					event.UnsetClaim.GlobalIndex, block.Num, err)
+			}
+
+			for _, claim := range existingClaims {
+				ic := NewInvalidClaim(&claim, InvalidGERClaimIncorrect.String())
+				if err = meddler.Insert(tx, invalidClaimTableName, ic); err != nil {
+					p.log.Errorf("failed to insert invalid claim for global index %s at block %d: %v",
+						claim.GlobalIndex.String(), block.Num, err)
+				}
+			}
+
 			if err = meddler.Insert(tx, unsetClaimTableName, event.UnsetClaim); err != nil {
 				p.log.Errorf("failed to insert unset claim event at block %d: %v", block.Num, err)
 				return err

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -38,6 +38,9 @@ const (
 	// claimTableName is the name of the table that stores claim events
 	claimTableName = "claim"
 
+	// invalidClaimTableName is the name of the table that stores invalid claim events
+	invalidClaimTableName = "invalid_claim"
+
 	// tokenMappingTableName is the name of the table that stores token mapping events
 	tokenMappingTableName = "token_mapping"
 
@@ -50,6 +53,21 @@ const (
 	// setClaimTableName is the name of the table that stores set claim events
 	setClaimTableName = "set_claim"
 )
+
+type DeleteClaimReason int
+
+const (
+	InvalidGERClaimCorrect DeleteClaimReason = iota
+)
+
+func (d DeleteClaimReason) String() string {
+	switch d {
+	case InvalidGERClaimCorrect:
+		return "invalid_ger_claim_correct"
+	default:
+		return "unknown"
+	}
+}
 
 const (
 	// orderByBlockDesc is the default order by clause for block-based queries
@@ -258,6 +276,56 @@ func (c *Claim) decodePreEtrogCalldata(data []any) (bool, error) {
 	c.GlobalExitRoot = crypto.Keccak256Hash(c.MainnetExitRoot.Bytes(), c.RollupExitRoot.Bytes())
 
 	return true, nil
+}
+
+type InvalidClaim struct {
+	// claim struct fields
+	ID                  int64          `meddler:"id,pk"`
+	BlockNum            uint64         `meddler:"block_num"`
+	BlockPos            uint64         `meddler:"block_pos"`
+	TxHash              common.Hash    `meddler:"tx_hash,hash"`
+	GlobalIndex         *big.Int       `meddler:"global_index,bigint"`
+	OriginNetwork       uint32         `meddler:"origin_network"`
+	OriginAddress       common.Address `meddler:"origin_address"`
+	DestinationAddress  common.Address `meddler:"destination_address"`
+	Amount              *big.Int       `meddler:"amount,bigint"`
+	ProofLocalExitRoot  types.Proof    `meddler:"proof_local_exit_root,merkleproof"`
+	ProofRollupExitRoot types.Proof    `meddler:"proof_rollup_exit_root,merkleproof"`
+	MainnetExitRoot     common.Hash    `meddler:"mainnet_exit_root,hash"`
+	RollupExitRoot      common.Hash    `meddler:"rollup_exit_root,hash"`
+	GlobalExitRoot      common.Hash    `meddler:"global_exit_root,hash"`
+	DestinationNetwork  uint32         `meddler:"destination_network"`
+	Metadata            []byte         `meddler:"metadata"`
+	IsMessage           bool           `meddler:"is_message"`
+	BlockTimestamp      uint64         `meddler:"block_timestamp"`
+	// additional fields
+	Reason    string    `meddler:"reason"`
+	CreatedAt time.Time `meddler:"created_at"`
+}
+
+// NewInvalidClaim creates a new InvalidClaim from a Claim and a reason
+func NewInvalidClaim(c *Claim, reason string) *InvalidClaim {
+	return &InvalidClaim{
+		BlockNum:            c.BlockNum,
+		BlockPos:            c.BlockPos,
+		TxHash:              c.TxHash,
+		GlobalIndex:         c.GlobalIndex,
+		OriginNetwork:       c.OriginNetwork,
+		OriginAddress:       c.OriginAddress,
+		DestinationAddress:  c.DestinationAddress,
+		Amount:              c.Amount,
+		ProofLocalExitRoot:  c.ProofLocalExitRoot,
+		ProofRollupExitRoot: c.ProofRollupExitRoot,
+		MainnetExitRoot:     c.MainnetExitRoot,
+		RollupExitRoot:      c.RollupExitRoot,
+		GlobalExitRoot:      c.GlobalExitRoot,
+		DestinationNetwork:  c.DestinationNetwork,
+		Metadata:            c.Metadata,
+		IsMessage:           c.IsMessage,
+		BlockTimestamp:      c.BlockTimestamp,
+		Reason:              reason,
+		CreatedAt:           time.Now().UTC(),
+	}
 }
 
 // TokenMapping representation of a NewWrappedToken event, that is emitted by the bridge contract
@@ -926,7 +994,8 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 
 		if event.Claim != nil {
-			_, unsetCount, err := p.GetUnsetClaimsPaged(ctx, 1, 1, event.Claim.GlobalIndex)
+			globalIndex := event.Claim.GlobalIndex
+			_, unsetCount, err := p.GetUnsetClaimsPaged(ctx, 1, 1, globalIndex)
 			if err != nil {
 				p.log.Errorf("failed to get unset claims for global index %s at block %d: %v",
 					event.Claim.GlobalIndex.String(), block.Num, err)
@@ -934,19 +1003,23 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			}
 
 			if unsetCount == 0 {
-				claims, err := p.GetClaimsByGlobalIndex(ctx, event.Claim.GlobalIndex)
+				existingClaims, err := p.GetClaimsByGlobalIndex(ctx, globalIndex)
 				if err != nil {
 					p.log.Errorf("failed to get claims for global index %d at block %d: %v",
 						event.Claim.GlobalIndex, block.Num, err)
 					return err
 				}
 
-				if len(claims) > 0 {
-					// TODO: figure out if we need to keep those claims for history
-					_, err = tx.Exec(`DELETE FROM claim WHERE global_index = ?`, event.Claim.GlobalIndex.String())
+				if len(existingClaims) > 0 {
+					_, err = tx.Exec(`DELETE FROM claim WHERE global_index = ?`, globalIndex.String())
 					if err != nil {
-						p.log.Errorf("failed to delete claims for global index %d: %v",
-							event.Claim.GlobalIndex, err)
+						p.log.Errorf("failed to delete claims for global index %d: %v", globalIndex, err)
+						return err
+					}
+
+					invalidClaim := NewInvalidClaim(event.Claim, InvalidGERClaimCorrect.String())
+					if err = meddler.Insert(tx, invalidClaimTableName, invalidClaim); err != nil {
+						p.log.Errorf("failed to insert invalid claim for global index %d: %v", globalIndex, err)
 						return err
 					}
 				}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -283,7 +283,6 @@ func (c *Claim) decodePreEtrogCalldata(data []any) (bool, error) {
 
 type InvalidClaim struct {
 	// claim struct fields
-	ID                  int64          `meddler:"id,pk"`
 	BlockNum            uint64         `meddler:"block_num"`
 	BlockPos            uint64         `meddler:"block_pos"`
 	TxHash              common.Hash    `meddler:"tx_hash,hash"`

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2939,3 +2939,34 @@ func TestProcessBlockWithClaims(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteClaimReason_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   DeleteClaimReason
+		expected string
+	}{
+		{
+			name:     "InvalidGERClaimCorrect",
+			reason:   InvalidGERClaimCorrect,
+			expected: "invalid_ger_claim_correct",
+		},
+		{
+			name:     "UnknownReason",
+			reason:   DeleteClaimReason(999), // something outside defined range
+			expected: "unknown",
+		},
+		{
+			name:     "NegativeReason",
+			reason:   DeleteClaimReason(-1),
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.reason.String()
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2883,10 +2883,7 @@ func TestProcessBlockWithClaims(t *testing.T) {
 
 	// Invalid claims
 	invalidClaim1 := NewInvalidClaim(claim1, InvalidGERClaimCorrect.String())
-	invalidClaim1.ID = 1
-
 	invalidClaim2 := NewInvalidClaim(claim2, InvalidGERClaimIncorrect.String())
-	invalidClaim2.ID = 2
 
 	tests := []struct {
 		name                  string

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2689,7 +2689,6 @@ func TestGetUnsetClaimsPaged(t *testing.T) {
 	t.Parallel()
 
 	path := path.Join(t.TempDir(), "bridgesyncGetUnsetClaimsPaged.sqlite")
-	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("module", "bridge-syncer")
 	p, err := newProcessor(path, "bridge-syncer", logger, dbQueryTimeout)
 	require.NoError(t, err)
@@ -2850,8 +2849,8 @@ func TestProcessBlockWithClaims(t *testing.T) {
 	p, err := newProcessor(path, "bridge-syncer", log.GetDefaultLogger(), dbQueryTimeout)
 	require.NoError(t, err)
 
-	newClaim := func(blockNum, pos uint64, gi int64, origin string, dest string, amount int64, mer string) Claim {
-		return Claim{
+	newClaim := func(blockNum, pos uint64, gi int64, origin string, dest string, amount int64, mer string) *Claim {
+		return &Claim{
 			BlockNum:           blockNum,
 			BlockPos:           pos,
 			GlobalIndex:        big.NewInt(gi),
@@ -2882,34 +2881,43 @@ func TestProcessBlockWithClaims(t *testing.T) {
 		CreatedAt:   uint64(time.Now().UTC().Unix()),
 	}
 
+	// Invalid claims
+	invalidClaim1 := NewInvalidClaim(claim1, InvalidGERClaimCorrect.String())
+	invalidClaim1.ID = 1
+
+	invalidClaim2 := NewInvalidClaim(claim2, InvalidGERClaimIncorrect.String())
+	invalidClaim2.ID = 2
+
 	tests := []struct {
 		name                  string
 		blocks                []sync.Block
-		expectedClaims        []Claim
+		expectedClaims        []*Claim
 		expectedInvalidClaims []*InvalidClaim
 	}{
 		{
 			name: "update claim with same global index",
 			blocks: []sync.Block{
-				block(1, Event{Claim: &claim1}, Event{Claim: &claim2}),
-				block(2, Event{Claim: &claim1Updated}),
+				block(1, Event{Claim: claim1}, Event{Claim: claim2}),
+				block(2, Event{Claim: claim1Updated}),
 			},
-			expectedClaims: []Claim{
+			expectedClaims: []*Claim{
 				claim1Updated,
 				claim2,
 			},
-			expectedInvalidClaims: []*InvalidClaim{
-				NewInvalidClaim(&claim1, 1, InvalidGERClaimCorrect.String()),
-			},
+			expectedInvalidClaims: []*InvalidClaim{invalidClaim1},
 		},
 		{
 			name: "original claim remains in the db when unclaimed",
 			blocks: []sync.Block{
 				block(3, Event{UnsetClaim: unsetClaim2}),
 			},
-			expectedClaims: []Claim{
+			expectedClaims: []*Claim{
 				claim1Updated,
 				claim2,
+			},
+			expectedInvalidClaims: []*InvalidClaim{
+				invalidClaim1,
+				invalidClaim2,
 			},
 		},
 	}
@@ -2926,7 +2934,7 @@ func TestProcessBlockWithClaims(t *testing.T) {
 				dbClaims, err := p.GetClaimsByGlobalIndex(context.Background(), expected.GlobalIndex)
 				require.NoError(t, err)
 				require.Len(t, dbClaims, 1)
-				require.Equal(t, expected, dbClaims[0])
+				require.Equal(t, expected, &dbClaims[0])
 			}
 
 			// check invalid_claim rows
@@ -2950,6 +2958,11 @@ func TestDeleteClaimReason_String(t *testing.T) {
 			name:     "InvalidGERClaimCorrect",
 			reason:   InvalidGERClaimCorrect,
 			expected: "invalid_ger_claim_correct",
+		},
+		{
+			name:     "InvalidGERClaimIncorrect",
+			reason:   InvalidGERClaimIncorrect,
+			expected: "invalid_ger_claim_incorrect",
 		},
 		{
 			name:     "UnknownReason",

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -386,7 +386,7 @@ func TestProcessor(t *testing.T) {
 var (
 	block1 = sync.Block{
 		Num: 1,
-		Events: []interface{}{
+		Events: []any{
 			Event{Bridge: &Bridge{
 				BlockNum:           1,
 				BlockPos:           0,
@@ -437,7 +437,7 @@ var (
 	}
 	block3 = sync.Block{
 		Num: 3,
-		Events: []interface{}{
+		Events: []any{
 			Event{Bridge: &Bridge{
 				BlockNum:           3,
 				BlockPos:           0,
@@ -466,11 +466,11 @@ var (
 	}
 	block4 = sync.Block{
 		Num:    4,
-		Events: []interface{}{},
+		Events: []any{},
 	}
 	block5 = sync.Block{
 		Num: 5,
-		Events: []interface{}{
+		Events: []any{
 			Event{Claim: &Claim{
 				BlockNum:           5,
 				BlockPos:           0,
@@ -669,7 +669,7 @@ func (a *getTotalRecordsAction) execute(t *testing.T) {
 	require.Equal(t, a.expectedRecordsNum, recordsNum)
 }
 
-func eventsToBridges(events []interface{}) []Bridge {
+func eventsToBridges(events []any) []Bridge {
 	bridges := []Bridge{}
 	for _, event := range events {
 		e, ok := event.(Event)
@@ -683,7 +683,7 @@ func eventsToBridges(events []interface{}) []Bridge {
 	return bridges
 }
 
-func eventsToClaims(events []interface{}) []Claim {
+func eventsToClaims(events []any) []Claim {
 	claims := []Claim{}
 	for _, event := range events {
 		e, ok := event.(Event)
@@ -878,8 +878,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 }
 
 func TestInsertAndGetClaim(t *testing.T) {
-	path := path.Join(t.TempDir(), "aggsenderTestInsertAndGetClaim.sqlite")
-	log.Debugf("sqlite path: %s", path)
+	path := path.Join(t.TempDir(), "TestInsertAndGetClaim.sqlite")
 	err := migrations.RunMigrations(path)
 	require.NoError(t, err)
 	logger := log.WithFields("bridge-syncer", "foo")
@@ -1005,7 +1004,7 @@ func TestProcessBlockInvalidIndex(t *testing.T) {
 	require.NoError(t, err)
 	err = p.ProcessBlock(context.Background(), sync.Block{
 		Num: 0,
-		Events: []interface{}{
+		Events: []any{
 			Event{Bridge: &Bridge{DepositCount: 5}},
 		},
 	})
@@ -1415,7 +1414,7 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 
 		block := sync.Block{
 			Num:    uint64(i + 1),
-			Events: []interface{}{Event{TokenMapping: tokenMappingEvt}},
+			Events: []any{Event{TokenMapping: tokenMappingEvt}},
 		}
 
 		allTokenMappings = append(allTokenMappings, tokenMappingEvt)
@@ -2075,12 +2074,12 @@ func TestQueryBlockRangeOrdering(t *testing.T) {
 	block1 := sync.Block{
 		Num:    1,
 		Hash:   common.HexToHash("0x1"),
-		Events: []interface{}{events[0], events[1], events[2]},
+		Events: []any{events[0], events[1], events[2]},
 	}
 	block2 := sync.Block{
 		Num:    2,
 		Hash:   common.HexToHash("0x2"),
-		Events: []interface{}{events[3]},
+		Events: []any{events[3]},
 	}
 
 	err = p.ProcessBlock(context.Background(), block1)
@@ -2442,7 +2441,7 @@ func TestProcessor_ErrorPathLogging(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
+			Events: []any{
 				Event{Bridge: createTestBridge(1, 0)},
 			},
 		}
@@ -2467,8 +2466,26 @@ func TestProcessor_ErrorPathLogging(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
-				Event{Claim: createTestClaim(1, 0)},
+			Events: []any{
+				Event{Claim: &Claim{
+					BlockNum:            1,
+					BlockPos:            0,
+					BlockTimestamp:      1234567890,
+					TxHash:              common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+					GlobalIndex:         big.NewInt(1000000000000000000),
+					OriginNetwork:       1,
+					OriginAddress:       common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					DestinationAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					Amount:              big.NewInt(1000000000000000000),
+					ProofLocalExitRoot:  [common.HashLength]common.Hash{},
+					ProofRollupExitRoot: [common.HashLength]common.Hash{},
+					MainnetExitRoot:     common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+					RollupExitRoot:      common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+					GlobalExitRoot:      common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+					DestinationNetwork:  1,
+					Metadata:            []byte{},
+					IsMessage:           false,
+				}},
 			},
 		}
 		require.NoError(t, p.ProcessBlock(context.Background(), testBlock))
@@ -2492,8 +2509,17 @@ func TestProcessor_ErrorPathLogging(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
-				Event{LegacyTokenMigration: createTestLegacyTokenMigration(1, 0)},
+			Events: []any{
+				Event{LegacyTokenMigration: &LegacyTokenMigration{
+					BlockNum:            1,
+					BlockPos:            0,
+					BlockTimestamp:      1234567890,
+					TxHash:              common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+					Sender:              common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					LegacyTokenAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					UpdatedTokenAddress: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					Amount:              big.NewInt(1000000000000000000),
+				}},
 			},
 		}
 		require.NoError(t, p.ProcessBlock(context.Background(), testBlock))
@@ -2517,7 +2543,7 @@ func TestProcessor_ErrorPathLogging(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
+			Events: []any{
 				Event{TokenMapping: createTestTokenMapping(1, 0)},
 			},
 		}
@@ -2556,7 +2582,7 @@ func TestProcessor_DatabaseConnectionErrors(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
+			Events: []any{
 				Event{TokenMapping: createTestTokenMapping(1, 0)},
 			},
 		}
@@ -2579,7 +2605,7 @@ func TestProcessor_CalculateOffsetErrors(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
+			Events: []any{
 				Event{TokenMapping: createTestTokenMapping(1, 0)},
 			},
 		}
@@ -2598,7 +2624,7 @@ func TestProcessor_CalculateOffsetErrors(t *testing.T) {
 		testBlock := sync.Block{
 			Num:  1,
 			Hash: common.HexToHash("0x1"),
-			Events: []interface{}{
+			Events: []any{
 				Event{Bridge: createTestBridge(1, 0)},
 			},
 		}
@@ -2643,29 +2669,6 @@ func createTestBridge(blockNum uint64, blockPos int) *Bridge {
 	}
 }
 
-// createTestClaim creates a test Claim event
-func createTestClaim(blockNum uint64, blockPos int) *Claim {
-	return &Claim{
-		BlockNum:            blockNum,
-		BlockPos:            uint64(blockPos),
-		BlockTimestamp:      1234567890,
-		TxHash:              common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		GlobalIndex:         big.NewInt(1000000000000000000),
-		OriginNetwork:       1,
-		OriginAddress:       common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		DestinationAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		Amount:              big.NewInt(1000000000000000000),
-		ProofLocalExitRoot:  [common.HashLength]common.Hash{},
-		ProofRollupExitRoot: [common.HashLength]common.Hash{},
-		MainnetExitRoot:     common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		RollupExitRoot:      common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		GlobalExitRoot:      common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		DestinationNetwork:  1,
-		Metadata:            []byte{},
-		IsMessage:           false,
-	}
-}
-
 // createTestTokenMapping creates a test TokenMapping event
 func createTestTokenMapping(blockNum uint64, blockPos int) *TokenMapping {
 	return &TokenMapping{
@@ -2679,20 +2682,6 @@ func createTestTokenMapping(blockNum uint64, blockPos int) *TokenMapping {
 		Metadata:            []byte{},
 		IsNotMintable:       false,
 		Type:                0,
-	}
-}
-
-// createTestLegacyTokenMigration creates a test LegacyTokenMigration event
-func createTestLegacyTokenMigration(blockNum uint64, blockPos int) *LegacyTokenMigration {
-	return &LegacyTokenMigration{
-		BlockNum:            blockNum,
-		BlockPos:            uint64(blockPos),
-		BlockTimestamp:      1234567890,
-		TxHash:              common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		Sender:              common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		LegacyTokenAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		UpdatedTokenAddress: common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		Amount:              big.NewInt(1000000000000000000),
 	}
 }
 
@@ -2735,7 +2724,7 @@ func TestGetUnsetClaimsPaged(t *testing.T) {
 		block := sync.Block{
 			Num:  uint64(i + 1),
 			Hash: common.HexToHash(fmt.Sprintf("0x%d", i+1)),
-			Events: []interface{}{
+			Events: []any{
 				Event{UnsetClaim: unsetClaim},
 			},
 		}
@@ -2854,4 +2843,99 @@ func TestDatabaseQueryTimeout(t *testing.T) {
 	_, err = pShortTimeout.GetClaims(ctx, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func TestProcessBlockWithClaims(t *testing.T) {
+	path := path.Join(t.TempDir(), fmt.Sprintf("%s.db", t.Name()))
+	p, err := newProcessor(path, "bridge-syncer", log.GetDefaultLogger(), dbQueryTimeout)
+	require.NoError(t, err)
+
+	newClaim := func(blockNum, pos uint64, gi int64, origin string, dest string, amount int64, mer string) Claim {
+		return Claim{
+			BlockNum:           blockNum,
+			BlockPos:           pos,
+			GlobalIndex:        big.NewInt(gi),
+			OriginNetwork:      uint32(gi), // just distinct per test
+			OriginAddress:      common.HexToAddress(origin),
+			DestinationAddress: common.HexToAddress(dest),
+			Amount:             big.NewInt(amount),
+			MainnetExitRoot:    common.HexToHash(mer),
+		}
+	}
+
+	block := func(num uint64, events ...any) sync.Block {
+		return sync.Block{Num: num, Events: events}
+	}
+
+	// Initial claims (block 1)
+	claim1 := newClaim(1, 0, 1, "1", "1", 1, "")
+	claim2 := newClaim(1, 1, 2, "2", "2", 2, "5ca1e1")
+
+	// Replacement claim (block 2)
+	claim1Updated := newClaim(2, 0, 1, "3", "3", 10, "5ca1e")
+
+	// Unset claim for claim2 (global index 2)
+	unsetClaim2 := &UnsetClaim{
+		BlockNum:    3,
+		BlockPos:    0,
+		GlobalIndex: claim2.GlobalIndex,
+		CreatedAt:   uint64(time.Now().UTC().Unix()),
+	}
+
+	tests := []struct {
+		name                  string
+		blocks                []sync.Block
+		expectedClaims        []Claim
+		expectedInvalidClaims []*InvalidClaim
+	}{
+		{
+			name: "update claim with same global index",
+			blocks: []sync.Block{
+				block(1, Event{Claim: &claim1}, Event{Claim: &claim2}),
+				block(2, Event{Claim: &claim1Updated}),
+			},
+			expectedClaims: []Claim{
+				claim1Updated,
+				claim2,
+			},
+			expectedInvalidClaims: []*InvalidClaim{
+				NewInvalidClaim(&claim1, 1, InvalidGERClaimCorrect.String()),
+			},
+		},
+		{
+			name: "original claim remains in the db when unclaimed",
+			blocks: []sync.Block{
+				block(3, Event{UnsetClaim: unsetClaim2}),
+			},
+			expectedClaims: []Claim{
+				claim1Updated,
+				claim2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// process blocks
+			for _, b := range tt.blocks {
+				require.NoError(t, p.ProcessBlock(context.Background(), b))
+			}
+
+			// check final claims
+			for _, expected := range tt.expectedClaims {
+				dbClaims, err := p.GetClaimsByGlobalIndex(context.Background(), expected.GlobalIndex)
+				require.NoError(t, err)
+				require.Len(t, dbClaims, 1)
+				require.Equal(t, expected, dbClaims[0])
+			}
+
+			// check invalid_claim rows
+			for _, expected := range tt.expectedInvalidClaims {
+				dbInvalidClaims, err := p.getInvalidClaimsByGlobalIndex(expected.GlobalIndex)
+				require.NoError(t, err)
+				require.Len(t, dbInvalidClaims, 1)
+				require.Equal(t, expected, dbInvalidClaims[0])
+			}
+		})
+	}
 }


### PR DESCRIPTION
## 🔄 Changes Summary
Implement upsertions of claims (in case there is no unset of the claim and fixed claim was "replayed"), which is needed for non-finalized GERs injection.

It also keeps track of invalid claims, which are being kept in the invalid_claim table. There are two cases:
- GER is invalid, but claim is correct (in that case we don't need to unset the claim)
- both GER and claims are invalid (in that case we need to unset the claim, and we insert the invalid claim in case when we index the unset claim event from contract)

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #1299 

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]
