### PR TITLE
feat: backwards on merkle tree

### DIFF
--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -592,7 +592,7 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) error
 type processor struct {
 	syncerID       string
 	db             *sql.DB
-	exitTree       *tree.AppendOnlyTree
+	exitTree       types.FullTreer
 	log            *log.Logger
 	mu             mutex.RWMutex
 	halted         bool

--- a/db/mocks/mock_d_ber.go
+++ b/db/mocks/mock_d_ber.go
@@ -150,6 +150,76 @@ func (_c *DBer_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.Res
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *DBer) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DBer_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type DBer_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *DBer_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *DBer_ExecContext_Call {
+	return &DBer_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *DBer_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *DBer_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *DBer_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *DBer_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *DBer_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *DBer_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *DBer) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/mocks/mock_querier.go
+++ b/db/mocks/mock_querier.go
@@ -91,6 +91,76 @@ func (_c *Querier_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *Querier) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Querier_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type Querier_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Querier_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *Querier_ExecContext_Call {
+	return &Querier_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Querier_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Querier_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Querier_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *Querier_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Querier_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *Querier_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *Querier) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/mocks/mock_sql_txer.go
+++ b/db/mocks/mock_sql_txer.go
@@ -136,6 +136,76 @@ func (_c *SQLTxer_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *SQLTxer) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SQLTxer_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type SQLTxer_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *SQLTxer_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *SQLTxer_ExecContext_Call {
+	return &SQLTxer_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *SQLTxer_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *SQLTxer_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SQLTxer_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *SQLTxer_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SQLTxer_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *SQLTxer_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *SQLTxer) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/mocks/mock_txer.go
+++ b/db/mocks/mock_txer.go
@@ -202,6 +202,76 @@ func (_c *Txer_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.Res
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *Txer) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Txer_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type Txer_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Txer_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *Txer_ExecContext_Call {
+	return &Txer_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Txer_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Txer_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Txer_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *Txer_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Txer_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *Txer_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *Txer) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/types/interface.go
+++ b/db/types/interface.go
@@ -11,6 +11,7 @@ import (
 // Implementations of this interface can be used to generalize database access logic.
 type Querier interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -247,8 +247,9 @@ func (t *Tree) Reorg(tx dbtypes.Txer, firstReorgedBlock uint64) error {
 }
 
 // BackwardToIndex deletes all the roots with index higher than targetIndex
-func (t *Tree) BackwardToIndex(ctx context.Context, targetIndex uint32) error {
-	_, err := t.db.Exec(
+func (t *Tree) BackwardToIndex(ctx context.Context, tx dbtypes.Txer, targetIndex uint32) error {
+	_, err := tx.ExecContext(
+		ctx,
 		fmt.Sprintf(`DELETE FROM %s WHERE position > $1`, t.rootTable),
 		targetIndex,
 	)

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -133,14 +133,11 @@ func (t *Tree) getRHTNode(tx dbtypes.Querier, nodeHash common.Hash) (*types.Tree
 }
 
 func (t *Tree) storeNodes(tx dbtypes.Txer, nodes []types.TreeNode) error {
-	for i := 0; i < len(nodes); i++ {
-		if err := meddler.Insert(tx, t.rhtTable, &nodes[i]); err != nil {
-			if sqliteErr, ok := db.SQLiteErr(err); ok {
-				if sqliteErr.ExtendedCode == db.UniqueConstrain {
-					// ignore repeated entries. This is likely to happen due to not
-					// cleaning RHT when reorg
-					continue
-				}
+	for _, node := range nodes {
+		if err := meddler.Insert(tx, t.rhtTable, &node); err != nil {
+			if sqliteErr, ok := db.SQLiteErr(err); ok && sqliteErr.ExtendedCode == db.UniqueConstrain {
+				// ignore repeated entries
+				continue
 			}
 			return err
 		}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -246,12 +246,21 @@ func (t *Tree) Reorg(tx dbtypes.Txer, firstReorgedBlock uint64) error {
 	return err
 }
 
+// BackwardToIndex deletes all the roots with index higher than targetIndex
+func (t *Tree) BackwardToIndex(ctx context.Context, targetIndex uint32) error {
+	_, err := t.db.Exec(
+		fmt.Sprintf(`DELETE FROM %s WHERE position > $1`, t.rootTable),
+		targetIndex,
+	)
+	return err
+}
+
 // CalculateRoot calculates the Merkle Root based on the leaf and proof	of inclusion
 func CalculateRoot(leafHash common.Hash, proof [types.DefaultHeight]common.Hash, index uint32) common.Hash {
 	node := leafHash
 
 	// Compute the Merkle root
-	for height := uint8(0); height < types.DefaultHeight; height++ {
+	for height := range types.DefaultHeight {
 		if (index>>height)&1 == 1 {
 			node = crypto.Keccak256Hash(proof[height].Bytes(), node.Bytes())
 		} else {

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -327,7 +327,7 @@ func TestTree_BackwardToIndex(t *testing.T) {
 		}
 
 		// Delete roots with index > 4
-		err := tree.Tree.BackwardToIndex(ctx, 4)
+		err := tree.BackwardToIndex(ctx, 4)
 		require.NoError(t, err)
 
 		// Roots with index 0..4 should exist
@@ -363,7 +363,7 @@ func TestTree_BackwardToIndex(t *testing.T) {
 
 		putTestLeaves(t, tree, treeDB, 3, 0)
 
-		err := tree.Tree.BackwardToIndex(ctx, 10)
+		err := tree.BackwardToIndex(ctx, 10)
 		require.NoError(t, err)
 
 		// All roots should still exist
@@ -380,7 +380,7 @@ func TestTree_BackwardToIndex(t *testing.T) {
 		treeDB := createTreeDBForTest(t)
 		tree := NewAppendOnlyTree(treeDB, "")
 
-		err := tree.Tree.BackwardToIndex(ctx, 0)
+		err := tree.BackwardToIndex(ctx, 0)
 		require.NoError(t, err)
 	})
 

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -306,6 +306,104 @@ func TestVerifyProof(t *testing.T) {
 	}
 }
 
+func TestTree_BackwardToIndex(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("deletes roots with index higher than targetIndex", func(t *testing.T) {
+		t.Parallel()
+
+		treeDB := createTreeDBForTest(t)
+		tree := NewAppendOnlyTree(treeDB, "")
+
+		// Add 8 leaves (roots with indices 0..7)
+		putTestLeaves(t, tree, treeDB, 8, 0)
+
+		// Confirm all roots exist
+		for i := range 8 {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+
+		// Delete roots with index > 4
+		err := tree.Tree.BackwardToIndex(ctx, 4)
+		require.NoError(t, err)
+
+		// Roots with index 0..4 should exist
+		for i := 0; i <= 4; i++ {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+
+		// Roots with index 5..7 should not exist
+		for i := 5; i < 8; i++ {
+			_, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.Error(t, err)
+			require.ErrorIs(t, err, db.ErrNotFound)
+		}
+
+		// Add more leaves to confirm tree is still functional
+		putTestLeaves(t, tree, treeDB, 3, 5) // adding leaves with indices 5,6,7
+
+		// Confirm new roots exist
+		for i := range 8 {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+	})
+
+	t.Run("no roots deleted if none above targetIndex", func(t *testing.T) {
+		t.Parallel()
+
+		treeDB := createTreeDBForTest(t)
+		tree := NewAppendOnlyTree(treeDB, "")
+
+		putTestLeaves(t, tree, treeDB, 3, 0)
+
+		err := tree.Tree.BackwardToIndex(ctx, 10)
+		require.NoError(t, err)
+
+		// All roots should still exist
+		for i := range 3 {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+	})
+
+	t.Run("handles empty table gracefully", func(t *testing.T) {
+		t.Parallel()
+
+		treeDB := createTreeDBForTest(t)
+		tree := NewAppendOnlyTree(treeDB, "")
+
+		err := tree.Tree.BackwardToIndex(ctx, 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error on database failure", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := path.Join(t.TempDir(), "tree_BackwardToIndex_dberr.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		treeDB, err := db.NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+
+		// Intentionally invalid table name
+		tree := &Tree{
+			db:        treeDB,
+			rootTable: "nonexistent_table",
+		}
+
+		err = tree.BackwardToIndex(ctx, 0)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no such table")
+	})
+}
+
 func createTreeDBForTest(t *testing.T) *sql.DB {
 	t.Helper()
 

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -326,9 +326,12 @@ func TestTree_BackwardToIndex(t *testing.T) {
 			require.Equal(t, uint32(i), root.Index)
 		}
 
-		// Delete roots with index > 4
-		err := tree.BackwardToIndex(ctx, 4)
+		tx, err := db.NewTx(context.Background(), treeDB)
 		require.NoError(t, err)
+
+		// Delete roots with index > 4
+		require.NoError(t, tree.BackwardToIndex(ctx, tx, 4))
+		require.NoError(t, tx.Commit())
 
 		// Roots with index 0..4 should exist
 		for i := 0; i <= 4; i++ {
@@ -363,8 +366,11 @@ func TestTree_BackwardToIndex(t *testing.T) {
 
 		putTestLeaves(t, tree, treeDB, 3, 0)
 
-		err := tree.BackwardToIndex(ctx, 10)
+		tx, err := db.NewTx(context.Background(), treeDB)
 		require.NoError(t, err)
+
+		require.NoError(t, tree.BackwardToIndex(ctx, tx, 10))
+		require.NoError(t, tx.Commit())
 
 		// All roots should still exist
 		for i := range 3 {
@@ -380,8 +386,10 @@ func TestTree_BackwardToIndex(t *testing.T) {
 		treeDB := createTreeDBForTest(t)
 		tree := NewAppendOnlyTree(treeDB, "")
 
-		err := tree.BackwardToIndex(ctx, 0)
+		tx, err := db.NewTx(context.Background(), treeDB)
 		require.NoError(t, err)
+
+		require.NoError(t, tree.BackwardToIndex(ctx, tx, 0))
 	})
 
 	t.Run("returns error on database failure", func(t *testing.T) {
@@ -398,8 +406,10 @@ func TestTree_BackwardToIndex(t *testing.T) {
 			rootTable: "nonexistent_table",
 		}
 
-		err = tree.BackwardToIndex(ctx, 0)
-		require.Error(t, err)
+		tx, err := db.NewTx(context.Background(), treeDB)
+		require.NoError(t, err)
+
+		err = tree.BackwardToIndex(ctx, tx, 0)
 		require.ErrorContains(t, err, "no such table")
 	})
 }

--- a/tree/types/interfaces.go
+++ b/tree/types/interfaces.go
@@ -25,6 +25,7 @@ type LeafWriter interface {
 type ReorganizeTreer interface {
 	ReadTreer
 	Reorg(tx dbtypes.Txer, firstReorgedBlock uint64) error
+	BackwardToIndex(ctx context.Context, tx dbtypes.Txer, targetIndex uint32) error
 }
 
 // FullTreer = fully-capable tree (read, write, reorg)

--- a/tree/types/mocks/mock_full_treer.go
+++ b/tree/types/mocks/mock_full_treer.go
@@ -27,6 +27,54 @@ func (_m *FullTreer) EXPECT() *FullTreer_Expecter {
 	return &FullTreer_Expecter{mock: &_m.Mock}
 }
 
+// BackwardToIndex provides a mock function with given fields: ctx, tx, targetIndex
+func (_m *FullTreer) BackwardToIndex(ctx context.Context, tx types.Txer, targetIndex uint32) error {
+	ret := _m.Called(ctx, tx, targetIndex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BackwardToIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.Txer, uint32) error); ok {
+		r0 = rf(ctx, tx, targetIndex)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// FullTreer_BackwardToIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BackwardToIndex'
+type FullTreer_BackwardToIndex_Call struct {
+	*mock.Call
+}
+
+// BackwardToIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tx types.Txer
+//   - targetIndex uint32
+func (_e *FullTreer_Expecter) BackwardToIndex(ctx interface{}, tx interface{}, targetIndex interface{}) *FullTreer_BackwardToIndex_Call {
+	return &FullTreer_BackwardToIndex_Call{Call: _e.mock.On("BackwardToIndex", ctx, tx, targetIndex)}
+}
+
+func (_c *FullTreer_BackwardToIndex_Call) Run(run func(ctx context.Context, tx types.Txer, targetIndex uint32)) *FullTreer_BackwardToIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.Txer), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *FullTreer_BackwardToIndex_Call) Return(_a0 error) *FullTreer_BackwardToIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *FullTreer_BackwardToIndex_Call) RunAndReturn(run func(context.Context, types.Txer, uint32) error) *FullTreer_BackwardToIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLastRoot provides a mock function with given fields: tx
 func (_m *FullTreer) GetLastRoot(tx types.Querier) (treetypes.Root, error) {
 	ret := _m.Called(tx)

--- a/tree/types/mocks/mock_reorganize_treer.go
+++ b/tree/types/mocks/mock_reorganize_treer.go
@@ -27,6 +27,54 @@ func (_m *ReorganizeTreer) EXPECT() *ReorganizeTreer_Expecter {
 	return &ReorganizeTreer_Expecter{mock: &_m.Mock}
 }
 
+// BackwardToIndex provides a mock function with given fields: ctx, tx, targetIndex
+func (_m *ReorganizeTreer) BackwardToIndex(ctx context.Context, tx types.Txer, targetIndex uint32) error {
+	ret := _m.Called(ctx, tx, targetIndex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BackwardToIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.Txer, uint32) error); ok {
+		r0 = rf(ctx, tx, targetIndex)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ReorganizeTreer_BackwardToIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BackwardToIndex'
+type ReorganizeTreer_BackwardToIndex_Call struct {
+	*mock.Call
+}
+
+// BackwardToIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tx types.Txer
+//   - targetIndex uint32
+func (_e *ReorganizeTreer_Expecter) BackwardToIndex(ctx interface{}, tx interface{}, targetIndex interface{}) *ReorganizeTreer_BackwardToIndex_Call {
+	return &ReorganizeTreer_BackwardToIndex_Call{Call: _e.mock.On("BackwardToIndex", ctx, tx, targetIndex)}
+}
+
+func (_c *ReorganizeTreer_BackwardToIndex_Call) Run(run func(ctx context.Context, tx types.Txer, targetIndex uint32)) *ReorganizeTreer_BackwardToIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.Txer), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *ReorganizeTreer_BackwardToIndex_Call) Return(_a0 error) *ReorganizeTreer_BackwardToIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorganizeTreer_BackwardToIndex_Call) RunAndReturn(run func(context.Context, types.Txer, uint32) error) *ReorganizeTreer_BackwardToIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLastRoot provides a mock function with given fields: tx
 func (_m *ReorganizeTreer) GetLastRoot(tx types.Querier) (treetypes.Root, error) {
 	ret := _m.Called(tx)


### PR DESCRIPTION
## 🔄 Changes Summary
This PR adds a function to rewind merkle tree to a previous root index. (This will be used for backwarding of `LocalExitTree`).

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI
