### PR TITLE
fix: compaction logic with unset claims consideration

### DIFF
--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -251,7 +251,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 	}, nil).Once()
 	mockStorage.EXPECT().SaveLastSentCertificate(mock.Anything, mock.Anything).Return(nil).Once()
 	mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(mock.Anything).Return(uint64(50), nil)
-	mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(mock.Anything, uint64(11), uint64(50), true).Return([]bridgesync.Bridge{
+	mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(mock.Anything, uint64(11), uint64(50)).Return([]bridgesync.Bridge{
 		{
 			BlockNum:           30,
 			BlockPos:           0,

--- a/aggsender/flows/builder_flow_aggchain_prover.go
+++ b/aggsender/flows/builder_flow_aggchain_prover.go
@@ -195,11 +195,7 @@ func (a *AggchainProverBuilderFlow) GetCertificateBuildParams(
 				"lastProvenBlock: %d + 1. Check update process 😅", lastSentCert.FromBlock, lastProvenBlock)
 		}
 
-		bridges, claims, err := a.l2BridgeQuerier.GetBridgesAndClaims(
-			ctx, fromBlock,
-			toBlock,
-			false, // do not compact claims
-		)
+		bridges, claims, err := a.l2BridgeQuerier.GetBridgesAndClaims(ctx, fromBlock, toBlock)
 		if err != nil {
 			return nil, fmt.Errorf("aggchainProverFlow - error getting bridges and claims: %w", err)
 		}

--- a/aggsender/flows/builder_flow_aggchain_prover_test.go
+++ b/aggsender/flows/builder_flow_aggchain_prover_test.go
@@ -77,7 +77,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 						LastProvenBlock: 1,
 						EndBlock:        10,
 					}, nil).Once()
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
 						GlobalExitRoot:  ger,
@@ -134,7 +134,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 					FinalizedL1InfoTreeRoot: &finalizedL1Root,
 					L1InfoTreeLeafCount:     11,
 				}, nil, nil).Once()
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
 						GlobalExitRoot:  ger,
@@ -194,7 +194,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoDataQuery.EXPECT().GetLatestFinalizedL1InfoRoot(mock.Anything).Return(
 					&treetypes.Root{Hash: finalizedL1Root, BlockNum: 10}, nil, nil)
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalIndex:     big.NewInt(1),
 						GlobalExitRoot:  ger,
@@ -219,7 +219,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockL1InfoDataQuery.EXPECT().GetLatestFinalizedL1InfoRoot(mock.Anything).Return(
 					&treetypes.Root{Hash: finalizedL1Root, BlockNum: 10}, nil, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10), false).Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
 				mockL2BridgeQuerier.EXPECT().GetUnsetClaimsForBlockRange(ctx, uint64(1), uint64(10)).Return([]bridgesynctypes.Unclaim{}, nil)
 				wrappedErr := fmt.Errorf("wrapped error: %w", query.ErrNoProofBuiltYet)
 				mockAggchainProofQuerier.EXPECT().GenerateAggchainProof(context.Background(), uint64(0), uint64(10), mock.Anything).
@@ -242,7 +242,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoDataQuery.EXPECT().GetLatestFinalizedL1InfoRoot(mock.Anything).Return(
 					&treetypes.Root{Hash: finalizedL1Root, BlockNum: 10, Index: 10}, nil, nil)
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{{
 					GlobalIndex:     big.NewInt(1),
 					GlobalExitRoot:  ger,
 					MainnetExitRoot: mer,
@@ -297,7 +297,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockL1InfoDataQuery.EXPECT().GetLatestFinalizedL1InfoRoot(mock.Anything).Return(
 					&treetypes.Root{Hash: finalizedL1Root, BlockNum: 10, Index: 10}, nil, nil)
 				mockL2BridgeQuerier.On("GetLastProcessedBlock", ctx).Return(uint64(10), nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), false).Return(
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return(
 					[]bridgesync.Bridge{{BlockNum: 6}, {BlockNum: 10}},
 					[]bridgesync.Claim{
 						{BlockNum: 8, GlobalIndex: big.NewInt(1), GlobalExitRoot: ger, MainnetExitRoot: mer, RollupExitRoot: rer},
@@ -360,7 +360,7 @@ func Test_AggchainProverFlow_GetCertificateBuildParams(t *testing.T) {
 				mockStorage,
 				mockL1InfoTreeDataQuerier,
 				mockLERQuerier,
-				NewBaseFlowConfig(0, 0, false, true, false))
+				NewBaseFlowConfig(0, 0, false, true))
 			flowBase.timeNowFunc = timeNowUTCForTest
 			aggchainFlow := NewAggchainProverBuilderFlow(
 				logger,
@@ -479,7 +479,7 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 				nil, // sotrage
 				nil, // l1InfoTreeDataQuerier,
 				nil, // lerQuerier
-				NewBaseFlowConfig(0, tc.startL2Block, false, true, false),
+				NewBaseFlowConfig(0, tc.startL2Block, false, true),
 			)
 			flow := NewAggchainProverBuilderFlow(
 				logger,

--- a/aggsender/flows/builder_flow_factory.go
+++ b/aggsender/flows/builder_flow_factory.go
@@ -49,7 +49,6 @@ func NewBuilderFlow(
 			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
 			true, // fullClaims required (with calldata)
-			true, // compact claims required
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
 			cfg.GlobalExitRootL1Addr,
@@ -97,8 +96,7 @@ func NewBuilderFlow(
 			aggchainFEPQuerier.StartL2Block(), cfg.RequireNoFEPBlockGap,
 			cfg.MaxCertSize, cfg.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.AggsenderPrivateKey,
-			true,  // full claims required (with calldata)
-			false, // compact claims disabled
+			true, // full claims required (with calldata)
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
 			cfg.GlobalExitRootL1Addr,
@@ -165,7 +163,6 @@ func CreateCommonFlowComponents(
 	delayBetweenRetries time.Duration,
 	signerCfg signertypes.SignerConfig,
 	fullClaimsRequired bool,
-	compactClaims bool,
 	requireCommitteeMembershipCheck bool,
 	agglayerBridgeL2Addr ethCommon.Address,
 	globalExitRootL1Addr ethCommon.Address,
@@ -200,7 +197,6 @@ func CreateCommonFlowComponents(
 			startL2Block,
 			requireNoFEPBlockGap,
 			fullClaimsRequired,
-			compactClaims,
 		),
 	)
 

--- a/aggsender/flows/builder_flow_pp_test.go
+++ b/aggsender/flows/builder_flow_pp_test.go
@@ -311,7 +311,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 					&treetypes.Root{Hash: common.HexToHash("0x123"), BlockNum: 10}, nil, nil)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return(nil, nil, errors.New("some error"))
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return(nil, nil, errors.New("some error"))
 			},
 			expectedError: "some error",
 		},
@@ -324,7 +324,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 					&treetypes.Root{Hash: common.HexToHash("0x123"), BlockNum: 10}, nil, nil)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
 				mockL2BridgeQuerier.EXPECT().GetUnsetClaimsForBlockRange(ctx, uint64(6), uint64(10)).Return([]bridgetypes.Unclaim{}, nil)
 			},
 			expectedParams: nil,
@@ -339,7 +339,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 					&treetypes.Root{Hash: common.HexToHash("0x123"), BlockNum: 10}, nil, nil)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1")}}, nil)
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1")}}, nil)
 				mockL2BridgeQuerier.EXPECT().GetUnsetClaimsForBlockRange(ctx, uint64(6), uint64(10)).Return([]bridgetypes.Unclaim{}, nil)
 				mockL1InfoTreeQuerier.EXPECT().IsGERFinalized(common.HexToHash("0x1"), uint32(1)).Return(true, nil).Once()
 			},
@@ -355,7 +355,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 					&treetypes.Root{Hash: common.HexToHash("0x123"), BlockNum: 10}, nil, nil)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1"), BlockNum: 10}}, nil)
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1"), BlockNum: 10}}, nil)
 				mockL2BridgeQuerier.EXPECT().GetUnsetClaimsForBlockRange(ctx, uint64(6), uint64(10)).Return([]bridgetypes.Unclaim{}, nil)
 				mockL1InfoTreeQuerier.EXPECT().IsGERFinalized(common.HexToHash("0x1"), uint32(1)).Return(false, errors.New("some error")).Once()
 			},
@@ -376,7 +376,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				rer2 := common.HexToHash("0x3")
 				mer2 := common.HexToHash("0x4")
 				ger2 := l1infotreesync.CalculateGER(mer2, rer2)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{}, []bridgesync.Claim{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{}, []bridgesync.Claim{
 					{
 						BlockNum:        9,
 						GlobalExitRoot:  ger1,
@@ -428,7 +428,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				rer := common.HexToHash("0x1")
 				mer := common.HexToHash("0x2")
 				ger := l1infotreesync.CalculateGER(mer, rer)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{}, []bridgesync.Claim{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{}, []bridgesync.Claim{
 					{
 						BlockNum:        1,
 						GlobalExitRoot:  ger,
@@ -469,7 +469,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 					&treetypes.Root{Hash: common.HexToHash("0x123"), BlockNum: 10}, nil, nil)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return(
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return(
 					[]bridgesync.Bridge{{}}, []bridgesync.Claim{{GlobalExitRoot: common.HexToHash("0x1")}}, nil)
 				mockL2BridgeQuerier.EXPECT().GetUnsetClaimsForBlockRange(ctx, uint64(6), uint64(10)).Return([]bridgetypes.Unclaim{}, nil)
 				mockL1InfoTreeQuerier.EXPECT().IsGERFinalized(common.HexToHash("0x1"), uint32(1)).Return(true, nil).Once()
@@ -497,7 +497,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 				ger := l1infotreesync.CalculateGER(mer, rer)
 				mockL2BridgeQuerier.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(10), nil)
 				mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&types.CertificateHeader{ToBlock: 5}, nil)
-				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10), true).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
+				mockL2BridgeQuerier.EXPECT().GetBridgesAndClaims(ctx, uint64(6), uint64(10)).Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{
 					{
 						GlobalExitRoot:  ger,
 						RollupExitRoot:  rer,
@@ -622,7 +622,7 @@ func TestGetLastSentBlockAndRetryCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			baseFlow := &baseFlow{cfg: NewBaseFlowConfig(0, tt.startL2Block, false, true, true)}
+			baseFlow := &baseFlow{cfg: NewBaseFlowConfig(0, tt.startL2Block, false, true)}
 
 			block, retryCount := baseFlow.getLastSentBlockAndRetryCount(tt.lastSentCertificate)
 

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -43,11 +43,6 @@ type BaseFlowConfig struct {
 	RequireNoFEPBlockGap bool
 	// FullClaimsNeeded indicates whether the flow requires full claims data
 	FullClaimsNeeded bool
-	// CompactClaims indicates whether the flow requires the l2 bridge syncer
-	// to compact the claims when retrieving them
-	//  (in case when we have an invalid claim with GlobalIndex=1, and then a valid claim
-	//   that fixes it with GlobalIndex=1, we only want to latest one in the certificate)
-	CompactClaims bool
 }
 
 // NewBaseFlowConfigDefault returns a BaseFlowConfig with default values
@@ -57,7 +52,6 @@ func NewBaseFlowConfigDefault() BaseFlowConfig {
 		StartL2Block:         0,     // 0 means start from the first block
 		RequireNoFEPBlockGap: false, // default is false, can be set to true if needed
 		FullClaimsNeeded:     true,  // default is true, can be set to false if full claims are not needed
-		CompactClaims:        true,  // default is true, can be set to false if compact claims are not needed
 	}
 }
 
@@ -67,14 +61,12 @@ func NewBaseFlowConfig(
 	startL2Block uint64,
 	requireNoFEPBlockGap bool,
 	fullClaimsNeeded bool,
-	compactClaims bool,
 ) BaseFlowConfig {
 	return BaseFlowConfig{
 		MaxCertSize:          maxCertSize,
 		StartL2Block:         startL2Block,
 		RequireNoFEPBlockGap: requireNoFEPBlockGap,
 		FullClaimsNeeded:     fullClaimsNeeded,
-		CompactClaims:        compactClaims,
 	}
 }
 
@@ -179,7 +171,7 @@ func (f *baseFlow) GenerateBuildParams(ctx context.Context,
 	}
 
 	bridges, claims, err := f.l2BridgeQuerier.GetBridgesAndClaims(ctx,
-		preParams.BlockRange.FromBlock, preParams.BlockRange.ToBlock, f.cfg.CompactClaims)
+		preParams.BlockRange.FromBlock, preParams.BlockRange.ToBlock)
 	if err != nil {
 		return nil, fmt.Errorf("generateBuildParams fails getting bridges and claims. Err: %w", err)
 	}
@@ -507,7 +499,7 @@ func (f *baseFlow) VerifyBlockRangeGaps(
 	}
 
 	bridgeDataInTheGap, claimDataInTheGap, err := f.l2BridgeQuerier.GetBridgesAndClaims(
-		ctx, gap.FromBlock, gap.ToBlock, f.cfg.CompactClaims)
+		ctx, gap.FromBlock, gap.ToBlock)
 	if err != nil {
 		return fmt.Errorf("error getting bridges and claims in the gap %s: %w", gap.String(), err)
 	}

--- a/aggsender/flows/flow_base_test.go
+++ b/aggsender/flows/flow_base_test.go
@@ -130,7 +130,7 @@ func Test_baseFlow_limitCertSize(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				NewBaseFlowConfig(tt.maxCertSize, 0, false, true, true))
+				NewBaseFlowConfig(tt.maxCertSize, 0, false, true))
 
 			result, err := f.LimitCertSize(tt.fullCert)
 
@@ -625,7 +625,7 @@ func Test_baseFlow_VerifyBlockRangeGaps(t *testing.T) {
 			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
 				// gap is [16,16]
 				mockL2BridgeQuerier.EXPECT().
-					GetBridgesAndClaims(ctx, uint64(16), uint64(16), false).
+					GetBridgesAndClaims(ctx, uint64(16), uint64(16)).
 					Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
 			},
 		},
@@ -642,7 +642,7 @@ func Test_baseFlow_VerifyBlockRangeGaps(t *testing.T) {
 			},
 			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
 				mockL2BridgeQuerier.EXPECT().
-					GetBridgesAndClaims(ctx, uint64(16), uint64(16), false).
+					GetBridgesAndClaims(ctx, uint64(16), uint64(16)).
 					Return([]bridgesync.Bridge{{}}, []bridgesync.Claim{}, nil)
 			},
 			expectedError: "there are new bridges or claims in the gap",
@@ -660,7 +660,7 @@ func Test_baseFlow_VerifyBlockRangeGaps(t *testing.T) {
 			},
 			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
 				mockL2BridgeQuerier.EXPECT().
-					GetBridgesAndClaims(ctx, uint64(16), uint64(16), false).
+					GetBridgesAndClaims(ctx, uint64(16), uint64(16)).
 					Return([]bridgesync.Bridge{}, []bridgesync.Claim{{}}, nil)
 			},
 			expectedError: "there are new bridges or claims in the gap",
@@ -679,7 +679,7 @@ func Test_baseFlow_VerifyBlockRangeGaps(t *testing.T) {
 			requireNoFEPGap: true,
 			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
 				mockL2BridgeQuerier.EXPECT().
-					GetBridgesAndClaims(ctx, uint64(16), uint64(16), false).
+					GetBridgesAndClaims(ctx, uint64(16), uint64(16)).
 					Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
 			},
 			expectedError: "block gap detected",
@@ -697,7 +697,7 @@ func Test_baseFlow_VerifyBlockRangeGaps(t *testing.T) {
 			},
 			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
 				mockL2BridgeQuerier.EXPECT().
-					GetBridgesAndClaims(ctx, uint64(16), uint64(16), false).
+					GetBridgesAndClaims(ctx, uint64(16), uint64(16)).
 					Return(nil, nil, errors.New("db error"))
 			},
 			expectedError: "error getting bridges and claims in the gap",
@@ -716,7 +716,7 @@ func Test_baseFlow_VerifyBlockRangeGaps(t *testing.T) {
 			mockFn: func(mockL2BridgeQuerier *mocks.BridgeQuerier) {
 				// lastSettledToBlock = 4, so gap is [5,6]
 				mockL2BridgeQuerier.EXPECT().
-					GetBridgesAndClaims(ctx, uint64(5), uint64(6), false).
+					GetBridgesAndClaims(ctx, uint64(5), uint64(6)).
 					Return([]bridgesync.Bridge{}, []bridgesync.Claim{}, nil)
 			},
 		},

--- a/aggsender/flows/verifier_flow_factory.go
+++ b/aggsender/flows/verifier_flow_factory.go
@@ -35,7 +35,6 @@ func NewVerifierFlow(
 			l1Client, l2Client, l1InfoTreeSyncer, l2Syncer, rollupDataQuerier, committeeQuerier, 0, false,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1, cfg.DelayBetweenRetries.Duration, cfg.Signer,
 			true, // full claims are (eventually) needed in validator mode
-			true, // compact claims are needed in validator PP mode
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
 			cfg.GlobalExitRootL1Addr,
@@ -64,8 +63,7 @@ func NewVerifierFlow(
 			0, cfg.FEPConfig.RequireNoBlockGap,
 			cfg.MaxCertSize, cfg.LerQuerier.RollupCreationBlockL1,
 			cfg.DelayBetweenRetries.Duration, cfg.Signer,
-			true,  // full claims are (eventually) needed in validator mode
-			false, // compact claims are not needed in validator FEP mode
+			true, // full claims are (eventually) needed in validator mode
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
 			cfg.GlobalExitRootL1Addr,

--- a/aggsender/mocks/mock_bridge_querier.go
+++ b/aggsender/mocks/mock_bridge_querier.go
@@ -26,9 +26,9 @@ func (_m *BridgeQuerier) EXPECT() *BridgeQuerier_Expecter {
 	return &BridgeQuerier_Expecter{mock: &_m.Mock}
 }
 
-// GetBridgesAndClaims provides a mock function with given fields: ctx, fromBlock, toBlock, compactedClaims
-func (_m *BridgeQuerier) GetBridgesAndClaims(ctx context.Context, fromBlock uint64, toBlock uint64, compactedClaims bool) ([]bridgesync.Bridge, []bridgesync.Claim, error) {
-	ret := _m.Called(ctx, fromBlock, toBlock, compactedClaims)
+// GetBridgesAndClaims provides a mock function with given fields: ctx, fromBlock, toBlock
+func (_m *BridgeQuerier) GetBridgesAndClaims(ctx context.Context, fromBlock uint64, toBlock uint64) ([]bridgesync.Bridge, []bridgesync.Claim, error) {
+	ret := _m.Called(ctx, fromBlock, toBlock)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBridgesAndClaims")
@@ -37,27 +37,27 @@ func (_m *BridgeQuerier) GetBridgesAndClaims(ctx context.Context, fromBlock uint
 	var r0 []bridgesync.Bridge
 	var r1 []bridgesync.Claim
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, bool) ([]bridgesync.Bridge, []bridgesync.Claim, error)); ok {
-		return rf(ctx, fromBlock, toBlock, compactedClaims)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) ([]bridgesync.Bridge, []bridgesync.Claim, error)); ok {
+		return rf(ctx, fromBlock, toBlock)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, bool) []bridgesync.Bridge); ok {
-		r0 = rf(ctx, fromBlock, toBlock, compactedClaims)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) []bridgesync.Bridge); ok {
+		r0 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]bridgesync.Bridge)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64, bool) []bridgesync.Claim); ok {
-		r1 = rf(ctx, fromBlock, toBlock, compactedClaims)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64) []bridgesync.Claim); ok {
+		r1 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]bridgesync.Claim)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, uint64, uint64, bool) error); ok {
-		r2 = rf(ctx, fromBlock, toBlock, compactedClaims)
+	if rf, ok := ret.Get(2).(func(context.Context, uint64, uint64) error); ok {
+		r2 = rf(ctx, fromBlock, toBlock)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -74,14 +74,13 @@ type BridgeQuerier_GetBridgesAndClaims_Call struct {
 //   - ctx context.Context
 //   - fromBlock uint64
 //   - toBlock uint64
-//   - compactedClaims bool
-func (_e *BridgeQuerier_Expecter) GetBridgesAndClaims(ctx interface{}, fromBlock interface{}, toBlock interface{}, compactedClaims interface{}) *BridgeQuerier_GetBridgesAndClaims_Call {
-	return &BridgeQuerier_GetBridgesAndClaims_Call{Call: _e.mock.On("GetBridgesAndClaims", ctx, fromBlock, toBlock, compactedClaims)}
+func (_e *BridgeQuerier_Expecter) GetBridgesAndClaims(ctx interface{}, fromBlock interface{}, toBlock interface{}) *BridgeQuerier_GetBridgesAndClaims_Call {
+	return &BridgeQuerier_GetBridgesAndClaims_Call{Call: _e.mock.On("GetBridgesAndClaims", ctx, fromBlock, toBlock)}
 }
 
-func (_c *BridgeQuerier_GetBridgesAndClaims_Call) Run(run func(ctx context.Context, fromBlock uint64, toBlock uint64, compactedClaims bool)) *BridgeQuerier_GetBridgesAndClaims_Call {
+func (_c *BridgeQuerier_GetBridgesAndClaims_Call) Run(run func(ctx context.Context, fromBlock uint64, toBlock uint64)) *BridgeQuerier_GetBridgesAndClaims_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].(uint64), args[3].(bool))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(uint64))
 	})
 	return _c
 }
@@ -91,7 +90,7 @@ func (_c *BridgeQuerier_GetBridgesAndClaims_Call) Return(_a0 []bridgesync.Bridge
 	return _c
 }
 
-func (_c *BridgeQuerier_GetBridgesAndClaims_Call) RunAndReturn(run func(context.Context, uint64, uint64, bool) ([]bridgesync.Bridge, []bridgesync.Claim, error)) *BridgeQuerier_GetBridgesAndClaims_Call {
+func (_c *BridgeQuerier_GetBridgesAndClaims_Call) RunAndReturn(run func(context.Context, uint64, uint64) ([]bridgesync.Bridge, []bridgesync.Claim, error)) *BridgeQuerier_GetBridgesAndClaims_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/mocks/mock_l2_bridge_syncer.go
+++ b/aggsender/mocks/mock_l2_bridge_syncer.go
@@ -147,9 +147,9 @@ func (_c *L2BridgeSyncer_GetBridges_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// GetClaims provides a mock function with given fields: ctx, fromBlock, toBlock, compacted
-func (_m *L2BridgeSyncer) GetClaims(ctx context.Context, fromBlock uint64, toBlock uint64, compacted bool) ([]bridgesync.Claim, error) {
-	ret := _m.Called(ctx, fromBlock, toBlock, compacted)
+// GetClaims provides a mock function with given fields: ctx, fromBlock, toBlock
+func (_m *L2BridgeSyncer) GetClaims(ctx context.Context, fromBlock uint64, toBlock uint64) ([]bridgesync.Claim, error) {
+	ret := _m.Called(ctx, fromBlock, toBlock)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetClaims")
@@ -157,19 +157,19 @@ func (_m *L2BridgeSyncer) GetClaims(ctx context.Context, fromBlock uint64, toBlo
 
 	var r0 []bridgesync.Claim
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, bool) ([]bridgesync.Claim, error)); ok {
-		return rf(ctx, fromBlock, toBlock, compacted)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) ([]bridgesync.Claim, error)); ok {
+		return rf(ctx, fromBlock, toBlock)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, bool) []bridgesync.Claim); ok {
-		r0 = rf(ctx, fromBlock, toBlock, compacted)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) []bridgesync.Claim); ok {
+		r0 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]bridgesync.Claim)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64, bool) error); ok {
-		r1 = rf(ctx, fromBlock, toBlock, compacted)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64) error); ok {
+		r1 = rf(ctx, fromBlock, toBlock)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -186,14 +186,13 @@ type L2BridgeSyncer_GetClaims_Call struct {
 //   - ctx context.Context
 //   - fromBlock uint64
 //   - toBlock uint64
-//   - compacted bool
-func (_e *L2BridgeSyncer_Expecter) GetClaims(ctx interface{}, fromBlock interface{}, toBlock interface{}, compacted interface{}) *L2BridgeSyncer_GetClaims_Call {
-	return &L2BridgeSyncer_GetClaims_Call{Call: _e.mock.On("GetClaims", ctx, fromBlock, toBlock, compacted)}
+func (_e *L2BridgeSyncer_Expecter) GetClaims(ctx interface{}, fromBlock interface{}, toBlock interface{}) *L2BridgeSyncer_GetClaims_Call {
+	return &L2BridgeSyncer_GetClaims_Call{Call: _e.mock.On("GetClaims", ctx, fromBlock, toBlock)}
 }
 
-func (_c *L2BridgeSyncer_GetClaims_Call) Run(run func(ctx context.Context, fromBlock uint64, toBlock uint64, compacted bool)) *L2BridgeSyncer_GetClaims_Call {
+func (_c *L2BridgeSyncer_GetClaims_Call) Run(run func(ctx context.Context, fromBlock uint64, toBlock uint64)) *L2BridgeSyncer_GetClaims_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].(uint64), args[3].(bool))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(uint64))
 	})
 	return _c
 }
@@ -203,7 +202,7 @@ func (_c *L2BridgeSyncer_GetClaims_Call) Return(_a0 []bridgesync.Claim, _a1 erro
 	return _c
 }
 
-func (_c *L2BridgeSyncer_GetClaims_Call) RunAndReturn(run func(context.Context, uint64, uint64, bool) ([]bridgesync.Claim, error)) *L2BridgeSyncer_GetClaims_Call {
+func (_c *L2BridgeSyncer_GetClaims_Call) RunAndReturn(run func(context.Context, uint64, uint64) ([]bridgesync.Claim, error)) *L2BridgeSyncer_GetClaims_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aggsender/prover/proof_generation_tool.go
+++ b/aggsender/prover/proof_generation_tool.go
@@ -169,7 +169,7 @@ func (a *AggchainProofGenerationTool) GenerateAggchainProof(
 	// get claims for the block range
 	a.logger.Debugf("Getting claims for block range [%d : %d]", fromBlock, maxEndBlock)
 
-	claims, err := a.l2Syncer.GetClaims(ctx, fromBlock, maxEndBlock, false)
+	claims, err := a.l2Syncer.GetClaims(ctx, fromBlock, maxEndBlock)
 	if err != nil {
 		return nil, fmt.Errorf("error getting claims (imported bridge exits): %w", err)
 	}

--- a/aggsender/prover/proof_generation_tool_test.go
+++ b/aggsender/prover/proof_generation_tool_test.go
@@ -37,7 +37,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 				mockFlow *mocks.AggchainProofFlow,
 			) {
 				mockL2Syncer.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(20), nil)
-				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10), false).Return([]bridgesync.Claim{}, nil)
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{}, nil)
 				certBuildParams := &types.CertificateBuildParams{
 					Claims: []bridgesync.Claim{},
 				}
@@ -65,7 +65,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 				mockFlow *mocks.AggchainProofFlow,
 			) {
 				mockL2Syncer.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(20), nil)
-				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10), false).Return(nil, errors.New("test error"))
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return(nil, errors.New("test error"))
 			},
 			expectedError: "error getting claims (imported bridge exits)",
 		},
