### PR TITLE
fix: replace ethClient.BlockByNumber by ethClient.HeaderByNumber

### DIFF
--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -153,14 +153,14 @@ func newBridgeSync(
 	}
 
 	if lastProcessedBlock < cfg.InitialBlockNum {
-		block, err := ethClient.BlockByNumber(ctx, new(big.Int).SetUint64(cfg.InitialBlockNum))
+		header, err := ethClient.HeaderByNumber(ctx, new(big.Int).SetUint64(cfg.InitialBlockNum))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get initial block %d: %w", cfg.InitialBlockNum, err)
 		}
 
 		err = processor.ProcessBlock(ctx, sync.Block{
 			Num:  cfg.InitialBlockNum,
-			Hash: block.Hash(),
+			Hash: header.Hash(),
 		})
 		if err != nil {
 			return nil, err

--- a/etherman/config/network.go
+++ b/etherman/config/network.go
@@ -90,7 +90,6 @@ type RPCMode string
 
 var (
 	RPCModeBasic RPCMode = "basic"
-	RPCModeHash  RPCMode = "hash"
 	RPCModeOp    RPCMode = "op"
 )
 

--- a/etherman/config/network.go
+++ b/etherman/config/network.go
@@ -90,6 +90,7 @@ type RPCMode string
 
 var (
 	RPCModeBasic RPCMode = "basic"
+	RPCModeHash  RPCMode = "hash"
 	RPCModeOp    RPCMode = "op"
 )
 

--- a/l1infotreesync/l1infotreesync.go
+++ b/l1infotreesync/l1infotreesync.go
@@ -376,10 +376,10 @@ func (s *L1InfoTreeSync) IsUpToDate(ctx context.Context, l1Client aggkittypes.Ba
 		return false, fmt.Errorf("failed to get last processed block: %w", err)
 	}
 
-	finalizedBlock, err := l1Client.BlockByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
+	finalizedBlock, err := l1Client.HeaderByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
 	if err != nil {
 		return false, fmt.Errorf("failed to get the latest finalized L1 block: %w", err)
 	}
 
-	return lastProcessedBlock >= finalizedBlock.NumberU64(), nil
+	return lastProcessedBlock >= finalizedBlock.Number.Uint64(), nil
 }

--- a/l1infotreesync/l1infotreesync_test.go
+++ b/l1infotreesync/l1infotreesync_test.go
@@ -265,7 +265,7 @@ func TestIsUpToDate(t *testing.T) {
 		}
 
 		mockL1Client := aggkittypesmocks.NewBaseEthereumClienter(t)
-		mockL1Client.EXPECT().BlockByNumber(mock.Anything, mock.Anything).Return(nil, errors.New("RPC error"))
+		mockL1Client.EXPECT().HeaderByNumber(mock.Anything, mock.Anything).Return(nil, errors.New("RPC error"))
 
 		ctx := context.Background()
 		result, err := s.IsUpToDate(ctx, mockL1Client)
@@ -287,7 +287,7 @@ func TestIsUpToDate(t *testing.T) {
 
 		block := ethtypes.NewBlock(&ethtypes.Header{Number: big.NewInt(0)}, nil, nil, nil)
 		mockL1Client := aggkittypesmocks.NewBaseEthereumClienter(t)
-		mockL1Client.EXPECT().BlockByNumber(mock.Anything, mock.Anything).Return(block, nil)
+		mockL1Client.EXPECT().HeaderByNumber(mock.Anything, mock.Anything).Return(block.Header(), nil)
 
 		ctx := context.Background()
 		result, err := s.IsUpToDate(ctx, mockL1Client)

--- a/test/helpers/reorg.go
+++ b/test/helpers/reorg.go
@@ -28,8 +28,8 @@ func Reorg(t *testing.T, client *simulated.Backend, reorgSizeInBlocks uint64) {
 	currentBlockNum, err := client.Client().BlockNumber(ctx)
 	require.NoError(t, err)
 
-	block, err := client.Client().BlockByNumber(ctx, big.NewInt(int64(currentBlockNum-reorgSizeInBlocks)))
-	log.Debugf("reorging until block %d. Current block %d (before reorg)", block.NumberU64(), currentBlockNum)
+	block, err := client.Client().HeaderByNumber(ctx, big.NewInt(int64(currentBlockNum-reorgSizeInBlocks)))
+	log.Debugf("reorging until block %d. Current block %d (before reorg)", block.Number.Uint64(), currentBlockNum)
 	require.NoError(t, err)
 	reorgFrom := block.Hash()
 	err = client.Fork(reorgFrom)

--- a/test/helpers/reorg.go
+++ b/test/helpers/reorg.go
@@ -29,9 +29,10 @@ func Reorg(t *testing.T, client *simulated.Backend, reorgSizeInBlocks uint64) {
 	require.NoError(t, err)
 
 	block, err := client.Client().HeaderByNumber(ctx, big.NewInt(int64(currentBlockNum-reorgSizeInBlocks)))
-	log.Debugf("reorging until block %d. Current block %d (before reorg)", block.Number.Uint64(), currentBlockNum)
+	header, err := client.Client().HeaderByNumber(ctx, new(big.Int).SetUint64(currentBlockNum-reorgSizeInBlocks))
+	log.Debugf("reorging until block %d. Current block %d (before reorg)", header.Number.Uint64(), currentBlockNum)
 	require.NoError(t, err)
-	reorgFrom := block.Hash()
+	reorgFrom := header.Hash()
 	err = client.Fork(reorgFrom)
 	require.NoError(t, err)
 }

--- a/test/helpers/reorg.go
+++ b/test/helpers/reorg.go
@@ -28,7 +28,6 @@ func Reorg(t *testing.T, client *simulated.Backend, reorgSizeInBlocks uint64) {
 	currentBlockNum, err := client.Client().BlockNumber(ctx)
 	require.NoError(t, err)
 
-	block, err := client.Client().HeaderByNumber(ctx, big.NewInt(int64(currentBlockNum-reorgSizeInBlocks)))
 	header, err := client.Client().HeaderByNumber(ctx, new(big.Int).SetUint64(currentBlockNum-reorgSizeInBlocks))
 	log.Debugf("reorging until block %d. Current block %d (before reorg)", header.Number.Uint64(), currentBlockNum)
 	require.NoError(t, err)


### PR DESCRIPTION
## 🔄 Changes Summary
In the enviroment `bali-63-outpost` appears the error `transaction type not supported`. To avoid that we can use `HeaderByNumber` instead of `BlockByNumber`

- replace [BlockByNumber](https://pkg.go.dev/github.com/ethereum/go-ethereum/ethclient#Client.BlockByNumber) by [HeaderByNumber](https://pkg.go.dev/github.com/ethereum/go-ethereum/ethclient#Client.HeaderByNumber)

## ✅ Testing
- 🤖 **Automatic**:

## 🐞 Issues
- Closes #1388

## 🔗 Related PRs
- https://github.com/agglayer/aggkit/pull/1169
