### PR TITLE
fix: remove multilingual tag from mdbook config

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Aggkit Team - Polygon Labs"]
 language = "en"
-multilingual = false
 src = "docs"
 title = "Aggkit Docs"
 


### PR DESCRIPTION
## 🔄 Changes Summary
Removes the multilingual tag from mdbook config, based on this [error](https://github.com/agglayer/aggkit/actions/runs/19704421209/job/56448313355).

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
