### PR TITLE
fix: TestWithReorgs unit test

### DIFF
--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -134,7 +134,7 @@ func TestWithReorgs(t *testing.T) {
 
 	rdConfig := reorgdetector.Config{
 		DBPath:              dbPathReorg,
-		CheckReorgsInterval: cfgtypes.NewDuration(time.Millisecond * 500),
+		CheckReorgsInterval: cfgtypes.NewDuration(time.Millisecond * 100),
 		FinalizedBlock:      aggkittypes.FinalizedBlock,
 	}
 	rd, err := reorgdetector.New(client.Client(), rdConfig, reorgdetector.L1)


### PR DESCRIPTION
## 🔄 Changes Summary
Fix `TestWithReorgs` unit test, by running reorgs checker more often.

```go
stefan@Stefan:~/go/src/Polygon/aggkit$ go test -count=20 -run ^TestWithReorgs$ github.com/agglayer/aggkit/l1infotreesync
ok      github.com/agglayer/aggkit/l1infotreesync       66.023s
```

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: `TestWithReorgs` test passes
