### PR TITLE
fix: deprecate polygonbridgeaddr

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
             fi
           else
             # For push/workflow_dispatch, use the fixed commit
-            COMMIT="b8b654a0659bc909d65af11255ee8c55010f53ea"
+            COMMIT="41a7b1db45a2625ab2dec1f6868161bc6b64980a"
             echo "Using fixed kurtosis-cdk commit: ${COMMIT}"
           fi
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,8 @@ const (
 
 	DefaultCreationFilePermissions = os.FileMode(0600)
 
+	bridgeAddrSetOnWrongSection = "Bridge contract address must be set in the L1 or L2 section of " +
+		"config file as BridgeAddr."
 	l2URLHint                = "Use L2URL instead"
 	bridgeMetadataAsHashHint = "BridgeMetaDataAsHash is deprecated, remove it from configuration " +
 		"(bridge metadata is always stored as hash)"
@@ -110,6 +112,10 @@ var (
 		{
 			FieldNamePattern: "AggOracle.EVMSender.URLRPCL2",
 			Reason:           l2URLHint,
+		},
+		{
+			FieldNamePattern: "polygonBridgeAddr",
+			Reason:           bridgeAddrSetOnWrongSection,
 		},
 		{
 			FieldNamePattern: "AggSender.URLRPCL2",

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,8 @@ const (
 
 	DefaultCreationFilePermissions = os.FileMode(0600)
 
-	bridgeAddrSetOnWrongSection = "polygonBridgeAddr is deprecated. Use L1Config.BridgeAddr for L1 bridge configuration and L2Config.BridgeAddr for L2 bridge configuration."
+	bridgeAddrSetOnWrongSection = "polygonBridgeAddr is deprecated. Use L1Config.BridgeAddr for L1 bridge configuration " +
+		"and L2Config.BridgeAddr for L2 bridge configuration."
 	l2URLHint                = "Use L2URL instead"
 	bridgeMetadataAsHashHint = "BridgeMetaDataAsHash is deprecated, remove it from configuration " +
 		"(bridge metadata is always stored as hash)"

--- a/config/config.go
+++ b/config/config.go
@@ -47,8 +47,7 @@ const (
 
 	DefaultCreationFilePermissions = os.FileMode(0600)
 
-	bridgeAddrSetOnWrongSection = "Bridge contract address must be set in the L1 or L2 section of " +
-		"config file as BridgeAddr."
+	bridgeAddrSetOnWrongSection = "polygonBridgeAddr is deprecated. Use L1Config.BridgeAddr for L1 bridge configuration and L2Config.BridgeAddr for L2 bridge configuration."
 	l2URLHint                = "Use L2URL instead"
 	bridgeMetadataAsHashHint = "BridgeMetaDataAsHash is deprecated, remove it from configuration " +
 		"(bridge metadata is always stored as hash)"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,6 +129,7 @@ func TestLoadConfigWithDeprecatedFields(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	_, err = tmpFile.Write([]byte(`
 
+	polygonBridgeAddr = "0x0000000000000000000000000000000000000000"
 	[Common]
 	IsValidiumMode = true
 	ContractVersions="banana"
@@ -136,6 +137,9 @@ func TestLoadConfigWithDeprecatedFields(t *testing.T) {
 
 	[L1NetworkConfig]
 	URL = "http://localhost:8545"
+
+	[L1Config]
+	polygonBridgeAddr = "0x0000000000000000000000000000000000000000"
 
 	[AggSender]
 	BridgeMetaDataAsHash = true
@@ -186,6 +190,7 @@ func TestLoadConfigWithDeprecatedFields(t *testing.T) {
 	_, err = Load(ctx)
 	require.Error(t, err)
 	require.ErrorContains(t, err, bridgeMetadataAsHashHint)
+	require.ErrorContains(t, err, bridgeAddrSetOnWrongSection)
 	require.ErrorContains(t, err, aggsenderAgglayerClientHint)
 	require.ErrorContains(t, err, aggsenderAggkitProverClientHint)
 	require.ErrorContains(t, err, aggsenderAggkitProverClientHint)


### PR DESCRIPTION
## 🔄 Changes Summary
- deprecate polygonbridgeaddr

## ⚠️ Breaking Changes
- 🛠️ **Config**: remove `polygonbridgeaddr`, instead set `L1Config.BridgeAddr` and `L2Config.BridgeAddr`

## 🐞 Issues
- Closes #1272 

## 🔗 Related PRs
- https://github.com/0xPolygon/kurtosis-cdk/pull/839