### PR TITLE
fix: handle block range too large rpc error, and do chunk calls (cherry-pick of #1387)

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test-unit:
+    name: test-unit
     strategy:
       fail-fast: false
       matrix:

--- a/bridgesync/agglayer_bridge_l2_reader.go
+++ b/bridgesync/agglayer_bridge_l2_reader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerbridgel2"
 	"github.com/agglayer/aggkit/bridgesync/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -43,6 +44,7 @@ func NewAgglayerBridgeL2Reader(
 // GetUnsetClaimsForBlockRange retrieves all unset claims (unclaims) within a specified block range.
 // It filters the UpdatedUnsetGlobalIndexHashChain events from the bridge contract and converts them
 // into Unclaim objects for further processing.
+// If the block range is too large, it automatically splits the request into smaller chunks.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control
@@ -57,6 +59,32 @@ func (r *AgglayerBridgeL2Reader) GetUnsetClaimsForBlockRange(ctx context.Context
 	if fromBlock > toBlock {
 		return nil, fmt.Errorf("invalid block range: fromBlock(%d) > toBlock(%d)", fromBlock, toBlock)
 	}
+
+	unclaims, err := r.fetchUnsetClaims(ctx, fromBlock, toBlock)
+	if err != nil {
+		// Check if error is due to block range being too large
+		maxRange, isMaxRangeErr := aggkitcommon.ParseMaxRangeFromError(err.Error())
+		if isMaxRangeErr {
+			log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
+			return aggkitcommon.ChunkedRangeQuery(
+				ctx, fromBlock, toBlock, maxRange,
+				r.fetchUnsetClaims,
+				func(all, chunk []types.Unclaim) []types.Unclaim {
+					return append(all, chunk...)
+				},
+				make([]types.Unclaim, 0),
+			)
+		}
+
+		return nil, err
+	}
+
+	return unclaims, nil
+}
+
+// fetchUnsetClaims performs the actual event filtering for a given block range
+func (r *AgglayerBridgeL2Reader) fetchUnsetClaims(ctx context.Context,
+	fromBlock, toBlock uint64) ([]types.Unclaim, error) {
 	unclaimIterator, err := r.agglayerBridgeL2.FilterUpdatedUnsetGlobalIndexHashChain(
 		&bind.FilterOpts{Context: ctx, Start: fromBlock, End: &toBlock})
 	if err != nil {

--- a/bridgesync/agglayer_bridge_l2_reader_test.go
+++ b/bridgesync/agglayer_bridge_l2_reader_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/agglayer/aggkit/bridgesync/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	mocksethclient "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
@@ -372,4 +374,199 @@ func TestAgglayerBridgeL2Reader_GetUnsetClaimsForBlockRange_ContextHandling(t *t
 	})
 
 	mockClient.AssertExpectations(t)
+}
+
+func TestGetUnsetClaimsInChunks(t *testing.T) {
+	ctx := context.Background()
+	bridgeAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	t.Run("exact chunk boundaries", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// Mock 3 successful chunk calls (blocks 0-999, 1000-1999, 2000-2999)
+		mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q interface{}) bool {
+			return true // Accept all filter queries for simplicity
+		})).Return([]ethtypes.Log{}, nil).Times(3)
+
+		unclaims, err := aggkitcommon.ChunkedRangeQuery(
+			ctx, 0, 2999, 1000,
+			reader.fetchUnsetClaims,
+			func(all, chunk []types.Unclaim) []types.Unclaim {
+				return append(all, chunk...)
+			},
+			[]types.Unclaim{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+		require.Empty(t, unclaims) // Empty results as we mocked empty logs
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("non-exact chunk boundaries", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// Mock 3 calls: 0-999, 1000-1999, 2000-2500
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Times(3)
+
+		unclaims, err := aggkitcommon.ChunkedRangeQuery(
+			ctx, 0, 2500, 1000,
+			reader.fetchUnsetClaims,
+			func(all, chunk []types.Unclaim) []types.Unclaim {
+				return append(all, chunk...)
+			},
+			[]types.Unclaim{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("single chunk (range smaller than maxRange)", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Once()
+
+		unclaims, err := aggkitcommon.ChunkedRangeQuery(ctx, 0, 500, 1000,
+			reader.fetchUnsetClaims,
+			func(all, chunk []types.Unclaim) []types.Unclaim {
+				return append(all, chunk...)
+			},
+			[]types.Unclaim{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("error in middle chunk", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// First chunk succeeds
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Once()
+		// Second chunk fails
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return(nil, errors.New("rpc error")).Once()
+
+		unclaims, err := aggkitcommon.ChunkedRangeQuery(ctx, 0, 2000, 1000,
+			reader.fetchUnsetClaims,
+			func(all, chunk []types.Unclaim) []types.Unclaim {
+				return append(all, chunk...)
+			},
+			[]types.Unclaim{},
+		)
+		require.ErrorContains(t, err, "rpc error")
+		require.Empty(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("zero maxRange", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// Should return error immediately without making any calls
+		unclaims, err := aggkitcommon.ChunkedRangeQuery(ctx, 0, 1000, 0,
+			reader.fetchUnsetClaims,
+			func(all, chunk []types.Unclaim) []types.Unclaim {
+				return append(all, chunk...)
+			},
+			[]types.Unclaim{},
+		)
+		require.ErrorContains(t, err, "maxRange must be greater than 0")
+		require.Empty(t, unclaims)
+
+		// No FilterLogs calls should have been made
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestGetUnsetClaimsForBlockRange_ChunkingIntegration(t *testing.T) {
+	ctx := context.Background()
+	bridgeAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	t.Run("normal fetch succeeds without chunking", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// Mock successful FilterLogs call
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Once()
+
+		unclaims, err := reader.GetUnsetClaimsForBlockRange(ctx, 0, 500)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("block range too large triggers chunking", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// First call fails with "block range too large"
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).
+			Return(nil, errors.New("block range too large, max range: 1000")).Once()
+
+		// Subsequent chunked calls succeed (0-999, 1000-1999, 2000-2500)
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).
+			Return([]ethtypes.Log{}, nil).Times(3)
+
+		unclaims, err := reader.GetUnsetClaimsForBlockRange(ctx, 0, 2500)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("non-parseable error returns original error", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// Return an error that doesn't match the pattern
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).
+			Return(nil, errors.New("some other RPC error")).Once()
+
+		unclaims, err := reader.GetUnsetClaimsForBlockRange(ctx, 0, 2500)
+		require.ErrorContains(t, err, "some other RPC error")
+		require.Nil(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("chunking fails partway through", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2Reader(bridgeAddr, mockClient)
+		require.NoError(t, err)
+
+		// First call triggers chunking
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).
+			Return(nil, errors.New("block range too large, max range: 1000")).Once()
+
+		// First chunk succeeds
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).
+			Return([]ethtypes.Log{}, nil).Once()
+
+		// Second chunk fails
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).
+			Return(nil, errors.New("connection timeout")).Once()
+
+		unclaims, err := reader.GetUnsetClaimsForBlockRange(ctx, 0, 2500)
+		require.ErrorContains(t, err, "connection timeout")
+		require.Empty(t, unclaims)
+
+		mockClient.AssertExpectations(t)
+	})
 }

--- a/common/block_range.go
+++ b/common/block_range.go
@@ -1,6 +1,9 @@
 package common
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 var (
 	BlockRangeZero = BlockRange{}
@@ -158,4 +161,33 @@ func (b BlockRange) Intersect(other BlockRange) BlockRange {
 		max(b.FromBlock, other.FromBlock),
 		min(b.ToBlock, other.ToBlock),
 	)
+}
+
+// ChunkedRangeQuery is a generic chunker for block range queries.
+// T is the result type (e.g., []Unclaim, map[common.Hash]GlobalExitRootInfo, []*RemovedGER, etc.)
+func ChunkedRangeQuery[T any](
+	ctx context.Context,
+	fromBlock, toBlock, maxRange uint64,
+	fetchChunk func(ctx context.Context, from, to uint64) (T, error),
+	combine func(all T, chunk T) T,
+	empty T,
+) (T, error) {
+	if maxRange == 0 {
+		return empty, fmt.Errorf("maxRange must be greater than 0")
+	}
+
+	all := empty
+	for currentFrom := fromBlock; currentFrom <= toBlock; {
+		currentTo := min(currentFrom+maxRange-1, toBlock)
+
+		chunk, err := fetchChunk(ctx, currentFrom, currentTo)
+		if err != nil {
+			return empty, fmt.Errorf("error in chunk %d-%d: %w", currentFrom, currentTo, err)
+		}
+
+		all = combine(all, chunk)
+		currentFrom = currentTo + 1
+	}
+
+	return all, nil
 }

--- a/common/block_range_test.go
+++ b/common/block_range_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -346,4 +348,126 @@ func TestBlockRange_Merge(t *testing.T) {
 	require.Equal(t, []BlockRange{NewBlockRange(1, 50)}, bn2.Merge(bn1))
 	require.Equal(t, []BlockRange{bn1, bn3}, bn1.Merge(bn3))
 	require.Equal(t, []BlockRange{bn1, bn3}, bn3.Merge(bn1))
+}
+
+func TestChunkedRangeQuery_IntSlice(t *testing.T) {
+	ctx := context.Background()
+	fromBlock := uint64(1)
+	toBlock := uint64(10)
+	maxRange := uint64(3)
+
+	// Simulate fetchChunk: returns a slice of ints representing block numbers
+	fetchChunk := func(ctx context.Context, from, to uint64) ([]int, error) {
+		result := make([]int, 0, to-from+1)
+		for i := from; i <= to; i++ {
+			result = append(result, int(i))
+		}
+		return result, nil
+	}
+
+	// Combine: append slices
+	combine := func(all, chunk []int) []int {
+		return append(all, chunk...)
+	}
+
+	empty := []int{}
+
+	result, err := ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange, fetchChunk, combine, empty)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, result)
+}
+
+func TestChunkedRangeQuery_ErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+	fromBlock := uint64(1)
+	toBlock := uint64(5)
+	maxRange := uint64(2)
+
+	fetchChunk := func(ctx context.Context, from, to uint64) ([]int, error) {
+		if from == 3 {
+			return nil, fmt.Errorf("simulated error")
+		}
+		result := make([]int, 0, to-from+1)
+		for i := from; i <= to; i++ {
+			result = append(result, int(i))
+		}
+		return result, nil
+	}
+
+	combine := func(all, chunk []int) []int {
+		return append(all, chunk...)
+	}
+
+	empty := []int{}
+
+	result, err := ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange, fetchChunk, combine, empty)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "simulated error")
+	require.Equal(t, empty, result)
+}
+
+func TestChunkedRangeQuery_ZeroMaxRange(t *testing.T) {
+	ctx := context.Background()
+	fromBlock := uint64(1)
+	toBlock := uint64(5)
+	maxRange := uint64(0)
+
+	fetchChunk := func(ctx context.Context, from, to uint64) ([]int, error) {
+		return []int{}, nil
+	}
+
+	combine := func(all, chunk []int) []int {
+		return append(all, chunk...)
+	}
+
+	empty := []int{}
+
+	result, err := ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange, fetchChunk, combine, empty)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maxRange must be greater than 0")
+	require.Equal(t, empty, result)
+}
+
+func TestChunkedRangeQuery_SingleBlock(t *testing.T) {
+	ctx := context.Background()
+	fromBlock := uint64(7)
+	toBlock := uint64(7)
+	maxRange := uint64(10)
+
+	fetchChunk := func(ctx context.Context, from, to uint64) ([]int, error) {
+		require.Equal(t, uint64(7), from)
+		require.Equal(t, uint64(7), to)
+		return []int{int(from)}, nil
+	}
+
+	combine := func(all, chunk []int) []int {
+		return append(all, chunk...)
+	}
+
+	empty := []int{}
+
+	result, err := ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange, fetchChunk, combine, empty)
+	require.NoError(t, err)
+	require.Equal(t, []int{7}, result)
+}
+
+func TestChunkedRangeQuery_EmptyRange(t *testing.T) {
+	ctx := context.Background()
+	fromBlock := uint64(10)
+	toBlock := uint64(9)
+	maxRange := uint64(5)
+
+	fetchChunk := func(ctx context.Context, from, to uint64) ([]int, error) {
+		return []int{}, nil
+	}
+
+	combine := func(all, chunk []int) []int {
+		return append(all, chunk...)
+	}
+
+	empty := []int{}
+
+	result, err := ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange, fetchChunk, combine, empty)
+	require.NoError(t, err)
+	require.Equal(t, empty, result)
 }

--- a/common/errors.go
+++ b/common/errors.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"regexp"
+	"strings"
+)
+
+const maxRangeMatchGroups = 2
+
+var re = regexp.MustCompile(`max range:\s*(\d+)`)
+
+// ParseMaxRangeFromError extracts the max range value from error message
+// Expected format: "block range too large, max range: 1000"
+func ParseMaxRangeFromError(errMsg string) (uint64, bool) {
+	if !strings.Contains(errMsg, "block range too large") {
+		return 0, false
+	}
+
+	matches := re.FindStringSubmatch(errMsg)
+	if len(matches) < maxRangeMatchGroups {
+		return 0, false
+	}
+
+	maxRange, err := ParseUint64HexOrDecimal(matches[1])
+	if err != nil {
+		return 0, false
+	}
+
+	return maxRange, true
+}

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -1,0 +1,116 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMaxRangeFromError(t *testing.T) {
+	tests := []struct {
+		name               string
+		errorMsg           string
+		expectedMaxBlock   uint64
+		expectedIsMaxRange bool
+	}{
+		{
+			name:               "standard error format",
+			errorMsg:           "block range too large, max range: 1000",
+			expectedMaxBlock:   1000,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "error with extra spaces",
+			errorMsg:           "block range too large, max range:   5000",
+			expectedMaxBlock:   5000,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "error with no spaces",
+			errorMsg:           "block range too large, max range:10000",
+			expectedMaxBlock:   10000,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "error with large number",
+			errorMsg:           "block range too large, max range: 999999",
+			expectedMaxBlock:   999999,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "error with different text",
+			errorMsg:           "some other error happened",
+			expectedMaxBlock:   0,
+			expectedIsMaxRange: false,
+		},
+		{
+			name:               "error with non-numeric range",
+			errorMsg:           "block range too large, max range: abc",
+			expectedMaxBlock:   0,
+			expectedIsMaxRange: false,
+		},
+		{
+			name:               "empty error message",
+			errorMsg:           "",
+			expectedMaxBlock:   0,
+			expectedIsMaxRange: false,
+		},
+		{
+			name:               "error with negative number (should fail)",
+			errorMsg:           "block range too large, max range: -100",
+			expectedMaxBlock:   0,
+			expectedIsMaxRange: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, isMaxRangeErr := ParseMaxRangeFromError(tt.errorMsg)
+			if tt.expectedIsMaxRange {
+				require.True(t, isMaxRangeErr)
+			} else {
+				require.False(t, isMaxRangeErr)
+				require.Equal(t, tt.expectedMaxBlock, result)
+			}
+		})
+	}
+}
+
+func TestParseMaxRangeFromError_WrappedErrors(t *testing.T) {
+	t.Run("wrapped error with fmt.Errorf", func(t *testing.T) {
+		baseErr := errors.New("block range too large, max range: 2000")
+		wrappedErr := fmt.Errorf("RPC error: %w", baseErr)
+
+		result, isMaxRangeErr := ParseMaxRangeFromError(wrappedErr.Error())
+		require.True(t, isMaxRangeErr)
+		require.Equal(t, uint64(2000), result)
+	})
+
+	t.Run("multiple levels of wrapping", func(t *testing.T) {
+		baseErr := errors.New("block range too large, max range: 3000")
+		wrappedErr1 := fmt.Errorf("contract call failed: %w", baseErr)
+		wrappedErr2 := fmt.Errorf("query failed: %w", wrappedErr1)
+
+		result, isMaxRangeErr := ParseMaxRangeFromError(wrappedErr2.Error())
+		require.True(t, isMaxRangeErr)
+		require.Equal(t, uint64(3000), result)
+	})
+
+	t.Run("error with prefix", func(t *testing.T) {
+		errMsg := "execution reverted: block range too large, max range: 1500"
+
+		result, isMaxRangeErr := ParseMaxRangeFromError(errMsg)
+		require.True(t, isMaxRangeErr)
+		require.Equal(t, uint64(1500), result)
+	})
+
+	t.Run("error with suffix", func(t *testing.T) {
+		errMsg := "block range too large, max range: 2500, please reduce range"
+
+		result, isMaxRangeErr := ParseMaxRangeFromError(errMsg)
+		require.True(t, isMaxRangeErr)
+		require.Equal(t, uint64(2500), result)
+	})
+}