@@ -77,7 +77,7 @@ func TestGenerateAggchainProof(t *testing.T) {
 				mockFlow *mocks.AggchainProofFlow,
 			) {
 				mockL2Syncer.EXPECT().GetLastProcessedBlock(ctx).Return(uint64(20), nil)
-				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10), false).Return([]bridgesync.Claim{}, nil)
+				mockL2Syncer.EXPECT().GetClaims(ctx, uint64(1), uint64(10)).Return([]bridgesync.Claim{}, nil)
 				certBuildParams := &types.CertificateBuildParams{
 					Claims: []bridgesync.Claim{},
 				}

--- a/aggsender/query/bridge_query.go
+++ b/aggsender/query/bridge_query.go
@@ -56,14 +56,13 @@ func NewBridgeDataQuerier(
 func (b *bridgeDataQuerier) GetBridgesAndClaims(
 	ctx context.Context,
 	fromBlock, toBlock uint64,
-	compactedClaims bool,
 ) ([]bridgesync.Bridge, []bridgesync.Claim, error) {
 	bridges, err := b.bridgeSyncer.GetBridges(ctx, fromBlock, toBlock)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting bridges: %w", err)
 	}
 
-	claims, err := b.bridgeSyncer.GetClaims(ctx, fromBlock, toBlock, compactedClaims)
+	claims, err := b.bridgeSyncer.GetClaims(ctx, fromBlock, toBlock)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting claims: %w", err)
 	}

--- a/aggsender/query/bridge_query_test.go
+++ b/aggsender/query/bridge_query_test.go
@@ -35,7 +35,7 @@ func TestGetBridgesAndClaims(t *testing.T) {
 				mockSyncer.EXPECT().GetBridges(ctx, uint64(100), uint64(200)).Return([]bridgesync.Bridge{
 					{BlockNum: 100, BlockPos: 1},
 				}, nil)
-				mockSyncer.EXPECT().GetClaims(ctx, uint64(100), uint64(200), false).Return([]bridgesync.Claim{
+				mockSyncer.EXPECT().GetClaims(ctx, uint64(100), uint64(200)).Return([]bridgesync.Claim{
 					{BlockNum: 200, BlockPos: 1},
 				}, nil)
 			},
@@ -65,7 +65,7 @@ func TestGetBridgesAndClaims(t *testing.T) {
 				mockSyncer.EXPECT().GetBridges(ctx, uint64(100), uint64(200)).Return([]bridgesync.Bridge{
 					{BlockNum: 100, BlockPos: 1},
 				}, nil)
-				mockSyncer.EXPECT().GetClaims(ctx, uint64(100), uint64(200), false).Return(nil, errors.New("some error"))
+				mockSyncer.EXPECT().GetClaims(ctx, uint64(100), uint64(200)).Return(nil, errors.New("some error"))
 			},
 			expectedError: "error getting claims: some error",
 		},
@@ -75,7 +75,7 @@ func TestGetBridgesAndClaims(t *testing.T) {
 			toBlock:   200,
 			mockFn: func(mockSyncer *mocks.L2BridgeSyncer) {
 				mockSyncer.EXPECT().GetBridges(ctx, uint64(100), uint64(200)).Return(nil, nil)
-				mockSyncer.EXPECT().GetClaims(ctx, uint64(100), uint64(200), false).Return(nil, nil)
+				mockSyncer.EXPECT().GetClaims(ctx, uint64(100), uint64(200)).Return(nil, nil)
 			},
 			expectedBridges: nil,
 			expectedClaims:  nil,
@@ -95,7 +95,7 @@ func TestGetBridgesAndClaims(t *testing.T) {
 
 			bridgeQuerier := NewBridgeDataQuerier(nil, mockSyncer, 0, AgglayerBridgeL2Reader)
 
-			bridges, claims, err := bridgeQuerier.GetBridgesAndClaims(ctx, tc.fromBlock, tc.toBlock, false)
+			bridges, claims, err := bridgeQuerier.GetBridgesAndClaims(ctx, tc.fromBlock, tc.toBlock)
 			if tc.expectedError != "" {
 				require.ErrorContains(t, err, tc.expectedError)
 			} else {

--- a/aggsender/types/interfaces.go
+++ b/aggsender/types/interfaces.go
@@ -98,7 +98,7 @@ type L2BridgeSyncer interface {
 	GetBlockByLER(ctx context.Context, ler common.Hash) (uint64, error)
 	GetExitRootByIndex(ctx context.Context, index uint32) (treetypes.Root, error)
 	GetBridges(ctx context.Context, fromBlock, toBlock uint64) ([]bridgesync.Bridge, error)
-	GetClaims(ctx context.Context, fromBlock, toBlock uint64, compacted bool) ([]bridgesync.Claim, error)
+	GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([]bridgesync.Claim, error)
 	OriginNetwork() uint32
 	GetLastProcessedBlock(ctx context.Context) (uint64, error)
 	GetExitRootByHash(ctx context.Context, root common.Hash) (*treetypes.Root, error)
@@ -111,7 +111,6 @@ type BridgeQuerier interface {
 	GetBridgesAndClaims(
 		ctx context.Context,
 		fromBlock, toBlock uint64,
-		compactedClaims bool,
 	) ([]bridgesync.Bridge, []bridgesync.Claim, error)
 	GetExitRootByIndex(ctx context.Context, index uint32) (common.Hash, error)
 	GetLastProcessedBlock(ctx context.Context) (uint64, error)

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -361,11 +361,11 @@ func (s *BridgeSync) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *bi
 	return s.processor.GetClaimsByGlobalIndex(ctx, globalIndex)
 }
 
-func (s *BridgeSync) GetClaims(ctx context.Context, fromBlock, toBlock uint64, compacted bool) ([]Claim, error) {
+func (s *BridgeSync) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([]Claim, error) {
 	if s.processor.isHalted() {
 		return nil, sync.ErrInconsistentState
 	}
-	return s.processor.GetClaims(ctx, fromBlock, toBlock, compacted)
+	return s.processor.GetClaims(ctx, fromBlock, toBlock)
 }
 
 func (s *BridgeSync) GetBridges(ctx context.Context, fromBlock, toBlock uint64) ([]Bridge, error) {

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -255,7 +255,7 @@ func TestGetExitRootByIndex(t *testing.T) {
 
 func TestGetClaims(t *testing.T) {
 	s := BridgeSync{processor: &processor{halted: true}}
-	_, err := s.GetClaims(context.Background(), 0, 0, false)
+	_, err := s.GetClaims(context.Background(), 0, 0)
 	require.ErrorIs(t, err, sync.ErrInconsistentState)
 }
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -59,6 +59,25 @@ const (
 	// orderByBlockDesc is the default order by clause for block-based queries
 	orderByBlockDesc = "block_num DESC, block_pos DESC"
 
+	// claimColumnsSQL is the list of all claim columns
+	claimColumnsSQL = `block_num,
+		block_pos,
+		tx_hash,
+		global_index,
+		origin_network,
+		origin_address,
+		destination_address,
+		amount,
+		proof_local_exit_root,
+		proof_rollup_exit_root,
+		mainnet_exit_root,
+		rollup_exit_root,
+		global_exit_root,
+		destination_network,
+		metadata,
+		is_message,
+		block_timestamp`
+
 	// compactedClaimsSelectSQL is the SELECT clause for compacted claims
 	// It combines metadata from the oldest claim with proofs and exit roots from the newest claim
 	compactedClaimsSelectSQL = `
@@ -100,9 +119,6 @@ var (
 
 	// getBridgesBlockRangeSelectSQL is the SELECT clause for bridges within a block range
 	getBridgesBlockRangeSelectSQL = fmt.Sprintf(queryBlockRangeSelectSQL, bridgeTableName)
-
-	// getClaimsBlockRangeSelectSQL is the SELECT clause for claims within a block range
-	getClaimsBlockRangeSelectSQL = fmt.Sprintf(queryBlockRangeSelectSQL, claimTableName)
 )
 
 // Bridge is the representation of a bridge event
@@ -659,23 +675,7 @@ func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([
 	claims_with_unset AS (
 		-- Case 1: Return all claims in range if unset_claim exists (no compaction)
 		SELECT 
-			c.block_num,
-			c.block_pos,
-			c.tx_hash,
-			c.global_index,
-			c.origin_network,
-			c.origin_address,
-			c.destination_address,
-			c.amount,
-			c.proof_local_exit_root,
-			c.proof_rollup_exit_root,
-			c.mainnet_exit_root,
-			c.rollup_exit_root,
-			c.global_exit_root,
-			c.destination_network,
-			c.metadata,
-			c.is_message,
-			c.block_timestamp
+			c.%s
 		FROM claims_in_range c
 		WHERE EXISTS (
 			SELECT 1 FROM unset_claim uc 
@@ -698,12 +698,8 @@ func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([
 	UNION ALL
 	SELECT * FROM compactable_claims
 	ORDER BY block_num ASC, block_pos ASC;
-`, compactedClaimsSelectSQL)
+`, claimColumnsSQL, compactedClaimsSelectSQL)
 
-	return p.getClaimsInternal(ctx, query, fromBlock, toBlock)
-}
-
-func (p *processor) getClaimsInternal(ctx context.Context, query string, fromBlock, toBlock uint64) ([]Claim, error) {
 	rows, err := p.queryBlockRange(ctx, p.db, fromBlock, toBlock, query)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
@@ -755,23 +751,7 @@ func (p *processor) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big
 	claims_with_unset AS (
 		-- Case 1: Return all claims if unset_claim exists (no compaction)
 		SELECT 
-			c.block_num,
-			c.block_pos,
-			c.tx_hash,
-			c.global_index,
-			c.origin_network,
-			c.origin_address,
-			c.destination_address,
-			c.amount,
-			c.proof_local_exit_root,
-			c.proof_rollup_exit_root,
-			c.mainnet_exit_root,
-			c.rollup_exit_root,
-			c.global_exit_root,
-			c.destination_network,
-			c.metadata,
-			c.is_message,
-			c.block_timestamp
+			c.%s
 		FROM all_claims_for_index c
 		WHERE EXISTS (
 			SELECT 1 FROM unset_claim uc 
@@ -794,7 +774,7 @@ func (p *processor) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big
 	UNION ALL
 	SELECT * FROM compactable_claims
 	ORDER BY block_num ASC, block_pos ASC;
-`, compactedClaimsSelectSQL)
+`, claimColumnsSQL, compactedClaimsSelectSQL)
 
 	// Create a context with database timeout
 	dbCtx, cancel := p.withDatabaseTimeout(ctx)
@@ -955,23 +935,7 @@ func (p *processor) GetClaimsPaged(
 		claims_with_unset_on_page AS (
 			-- Case 1: Return all claims on page if unset_claim exists (no compaction)
 			SELECT 
-				pc.block_num,
-				pc.block_pos,
-				pc.tx_hash,
-				pc.global_index,
-				pc.origin_network,
-				pc.origin_address,
-				pc.destination_address,
-				pc.amount,
-				pc.proof_local_exit_root,
-				pc.proof_rollup_exit_root,
-				pc.mainnet_exit_root,
-				pc.rollup_exit_root,
-				pc.global_exit_root,
-				pc.destination_network,
-				pc.metadata,
-				pc.is_message,
-				pc.block_timestamp
+				pc.%s
 			FROM page_claims pc
 			WHERE EXISTS (
 				SELECT 1 FROM unset_claim uc 
@@ -1001,7 +965,7 @@ func (p *processor) GetClaimsPaged(
 		UNION ALL
 		SELECT * FROM compactable_claims
 		ORDER BY block_num DESC, block_pos DESC;
-	`, whereClause, whereClause, compactedClaimsSelectSQL)
+	`, whereClause, whereClause, claimColumnsSQL, compactedClaimsSelectSQL)
 
 	rows, err := p.db.QueryContext(dbCtx, query, pageSize, offset)
 	if err != nil {

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -638,70 +638,67 @@ func (p *processor) GetBridges(
 	return bridges, nil
 }
 
-func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64, compacted bool) ([]Claim, error) {
-	query := getClaimsBlockRangeSelectSQL
-	if compacted {
-		// SQL query with compaction logic implementing three cases:
-		// Case 1: If unset_claim exists for a global_index, return all claims in range uncompacted
-		// Case 2: If no unset_claim exists and globally oldest is in range, return compacted claim
-		// Case 3: If globally oldest is outside range and no unset_claim exists, return nothing
-		query = fmt.Sprintf(`
-		WITH all_claims_ranked AS (
-			SELECT 
-				*,
-				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num ASC, block_pos ASC) AS rn_oldest_global,
-				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num DESC, block_pos DESC) AS rn_newest_global
-			FROM claim
-		),
-		claims_in_range AS (
-			SELECT *
-			FROM all_claims_ranked
-			WHERE block_num >= $1 AND block_num <= $2
-		),
-		claims_with_unset AS (
-			-- Case 1: Return all claims in range if unset_claim exists (no compaction)
-			SELECT 
-				c.block_num,
-				c.block_pos,
-				c.tx_hash,
-				c.global_index,
-				c.origin_network,
-				c.origin_address,
-				c.destination_address,
-				c.amount,
-				c.proof_local_exit_root,
-				c.proof_rollup_exit_root,
-				c.mainnet_exit_root,
-				c.rollup_exit_root,
-				c.global_exit_root,
-				c.destination_network,
-				c.metadata,
-				c.is_message,
-				c.block_timestamp
-			FROM claims_in_range c
-			WHERE EXISTS (
-				SELECT 1 FROM unset_claim uc 
-				WHERE uc.global_index = c.global_index
-			)
-		),
-		compactable_claims AS (
-			-- Case 2 & 3: Handle claims without unset_claim
-			SELECT 
-			%s
-			FROM claims_in_range o
-			JOIN claims_in_range n ON o.global_index = n.global_index AND n.rn_newest_global = 1
-			WHERE o.rn_oldest_global = 1  -- Globally oldest claim must be in range
-			AND NOT EXISTS (
-				SELECT 1 FROM unset_claim uc 
-				WHERE uc.global_index = o.global_index
-			)
+func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64) ([]Claim, error) {
+	// SQL query with compaction logic implementing three cases:
+	// Case 1: If unset_claim exists for a global_index, return all claims in range uncompacted
+	// Case 2: If no unset_claim exists and globally oldest is in range, return compacted claim
+	// Case 3: If globally oldest is outside range and no unset_claim exists, return nothing
+	query := fmt.Sprintf(`
+	WITH all_claims_ranked AS (
+		SELECT 
+			*,
+			ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num ASC, block_pos ASC) AS rn_oldest_global,
+			ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num DESC, block_pos DESC) AS rn_newest_global
+		FROM claim
+	),
+	claims_in_range AS (
+		SELECT *
+		FROM all_claims_ranked
+		WHERE block_num >= $1 AND block_num <= $2
+	),
+	claims_with_unset AS (
+		-- Case 1: Return all claims in range if unset_claim exists (no compaction)
+		SELECT 
+			c.block_num,
+			c.block_pos,
+			c.tx_hash,
+			c.global_index,
+			c.origin_network,
+			c.origin_address,
+			c.destination_address,
+			c.amount,
+			c.proof_local_exit_root,
+			c.proof_rollup_exit_root,
+			c.mainnet_exit_root,
+			c.rollup_exit_root,
+			c.global_exit_root,
+			c.destination_network,
+			c.metadata,
+			c.is_message,
+			c.block_timestamp
+		FROM claims_in_range c
+		WHERE EXISTS (
+			SELECT 1 FROM unset_claim uc 
+			WHERE uc.global_index = c.global_index
 		)
-		SELECT * FROM claims_with_unset
-		UNION ALL
-		SELECT * FROM compactable_claims
-		ORDER BY block_num ASC, block_pos ASC;
-	`, compactedClaimsSelectSQL)
-	}
+	),
+	compactable_claims AS (
+		-- Case 2 & 3: Handle claims without unset_claim
+		SELECT 
+		%s
+		FROM claims_in_range o
+		JOIN claims_in_range n ON o.global_index = n.global_index AND n.rn_newest_global = 1
+		WHERE o.rn_oldest_global = 1  -- Globally oldest claim must be in range
+		AND NOT EXISTS (
+			SELECT 1 FROM unset_claim uc 
+			WHERE uc.global_index = o.global_index
+		)
+	)
+	SELECT * FROM claims_with_unset
+	UNION ALL
+	SELECT * FROM compactable_claims
+	ORDER BY block_num ASC, block_pos ASC;
+`, compactedClaimsSelectSQL)
 
 	return p.getClaimsInternal(ctx, query, fromBlock, toBlock)
 }

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -641,26 +641,64 @@ func (p *processor) GetBridges(
 func (p *processor) GetClaims(ctx context.Context, fromBlock, toBlock uint64, compacted bool) ([]Claim, error) {
 	query := getClaimsBlockRangeSelectSQL
 	if compacted {
-		// SQL query with compaction logic:
-		// - Gets the oldest claim for each global_index (preserves all metadata)
-		// - Updates only the proof fields from the newest claim with same global_index
+		// SQL query with compaction logic implementing three cases:
+		// Case 1: If unset_claim exists for a global_index, return all claims in range uncompacted
+		// Case 2: If no unset_claim exists and globally oldest is in range, return compacted claim
+		// Case 3: If globally oldest is outside range and no unset_claim exists, return nothing
 		query = fmt.Sprintf(`
-		WITH ranked_claims AS (
+		WITH all_claims_ranked AS (
 			SELECT 
 				*,
-				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num ASC, block_pos ASC) AS rn_oldest,
-				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num DESC, block_pos DESC) AS rn_newest
+				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num ASC, block_pos ASC) AS rn_oldest_global,
+				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num DESC, block_pos DESC) AS rn_newest_global
 			FROM claim
+		),
+		claims_in_range AS (
+			SELECT *
+			FROM all_claims_ranked
 			WHERE block_num >= $1 AND block_num <= $2
 		),
-		oldest_with_newest_proofs AS (
+		claims_with_unset AS (
+			-- Case 1: Return all claims in range if unset_claim exists (no compaction)
+			SELECT 
+				c.block_num,
+				c.block_pos,
+				c.tx_hash,
+				c.global_index,
+				c.origin_network,
+				c.origin_address,
+				c.destination_address,
+				c.amount,
+				c.proof_local_exit_root,
+				c.proof_rollup_exit_root,
+				c.mainnet_exit_root,
+				c.rollup_exit_root,
+				c.global_exit_root,
+				c.destination_network,
+				c.metadata,
+				c.is_message,
+				c.block_timestamp
+			FROM claims_in_range c
+			WHERE EXISTS (
+				SELECT 1 FROM unset_claim uc 
+				WHERE uc.global_index = c.global_index
+			)
+		),
+		compactable_claims AS (
+			-- Case 2 & 3: Handle claims without unset_claim
 			SELECT 
 			%s
-			FROM ranked_claims o
-			JOIN ranked_claims n ON o.global_index = n.global_index AND n.rn_newest = 1
-			WHERE o.rn_oldest = 1
+			FROM claims_in_range o
+			JOIN claims_in_range n ON o.global_index = n.global_index AND n.rn_newest_global = 1
+			WHERE o.rn_oldest_global = 1  -- Globally oldest claim must be in range
+			AND NOT EXISTS (
+				SELECT 1 FROM unset_claim uc 
+				WHERE uc.global_index = o.global_index
+			)
 		)
-		SELECT * FROM oldest_with_newest_proofs
+		SELECT * FROM claims_with_unset
+		UNION ALL
+		SELECT * FROM compactable_claims
 		ORDER BY block_num ASC, block_pos ASC;
 	`, compactedClaimsSelectSQL)
 	}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -98,12 +98,6 @@ const (
 		o.metadata,
 		o.is_message,
 		o.block_timestamp`
-
-	queryBlockRangeSelectSQL = `
-		SELECT * FROM %s
-		WHERE block_num >= $1 AND block_num <= $2
-		ORDER BY block_num ASC, block_pos ASC;
-	`
 )
 
 var (
@@ -118,7 +112,11 @@ var (
 	deleteLegacyTokenSQL = fmt.Sprintf("DELETE FROM %s WHERE legacy_token_address = $1", legacyTokenMigrationTableName)
 
 	// getBridgesBlockRangeSelectSQL is the SELECT clause for bridges within a block range
-	getBridgesBlockRangeSelectSQL = fmt.Sprintf(queryBlockRangeSelectSQL, bridgeTableName)
+	getBridgesBlockRangeSelectSQL = fmt.Sprintf(`
+	SELECT * FROM %s
+		WHERE block_num >= $1 AND block_num <= $2
+		ORDER BY block_num ASC, block_pos ASC;
+	`, bridgeTableName)
 )
 
 // Bridge is the representation of a bridge event

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -739,20 +739,94 @@ func (p *processor) GetClaimsByGlobalIndex(ctx context.Context, globalIndex *big
 		return nil, fmt.Errorf("global index parameter cannot be nil")
 	}
 
-	var results []*Claim
-	if err := meddler.QueryAll(p.db, &results, fmt.Sprintf(`
-		SELECT *
-		FROM %s
+	// SQL query with compaction logic implementing three cases:
+	// Case 1: If unset_claim exists for the global_index, return all claims uncompacted
+	// Case 2: If no unset_claim exists, return compacted claim (oldest metadata + newest proofs)
+	// Case 3: Same as case 2 (all claims for this global_index are considered "in range")
+	query := fmt.Sprintf(`
+	WITH all_claims_for_index AS (
+		SELECT 
+			*,
+			ROW_NUMBER() OVER (ORDER BY block_num ASC, block_pos ASC) AS rn_oldest,
+			ROW_NUMBER() OVER (ORDER BY block_num DESC, block_pos DESC) AS rn_newest
+		FROM claim
 		WHERE global_index = $1
-		ORDER BY block_num ASC, block_pos ASC;
-	`, claimTableName), globalIndex.String()); err != nil {
+	),
+	claims_with_unset AS (
+		-- Case 1: Return all claims if unset_claim exists (no compaction)
+		SELECT 
+			c.block_num,
+			c.block_pos,
+			c.tx_hash,
+			c.global_index,
+			c.origin_network,
+			c.origin_address,
+			c.destination_address,
+			c.amount,
+			c.proof_local_exit_root,
+			c.proof_rollup_exit_root,
+			c.mainnet_exit_root,
+			c.rollup_exit_root,
+			c.global_exit_root,
+			c.destination_network,
+			c.metadata,
+			c.is_message,
+			c.block_timestamp
+		FROM all_claims_for_index c
+		WHERE EXISTS (
+			SELECT 1 FROM unset_claim uc 
+			WHERE uc.global_index = $1
+		)
+	),
+	compactable_claims AS (
+		-- Case 2: Handle claims without unset_claim (compact)
+		SELECT 
+		%s
+		FROM all_claims_for_index o
+		JOIN all_claims_for_index n ON n.rn_newest = 1
+		WHERE o.rn_oldest = 1
+		AND NOT EXISTS (
+			SELECT 1 FROM unset_claim uc 
+			WHERE uc.global_index = $1
+		)
+	)
+	SELECT * FROM claims_with_unset
+	UNION ALL
+	SELECT * FROM compactable_claims
+	ORDER BY block_num ASC, block_pos ASC;
+`, compactedClaimsSelectSQL)
+
+	// Create a context with database timeout
+	dbCtx, cancel := p.withDatabaseTimeout(ctx)
+	defer cancel()
+
+	rows, err := p.db.QueryContext(dbCtx, query, globalIndex.String())
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			p.log.Debugf("no claims were found for global index: %s", globalIndex.String())
+			return []Claim{}, nil
+		}
+		p.log.Errorf("GetClaimsByGlobalIndex: query failed for global index %s: %v", globalIndex.String(), err)
 		return nil, fmt.Errorf("failed to query claims by global index: %s: %w", globalIndex.String(), err)
 	}
 
-	claimsSlice := db.SlicePtrsToSlice(results)
-	claims, ok := claimsSlice.([]Claim)
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			p.log.Errorf("error closing rows: %v", cerr)
+		}
+	}()
+
+	claimPtrs := []*Claim{}
+	if err = meddler.ScanAll(rows, &claimPtrs); err != nil {
+		p.log.Errorf("GetClaimsByGlobalIndex: meddler.ScanAll failed for global index %s: %v", globalIndex.String(), err)
+		return nil, fmt.Errorf("failed to scan claims for global index: %s: %w", globalIndex.String(), err)
+	}
+
+	claimsIface := db.SlicePtrsToSlice(claimPtrs)
+	claims, ok := claimsIface.([]Claim)
 	if !ok {
-		p.log.Errorf("GetClaims: failed to convert from []*Claim to []Claim for global index: %s", globalIndex.String())
+		p.log.Errorf("GetClaimsByGlobalIndex: failed to convert from []*Claim to []Claim for global index: %s",
+			globalIndex.String())
 		return nil, errFailToConvertClaims
 	}
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -854,15 +854,16 @@ func (p *processor) GetClaimsPaged(
 	dbCtx, cancel := p.withDatabaseTimeout(ctx)
 	defer cancel()
 
-	// Step 1: Get the raw claims for this page
-	// Step 2: For each claim on this page, check if it's the newest with its global_index
-	// Step 3: If it IS the newest, compact it with the oldest claim of same global_index
-	// Step 4: If it's NOT the newest, exclude it from results
+	// Pagination query with compaction logic implementing three cases:
+	// Case 1: If unset_claim exists for a global_index, return all claims on page uncompacted
+	// Case 2: If no unset_claim exists and globally oldest is on page, return compacted claim
+	// Case 3: If globally oldest is outside page and no unset_claim exists, exclude from results
 	//
 	// This query:
-	// - Gets claims for the requested page
+	// - Gets claims for the requested page (DESC order: newest first)
 	// - Ranks all claims globally by global_index to find oldest and newest
-	// - Only returns compacted claims where the newest claim appears on this page
+	// - For claims with unset_claim: returns all instances on the page uncompacted
+	// - For claims without unset_claim: only returns compacted version if newest is on page
 	//nolint:gosec
 	query := fmt.Sprintf(`
 		WITH page_claims AS (
@@ -875,24 +876,60 @@ func (p *processor) GetClaimsPaged(
 		all_claims_ranked AS (
 			SELECT 
 				*,
-				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num ASC, block_pos ASC) AS rn_oldest,
-				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num DESC, block_pos DESC) AS rn_newest
+				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num ASC, block_pos ASC) AS rn_oldest_global,
+				ROW_NUMBER() OVER (PARTITION BY global_index ORDER BY block_num DESC, block_pos DESC) AS rn_newest_global
 			FROM claim
 			%s
+		),
+		claims_with_unset_on_page AS (
+			-- Case 1: Return all claims on page if unset_claim exists (no compaction)
+			SELECT 
+				pc.block_num,
+				pc.block_pos,
+				pc.tx_hash,
+				pc.global_index,
+				pc.origin_network,
+				pc.origin_address,
+				pc.destination_address,
+				pc.amount,
+				pc.proof_local_exit_root,
+				pc.proof_rollup_exit_root,
+				pc.mainnet_exit_root,
+				pc.rollup_exit_root,
+				pc.global_exit_root,
+				pc.destination_network,
+				pc.metadata,
+				pc.is_message,
+				pc.block_timestamp
+			FROM page_claims pc
+			WHERE EXISTS (
+				SELECT 1 FROM unset_claim uc 
+				WHERE uc.global_index = pc.global_index
+			)
 		),
 		newest_on_page AS (
 			SELECT DISTINCT pc.global_index
 			FROM page_claims pc
-			JOIN all_claims_ranked acr ON pc.global_index = acr.global_index AND acr.rn_newest = 1
+			JOIN all_claims_ranked acr ON pc.global_index = acr.global_index AND acr.rn_newest_global = 1
 			WHERE pc.block_num = acr.block_num AND pc.block_pos = acr.block_pos
-		)
-		SELECT 
-		%s
-		FROM all_claims_ranked o
-		JOIN all_claims_ranked n ON o.global_index = n.global_index AND n.rn_newest = 1
-		WHERE o.rn_oldest = 1
+			AND NOT EXISTS (
+				SELECT 1 FROM unset_claim uc 
+				WHERE uc.global_index = pc.global_index
+			)
+		),
+		compactable_claims AS (
+			-- Case 2 & 3: Handle claims without unset_claim
+			SELECT 
+			%s
+			FROM all_claims_ranked o
+			JOIN all_claims_ranked n ON o.global_index = n.global_index AND n.rn_newest_global = 1
+			WHERE o.rn_oldest_global = 1  -- Globally oldest claim
 			AND o.global_index IN (SELECT global_index FROM newest_on_page)
-		ORDER BY o.block_num DESC, o.block_pos DESC;
+		)
+		SELECT * FROM claims_with_unset_on_page
+		UNION ALL
+		SELECT * FROM compactable_claims
+		ORDER BY block_num DESC, block_pos DESC;
 	`, whereClause, whereClause, compactedClaimsSelectSQL)
 
 	rows, err := p.db.QueryContext(dbCtx, query, pageSize, offset)

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2747,7 +2747,6 @@ func TestDatabaseQueryTimeout(t *testing.T) {
 	require.Contains(t, err.Error(), "context deadline exceeded")
 }
 
-//nolint:dupl
 func TestGetClaims_Compact(t *testing.T) {
 	// Define all claims used across test cases
 	claims := []*Claim{
@@ -3111,6 +3110,26 @@ func TestGetClaims_Compact(t *testing.T) {
 			IsMessage:           false,
 			BlockTimestamp:      3000,
 		},
+		// claims[18] - block 3, pos 1 with GlobalIndex=200
+		{
+			BlockNum:            3,
+			BlockPos:            1,
+			TxHash:              common.HexToHash("0x112"),
+			GlobalIndex:         big.NewInt(200),
+			OriginNetwork:       3,
+			OriginAddress:       common.HexToAddress("0xccc"),
+			DestinationAddress:  common.HexToAddress("0xddd"),
+			Amount:              big.NewInt(200),
+			ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2ab")},
+			ProofRollupExitRoot: types.Proof{common.HexToHash("0x2bc")},
+			MainnetExitRoot:     common.HexToHash("0x2ce"),
+			RollupExitRoot:      common.HexToHash("0x2df"),
+			GlobalExitRoot:      common.HexToHash("0x2ee"),
+			DestinationNetwork:  88,
+			Metadata:            []byte("block3pos1"),
+			IsMessage:           true,
+			BlockTimestamp:      3001,
+		},
 	}
 
 	testCases := []struct {
@@ -3446,27 +3465,12 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 			queryFrom:     2,
 			queryTo:       3,
-			expectedCount: 1,
+			expectedCount: 0, // Changed from 1 to 0: globally oldest claim (block 1) is outside query range
 			validateResults: func(t *testing.T, claims []Claim) {
 				t.Helper()
-				claim := claims[0]
-				// Fields from oldest claim in range (block 2) - should be preserved
-				require.Equal(t, uint64(2), claim.BlockNum, "BlockNum should be from oldest in range")
-				require.Equal(t, uint64(0), claim.BlockPos, "BlockPos should be from oldest in range")
-				require.Equal(t, uint32(99), claim.OriginNetwork, "OriginNetwork should be from oldest in range")
-				require.Equal(t, common.HexToAddress("0xccc"), claim.OriginAddress, "OriginAddress should be from oldest in range")
-				require.Equal(t, common.HexToAddress("0xddd"), claim.DestinationAddress, "DestinationAddress should be from oldest in range")
-				require.Equal(t, big.NewInt(200), claim.Amount, "Amount should be from oldest in range")
-				require.Equal(t, uint32(88), claim.DestinationNetwork, "DestinationNetwork should be from oldest in range")
-				require.Equal(t, []byte("block2"), claim.Metadata, "Metadata should be from oldest in range")
-				require.Equal(t, true, claim.IsMessage, "IsMessage should be from oldest in range")
-				require.Equal(t, uint64(2000), claim.BlockTimestamp, "BlockTimestamp should be from oldest in range")
-				// Fields from newest claim in range (block 3) - should be updated
-				require.Equal(t, common.HexToHash("0x3a"), claim.ProofLocalExitRoot[0], "ProofLocalExitRoot should be from newest in range")
-				require.Equal(t, common.HexToHash("0x3b"), claim.ProofRollupExitRoot[0], "ProofRollupExitRoot should be from newest in range")
-				require.Equal(t, common.HexToHash("0x3c"), claim.MainnetExitRoot, "MainnetExitRoot should be from newest in range")
-				require.Equal(t, common.HexToHash("0x3d"), claim.RollupExitRoot, "RollupExitRoot should be from newest in range")
-				require.Equal(t, common.HexToHash("0x3e"), claim.GlobalExitRoot, "GlobalExitRoot should be from newest in range")
+				// Case 3: Since globally oldest claim (block 1) is outside the query range (2-3),
+				// we should not return anything for this global_index (no unset claim exists)
+				require.Empty(t, claims, "should return no claims when globally oldest is outside range")
 			},
 		},
 		{
@@ -3690,6 +3694,230 @@ func TestGetClaims_Compact(t *testing.T) {
 				require.Equal(t, big.NewInt(2), claims[1].GlobalIndex, "Second claim - claims[1] was added to block 4 but has BlockNum=2 in its data")
 				require.Equal(t, uint64(1), claims[0].BlockNum)
 				require.Equal(t, uint64(2), claims[1].BlockNum, "BlockNum comes from claim data, not the block it was added to")
+			},
+		},
+		{
+			name:      "Case 1: don't compact if unset claim exists for global_index",
+			compacted: true,
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: claims[2]}, // GlobalIndex=100, block 1, pos 1
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{UnsetClaim: &UnsetClaim{ // Unset claim for GlobalIndex=1
+								GlobalIndex:               big.NewInt(100),
+								BlockNum:                  2,
+								BlockPos:                  0,
+								TxHash:                    common.Hash{},
+								UnsetGlobalIndexHashChain: common.Hash{},
+							}},
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x3"),
+						Events: []any{
+							Event{Claim: claims[4]}, // GlobalIndex=1, block 3, pos 0
+						},
+					},
+				}
+			},
+			queryFrom:     1,
+			queryTo:       3,
+			expectedCount: 2, // Should return all claims without compacting GlobalIndex=100 due to unset claim
+			validateResults: func(t *testing.T, resultClaims []Claim) {
+				t.Helper()
+				// Should return: claim (GI=100, block 1), claim (GI=100, block 3)
+				require.Len(t, resultClaims, 2, "should not compact GlobalIndex=100 when unset claim exists")
+				require.Equal(t, *claims[2], resultClaims[0])
+				require.Equal(t, *claims[4], resultClaims[1])
+			},
+		},
+		{
+			name:      "Case 2: compact if no unset claim exists",
+			compacted: true,
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: claims[2]}, // GlobalIndex=100, block 1 (oldest)
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{Claim: claims[3]}, // GlobalIndex=100, block 2
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x3"),
+						Events: []any{
+							Event{Claim: claims[4]}, // GlobalIndex=100, block 3 (newest)
+							// No unset claim - should compact
+						},
+					},
+				}
+			},
+			queryFrom:     1,
+			queryTo:       3,
+			expectedCount: 1, // Should return 1 compacted claim
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				// Should compact all 3 claims into 1
+				require.Len(t, claims, 1, "should compact when no unset claim exists")
+				claim := claims[0]
+				require.Equal(t, big.NewInt(100), claim.GlobalIndex)
+				// Metadata from oldest (block 1)
+				require.Equal(t, uint64(1), claim.BlockNum, "should preserve oldest block")
+				require.Equal(t, uint64(0), claim.BlockPos, "should preserve oldest position")
+				require.Equal(t, []byte("original_metadata"), claim.Metadata, "should preserve oldest metadata")
+				require.Equal(t, big.NewInt(100), claim.Amount, "should preserve oldest amount")
+				require.Equal(t, uint32(1), claim.OriginNetwork, "should preserve oldest origin network")
+				// Proofs from newest (block 3)
+				require.Equal(t, common.HexToHash("0x3a"), claim.ProofLocalExitRoot[0], "should use newest proof")
+				require.Equal(t, common.HexToHash("0x3c"), claim.MainnetExitRoot, "should use newest MainnetExitRoot")
+				require.Equal(t, common.HexToHash("0x3d"), claim.RollupExitRoot, "should use newest RollupExitRoot")
+				require.Equal(t, common.HexToHash("0x3e"), claim.GlobalExitRoot, "should use newest GlobalExitRoot")
+			},
+		},
+		{
+			name:      "Case 3: don't return if globally oldest is outside query range",
+			compacted: true,
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: claims[2]}, // GlobalIndex=100, block 1 (globally oldest)
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{Claim: claims[3]}, // GlobalIndex=100, block 2
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x3"),
+						Events: []any{
+							Event{Claim: claims[4]}, // GlobalIndex=100, block 3 (newest)
+						},
+					},
+				}
+			},
+			queryFrom:     2, // Query starts at block 2, but globally oldest is at block 1
+			queryTo:       3,
+			expectedCount: 0, // Should return nothing because globally oldest (block 1) is outside range
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				// Should return no claims because the globally oldest claim (block 1) is outside the query range (2-3)
+				require.Empty(t, claims, "should not return claims when globally oldest is outside query range")
+			},
+		},
+		{
+			name:      "Case 3 exception: return if unset claim exists even when globally oldest is outside range",
+			compacted: true,
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: claims[0]}, // GlobalIndex=1, block 1, pos 0
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{UnsetClaim: &UnsetClaim{ // Unset claim for GlobalIndex=100
+								GlobalIndex:               big.NewInt(1),
+								BlockNum:                  1,
+								BlockPos:                  1,
+								TxHash:                    common.Hash{},
+								UnsetGlobalIndexHashChain: common.Hash{},
+							}},
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x3"),
+						Events: []any{
+							Event{Claim: claims[4]}, // GlobalIndex=1, block 3, pos 0
+						},
+					},
+				}
+			},
+			queryFrom:     3, // Query starts at block 3, globally oldest is at block 1
+			queryTo:       3,
+			expectedCount: 1, // Should return claim from block 3 (uncompacted) because unset claim exists
+			validateResults: func(t *testing.T, resultClaims []Claim) {
+				t.Helper()
+				// Should return claim from block 3 even though globally oldest is outside range
+				// because an unset claim exists for this global_index
+				require.Len(t, resultClaims, 1, "should return claims when unset claim exists, even if globally oldest is outside range")
+				require.Equal(t, *claims[4], resultClaims[0])
+			},
+		},
+		{
+			name:      "Multiple global_indexes with different compaction rules",
+			compacted: true,
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: claims[2]}, // GlobalIndex=100, block 1, pos 0 (globally oldest)
+							Event{Claim: claims[6]}, // GlobalIndex=200, block 1, pos 1 (globally oldest)
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{UnsetClaim: &UnsetClaim{ // Unset claim for GlobalIndex=100
+								GlobalIndex: big.NewInt(100),
+								BlockNum:    1,
+								BlockPos:    1,
+							}},
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{Claim: claims[4]},  // GlobalIndex=100, block 3, pos 0
+							Event{Claim: claims[18]}, // GlobalIndex=200, block 3, pos 1
+						},
+					},
+				}
+			},
+			queryFrom:     3, // Query block 3
+			queryTo:       3,
+			expectedCount: 1, // GlobalIndex=100: 1 claim (uncompacted, block 2 due to unset claim)
+			// GlobalIndex=456: 0 claims (globally oldest is at block 1, outside range)
+			// GlobalIndex=1: 0 claims (only exists at block 1, outside range)
+			validateResults: func(t *testing.T, resultClaims []Claim) {
+				t.Helper()
+				require.Len(t, resultClaims, 1, "should apply different rules per global_index")
+				// Should be GlobalIndex=100 (the one with unset claim)
+				require.Equal(t, *claims[4], resultClaims[0])
 			},
 		},
 	}

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -3135,7 +3135,6 @@ func TestGetClaims_Compact(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		compacted       bool
 		setupBlocks     func() []sync.Block
 		queryFrom       uint64
 		queryTo         uint64
@@ -3144,8 +3143,7 @@ func TestGetClaims_Compact(t *testing.T) {
 		validateResults func(t *testing.T, claims []Claim)
 	}{
 		{
-			name:      "non-compacted mode with different claims",
-			compacted: false,
+			name: "non-compacted mode with different claims",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3175,56 +3173,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "non-compacted mode with duplicates",
-			compacted: false,
-			setupBlocks: func() []sync.Block {
-				return []sync.Block{
-					{
-						Num:  1,
-						Hash: common.HexToHash("0x1"),
-						Events: []any{
-							Event{Claim: claims[2]}, // GlobalIndex=100
-						},
-					},
-					{
-						Num:  2,
-						Hash: common.HexToHash("0x2"),
-						Events: []any{
-							Event{Claim: claims[3]}, // GlobalIndex=100
-						},
-					},
-					{
-						Num:  3,
-						Hash: common.HexToHash("0x3"),
-						Events: []any{
-							Event{Claim: claims[4]}, // GlobalIndex=100
-						},
-					},
-				}
-			},
-			queryFrom:     1,
-			queryTo:       3,
-			expectedCount: 3,
-			validateResults: func(t *testing.T, claims []Claim) {
-				t.Helper()
-				require.Len(t, claims, 3, "all duplicate claims should be returned in non-compacted mode")
-				// Verify all three claims have the same GlobalIndex
-				require.Equal(t, big.NewInt(100), claims[0].GlobalIndex)
-				require.Equal(t, big.NewInt(100), claims[1].GlobalIndex)
-				require.Equal(t, big.NewInt(100), claims[2].GlobalIndex)
-				// Verify they are ordered by block number
-				require.Equal(t, uint64(1), claims[0].BlockNum)
-				require.Equal(t, uint64(2), claims[1].BlockNum)
-				require.Equal(t, uint64(3), claims[2].BlockNum)
-				// Verify metadata from each claim is preserved (no compaction)
-				require.Equal(t, []byte("original_metadata"), claims[0].Metadata)
-				require.Equal(t, []byte("middle_metadata"), claims[1].Metadata)
-				require.Equal(t, []byte("newest_metadata"), claims[2].Metadata)
-			},
-		},
-		{
-			name:      "compacted mode with no duplicates",
-			compacted: true,
+			name: "compacted mode with no duplicates",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3254,8 +3203,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "compacted mode with duplicates across blocks",
-			compacted: true,
+			name: "compacted mode with duplicates across blocks",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3309,8 +3257,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "compacted mode with multiple duplicate groups",
-			compacted: true,
+			name: "compacted mode with multiple duplicate groups",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3380,8 +3327,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "compacted mode same block multiple positions",
-			compacted: true,
+			name: "compacted mode same block multiple positions",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3421,8 +3367,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "compacted mode empty range",
-			compacted: true,
+			name: "compacted mode empty range",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3437,8 +3382,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
-			name:      "compacted mode partial range",
-			compacted: true,
+			name: "compacted mode partial range",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3475,8 +3419,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "ordering preserved by block number and position",
-			compacted: true,
+			name: "ordering preserved by block number and position",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3514,8 +3457,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "invalid block range - fromBlock greater than toBlock",
-			compacted: true,
+			name: "invalid block range - fromBlock greater than toBlock",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3559,8 +3501,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "fromBlock = 0 edge case",
-			compacted: true,
+			name: "fromBlock = 0 edge case",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3602,8 +3543,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "claims at both fromBlock and toBlock boundaries with compaction",
-			compacted: true,
+			name: "claims at both fromBlock and toBlock boundaries with compaction",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3651,8 +3591,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "block range with gaps in processed blocks",
-			compacted: true,
+			name: "block range with gaps in processed blocks",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3698,8 +3637,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "Case 1: don't compact if unset claim exists for global_index",
-			compacted: true,
+			name: "Case 1: don't compact if unset claim exists for global_index",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3743,8 +3681,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "Case 2: compact if no unset claim exists",
-			compacted: true,
+			name: "Case 2: compact if no unset claim exists",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3794,8 +3731,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "Case 3: don't return if globally oldest is outside query range",
-			compacted: true,
+			name: "Case 3: don't return if globally oldest is outside query range",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3831,8 +3767,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "Case 3 exception: return if unset claim exists even when globally oldest is outside range",
-			compacted: true,
+			name: "Case 3 exception: return if unset claim exists even when globally oldest is outside range",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3876,8 +3811,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			},
 		},
 		{
-			name:      "Multiple global_indexes with different compaction rules",
-			compacted: true,
+			name: "Multiple global_indexes with different compaction rules",
 			setupBlocks: func() []sync.Block {
 				return []sync.Block{
 					{
@@ -3938,7 +3872,7 @@ func TestGetClaims_Compact(t *testing.T) {
 			}
 
 			// Execute test
-			claims, err := p.GetClaims(ctx, tc.queryFrom, tc.queryTo, tc.compacted)
+			claims, err := p.GetClaims(ctx, tc.queryFrom, tc.queryTo)
 
 			// Validate error expectations
 			if tc.errorContains != "" {

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2226,9 +2226,21 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 	t.Run("retrieve existing claims", func(t *testing.T) {
 		claims, err := p.GetClaimsByGlobalIndex(ctx, globalIndexToTest)
 		require.NoError(t, err)
-		require.Len(t, claims, 2)                   // Two claims with the same global index
-		require.Equal(t, *testClaims[1], claims[0]) // Check first claim
-		require.Equal(t, *testClaims[2], claims[1]) // Check second claim
+		require.Len(t, claims, 1)
+		// no unset claim, so the claims got compacted
+		require.Equal(t, testClaims[1].BlockNum, claims[0].BlockNum)
+		require.Equal(t, testClaims[1].BlockPos, claims[0].BlockPos)
+		require.Equal(t, testClaims[1].GlobalIndex, claims[0].GlobalIndex)
+		require.Equal(t, testClaims[1].OriginAddress, claims[0].OriginAddress)
+		require.Equal(t, testClaims[1].DestinationAddress, claims[0].DestinationAddress)
+		require.Equal(t, testClaims[1].Amount, claims[0].Amount)
+		require.Equal(t, testClaims[1].Metadata, claims[0].Metadata)
+		require.Equal(t, testClaims[1].IsMessage, claims[0].IsMessage)
+		require.Equal(t, testClaims[2].MainnetExitRoot, claims[0].MainnetExitRoot)
+		require.Equal(t, testClaims[2].RollupExitRoot, claims[0].RollupExitRoot)
+		require.Equal(t, testClaims[2].GlobalExitRoot, claims[0].GlobalExitRoot)
+		require.Equal(t, testClaims[2].ProofLocalExitRoot, claims[0].ProofLocalExitRoot)
+		require.Equal(t, testClaims[2].ProofRollupExitRoot, claims[0].ProofRollupExitRoot)
 	})
 
 	// Test case 4: Test with very large global index
@@ -2329,6 +2341,378 @@ func TestGetClaimByGlobalIndex(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, claims)
 	})
+}
+
+// TestGetClaimsByGlobalIndex_Compact tests the compaction behavior of GetClaimsByGlobalIndex
+// It mirrors the test cases from TestGetClaims_Compact to ensure consistent behavior
+//
+//nolint:dupl
+func TestGetClaimsByGlobalIndex_Compact(t *testing.T) {
+	logger := log.WithFields("module", "bridge-syncer")
+	ctx := context.Background()
+
+	// Define test claims used across test cases
+	oldProof := types.Proof{}
+	oldProof[0] = common.HexToHash("0x01")
+
+	newProof := types.Proof{}
+	newProof[0] = common.HexToHash("0x02")
+
+	testCases := []struct {
+		name            string
+		globalIndex     *big.Int
+		setupBlocks     func() []sync.Block
+		expectedCount   int
+		validateResults func(t *testing.T, claims []Claim)
+	}{
+		{
+			name:        "Case 1: don't compact if unset_claim exists for global_index",
+			globalIndex: big.NewInt(100),
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            1,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x111"),
+								GlobalIndex:         big.NewInt(100),
+								OriginNetwork:       1,
+								OriginAddress:       common.HexToAddress("0xaaa"),
+								DestinationAddress:  common.HexToAddress("0xbbb"),
+								Amount:              big.NewInt(100),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+								MainnetExitRoot:     common.HexToHash("0x1c"),
+								RollupExitRoot:      common.HexToHash("0x1d"),
+								GlobalExitRoot:      common.HexToHash("0x1e"),
+								DestinationNetwork:  2,
+								Metadata:            []byte("original_metadata"),
+								IsMessage:           false,
+								BlockTimestamp:      1000,
+							}},
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{UnsetClaim: &UnsetClaim{
+								GlobalIndex: big.NewInt(100),
+								BlockNum:    2,
+								BlockPos:    0,
+								TxHash:      common.Hash{},
+							}},
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x3"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            3,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x333"),
+								GlobalIndex:         big.NewInt(100),
+								OriginNetwork:       77,
+								OriginAddress:       common.HexToAddress("0x999"),
+								DestinationAddress:  common.HexToAddress("0x888"),
+								Amount:              big.NewInt(777),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x3a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x3b")},
+								MainnetExitRoot:     common.HexToHash("0x3c"),
+								RollupExitRoot:      common.HexToHash("0x3d"),
+								GlobalExitRoot:      common.HexToHash("0x3e"),
+								DestinationNetwork:  66,
+								Metadata:            []byte("newest_metadata"),
+								IsMessage:           true,
+								BlockTimestamp:      3000,
+							}},
+						},
+					},
+				}
+			},
+			expectedCount: 2, // Should return all claims without compacting because unset_claim exists
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				require.Len(t, claims, 2, "should not compact when unset claim exists")
+				// Claims should be ordered by block_num ASC
+				require.Equal(t, uint64(1), claims[0].BlockNum)
+				require.Equal(t, []byte("original_metadata"), claims[0].Metadata)
+				require.Equal(t, uint64(3), claims[1].BlockNum)
+				require.Equal(t, []byte("newest_metadata"), claims[1].Metadata)
+			},
+		},
+		{
+			name:        "Case 2: compact if no unset_claim exists",
+			globalIndex: big.NewInt(200),
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            1,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x111"),
+								GlobalIndex:         big.NewInt(200),
+								OriginNetwork:       1,
+								OriginAddress:       common.HexToAddress("0xaaa"),
+								DestinationAddress:  common.HexToAddress("0xbbb"),
+								Amount:              big.NewInt(100),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+								MainnetExitRoot:     common.HexToHash("0x1c"),
+								RollupExitRoot:      common.HexToHash("0x1d"),
+								GlobalExitRoot:      common.HexToHash("0x1e"),
+								DestinationNetwork:  2,
+								Metadata:            []byte("original_metadata"),
+								IsMessage:           false,
+								BlockTimestamp:      1000,
+							}},
+						},
+					},
+					{
+						Num:  2,
+						Hash: common.HexToHash("0x2"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            2,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x222"),
+								GlobalIndex:         big.NewInt(200),
+								OriginNetwork:       99,
+								OriginAddress:       common.HexToAddress("0xfff"),
+								DestinationAddress:  common.HexToAddress("0xeee"),
+								Amount:              big.NewInt(999),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x2b")},
+								MainnetExitRoot:     common.HexToHash("0x2c"),
+								RollupExitRoot:      common.HexToHash("0x2d"),
+								GlobalExitRoot:      common.HexToHash("0x2e"),
+								DestinationNetwork:  88,
+								Metadata:            []byte("middle_metadata"),
+								IsMessage:           true,
+								BlockTimestamp:      2000,
+							}},
+						},
+					},
+					{
+						Num:  3,
+						Hash: common.HexToHash("0x3"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            3,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x333"),
+								GlobalIndex:         big.NewInt(200),
+								OriginNetwork:       77,
+								OriginAddress:       common.HexToAddress("0x999"),
+								DestinationAddress:  common.HexToAddress("0x888"),
+								Amount:              big.NewInt(777),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x3a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x3b")},
+								MainnetExitRoot:     common.HexToHash("0x3c"),
+								RollupExitRoot:      common.HexToHash("0x3d"),
+								GlobalExitRoot:      common.HexToHash("0x3e"),
+								DestinationNetwork:  66,
+								Metadata:            []byte("newest_metadata"),
+								IsMessage:           true,
+								BlockTimestamp:      3000,
+							}},
+						},
+					},
+				}
+			},
+			expectedCount: 1, // Should return 1 compacted claim
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				require.Len(t, claims, 1, "should compact when no unset claim exists")
+				claim := claims[0]
+				require.Equal(t, big.NewInt(200), claim.GlobalIndex)
+				// Metadata from oldest (block 1)
+				require.Equal(t, uint64(1), claim.BlockNum, "should preserve oldest block")
+				require.Equal(t, uint64(0), claim.BlockPos, "should preserve oldest position")
+				require.Equal(t, []byte("original_metadata"), claim.Metadata, "should preserve oldest metadata")
+				require.Equal(t, big.NewInt(100), claim.Amount, "should preserve oldest amount")
+				require.Equal(t, uint32(1), claim.OriginNetwork, "should preserve oldest origin network")
+				// Proofs from newest (block 3)
+				require.Equal(t, common.HexToHash("0x3a"), claim.ProofLocalExitRoot[0], "should use newest proof")
+				require.Equal(t, common.HexToHash("0x3c"), claim.MainnetExitRoot, "should use newest MainnetExitRoot")
+				require.Equal(t, common.HexToHash("0x3d"), claim.RollupExitRoot, "should use newest RollupExitRoot")
+				require.Equal(t, common.HexToHash("0x3e"), claim.GlobalExitRoot, "should use newest GlobalExitRoot")
+			},
+		},
+		{
+			name:        "Single claim - no compaction needed",
+			globalIndex: big.NewInt(300),
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            1,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x111"),
+								GlobalIndex:         big.NewInt(300),
+								OriginNetwork:       5,
+								OriginAddress:       common.HexToAddress("0x555"),
+								DestinationAddress:  common.HexToAddress("0x666"),
+								Amount:              big.NewInt(500),
+								ProofLocalExitRoot:  oldProof,
+								ProofRollupExitRoot: oldProof,
+								MainnetExitRoot:     common.HexToHash("0xaaa"),
+								RollupExitRoot:      common.HexToHash("0xbbb"),
+								GlobalExitRoot:      common.HexToHash("0xccc"),
+								DestinationNetwork:  6,
+								Metadata:            []byte("single_claim"),
+								IsMessage:           false,
+								BlockTimestamp:      1000,
+							}},
+						},
+					},
+				}
+			},
+			expectedCount: 1,
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				require.Len(t, claims, 1)
+				require.Equal(t, big.NewInt(300), claims[0].GlobalIndex)
+				require.Equal(t, []byte("single_claim"), claims[0].Metadata)
+			},
+		},
+		{
+			name:        "Non-existent global index",
+			globalIndex: big.NewInt(999999),
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            1,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x111"),
+								GlobalIndex:         big.NewInt(400),
+								OriginNetwork:       1,
+								OriginAddress:       common.HexToAddress("0xaaa"),
+								DestinationAddress:  common.HexToAddress("0xbbb"),
+								Amount:              big.NewInt(100),
+								ProofLocalExitRoot:  oldProof,
+								ProofRollupExitRoot: oldProof,
+								MainnetExitRoot:     common.HexToHash("0x1c"),
+								RollupExitRoot:      common.HexToHash("0x1d"),
+								GlobalExitRoot:      common.HexToHash("0x1e"),
+								DestinationNetwork:  2,
+								Metadata:            []byte("different_index"),
+								IsMessage:           false,
+								BlockTimestamp:      1000,
+							}},
+						},
+					},
+				}
+			},
+			expectedCount: 0,
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				require.Empty(t, claims, "should return empty for non-existent global index")
+			},
+		},
+		{
+			name:        "Multiple claims same block - compact using position",
+			globalIndex: big.NewInt(500),
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{Claim: &Claim{
+								BlockNum:            1,
+								BlockPos:            0,
+								TxHash:              common.HexToHash("0x111"),
+								GlobalIndex:         big.NewInt(500),
+								OriginNetwork:       1,
+								OriginAddress:       common.HexToAddress("0xaaa"),
+								DestinationAddress:  common.HexToAddress("0xbbb"),
+								Amount:              big.NewInt(100),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+								MainnetExitRoot:     common.HexToHash("0x1c"),
+								RollupExitRoot:      common.HexToHash("0x1d"),
+								GlobalExitRoot:      common.HexToHash("0x1e"),
+								DestinationNetwork:  2,
+								Metadata:            []byte("pos_0_metadata"),
+								IsMessage:           false,
+								BlockTimestamp:      1000,
+							}},
+							Event{Claim: &Claim{
+								BlockNum:            1,
+								BlockPos:            1,
+								TxHash:              common.HexToHash("0x112"),
+								GlobalIndex:         big.NewInt(500),
+								OriginNetwork:       1,
+								OriginAddress:       common.HexToAddress("0xaaa"),
+								DestinationAddress:  common.HexToAddress("0xbbb"),
+								Amount:              big.NewInt(100),
+								ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2a")},
+								ProofRollupExitRoot: types.Proof{common.HexToHash("0x2b")},
+								MainnetExitRoot:     common.HexToHash("0x2c"),
+								RollupExitRoot:      common.HexToHash("0x2d"),
+								GlobalExitRoot:      common.HexToHash("0x2e"),
+								DestinationNetwork:  2,
+								Metadata:            []byte("pos_1_metadata"),
+								IsMessage:           false,
+								BlockTimestamp:      1000,
+							}},
+						},
+					},
+				}
+			},
+			expectedCount: 1,
+			validateResults: func(t *testing.T, claims []Claim) {
+				t.Helper()
+				require.Len(t, claims, 1, "should compact multiple claims in same block")
+				claim := claims[0]
+				require.Equal(t, uint64(1), claim.BlockNum)
+				require.Equal(t, uint64(0), claim.BlockPos, "should use oldest position")
+				require.Equal(t, []byte("pos_0_metadata"), claim.Metadata, "should use oldest metadata")
+				require.Equal(t, common.HexToHash("0x2a"), claim.ProofLocalExitRoot[0], "should use newest proof")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a fresh database for each test case
+			dbPath := filepath.Join(t.TempDir(), "testcase.sqlite")
+			require.NoError(t, migrations.RunMigrations(dbPath))
+			testP, err := newProcessor(dbPath, "bridge-syncer", logger, dbQueryTimeout)
+			require.NoError(t, err)
+
+			// Setup blocks
+			blocks := tc.setupBlocks()
+			for _, block := range blocks {
+				require.NoError(t, testP.ProcessBlock(ctx, block))
+			}
+
+			// Execute test
+			claims, err := testP.GetClaimsByGlobalIndex(ctx, tc.globalIndex)
+			require.NoError(t, err)
+
+			// Validate results
+			require.Len(t, claims, tc.expectedCount)
+			if tc.validateResults != nil {
+				tc.validateResults(t, claims)
+			}
+		})
+	}
 }
 
 func intPtr(i int) *int {
@@ -2748,6 +3132,7 @@ func TestDatabaseQueryTimeout(t *testing.T) {
 	require.Contains(t, err.Error(), "context deadline exceeded")
 }
 
+//nolint:dupl
 func TestGetClaims_Compact(t *testing.T) {
 	// Define all claims used across test cases
 	claims := []*Claim{

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -9,8 +9,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -5098,4 +5101,55 @@ func TestGetClaimsPaged_CompactionAcrossPages(t *testing.T) {
 		require.Equal(t, 2, claimsByGlobalIndex[100]) // Uncompacted
 		require.Equal(t, 1, claimsByGlobalIndex[200]) // Compacted
 	})
+}
+
+// TestClaimColumnsSQL_ReflectionCheck verifies that all meddler-tagged fields
+// in the Claim struct are present in the claimColumnsSQL constant.
+// This test uses reflection to ensure maintainability - if a new field is added
+// to Claim with a meddler tag, this test will fail until claimColumnsSQL is updated.
+func TestClaimColumnsSQL_ReflectionCheck(t *testing.T) {
+	t.Parallel()
+
+	claimType := reflect.TypeOf(Claim{})
+
+	// Collect meddler-tagged column names
+	var meddlerColumns []string
+	for i := 0; i < claimType.NumField(); i++ {
+		tag := claimType.Field(i).Tag.Get("meddler")
+		if tag == "" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name != "" && name != "-" {
+			meddlerColumns = append(meddlerColumns, name)
+		}
+	}
+
+	require.NotEmpty(t, meddlerColumns, "Claim struct should have meddler-tagged fields")
+
+	// Normalize whitespace and split columns
+	ws := regexp.MustCompile(`\s+`)
+	normalized := strings.TrimSpace(ws.ReplaceAllString(claimColumnsSQL, " "))
+
+	var sqlColumns []string
+	for col := range strings.SplitSeq(normalized, ",") {
+		if col = strings.TrimSpace(col); col != "" {
+			sqlColumns = append(sqlColumns, col)
+		}
+	}
+
+	require.Equal(t, len(meddlerColumns), len(sqlColumns),
+		"SQL column count must match meddler-tagged field count")
+
+	// Turn SQL columns into a lookup set
+	sqlSet := make(map[string]struct{}, len(sqlColumns))
+	for _, col := range sqlColumns {
+		sqlSet[col] = struct{}{}
+	}
+
+	// Ensure every struct tag column exists in SQL
+	for _, col := range meddlerColumns {
+		_, ok := sqlSet[col]
+		require.True(t, ok, "Missing SQL column for meddler-tag '%s'", col)
+	}
 }

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -484,7 +484,7 @@ func (a *getClaims) desc() string {
 
 func (a *getClaims) execute(t *testing.T) {
 	t.Helper()
-	actualEvents, actualErr := a.p.getClaimsInternal(a.ctx, getClaimsBlockRangeSelectSQL, a.fromBlock, a.toBlock)
+	actualEvents, actualErr := a.p.GetClaims(a.ctx, a.fromBlock, a.toBlock)
 	require.Equal(t, a.expectedErr, actualErr)
 	require.Equal(t, a.expectedClaims, actualEvents)
 }
@@ -860,7 +860,7 @@ func TestInsertAndGetClaim(t *testing.T) {
 	require.NoError(t, tx.Commit())
 
 	// get test claim
-	claims, err := p.getClaimsInternal(context.Background(), getClaimsBlockRangeSelectSQL, 1, 1)
+	claims, err := p.GetClaims(context.Background(), 1, 1)
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 	require.Equal(t, testClaim, &claims[0])
@@ -3127,7 +3127,7 @@ func TestDatabaseQueryTimeout(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context deadline exceeded")
 
-	_, err = pShortTimeout.getClaimsInternal(ctx, queryBlockRangeSelectSQL, 1, 1)
+	_, err = pShortTimeout.GetClaims(ctx, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context deadline exceeded")
 }

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"testing"
@@ -36,7 +37,7 @@ func TestBigIntString(t *testing.T) {
 	_, ok := new(big.Int).SetString(globalIndex.String(), 10)
 	require.True(t, ok)
 
-	dbPath := path.Join(t.TempDir(), "bridgesyncTestBigIntString.sqlite")
+	dbPath := filepath.Join(t.TempDir(), "bridgesyncTestBigIntString.sqlite")
 
 	err := migrations.RunMigrations(dbPath)
 	require.NoError(t, err)
@@ -3958,6 +3959,8 @@ func TestGetClaims_Compact(t *testing.T) {
 
 // TestGetClaimsPaged_CompactionAcrossPages tests the compaction behavior when
 // claims with the same global_index span across multiple pages
+//
+//nolint:dupl
 func TestGetClaimsPaged_CompactionAcrossPages(t *testing.T) {
 	path := path.Join(t.TempDir(), "claimsPaged_compaction.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
@@ -4286,5 +4289,494 @@ func TestGetClaimsPaged_CompactionAcrossPages(t *testing.T) {
 		require.Equal(t, 0, count) // No claims match both filters
 
 		require.Len(t, result, 0)
+	})
+
+	// ========== Additional comprehensive test cases (mirroring TestGetClaims_Compact) ==========
+
+	// Test Case 1: Don't compact if unset_claim exists for global_index
+	t.Run("Case 1: don't compact if unset_claim exists for global_index", func(t *testing.T) {
+		// Create a new database for this test
+		dbPath := filepath.Join(t.TempDir(), "case1.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		testP, err := newProcessor(dbPath, "bridge-syncer", logger, dbQueryTimeout)
+		require.NoError(t, err)
+
+		// Setup: Insert 3 claims with same global_index and 1 unset_claim
+		tx, err := testP.db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+
+		for i := uint64(1); i <= 3; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, i)
+			require.NoError(t, err)
+		}
+
+		testClaims := []*Claim{
+			{
+				BlockNum:            1,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x111"),
+				GlobalIndex:         big.NewInt(1),
+				OriginNetwork:       1,
+				OriginAddress:       common.HexToAddress("0xaaa"),
+				DestinationAddress:  common.HexToAddress("0xbbb"),
+				Amount:              big.NewInt(100),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+				MainnetExitRoot:     common.HexToHash("0x1c"),
+				RollupExitRoot:      common.HexToHash("0x1d"),
+				GlobalExitRoot:      common.HexToHash("0x1e"),
+				DestinationNetwork:  2,
+				Metadata:            []byte("metadata1"),
+				IsMessage:           false,
+				BlockTimestamp:      1000,
+			},
+			{
+				BlockNum:            2,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x222"),
+				GlobalIndex:         big.NewInt(1),
+				OriginNetwork:       3,
+				OriginAddress:       common.HexToAddress("0xccc"),
+				DestinationAddress:  common.HexToAddress("0xddd"),
+				Amount:              big.NewInt(200),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x2b")},
+				MainnetExitRoot:     common.HexToHash("0x2c"),
+				RollupExitRoot:      common.HexToHash("0x2d"),
+				GlobalExitRoot:      common.HexToHash("0x2e"),
+				DestinationNetwork:  4,
+				Metadata:            []byte("metadata2"),
+				IsMessage:           true,
+				BlockTimestamp:      2000,
+			},
+		}
+
+		for _, claim := range testClaims {
+			require.NoError(t, meddler.Insert(tx, "claim", claim))
+		}
+
+		// Insert unset_claim for global_index 1
+		unsetClaim := &UnsetClaim{
+			BlockNum:    1,
+			BlockPos:    1,
+			GlobalIndex: big.NewInt(1),
+		}
+		require.NoError(t, meddler.Insert(tx, "unset_claim", unsetClaim))
+		require.NoError(t, tx.Commit())
+
+		// Query: Should return all claims uncompacted because unset_claim exists
+		result, count, err := testP.GetClaimsPaged(ctx, 1, 10, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+		require.Len(t, result, 2)
+		require.Equal(t, result[0], testClaims[1]) // they are returned in DESC order
+		require.Equal(t, result[1], testClaims[0])
+	})
+
+	// Test Case 2: Compact if no unset_claim exists
+	t.Run("Case 2: compact if no unset_claim exists", func(t *testing.T) {
+		// Create a new database for this test
+		dbPath := filepath.Join(t.TempDir(), "case2.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		testP, err := newProcessor(dbPath, "bridge-syncer", logger, dbQueryTimeout)
+		require.NoError(t, err)
+
+		// Setup: Insert 3 claims with same global_index, NO unset_claim
+		tx, err := testP.db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+
+		for i := uint64(1); i <= 3; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, i)
+			require.NoError(t, err)
+		}
+
+		testClaims := []*Claim{
+			{
+				BlockNum:            1,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x111"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       1,
+				OriginAddress:       common.HexToAddress("0xaaa"),
+				DestinationAddress:  common.HexToAddress("0xbbb"),
+				Amount:              big.NewInt(100),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+				MainnetExitRoot:     common.HexToHash("0x1c"),
+				RollupExitRoot:      common.HexToHash("0x1d"),
+				GlobalExitRoot:      common.HexToHash("0x1e"),
+				DestinationNetwork:  2,
+				Metadata:            []byte("original_metadata"),
+				IsMessage:           false,
+				BlockTimestamp:      1000,
+			},
+			{
+				BlockNum:            2,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x222"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       99,
+				OriginAddress:       common.HexToAddress("0xfff"),
+				DestinationAddress:  common.HexToAddress("0xeee"),
+				Amount:              big.NewInt(999),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x2b")},
+				MainnetExitRoot:     common.HexToHash("0x2c"),
+				RollupExitRoot:      common.HexToHash("0x2d"),
+				GlobalExitRoot:      common.HexToHash("0x2e"),
+				DestinationNetwork:  88,
+				Metadata:            []byte("middle_metadata"),
+				IsMessage:           true,
+				BlockTimestamp:      2000,
+			},
+			{
+				BlockNum:            3,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x333"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       77,
+				OriginAddress:       common.HexToAddress("0x999"),
+				DestinationAddress:  common.HexToAddress("0x888"),
+				Amount:              big.NewInt(777),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x3a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x3b")},
+				MainnetExitRoot:     common.HexToHash("0x3c"),
+				RollupExitRoot:      common.HexToHash("0x3d"),
+				GlobalExitRoot:      common.HexToHash("0x3e"),
+				DestinationNetwork:  66,
+				Metadata:            []byte("newest_metadata"),
+				IsMessage:           true,
+				BlockTimestamp:      3000,
+			},
+		}
+
+		for _, claim := range testClaims {
+			require.NoError(t, meddler.Insert(tx, "claim", claim))
+		}
+		require.NoError(t, tx.Commit())
+
+		// Query: Should return 1 compacted claim (oldest metadata + newest proofs)
+		result, count, err := testP.GetClaimsPaged(ctx, 1, 10, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+		require.Len(t, result, 1)
+
+		// Verify compaction: oldest claim's metadata with newest claim's proofs
+		require.Equal(t, big.NewInt(100), result[0].GlobalIndex)
+		require.Equal(t, uint64(1), result[0].BlockNum)                                       // Oldest claim's block
+		require.Equal(t, common.HexToHash("0x111"), result[0].TxHash)                         // Oldest claim's tx
+		require.Equal(t, []byte("original_metadata"), result[0].Metadata)                     // Oldest claim's metadata
+		require.Equal(t, types.Proof{common.HexToHash("0x3a")}, result[0].ProofLocalExitRoot) // Newest claim's proof
+		require.Equal(t, common.HexToHash("0x3c"), result[0].MainnetExitRoot)                 // Newest claim's root
+	})
+
+	// Test Case 3: Don't return if globally oldest is outside page range
+	t.Run("Case 3: don't return if globally oldest is outside page range", func(t *testing.T) {
+		// Create a new database for this test
+		dbPath := filepath.Join(t.TempDir(), "case3.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		testP, err := newProcessor(dbPath, "bridge-syncer", logger, dbQueryTimeout)
+		require.NoError(t, err)
+
+		// Setup: Insert claims where oldest is at block 1, newest at block 3
+		tx, err := testP.db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+
+		for i := uint64(1); i <= 3; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, i)
+			require.NoError(t, err)
+		}
+
+		testClaims := []*Claim{
+			// Oldest claim (block 1)
+			{
+				BlockNum:            1,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x111"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       1,
+				OriginAddress:       common.HexToAddress("0xaaa"),
+				DestinationAddress:  common.HexToAddress("0xbbb"),
+				Amount:              big.NewInt(100),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+				MainnetExitRoot:     common.HexToHash("0x1c"),
+				RollupExitRoot:      common.HexToHash("0x1d"),
+				GlobalExitRoot:      common.HexToHash("0x1e"),
+				DestinationNetwork:  2,
+				Metadata:            []byte("original_metadata"),
+				IsMessage:           false,
+				BlockTimestamp:      1000,
+			},
+			// Middle claim (block 2)
+			{
+				BlockNum:            2,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x222"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       99,
+				OriginAddress:       common.HexToAddress("0xfff"),
+				DestinationAddress:  common.HexToAddress("0xeee"),
+				Amount:              big.NewInt(999),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x2b")},
+				MainnetExitRoot:     common.HexToHash("0x2c"),
+				RollupExitRoot:      common.HexToHash("0x2d"),
+				GlobalExitRoot:      common.HexToHash("0x2e"),
+				DestinationNetwork:  88,
+				Metadata:            []byte("middle_metadata"),
+				IsMessage:           true,
+				BlockTimestamp:      2000,
+			},
+			// Newest claim (block 3)
+			{
+				BlockNum:            3,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x333"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       77,
+				OriginAddress:       common.HexToAddress("0x999"),
+				DestinationAddress:  common.HexToAddress("0x888"),
+				Amount:              big.NewInt(777),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x3a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x3b")},
+				MainnetExitRoot:     common.HexToHash("0x3c"),
+				RollupExitRoot:      common.HexToHash("0x3d"),
+				GlobalExitRoot:      common.HexToHash("0x3e"),
+				DestinationNetwork:  66,
+				Metadata:            []byte("newest_metadata"),
+				IsMessage:           true,
+				BlockTimestamp:      3000,
+			},
+		}
+
+		for _, claim := range testClaims {
+			require.NoError(t, meddler.Insert(tx, "claim", claim))
+		}
+		require.NoError(t, tx.Commit())
+
+		// Query page 2 (which contains block 2): The newest (block 3) is NOT on this page
+		// Page 1 would have block 3, Page 2 would have block 2, Page 3 would have block 1
+		result, count, err := testP.GetClaimsPaged(ctx, 2, 1, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+
+		// Should return 0 claims because the newest for global_index 100 is not on this page
+		require.Len(t, result, 0)
+	})
+
+	// Test Case 3 Exception: Return if unset_claim exists even when globally oldest is outside range
+	t.Run("Case 3 exception: return if unset_claim exists even when globally oldest is outside range", func(t *testing.T) {
+		// Create a new database for this test
+		dbPath := filepath.Join(t.TempDir(), "case3_exception.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		testP, err := newProcessor(dbPath, "bridge-syncer", logger, dbQueryTimeout)
+		require.NoError(t, err)
+
+		// Setup: Insert claims + unset_claim
+		tx, err := testP.db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+
+		for i := uint64(1); i <= 3; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, i)
+			require.NoError(t, err)
+		}
+
+		testClaims := []*Claim{
+			// Oldest claim (block 1)
+			{
+				BlockNum:            1,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x111"),
+				GlobalIndex:         big.NewInt(1),
+				OriginNetwork:       1,
+				OriginAddress:       common.HexToAddress("0xaaa"),
+				DestinationAddress:  common.HexToAddress("0xbbb"),
+				Amount:              big.NewInt(100),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+				MainnetExitRoot:     common.HexToHash("0x1c"),
+				RollupExitRoot:      common.HexToHash("0x1d"),
+				GlobalExitRoot:      common.HexToHash("0x1e"),
+				DestinationNetwork:  2,
+				Metadata:            []byte("metadata1"),
+				IsMessage:           false,
+				BlockTimestamp:      1000,
+			},
+			// Newest claim (block 3)
+			{
+				BlockNum:            3,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x333"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       77,
+				OriginAddress:       common.HexToAddress("0x999"),
+				DestinationAddress:  common.HexToAddress("0x888"),
+				Amount:              big.NewInt(777),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x3a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x3b")},
+				MainnetExitRoot:     common.HexToHash("0x3c"),
+				RollupExitRoot:      common.HexToHash("0x3d"),
+				GlobalExitRoot:      common.HexToHash("0x3e"),
+				DestinationNetwork:  66,
+				Metadata:            []byte("newest_metadata"),
+				IsMessage:           true,
+				BlockTimestamp:      3000,
+			},
+		}
+
+		for _, claim := range testClaims {
+			require.NoError(t, meddler.Insert(tx, "claim", claim))
+		}
+
+		// Insert unset_claim for global_index 1
+		unsetClaim := &UnsetClaim{
+			BlockNum:    1,
+			BlockPos:    1,
+			GlobalIndex: big.NewInt(1),
+		}
+		require.NoError(t, meddler.Insert(tx, "unset_claim", unsetClaim))
+		require.NoError(t, tx.Commit())
+
+		// Query: Even though oldest is outside page, should return claim because unset_claim exists
+		result, count, err := testP.GetClaimsPaged(ctx, 1, 10, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+
+		// Should return both claims uncompacted
+		require.Len(t, result, 2)
+		require.Equal(t, result[0], testClaims[1]) // they are returned in DESC order
+		require.Equal(t, result[1], testClaims[0])
+	})
+
+	// Test: Multiple global_indexes with different compaction rules
+	t.Run("Multiple global_indexes with different compaction rules", func(t *testing.T) {
+		// Create a new database for this test
+		dbPath := filepath.Join(t.TempDir(), "multiple_indexes.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		testP, err := newProcessor(dbPath, "bridge-syncer", logger, dbQueryTimeout)
+		require.NoError(t, err)
+
+		// Setup: Multiple global indexes with different scenarios
+		tx, err := testP.db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+
+		for i := uint64(1); i <= 3; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, i)
+			require.NoError(t, err)
+		}
+
+		testClaims := []*Claim{
+			// Global index 100 - oldest (block 1, pos 0)
+			{
+				BlockNum:            1,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x111"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       1,
+				OriginAddress:       common.HexToAddress("0xa1"),
+				DestinationAddress:  common.HexToAddress("0xb1"),
+				Amount:              big.NewInt(100),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x1a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x1b")},
+				MainnetExitRoot:     common.HexToHash("0x1c"),
+				RollupExitRoot:      common.HexToHash("0x1d"),
+				GlobalExitRoot:      common.HexToHash("0x1e"),
+				DestinationNetwork:  2,
+				Metadata:            []byte("index1_old"),
+				IsMessage:           false,
+				BlockTimestamp:      1000,
+			},
+			// Global index 200 - oldest (block 1, pos 1)
+			{
+				BlockNum:            1,
+				BlockPos:            1,
+				TxHash:              common.HexToHash("0x112"),
+				GlobalIndex:         big.NewInt(200),
+				OriginNetwork:       3,
+				OriginAddress:       common.HexToAddress("0xa2"),
+				DestinationAddress:  common.HexToAddress("0xb2"),
+				Amount:              big.NewInt(200),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x2b")},
+				MainnetExitRoot:     common.HexToHash("0x2c"),
+				RollupExitRoot:      common.HexToHash("0x2d"),
+				GlobalExitRoot:      common.HexToHash("0x2e"),
+				DestinationNetwork:  4,
+				Metadata:            []byte("index2_old"),
+				IsMessage:           true,
+				BlockTimestamp:      1001,
+			},
+			// Global index 200 - newest (block 3, pos 1)
+			{
+				BlockNum:            3,
+				BlockPos:            1,
+				TxHash:              common.HexToHash("0x112"),
+				GlobalIndex:         big.NewInt(200),
+				OriginNetwork:       3,
+				OriginAddress:       common.HexToAddress("0xccc"),
+				DestinationAddress:  common.HexToAddress("0xddd"),
+				Amount:              big.NewInt(200),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x2ab")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x2bc")},
+				MainnetExitRoot:     common.HexToHash("0x2ce"),
+				RollupExitRoot:      common.HexToHash("0x2df"),
+				GlobalExitRoot:      common.HexToHash("0x2ee"),
+				DestinationNetwork:  88,
+				Metadata:            []byte("block3pos1"),
+				IsMessage:           true,
+				BlockTimestamp:      3001,
+			},
+			// Global index 100 - newest (block 3, pos 0)
+			{
+				BlockNum:            3,
+				BlockPos:            0,
+				TxHash:              common.HexToHash("0x333"),
+				GlobalIndex:         big.NewInt(100),
+				OriginNetwork:       77,
+				OriginAddress:       common.HexToAddress("0xc2"),
+				DestinationAddress:  common.HexToAddress("0xd2"),
+				Amount:              big.NewInt(777),
+				ProofLocalExitRoot:  types.Proof{common.HexToHash("0x4a")},
+				ProofRollupExitRoot: types.Proof{common.HexToHash("0x4b")},
+				MainnetExitRoot:     common.HexToHash("0x4c"),
+				RollupExitRoot:      common.HexToHash("0x4d"),
+				GlobalExitRoot:      common.HexToHash("0x4e"),
+				DestinationNetwork:  66,
+				Metadata:            []byte("index1_new"),
+				IsMessage:           false,
+				BlockTimestamp:      2001,
+			},
+		}
+
+		for _, claim := range testClaims {
+			require.NoError(t, meddler.Insert(tx, "claim", claim))
+		}
+
+		// Insert unset_claim for global_index 100 only
+		unsetClaim := &UnsetClaim{
+			BlockNum:    1,
+			BlockPos:    1,
+			GlobalIndex: big.NewInt(100),
+		}
+		require.NoError(t, meddler.Insert(tx, "unset_claim", unsetClaim))
+		require.NoError(t, tx.Commit())
+
+		// Query: Should return:
+		// - Global index 100: both claims uncompacted (because unset_claim exists)
+		// - Global index 200: 1 compacted claim
+		result, count, err := testP.GetClaimsPaged(ctx, 1, 10, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 4, count)
+		require.Len(t, result, 3) // 2 for index 100 (uncompacted) + 1 for index 200 (compacted)
+
+		// Count claims by global index
+		claimsByGlobalIndex := make(map[int64]int)
+		for _, claim := range result {
+			claimsByGlobalIndex[claim.GlobalIndex.Int64()]++
+		}
+
+		require.Equal(t, 2, claimsByGlobalIndex[100]) // Uncompacted
+		require.Equal(t, 1, claimsByGlobalIndex[200]) // Compacted
 	})
 }


### PR DESCRIPTION
## 🔄 Changes Summary
This PR modifes the compaction logic of `claims` to take into consideration the `unset claim` events as well to do compaction logic.

The compaction logic for getting claims for a block range (`certificates`) works like this now:
- Find all claims with the same global_index across ALL blocks (not just in range)
- Check if there's an unset claim for that global_index
- If no unset claim AND the globally oldest claim is within the query range, return the compacted claim (take everything from the old claim, except the proof and exit root fields which are taken from the newest claim)
- Otherwise, return nothing for that global_index

For the `bridge service` logic when queried by page:
- Returns all claims on the page uncompacted if an `unset_claim` exists for that `global_index`.
- For claims without `unset_claims`, compacts them by combining oldest claim metadata with newest claim proofs, but only if the newest claim appears on the requested page
- Claims without `unset_claims` where the newest instance is not on the current page are excluded from results

The same logic was applied to functions:
- `GetClaims`
- `GetClaimsPaged`
- `GetClaimsByGlobalIndex`

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI

## 🔗 Related PRs
#1336