--- a/l2gersync/l2_evm_ger_reader.go
+++ b/l2gersync/l2_evm_ger_reader.go
@@ -3,10 +3,12 @@ package l2gersync
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayergerl2"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggoracle/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -54,12 +56,39 @@ func validateL2GERContract(l2GERManager types.L2GERManagerContract, l2GERManager
 }
 
 // GetInjectedGERsForRange returns the injected GlobalExitRoots for the given block range
+// If the block range is too large, it automatically splits the request into smaller chunks.
 func (e *L2EVMGERReader) GetInjectedGERsForRange(ctx context.Context,
 	fromBlock, toBlock uint64) (map[common.Hash]GlobalExitRootInfo, error) {
 	if fromBlock > toBlock {
 		return nil, fmt.Errorf("invalid block range: fromBlock(%d) > toBlock(%d)", fromBlock, toBlock)
 	}
 
+	injectedGERs, err := e.fetchInjectedGERs(ctx, fromBlock, toBlock)
+	if err != nil {
+		// Check if error is due to block range being too large
+		maxRange, isMaxRangeErr := aggkitcommon.ParseMaxRangeFromError(err.Error())
+		if isMaxRangeErr {
+			log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
+			return aggkitcommon.ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange,
+				e.fetchInjectedGERs,
+				func(all map[common.Hash]GlobalExitRootInfo,
+					chunk map[common.Hash]GlobalExitRootInfo,
+				) map[common.Hash]GlobalExitRootInfo {
+					maps.Copy(all, chunk)
+					return all
+				},
+				make(map[common.Hash]GlobalExitRootInfo),
+			)
+		}
+		return nil, err
+	}
+
+	return injectedGERs, nil
+}
+
+// fetchInjectedGERs performs the actual event filtering for injected GERs
+func (e *L2EVMGERReader) fetchInjectedGERs(ctx context.Context,
+	fromBlock, toBlock uint64) (map[common.Hash]GlobalExitRootInfo, error) {
 	// first get all inserted GERs in the block range
 	insertIterator, err := e.l2GERManager.FilterUpdateHashChainValue(
 		&bind.FilterOpts{
@@ -126,12 +155,36 @@ func (e *L2EVMGERReader) GetInjectedGERsForRange(ctx context.Context,
 }
 
 // GetRemovedGERsForRange returns the removed GlobalExitRoots for the given block range
+// If the block range is too large, it automatically splits the request into smaller chunks.
 func (e *L2EVMGERReader) GetRemovedGERsForRange(ctx context.Context,
 	fromBlock, toBlock uint64) ([]*agglayertypes.RemovedGER, error) {
 	if fromBlock > toBlock {
 		return nil, fmt.Errorf("invalid block range: fromBlock(%d) > toBlock(%d)", fromBlock, toBlock)
 	}
 
+	removedGERs, err := e.fetchRemovedGERs(ctx, fromBlock, toBlock)
+	if err != nil {
+		// Check if error is due to block range being too large
+		maxRange, isMaxRangeErr := aggkitcommon.ParseMaxRangeFromError(err.Error())
+		if isMaxRangeErr {
+			log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
+			return aggkitcommon.ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange,
+				e.fetchRemovedGERs,
+				func(all, chunk []*agglayertypes.RemovedGER) []*agglayertypes.RemovedGER {
+					return append(all, chunk...)
+				},
+				[]*agglayertypes.RemovedGER{},
+			)
+		}
+		return nil, err
+	}
+
+	return removedGERs, nil
+}
+
+// fetchRemovedGERs performs the actual event filtering for removed GERs
+func (e *L2EVMGERReader) fetchRemovedGERs(ctx context.Context,
+	fromBlock, toBlock uint64) ([]*agglayertypes.RemovedGER, error) {
 	removalIterator, err := e.l2GERManager.FilterUpdateRemovalHashChainValue(
 		&bind.FilterOpts{
 			Context: ctx,

--- a/l2gersync/l2_evm_ger_reader_test.go
+++ b/l2gersync/l2_evm_ger_reader_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayergerl2"
 	aggoraclemocks "github.com/agglayer/aggkit/aggoracle/mocks"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/l2gersync/mocks"
 	"github.com/agglayer/aggkit/test/helpers"
+	mocksethclient "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
@@ -115,6 +117,54 @@ func TestL2EVMGERReader_GetInjectedGERsForRange(t *testing.T) {
 		require.True(t, exists)
 		require.Equal(t, expectedGER, ger.GlobalExitRoot)
 	})
+
+	t.Run("block range too large triggers chunking", func(t *testing.T) {
+		t.Parallel()
+
+		mockL2Client := mocksethclient.NewBaseEthereumClienter(t)
+		mockL2GERManager, err := agglayergerl2.NewAgglayergerl2(
+			common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"), mockL2Client)
+		require.NoError(t, err)
+
+		gerReader := &L2EVMGERReader{
+			l2GERManager: mockL2GERManager,
+		}
+
+		// First call fails with "block range too large"
+		mockL2Client.On("FilterLogs", mock.Anything, mock.Anything).
+			Return(nil, errors.New("block range too large, max range: 1000")).Once()
+
+		// Subsequent chunked calls succeed (0-999, 1000-1999, 2000-2500)
+		mockL2Client.On("FilterLogs", mock.Anything, mock.Anything).
+			Return([]types.Log{}, nil).Times(6) // 3 chunks for inserts, 3 chunks for removals
+
+		injectedGERs, err := gerReader.GetInjectedGERsForRange(ctx, 0, 2500)
+		require.NoError(t, err)
+		require.NotNil(t, injectedGERs)
+
+		mockL2Client.AssertExpectations(t)
+	})
+
+	t.Run("non-parseable error returns original error", func(t *testing.T) {
+		t.Parallel()
+
+		mockL2GERManager := aggoraclemocks.NewL2GERManagerContract(t)
+
+		gerReader := &L2EVMGERReader{
+			l2GERManager: mockL2GERManager,
+		}
+
+		// Return an error that doesn't match the pattern
+		mockL2GERManager.EXPECT().
+			FilterUpdateHashChainValue(mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, errors.New("some other RPC error")).Once()
+
+		injectedGERs, err := gerReader.GetInjectedGERsForRange(ctx, 0, 2500)
+		require.ErrorContains(t, err, "some other RPC error")
+		require.Nil(t, injectedGERs)
+
+		mockL2GERManager.AssertExpectations(t)
+	})
 }
 
 func TestL2EVMGERReader_GetRemovedGERsForRange(t *testing.T) {
@@ -135,6 +185,44 @@ func TestL2EVMGERReader_GetRemovedGERsForRange(t *testing.T) {
 
 		_, err := gerReader.GetRemovedGERsForRange(ctx, 1, toBlock)
 		require.ErrorContains(t, err, "failed to create removal iterator")
+	})
+
+	t.Run("block range too large triggers chunking", func(t *testing.T) {
+		t.Parallel()
+
+		mockL2GERManager := aggoraclemocks.NewL2GERManagerContract(t)
+		// First call: return error that triggers chunking
+		mockL2GERManager.EXPECT().
+			FilterUpdateRemovalHashChainValue(mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, errors.New("block range too large, max range: 1000")).Once()
+		// Second call (first chunk): return a different error to prove chunking was triggered
+		mockL2GERManager.EXPECT().
+			FilterUpdateRemovalHashChainValue(mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, errors.New("mock iterator error for removal")).Once()
+
+		gerReader := &L2EVMGERReader{l2GERManager: mockL2GERManager}
+
+		_, err := gerReader.GetRemovedGERsForRange(ctx, 0, 2000)
+		// Verify that chunking was triggered by checking for the second error
+		require.ErrorContains(t, err, "mock iterator error for removal")
+
+		mockL2GERManager.AssertExpectations(t)
+	})
+
+	t.Run("non-parseable error returns original error", func(t *testing.T) {
+		t.Parallel()
+
+		mockL2GERManager := aggoraclemocks.NewL2GERManagerContract(t)
+		mockL2GERManager.EXPECT().
+			FilterUpdateRemovalHashChainValue(mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, errors.New("some other RPC error"))
+
+		gerReader := &L2EVMGERReader{l2GERManager: mockL2GERManager}
+
+		_, err := gerReader.GetRemovedGERsForRange(ctx, 0, 2000)
+		require.ErrorContains(t, err, "some other RPC error")
+
+		mockL2GERManager.AssertExpectations(t)
 	})
 
 	t.Run("success with no removed GERs", func(t *testing.T) {
@@ -291,5 +379,56 @@ func TestL2EVMGERReader_GetRemovedGERsForRange(t *testing.T) {
 		removedGERs, err := gerReader.GetRemovedGERsForRange(ctx, 1, 5)
 		require.NoError(t, err)
 		require.Len(t, removedGERs, 0)
+	})
+
+	t.Run("block range too large triggers chunking", func(t *testing.T) {
+		t.Parallel()
+
+		mockL2Client := mocksethclient.NewBaseEthereumClienter(t)
+		mockL2GERManager, err := agglayergerl2.NewAgglayergerl2(
+			common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"), mockL2Client)
+		require.NoError(t, err)
+
+		gerReader := &L2EVMGERReader{
+			l2GERManager: mockL2GERManager,
+		}
+
+		// First call fails with "block range too large"
+		mockL2Client.On("FilterLogs", mock.Anything, mock.Anything).
+			Return(nil, errors.New("block range too large, max range: 1000")).Once()
+
+		// Subsequent chunked calls succeed (0-999, 1000-1999, 2000-2500)
+		mockL2Client.On("FilterLogs", mock.Anything, mock.Anything).
+			Return([]types.Log{}, nil).Times(3)
+
+		removedGERs, err := gerReader.GetRemovedGERsForRange(ctx, 0, 2500)
+		require.NoError(t, err)
+		require.NotNil(t, removedGERs)
+
+		mockL2Client.AssertExpectations(t)
+	})
+
+	t.Run("non-parseable error returns original error", func(t *testing.T) {
+		t.Parallel()
+
+		mockL2Client := mocksethclient.NewBaseEthereumClienter(t)
+		mockL2GERManager, err := agglayergerl2.NewAgglayergerl2(
+			common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"), mockL2Client)
+		require.NoError(t, err)
+
+		gerReader := &L2EVMGERReader{
+			l2GERManager: mockL2GERManager,
+		}
+
+		// Return an error that doesn't match the pattern
+		mockL2Client.EXPECT().
+			FilterLogs(mock.Anything, mock.Anything).
+			Return(nil, errors.New("some other RPC error")).Once()
+
+		removedGERs, err := gerReader.GetRemovedGERsForRange(ctx, 0, 2500)
+		require.ErrorContains(t, err, "some other RPC error")
+		require.Empty(t, removedGERs)
+
+		mockL2Client.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## 🔄 Changes Summary
This PR is the cherry pick of PR #1387 to `develop` branch.

This PR addresses the issue that happened on one of the testnets, which reported block range too large error when reading a contract for specific logs in a block range.

The PR adds a generic way to recognize the given error when reading contracts and does a chunk calls to get all the data to avoid the error.

## ⚠️ Breaking Changes
NA

## 📋 Config Updates
NA

## ✅ Testing
- 🤖 **Automatic**: `aggkit` CI
