### PR TITLE
fix: From field for bridge event syncronization (cherry pick 1372 to release/0.8)

### DIFF
--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -3,14 +3,18 @@ package bridgesync
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerbridge"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/russross/meddler"
 )
 
 const (
@@ -81,8 +85,8 @@ func (b *BackfillTxnSender) backfillTable(ctx context.Context, tableName string)
 		return nil
 	}
 
-	b.log.Infof("Found %d records in %s table that need txn_sender backfilling", totalCount, tableName)
-
+	b.log.Infof("Found %d records in %s table that need txn_sender or from_address backfilling", totalCount, tableName)
+	pending := totalCount
 	// Process records in batches
 	for {
 		// Check if context is cancelled before processing next batch
@@ -103,6 +107,8 @@ func (b *BackfillTxnSender) backfillTable(ctx context.Context, tableName string)
 		}
 
 		b.processBatch(ctx, tableName, records)
+		pending -= len(records)
+		b.log.Infof("%d records remaining to backfill in %s table", pending, tableName)
 	}
 
 	b.log.Infof("Completed backfilling for %s table", tableName)
@@ -111,10 +117,20 @@ func (b *BackfillTxnSender) backfillTable(ctx context.Context, tableName string)
 
 // RecordToBackfill represents a record that needs txn_sender backfilling
 type RecordToBackfill struct {
-	BlockNum  uint64
-	BlockPos  uint64
-	TxHash    common.Hash
-	TxnSender common.Address
+	BlockNum           uint64         `meddler:"block_num"`
+	BlockPos           uint64         `meddler:"block_pos"`
+	FromAddress        *string        `meddler:"from_address"`
+	TxHash             common.Hash    `meddler:"tx_hash,hash"`
+	BlockTimestamp     uint64         `meddler:"block_timestamp"`
+	LeafType           uint8          `meddler:"leaf_type"`
+	OriginNetwork      uint32         `meddler:"origin_network"`
+	OriginAddress      common.Address `meddler:"origin_address,address"`
+	DestinationNetwork uint32         `meddler:"destination_network"`
+	DestinationAddress common.Address `meddler:"destination_address,address"`
+	Amount             *big.Int       `meddler:"amount,bigint"`
+	Metadata           []byte         `meddler:"metadata"`
+	DepositCount       uint32         `meddler:"deposit_count"`
+	TxnSender          *string        `meddler:"txn_sender"`
 }
 
 // RecordUpdate represents a record update with txn_sender data
@@ -122,6 +138,12 @@ type RecordUpdate struct {
 	BlockNum  uint64
 	BlockPos  uint64
 	TxnSender common.Address
+	FromAddr  common.Address
+}
+
+func (r *RecordUpdate) String() string {
+	return fmt.Sprintf("BlockNum: %d, BlockPos: %d, TxnSender: %s",
+		r.BlockNum, r.BlockPos, r.TxnSender.Hex())
 }
 
 // TxnSenderJob represents a job for extracting transaction sender
@@ -141,12 +163,13 @@ func (b *BackfillTxnSender) getRecordsNeedingBackfillCount(ctx context.Context, 
 	query := fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM %s
-		WHERE txn_sender = '' OR txn_sender IS NULL
+		WHERE txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL
 	`, tableName)
 
 	var count int
 	dbCtx, cancel := context.WithTimeout(ctx, b.dbTimeout)
 	defer cancel()
+
 	err := b.db.QueryRowContext(dbCtx, query).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count records needing backfill: %w", err)
@@ -163,9 +186,9 @@ func (b *BackfillTxnSender) getRecordsNeedingBackfill(
 ) ([]RecordToBackfill, error) {
 	//nolint:gosec
 	query := fmt.Sprintf(`
-		SELECT block_num, block_pos, tx_hash
+		SELECT *
 		FROM %s
-		WHERE txn_sender = '' OR txn_sender IS NULL
+		WHERE txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL
 		LIMIT $1
 	`, tableName)
 
@@ -176,21 +199,15 @@ func (b *BackfillTxnSender) getRecordsNeedingBackfill(
 		return nil, fmt.Errorf("failed to query records needing backfill: %w", err)
 	}
 	defer rows.Close()
-
-	var records []RecordToBackfill
-	for rows.Next() {
-		var record RecordToBackfill
-		var txHashStr string
-
-		err := rows.Scan(&record.BlockNum, &record.BlockPos, &txHashStr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to scan record: %w", err)
-		}
-
-		record.TxHash = common.HexToHash(txHashStr)
-		records = append(records, record)
+	var recordsPtr []*RecordToBackfill
+	if err = meddler.ScanAll(rows, &recordsPtr); err != nil {
+		return nil, fmt.Errorf("meddler.ScanAll failed to scan records: %w", err)
 	}
-
+	recordsIface := db.SlicePtrsToSlice(recordsPtr)
+	records, ok := recordsIface.([]RecordToBackfill)
+	if !ok {
+		return nil, errors.New("failed to convert")
+	}
 	return records, nil
 }
 
@@ -235,7 +252,7 @@ func (b *BackfillTxnSender) processBatch(
 	for result := range resultChan {
 		if result.Error != nil {
 			b.log.Errorf("Failed to extract txn_sender for tx %s: %v",
-				result.Update.BlockNum, result.Error)
+				result.Update.String(), result.Error)
 			continue
 		}
 		updates = append(updates, result.Update)
@@ -251,7 +268,7 @@ func (b *BackfillTxnSender) processBatch(
 
 	// Perform bulk update if we have any successful extractions
 	if len(updates) > 0 {
-		if err := b.bulkUpdateTxnSender(ctx, tableName, updates); err != nil {
+		if err := b.bulkUpdate(ctx, tableName, updates); err != nil {
 			b.log.Errorf("Failed to bulk update txn_sender for %d records: %v", len(updates), err)
 		} else {
 			b.log.Infof("Successfully bulk updated txn_sender for %d records", len(updates))
@@ -277,15 +294,25 @@ func (b *BackfillTxnSender) worker(
 			return
 		default:
 		}
-
+		logEvent := &agglayerbridge.AgglayerbridgeBridgeEvent{
+			LeafType:           job.Record.LeafType,
+			DestinationNetwork: job.Record.DestinationNetwork,
+			DestinationAddress: job.Record.DestinationAddress,
+			OriginAddress:      job.Record.OriginAddress,
+			OriginNetwork:      job.Record.OriginNetwork,
+			DepositCount:       job.Record.DepositCount,
+			Metadata:           job.Record.Metadata,
+			Amount:             job.Record.Amount,
+		}
 		// Extract txn_sender from transaction hash
-		txnSender, err := b.extractTxnSender(ctx, job.Record.TxHash)
+		txnSender, fromAddr, err := b.extractData(ctx, job.Record.TxHash, logEvent)
 
 		result := TxnSenderResult{
 			Update: RecordUpdate{
 				BlockNum:  job.Record.BlockNum,
 				BlockPos:  job.Record.BlockPos,
 				TxnSender: txnSender,
+				FromAddr:  fromAddr,
 			},
 			Error: err,
 		}
@@ -300,48 +327,21 @@ func (b *BackfillTxnSender) worker(
 	}
 }
 
-// Transaction represents the structure of a transaction returned by eth_getTransactionByHash
-type Transaction struct {
-	From             string `json:"from"`
-	To               string `json:"to"`
-	Hash             string `json:"hash"`
-	Value            string `json:"value"`
-	Gas              string `json:"gas"`
-	GasPrice         string `json:"gasPrice"`
-	Nonce            string `json:"nonce"`
-	Input            string `json:"input"`
-	BlockHash        string `json:"blockHash"`
-	BlockNumber      string `json:"blockNumber"`
-	TransactionIndex string `json:"transactionIndex"`
-}
-
-// extractTxnSender extracts the transaction sender from a transaction hash
-func (b *BackfillTxnSender) extractTxnSender(ctx context.Context, txHash common.Hash) (common.Address, error) {
+// extractData extracts the transaction txn_sender and from_address
+func (b *BackfillTxnSender) extractData(ctx context.Context,
+	txHash common.Hash,
+	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) (txnSender common.Address, fromAddr common.Address, err error) {
 	// Check if context is cancelled before making network call
 	select {
 	case <-ctx.Done():
-		return common.Address{}, ctx.Err()
+		return common.Address{}, common.Address{}, ctx.Err()
 	default:
 	}
-
-	// Use client.Call to fetch transaction details using eth_getTransactionByHash
-	var tx Transaction
-	err := b.client.Call(&tx, "eth_getTransactionByHash", txHash.Hex())
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to fetch transaction by hash: %w", err)
-	}
-
-	// Extract the 'from' field and convert to common.Address
-	if tx.From == "" {
-		return common.Address{}, fmt.Errorf("transaction from field is empty")
-	}
-
-	fromAddr := common.HexToAddress(tx.From)
-	return fromAddr, nil
+	return ExtractTxnSenderAndFrom(ctx, b.client, b.bridgeAddr, txHash, logEvent, b.log)
 }
 
-// bulkUpdateTxnSender performs a bulk update of txn_sender for multiple records
-func (b *BackfillTxnSender) bulkUpdateTxnSender(
+// bulkUpdate performs a bulk update of multiple records
+func (b *BackfillTxnSender) bulkUpdate(
 	ctx context.Context,
 	tableName string,
 	updates []RecordUpdate,
@@ -370,7 +370,9 @@ func (b *BackfillTxnSender) bulkUpdateTxnSender(
 
 	stmt, err := tx.PrepareContext(dbCtx, fmt.Sprintf(`
 		UPDATE %s
-		SET txn_sender = ?
+		SET 
+			txn_sender = COALESCE(NULLIF(txn_sender, ''), ?),
+			from_address = COALESCE(NULLIF(from_address, ''), ?)
 		WHERE block_num = ? AND block_pos = ?;
 	`, tableName))
 	if err != nil {
@@ -379,7 +381,7 @@ func (b *BackfillTxnSender) bulkUpdateTxnSender(
 	defer stmt.Close()
 
 	for _, update := range updates {
-		_, err := stmt.ExecContext(dbCtx, update.TxnSender.Hex(), update.BlockNum, update.BlockPos)
+		_, err := stmt.ExecContext(dbCtx, update.TxnSender.Hex(), update.FromAddr.Hex(), update.BlockNum, update.BlockPos)
 		if err != nil {
 			return fmt.Errorf("failed to execute update for block %d pos %d: %w",
 				update.BlockNum, update.BlockPos, err)

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerbridge"
 	"github.com/agglayer/aggkit/bridgesync/migrations"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/log"
@@ -50,11 +51,13 @@ func TestBackfillTxnSender(t *testing.T) {
 
 	_, err = tx.Exec(`
 		INSERT INTO bridge (
-			block_num, block_pos, leaf_type, origin_network, origin_address,
+			block_num, block_pos, leaf_type,
+			origin_network, origin_address,
 			destination_network, destination_address, amount, metadata, deposit_count,
 			tx_hash, block_timestamp, from_address, txn_sender
 		) VALUES (
-			1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
+			1, 0, 1, 
+			1, '0x1234567890123456789012345678901234567890',
 			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
 			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
 			1234567890, '0x1111111111111111111111111111111111111111', ''
@@ -203,10 +206,9 @@ func TestBackfillTxnSender_BackfillAll(t *testing.T) {
 			if !ok {
 				return
 			}
-			tx.From = testAddress
+			tx.FromRaw = testAddress
 			tx.To = "0x1234"
 		})
-
 		err = backfiller.BackfillAll(ctx)
 		require.NoError(t, err)
 	})
@@ -305,7 +307,7 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 			if !ok {
 				return
 			}
-			tx.From = testAddress
+			tx.FromRaw = testAddress
 			tx.To = "0x1234"
 		})
 
@@ -551,16 +553,12 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
-		// Mock the extractTxnSender function behavior (via eth_getTransactionByHash)
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			tx, ok := args.Get(0).(*Transaction)
-			if !ok {
-				return
-			}
-			tx.From = testAddress
-			tx.To = "0x1234"
-		})
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+			}).Return(nil).Maybe()
 
 		ctx := context.Background()
 		records := []RecordToBackfill{
@@ -588,9 +586,7 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 		require.NoError(t, err)
 		defer backfiller.Close()
 
-		// Mock the extractTxnSender function to return an error (via eth_getTransactionByHash)
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("transaction not found"))
-
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
 		ctx := context.Background()
 		records := []RecordToBackfill{
 			{
@@ -616,26 +612,30 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
-		// Mock the extractTxnSender function behavior (via eth_getTransactionByHash)
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			tx, ok := args.Get(0).(*Transaction)
-			if !ok {
-				return
-			}
-			tx.From = testAddress
-			tx.To = "0x1234"
-		})
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+			}).Return(nil).Maybe()
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+			}).Return(nil).Maybe()
 
 		// Close the database to cause bulk update error
 		backfiller.db.Close()
 
 		ctx := t.Context()
+		addr := "0x1111111111111111111111111111111111111111"
 		records := []RecordToBackfill{
 			{
-				BlockNum: 1,
-				BlockPos: 0,
-				TxHash:   common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+				BlockNum:    1,
+				BlockPos:    0,
+				TxHash:      common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+				FromAddress: &addr,
 			},
 		}
 
@@ -658,19 +658,21 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 		require.NoError(t, err)
 		defer backfiller.Close()
 
-		// Mock the extractTxnSender function behavior (via eth_getTransactionByHash)
 		expectedSender := common.HexToAddress(testAddress)
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			tx, ok := args.Get(0).(*Transaction)
-			if !ok {
-				return
-			}
-			tx.From = expectedSender.Hex()
-			tx.To = "0x1234"
-		})
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+				arg.From = expectedSender
+				arg.To = common.HexToAddress("0x1234")
+			}).Return(nil).Maybe()
 
 		txHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-		sender, err := backfiller.extractTxnSender(t.Context(), txHash)
+		sender, _, err := backfiller.extractData(t.Context(), txHash,
+			&agglayerbridge.AgglayerbridgeBridgeEvent{
+				LeafType: bridgeLeafTypeAsset,
+			})
 		require.NoError(t, err)
 		require.Equal(t, expectedSender, sender)
 	})
@@ -689,14 +691,15 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 		require.NoError(t, err)
 		defer backfiller.Close()
 
-		// Mock the extractTxnSender function to return an error (via eth_getTransactionByHash)
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("transaction not found"))
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
 
 		txHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-		sender, err := backfiller.extractTxnSender(t.Context(), txHash)
+		sender, _, err := backfiller.extractData(t.Context(), txHash, &agglayerbridge.AgglayerbridgeBridgeEvent{
+			LeafType: bridgeLeafTypeAsset,
+		})
 		require.Error(t, err)
 		require.Equal(t, common.Address{}, sender)
-		require.Contains(t, err.Error(), "failed to fetch transaction by hash")
+		require.Contains(t, err.Error(), "failed")
 	})
 }
 
@@ -753,7 +756,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 			},
 		}
 
-		err = backfiller.bulkUpdateTxnSender(ctx, "bridge", updates)
+		err = backfiller.bulkUpdate(ctx, "bridge", updates)
 		require.NoError(t, err)
 	})
 
@@ -817,7 +820,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 			},
 		}
 
-		err = backfiller.bulkUpdateTxnSender(ctx, "bridge", updates)
+		err = backfiller.bulkUpdate(ctx, "bridge", updates)
 		require.NoError(t, err)
 	})
 
@@ -836,7 +839,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 		defer backfiller.Close()
 
 		ctx := t.Context()
-		err = backfiller.bulkUpdateTxnSender(ctx, "bridge", []RecordUpdate{})
+		err = backfiller.bulkUpdate(ctx, "bridge", []RecordUpdate{})
 		require.NoError(t, err)
 	})
 
@@ -866,7 +869,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 			},
 		}
 
-		err = backfiller.bulkUpdateTxnSender(ctx, "bridge", updates)
+		err = backfiller.bulkUpdate(ctx, "bridge", updates)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to bulk update txn_sender")
 	})
@@ -944,15 +947,14 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		require.NoError(t, err)
 		defer backfiller.Close()
 
-		// Mock successful extractions for all records
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			tx, ok := args.Get(0).(*Transaction)
-			if !ok {
-				return
-			}
-			tx.From = testAddress
-			tx.To = "0x1234"
-		}).Maybe() // Allow multiple calls
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+				arg.From = common.HexToAddress(testAddress)
+				arg.To = common.HexToAddress("0x1234")
+			}).Return(nil).Maybe()
 
 		records := []RecordToBackfill{
 			{
@@ -1030,22 +1032,18 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		defer backfiller.Close()
 
 		// Mock mixed results: first call succeeds, second fails
-		var callCount int64
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			count := atomic.AddInt64(&callCount, 1)
-			if count == 1 {
-				// First call succeeds
-				tx, ok := args.Get(0).(*Transaction)
-				if !ok {
-					return
-				}
-				tx.From = testAddress
-				tx.To = "0x1234"
-			}
-		}).Once()
+
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+				arg.From = common.HexToAddress(testAddress)
+				arg.To = common.HexToAddress("0x1234")
+			}).Return(nil).Once()
 
 		// Mock the second call to fail
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("transaction not found")).Once()
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Once()
 
 		records := []RecordToBackfill{
 			{
@@ -1123,7 +1121,8 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		defer backfiller.Close()
 
 		// Mock all calls to fail
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("network error"))
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
+		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("network error")).Maybe()
 
 		records := []RecordToBackfill{
 			{
@@ -1203,17 +1202,13 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		// Create a context that will be cancelled
 		cancelCtx, cancel := context.WithCancel(ctx)
 
-		// Mock calls that will be slow to allow cancellation
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			// Simulate some processing time
-			time.Sleep(10 * time.Millisecond)
-			tx, ok := args.Get(0).(*Transaction)
-			if !ok {
-				return
-			}
-			tx.From = testAddress
-			tx.To = "0x1234"
-		})
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				time.Sleep(10 * time.Millisecond)
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+			}).Return(nil).Maybe()
 
 		records := []RecordToBackfill{
 			{
@@ -1321,15 +1316,14 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		require.NoError(t, err)
 		defer backfiller.Close()
 
-		// Mock successful extractions for all records
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			tx, ok := args.Get(0).(*Transaction)
-			if !ok {
-				return
-			}
-			tx.From = testAddress
-			tx.To = "0x1234"
-		})
+		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			Run(func(result any, method string, args ...any) {
+				arg, ok := result.(*Call)
+				require.True(t, ok)
+				arg.Input = BridgeAssetMethodID
+				arg.From = common.HexToAddress(testAddress)
+				arg.To = common.HexToAddress("0x1234")
+			}).Return(nil).Maybe()
 
 		backfiller.processBatch(ctx, "bridge", records)
 
@@ -1408,7 +1402,7 @@ func TestBackfillTxnSender_BackfillAll_WithDifferentRecordCounts(t *testing.T) {
 				if !ok {
 					return
 				}
-				tx.From = testAddress
+				tx.FromRaw = testAddress
 				tx.To = "0x1234"
 			})
 
@@ -1492,7 +1486,7 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 			if !ok {
 				return
 			}
-			tx.From = testAddress
+			tx.FromRaw = testAddress
 			tx.To = "0x1234"
 		}).Maybe() // Allow multiple calls
 
@@ -1577,7 +1571,7 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 			if !ok {
 				return
 			}
-			tx.From = testAddress
+			tx.FromRaw = testAddress
 			tx.To = "0x1234"
 		}).Maybe() // Allow multiple calls
 

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -177,7 +177,7 @@ func newBridgeSync(
 		return nil, fmt.Errorf("failed to resolve bridge deployment. Reason: %w", err)
 	}
 
-	appender, err := buildAppender(ethClient, cfg.BridgeAddr, syncFullClaims, bridgeDeployment, logger)
+	appender, err := buildAppender(ctx, ethClient, cfg.BridgeAddr, syncFullClaims, bridgeDeployment, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -2,6 +2,7 @@ package bridgesync
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/big"
 
@@ -75,9 +76,13 @@ const (
 
 	// methodIDLength is the length of the method ID in bytes
 	methodIDLength = 4
+
+	bridgeLeafTypeMessage = uint8(bridgesynctypes.LeafTypeMessage)
+	bridgeLeafTypeAsset   = uint8(bridgesynctypes.LeafTypeAsset)
 )
 
 func buildAppender(
+	ctx context.Context,
 	client aggkittypes.EthClienter,
 	bridgeAddr common.Address,
 	syncFullClaims bool,
@@ -93,7 +98,7 @@ func buildAppender(
 
 	// Add event handlers for the bridge contract
 	appender[bridgeEventSignature] = buildBridgeEventHandler(
-		bridgeDeployment.agglayerBridge, bridgeAddr, client, logger)
+		ctx, bridgeDeployment.agglayerBridge, bridgeAddr, client, logger)
 	appender[claimEventSignaturePreEtrog] = buildClaimEventHandlerPreEtrog(
 		legacyBridge, client, bridgeAddr, syncFullClaims, logger)
 	appender[tokenMappingEventSignature] = buildTokenMappingHandler(bridgeDeployment.agglayerBridge)
@@ -115,8 +120,227 @@ func buildAppender(
 	return appender, nil
 }
 
+// Transaction represents the structure of a transaction returned by eth_getTransactionByHash
+type Transaction struct {
+	FromRaw          string `json:"from"`
+	To               string `json:"to"`
+	Hash             string `json:"hash"`
+	Value            string `json:"value"`
+	Gas              string `json:"gas"`
+	GasPrice         string `json:"gasPrice"`
+	Nonce            string `json:"nonce"`
+	Input            string `json:"input"`
+	BlockHash        string `json:"blockHash"`
+	BlockNumber      string `json:"blockNumber"`
+	TransactionIndex string `json:"transactionIndex"`
+}
+
+func (t *Transaction) From() common.Address {
+	return common.HexToAddress(t.FromRaw)
+}
+
+func RPCTransactionByHash(client aggkittypes.EthClienter,
+	txHash common.Hash) (*Transaction, error) {
+	// Use client.Call to fetch transaction details using eth_getTransactionByHash
+	var tx Transaction
+	err := client.Call(&tx, "eth_getTransactionByHash", txHash.Hex())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch transaction by hash: %w", err)
+	}
+	return &tx, nil
+}
+
+func extractTxnSender(
+	client aggkittypes.EthClienter,
+	txHash common.Hash) (common.Address, error) {
+	tx, err := RPCTransactionByHash(client, txHash)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to get transaction by hash for %s: %w", txHash.Hex(), err)
+	}
+	return tx.From(), nil
+}
+
+// ExtractTxnSenderAndFrom extracts the txn_sender and from address from the transaction trace.
+// Return txnSender (same for all events in the same transaction) and fromAddr (specific for the event)
+func ExtractTxnSenderAndFrom(ctx context.Context,
+	client aggkittypes.EthClienter,
+	bridgeAddr common.Address,
+	txHash common.Hash,
+	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent,
+	logger *logger.Logger) (txnSender common.Address, fromAddr common.Address, err error) {
+	// If event is a message, fromAddr is log.origin_address
+	// so we only need the txn_sender that can be obtained from hash_receipt
+	if logEvent.LeafType == bridgeLeafTypeMessage {
+		txnSender, err = extractTxnSender(client, txHash)
+		if err != nil {
+			return common.Address{}, common.Address{},
+				fmt.Errorf("extractTxnSenderAndFrom: failed to extract txn sender from tx_hash:%s: %w", txHash.Hex(), err)
+		}
+		return txnSender, logEvent.OriginAddress, nil
+	}
+	foundCalls, rootCall, err := extractCallData(client, bridgeAddr, txHash, logger, func(c Call) (bool, error) {
+		if logEvent.LeafType == bridgeLeafTypeAsset {
+			return bytes.HasPrefix(c.Input, BridgeAssetMethodID), nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return common.Address{}, common.Address{},
+			fmt.Errorf("extractTxnSenderAndFrom:failed to extract bridge event data (tx hash: %s): %w", txHash, err)
+	}
+	txnSender = rootCall.From
+	fromAddr, err = ExtractFromAddrFromCalls(foundCalls, logEvent)
+	if err != nil {
+		return common.Address{}, common.Address{},
+			fmt.Errorf("extractTxnSenderAndFrom: failed to extract fromAddr from tx_hash:%s calls: %w",
+				txHash.Hex(), err)
+	}
+
+	return txnSender, fromAddr, nil
+}
+
+type bridgeCallParams struct {
+	LeafType           uint8
+	DestinationNetwork uint32
+	DestinationAddress common.Address
+	Amount             *big.Int
+	// can't use Token because could be a token network that native eth is a token or a wrapped token
+	// in these cases the calling value doesn't match the event (event field: OriginTokenAddress)
+	Token common.Address
+}
+
+func (b *bridgeCallParams) String() string {
+	if b == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("LeafType: %d, DestinationNetwork: %d, DestinationAddress: %s, Amount: %s, Token: %s",
+		b.LeafType, b.DestinationNetwork, b.DestinationAddress.Hex(), b.Amount.String(), b.Token.Hex())
+}
+
+func (b *bridgeCallParams) Equal(logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) bool {
+	return b.LeafType == logEvent.LeafType &&
+		b.DestinationNetwork == logEvent.DestinationNetwork &&
+		b.DestinationAddress == logEvent.DestinationAddress &&
+		b.Amount.Cmp(logEvent.Amount) == 0
+}
+
+func ExtractParamFromCallData(callData []byte) (*bridgeCallParams, error) {
+	if len(callData) < methodIDLength {
+		return nil, fmt.Errorf("call data too short to extract method ID")
+	}
+	bridgeV2ABI, err := agglayerbridge.AgglayerbridgeMetaData.GetAbi()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bridge V2 ABI: %w", err)
+	}
+	methodID := callData[:methodIDLength]
+	method, err := bridgeV2ABI.MethodById(methodID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get method %s by ID: %w", common.Bytes2Hex(methodID), err)
+	}
+	data, err := method.Inputs.Unpack(callData[methodIDLength:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack inputs call data: %w", err)
+	}
+	destinationNetwork, ok := data[0].(uint32)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert destinationNetwork as uint32")
+	}
+	destinationAddress, ok := data[1].(common.Address)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert destinationAddress as common.Address")
+	}
+
+	if bytes.HasPrefix(callData, BridgeMessageMethodID) {
+		return &bridgeCallParams{
+			LeafType:           bridgeLeafTypeMessage,
+			DestinationNetwork: destinationNetwork,
+			DestinationAddress: destinationAddress,
+			Amount:             big.NewInt(0),
+		}, nil
+	}
+	if bytes.HasPrefix(callData, BridgeAssetMethodID) {
+		amount, ok := data[2].(*big.Int)
+		if !ok {
+			return nil, fmt.Errorf("failed to assert amount as *big.Int")
+		}
+		token, ok := data[3].(common.Address)
+		if !ok {
+			return nil, fmt.Errorf("failed to assert token as common.Address")
+		}
+		return &bridgeCallParams{
+			LeafType:           bridgeLeafTypeAsset,
+			DestinationNetwork: destinationNetwork,
+			DestinationAddress: destinationAddress,
+			Amount:             amount,
+			Token:              token,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported call data method ID: %s (only support BridgeAssetMethodID)",
+		common.Bytes2Hex(callData[:methodIDLength]))
+}
+
+func haveCommonFromForCalls(calls []*Call) (common.Address, bool) {
+	if len(calls) == 0 {
+		return common.Address{}, false
+	}
+
+	commonFrom := calls[0].From
+	for _, call := range calls[1:] {
+		if call.From != commonFrom {
+			return common.Address{}, false
+		}
+	}
+
+	return commonFrom, true
+}
+
+func ExtractFromAddrFromCalls(foundCalls []*Call,
+	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) (common.Address, error) {
+	switch len(foundCalls) {
+	case 0:
+		return common.Address{}, fmt.Errorf("extractFromAddrFromCalls: no calls found")
+	case 1:
+		return foundCalls[0].From, nil
+	default:
+		// If all calls have same From we don't need to dig further
+		commonFrom, ok := haveCommonFromForCalls(foundCalls)
+		if ok {
+			return commonFrom, nil
+		}
+		// Multiple calls found, try to find addr
+		var candidate *Call
+		var candidateCallParams *bridgeCallParams
+		for _, call := range foundCalls {
+			callParams, err := ExtractParamFromCallData(call.Input)
+			if err != nil {
+				return common.Address{}, fmt.Errorf("extractFromAddrFromCalls: failed to extract bridge call params: %w", err)
+			}
+			if callParams.Equal(logEvent) {
+				if candidate != nil {
+					// Desperate try: to match by token address
+					if candidateCallParams.Token.Hex() == logEvent.OriginAddress.Hex() {
+						continue
+					}
+					if callParams.Token.Hex() != logEvent.OriginAddress.Hex() {
+						return common.Address{}, fmt.Errorf("extractFromAddrFromCalls: multiple matching "+
+							"calls found to extract txn sender. Previous: %s, Current: %s Event: OriginAddress: %s",
+							candidateCallParams.String(), callParams.String(), logEvent.OriginAddress.Hex())
+					}
+				}
+				candidate = call
+				candidateCallParams = callParams
+			}
+		}
+		if candidate == nil || candidateCallParams == nil {
+			return common.Address{}, fmt.Errorf("extractFromAddrFromCalls: no matching call found")
+		}
+		return candidate.From, nil
+	}
+}
+
 // buildBridgeEventHandler creates a handler for the Bridge event log.
 func buildBridgeEventHandler(
+	ctx context.Context,
 	contract *agglayerbridge.Agglayerbridge,
 	bridgeAddr common.Address,
 	client aggkittypes.EthClienter,
@@ -127,17 +351,12 @@ func buildBridgeEventHandler(
 		if err != nil {
 			return fmt.Errorf("error parsing BridgeEvent log %+v: %w", l, err)
 		}
-
-		// Extract call data and root call for txn_sender
-		foundCall, rootCall, err := extractCallData(client, bridgeAddr, l.TxHash, logger, func(c Call) (bool, error) {
-			switch bridgeEvent.LeafType {
-			case bridgesynctypes.LeafTypeAsset.Uint8():
-				return bytes.HasPrefix(c.Input, BridgeAssetMethodID), nil
-			case bridgesynctypes.LeafTypeMessage.Uint8():
-				return bytes.HasPrefix(c.Input, BridgeMessageMethodID), nil
-			}
-			return false, nil
-		})
+		logger.Debugf("Parsed BridgeEvent: LeafType: %d, OriginNetwork:%d, OriginAddress: %s\n"+
+			"DestinationNetwork: %d, DestinationAddress: %s, DepositCount: %d, Amount: %s, ",
+			bridgeEvent.LeafType, bridgeEvent.OriginNetwork, bridgeEvent.OriginAddress.Hex(), bridgeEvent.DestinationNetwork,
+			bridgeEvent.DestinationAddress.Hex(), bridgeEvent.DepositCount, bridgeEvent.Amount.String())
+		txnSender, fromAddress, err := ExtractTxnSenderAndFrom(ctx, client, bridgeAddr, l.TxHash,
+			bridgeEvent, logger)
 		if err != nil {
 			return fmt.Errorf("failed to extract bridge event data (tx hash: %s): %w", l.TxHash, err)
 		}
@@ -145,7 +364,7 @@ func buildBridgeEventHandler(
 		b.Events = append(b.Events, Event{Bridge: &Bridge{
 			BlockNum:           b.Num,
 			BlockPos:           uint64(l.Index),
-			FromAddress:        foundCall.From,
+			FromAddress:        fromAddress,
 			TxHash:             l.TxHash,
 			BlockTimestamp:     b.Timestamp,
 			LeafType:           bridgeEvent.LeafType,
@@ -156,7 +375,7 @@ func buildBridgeEventHandler(
 			Amount:             bridgeEvent.Amount,
 			Metadata:           bridgeEvent.Metadata,
 			DepositCount:       bridgeEvent.DepositCount,
-			TxnSender:          rootCall.From,
+			TxnSender:          txnSender,
 		}})
 		return nil
 	}
@@ -434,10 +653,10 @@ type tracerCfg struct {
 
 // findCall traverses the call trace using DFS and either returns the call or stops when a callback succeeds.
 func findCall(rootCall Call, targetAddr common.Address, callback func(Call) (bool, error), logger *logger.Logger,
-) (*Call, error) {
+) ([]*Call, error) {
 	callStack := stack.New()
 	callStack.Push(rootCall)
-
+	matchingCalls := []*Call{}
 	for callStack.Len() > 0 {
 		currentCallInterface := callStack.Pop()
 		currentCall, ok := currentCallInterface.(Call)
@@ -459,10 +678,10 @@ func findCall(rootCall Call, targetAddr common.Address, callback func(Call) (boo
 					return nil, err
 				}
 				if found {
-					return &currentCall, nil
+					matchingCalls = append(matchingCalls, &currentCall)
 				}
 			} else {
-				return &currentCall, nil
+				matchingCalls = append(matchingCalls, &currentCall)
 			}
 		}
 
@@ -470,11 +689,11 @@ func findCall(rootCall Call, targetAddr common.Address, callback func(Call) (boo
 		for _, c := range currentCall.Calls {
 			if c.Err == nil {
 				callStack.Push(c)
-			} else {
-				logger.Debugf("skipping reverted nested call to %s from %s: %s",
-					c.To.Hex(), c.From.Hex(), *c.Err)
 			}
 		}
+	}
+	if len(matchingCalls) > 0 {
+		return matchingCalls, nil
 	}
 	return nil, db.ErrNotFound
 }
@@ -495,7 +714,7 @@ func extractCallData(
 	txHash common.Hash,
 	logger *logger.Logger,
 	callback func(c Call) (bool, error),
-) (foundCall *Call, rootCall *Call, err error) {
+) (foundCalls []*Call, rootCall *Call, err error) {
 	// Extract root call first
 	rootCall, err = extractRootCall(client, bridgeAddr, txHash)
 	if err != nil {
@@ -503,12 +722,12 @@ func extractCallData(
 	}
 
 	// Find the specific call to the bridge contract
-	foundCall, err = findCall(*rootCall, bridgeAddr, callback, logger)
+	foundCalls, err = findCall(*rootCall, bridgeAddr, callback, logger)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return foundCall, rootCall, nil
+	return foundCalls, rootCall, nil
 }
 
 // setClaimCalldataFromRoot finds and decodes calldata for the given bridge address using an already traced root call.

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerbridge"
@@ -13,12 +14,238 @@ import (
 	logger "github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
 	treetypes "github.com/agglayer/aggkit/tree/types"
+	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/agglayer/aggkit/types/mocks"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// mainnet:
+// case https://etherscan.io/tx/0x8db8e288d25102b64d8a37ad05769817d1b43f0384dd05da075d24d2cee9cb65 (bn: 19566985) -> fix
+// case: https://etherscan.io/tx/0x0b276867aa22d1c162c2700d35c500a124a6a953c7b24931a1d3efc63f7cd4ab  (bn: 22770713)
+func TestExtractTxnSenderAndFromExploratory(t *testing.T) {
+	t.Skip("Skipping exploratory test")
+	ctx := t.Context()
+	l1url := os.Getenv("L1URL")
+	ethRawClient, err := ethclient.Dial(l1url)
+	require.NoError(t, err)
+	ethClient := aggkittypes.NewDefaultEthClient(ethRawClient, ethRawClient.Client())
+	bridgeAddr := common.HexToAddress("0x2a3dd3eb832af982ec71669e178424b10dca2ede")
+	agglayerBridge, err := agglayerbridge.NewAgglayerbridge(bridgeAddr, ethRawClient)
+	require.NoError(t, err)
+	logger := logger.WithFields("module", "test")
+	bn := big.NewInt(0).SetUint64(22770713)
+	handler := buildBridgeEventHandler(ctx, agglayerBridge, bridgeAddr, ethClient, logger)
+	filterQuery := ethereum.FilterQuery{
+		Addresses: []common.Address{bridgeAddr},
+		FromBlock: bn,
+		ToBlock:   bn,
+	}
+	logs, err := ethClient.FilterLogs(t.Context(), filterQuery)
+	require.NoError(t, err)
+	foundCalls, rootCall, err := extractCallData(ethClient, common.HexToAddress("0x2a3dd3eb832af982ec71669e178424b10dca2ede"),
+		common.HexToHash("0x0b276867aa22d1c162c2700d35c500a124a6a953c7b24931a1d3efc63f7cd4ab"),
+		logger.WithFields("module", "test"), nil)
+	require.NoError(t, err)
+	require.NotNil(t, foundCalls)
+	require.NotNil(t, rootCall)
+	showListPtrCall(t, foundCalls)
+	showListCall(t, rootCall.Calls, 0)
+	showLogs(t, logs, &bridgeEventSignature)
+	for _, vLog := range logs {
+		if vLog.Topics[0] == bridgeEventSignature {
+			err := handler(&sync.EVMBlock{EVMBlockHeader: sync.EVMBlockHeader{Num: bn.Uint64()}}, vLog)
+			require.NoError(t, err)
+		}
+	}
+}
+func showLogs(t *testing.T, logs []types.Log, equalTo *common.Hash) {
+	t.Helper()
+	for i, vLog := range logs {
+		if equalTo != nil && vLog.Topics[0] != *equalTo {
+			continue
+		}
+		fmt.Printf("Log %d: index: %d, Address:%s, Topics: +%v, BlockNumber:%d, TxHash:%s\n", i,
+			vLog.Index, vLog.Address, vLog.Topics, vLog.BlockNumber, vLog.TxHash.Hex())
+	}
+}
+func showCall(call *Call, nestedLevel int) {
+	nestedPrefixStr := string(bytes.Repeat([]byte("*"), nestedLevel))
+
+	hash := crypto.Keccak256(call.Input)
+	fmt.Printf("%s Root Call To: %s From: %s Input Hash: %s\n", nestedPrefixStr, call.To.Hex(), call.From.Hex(),
+		common.Bytes2Hex(hash))
+	fmt.Printf("%s -- Input: %s\n", nestedPrefixStr, common.Bytes2Hex(call.Input))
+	params, err := ExtractParamFromCallData(call.Input)
+	if err == nil {
+		fmt.Printf("%s  ---- Params: LeafType: %d DestNetwork: %d DestAddress: %s Amount: %s Token: %s Input: %s\n",
+			nestedPrefixStr, params.LeafType, params.DestinationNetwork, params.DestinationAddress.Hex(), params.Amount.String(), params.Token.Hex(),
+			common.Bytes2Hex(call.Input))
+	} else {
+		fmt.Printf("%s  ---- ???\n", nestedPrefixStr)
+	}
+}
+func showListCall(t *testing.T, calls []Call, nestedLevel int) {
+	t.Helper()
+	for _, call := range calls {
+		showCall(&call, nestedLevel)
+		if len(call.Calls) > 0 {
+			showListCall(t, call.Calls, nestedLevel+1)
+		}
+	}
+}
+func showListPtrCall(t *testing.T, calls []*Call) {
+	t.Helper()
+	for _, call := range calls {
+		showCall(call, 0)
+	}
+}
+
+// This case is https://etherscan.io/tx/0x280334ea89e49380d29e3c3931b9217bf699eaa7fa23e126c74a05eea1258503
+// 2 calls everything is the same except the token address but is translated to event so doesn't match the call and the event
+// this case is solved because the From is the same for both calls
+func TestExtractCallDataCaseNotMatchingExploratory(t *testing.T) {
+	t.Skip("Skipping exploratory test")
+	l1url := os.Getenv("L1URL")
+	ethRawClient, err := ethclient.Dial(l1url)
+	require.NoError(t, err)
+	ethClient := aggkittypes.NewDefaultEthClient(ethRawClient, ethRawClient.Client())
+	foundCalls, rootCall, err := extractCallData(ethClient, common.HexToAddress("0x2a3dd3eb832af982ec71669e178424b10dca2ede"),
+		common.HexToHash("0x280334ea89e49380d29e3c3931b9217bf699eaa7fa23e126c74a05eea1258503"),
+		logger.WithFields("module", "test"), nil)
+	require.NoError(t, err)
+	fmt.Printf("rootCall To: %s From: %s\n", rootCall.To.Hex(), rootCall.From.Hex())
+	showListPtrCall(t, foundCalls)
+	amount, ok := big.NewInt(0).SetString("3308702758450298978558701", 10)
+	require.True(t, ok)
+	txnSender, err := ExtractFromAddrFromCalls(foundCalls, &agglayerbridge.AgglayerbridgeBridgeEvent{
+		LeafType:           bridgeLeafTypeAsset,
+		DestinationNetwork: 1,
+		DestinationAddress: common.HexToAddress("0x3CF5Ed527DB2E08e5DdD5A2c692Dc5Ae35778D46"),
+		Amount:             amount,
+		OriginAddress:      common.HexToAddress("0x25722Cd432d02895d9BE45f5dEB60fc479c8781E"),
+	})
+	require.NoError(t, err)
+	fmt.Printf("Txn Sender: %s\n", txnSender.Hex())
+}
+
+func TestExtractCallDataCaseMessageExploratory(t *testing.T) {
+	t.Skip("Skipping exploratory test")
+	l1url := os.Getenv("L1URL")
+	ethRawClient, err := ethclient.Dial(l1url)
+	require.NoError(t, err)
+	ethClient := aggkittypes.NewDefaultEthClient(ethRawClient, ethRawClient.Client())
+	foundCalls, rootCall, err := extractCallData(ethClient, common.HexToAddress("0x2a3dd3eb832af982ec71669e178424b10dca2ede"),
+		common.HexToHash("0x84a7e20778bd35231bfaefdcbb4ada9169b08658db49d69d38e3f467a799db38"),
+		logger.WithFields("module", "test"), nil)
+	require.NoError(t, err)
+	fmt.Printf("rootCall To: %s From: %s\n", rootCall.To.Hex(), rootCall.From.Hex())
+	for _, call := range foundCalls {
+		fmt.Printf("Root Call To: %s From: %s\n", call.To.Hex(), call.From.Hex())
+	}
+	txnSender, err := ExtractFromAddrFromCalls(foundCalls, &agglayerbridge.AgglayerbridgeBridgeEvent{
+		LeafType:           bridgeLeafTypeAsset,
+		DestinationNetwork: 1,
+		DestinationAddress: common.HexToAddress("0x679606F3b37c49946F5AA7774a37f03387c7f264"),
+		Amount:             big.NewInt(10000000000000000),
+	})
+	require.NoError(t, err)
+	fmt.Printf("Txn Sender: %s\n", txnSender.Hex())
+}
+
+func TestExtractTxnSenderFromCalls(t *testing.T) {
+	bridgeAddr := common.HexToAddress("0x10")
+	fromAddr1 := common.HexToAddress("0x20")
+	fromAddr2 := common.HexToAddress("0x30")
+	callFromAddr1 := &Call{
+		To:    bridgeAddr,
+		From:  fromAddr1,
+		Err:   nil,
+		Input: BridgeAssetMethodID,
+	}
+	callFromAddr2 := &Call{
+		To:    bridgeAddr,
+		From:  fromAddr2,
+		Err:   nil,
+		Input: BridgeAssetMethodID,
+	}
+	event1 := &agglayerbridge.AgglayerbridgeBridgeEvent{
+		LeafType:           bridgeLeafTypeAsset,
+		DestinationNetwork: 1,
+		DestinationAddress: common.HexToAddress("0x30"),
+		Amount:             big.NewInt(100),
+	}
+	tests := []struct {
+		name       string
+		callFrames []*Call
+		event      *agglayerbridge.AgglayerbridgeBridgeEvent
+		expectAddr common.Address
+		expectErr  string
+	}{
+		{
+			name:       "single matching call",
+			callFrames: []*Call{callFromAddr1},
+			event:      event1,
+			expectAddr: fromAddr1,
+		},
+		{
+			name:       "no matching call",
+			callFrames: []*Call{},
+			event:      event1,
+			expectErr:  "no calls found",
+		},
+		{
+			name:       "multiple calls same from",
+			callFrames: []*Call{callFromAddr1, callFromAddr1},
+			event:      event1,
+			expectAddr: fromAddr1,
+		},
+		{
+			name:       "multiple calls not same from,bad input data",
+			callFrames: []*Call{callFromAddr1, callFromAddr2},
+			event:      event1,
+			expectErr:  " unpack inputs call data",
+		},
+		{
+			name: "case: not same from, no match token and origin address",
+			callFrames: []*Call{
+				{
+					To:    bridgeAddr,
+					From:  common.HexToAddress("0x047E0b64743071b897A6177F1796E98b4C3f344E"),
+					Input: common.Hex2Bytes("cd58657900000000000000000000000000000000000000000000000000000000000000010000000000000000000000003cf5ed527db2e08e5ddd5a2c692dc5ae35778d4600000000000000000000000000000000000000000000000000038d7ea4c680000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000000"),
+				},
+				{
+					To:    bridgeAddr,
+					From:  common.HexToAddress("0x047E0b64743071b897A6177F1796E98b4C3f344E"),
+					Input: common.Hex2Bytes("cd586579000000000000000000000000000000000000000000000000000000000000000100000000000000000000000025722cd432d02895d9be45f5deb60fc479c87810000000000000000000000003cf5ed527db2e08e5ddd5a2c692dc5ae35778d4600000000000000000000000000000000000000000000000000038d7ea4c68000000000000000000000000000000000000000000000000000000000000000000"),
+				},
+			},
+			event: &agglayerbridge.AgglayerbridgeBridgeEvent{
+				LeafType:           bridgeLeafTypeAsset,
+				DestinationNetwork: 1,
+				DestinationAddress: common.HexToAddress("0x679606F3b37c49946F5AA7774a37f03387c7f264"),
+				Amount:             big.NewInt(10000000000000000),
+			},
+			expectAddr: common.HexToAddress("0x047E0b64743071b897A6177F1796E98b4C3f344E"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txnSender, err := ExtractFromAddrFromCalls(tt.callFrames, tt.event)
+			if tt.expectErr != "" {
+				require.ErrorContains(t, err, tt.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectAddr, txnSender)
+			}
+		})
+	}
+}
 
 func TestBuildAppender(t *testing.T) {
 	bridgeAddr := common.HexToAddress("0x10")
@@ -355,7 +582,7 @@ func TestBuildAppender(t *testing.T) {
 
 			logger := logger.WithFields("module", "test")
 			bridgeDeployment.kind = tt.deploymentKind
-			appenderMap, err := buildAppender(ethClient, bridgeAddr, false, bridgeDeployment, logger)
+			appenderMap, err := buildAppender(t.Context(), ethClient, bridgeAddr, false, bridgeDeployment, logger)
 			require.NoError(t, err)
 			require.NotNil(t, appenderMap)
 
@@ -382,10 +609,10 @@ func TestFindCall(t *testing.T) {
 		From: fromAddr,
 		Err:  nil,
 	}
-	found, err := findCall(root, bridgeAddr, nil, logger)
+	founds, err := findCall(root, bridgeAddr, nil, logger)
 	require.NoError(t, err)
-	require.NotNil(t, found)
-	require.Equal(t, bridgeAddr, found.To)
+	require.NotNil(t, founds)
+	require.Equal(t, bridgeAddr, founds[0].To)
 
 	// Reverted call should be skipped
 	root = Call{
@@ -414,10 +641,10 @@ func TestFindCall(t *testing.T) {
 			},
 		},
 	}
-	found, err = findCall(root, bridgeAddr, nil, logger)
+	founds, err = findCall(root, bridgeAddr, nil, logger)
 	require.NoError(t, err)
-	require.NotNil(t, found)
-	require.Equal(t, bridgeAddr, found.To)
+	require.NotNil(t, founds)
+	require.Equal(t, bridgeAddr, founds[0].To)
 }
 
 func TestFindCallWithMixedMethods(t *testing.T) {
@@ -456,7 +683,7 @@ func TestFindCallWithMixedMethods(t *testing.T) {
 	}
 
 	// Test that findCall continues searching and finds the first valid claim method
-	found, err := findCall(rootCall, bridgeAddr, func(call Call) (bool, error) {
+	founds, err := findCall(rootCall, bridgeAddr, func(call Call) (bool, error) {
 		// Simulate tryDecodeClaimCalldata behavior
 		if len(call.Input) < methodIDLength {
 			return false, fmt.Errorf("input too short")
@@ -469,10 +696,10 @@ func TestFindCallWithMixedMethods(t *testing.T) {
 	}, logger)
 
 	require.NoError(t, err)
-	require.NotNil(t, found)
-	require.Equal(t, bridgeAddr, found.To)
+	require.NotNil(t, founds)
+	require.Equal(t, bridgeAddr, founds[0].To)
 	// Note: DFS traversal processes calls in reverse order (stack), so it finds claimMessage first
-	require.Equal(t, claimMessageEtrogMethodID, []byte(found.Input[:4])) // Should find the first claim method in DFS order
+	require.Equal(t, claimMessageEtrogMethodID, []byte(founds[0].Input[:4])) // Should find the first claim method in DFS order
 }
 
 func TestFindCallWithOnlyUnrecognizedMethods(t *testing.T) {
@@ -642,7 +869,7 @@ func TestTxnSenderField(t *testing.T) {
 				Calls: []Call{
 					{
 						To:    bridgeAddr,
-						From:  common.HexToAddress("0x20"),
+						From:  expectedTxnSender,
 						Err:   nil,
 						Input: BridgeMessageMethodID,
 					},
@@ -749,6 +976,15 @@ func TestTxnSenderField(t *testing.T) {
 				Return(nil).
 				Maybe()
 
+			ethClient.EXPECT().
+				Call(mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).
+				Run(func(result any, method string, args ...any) {
+					arg, ok := result.(*Transaction)
+					require.True(t, ok)
+					arg.FromRaw = tt.callFrame.From.Hex()
+				}).
+				Return(nil).
+				Maybe()
 			agglayerBridge, err := agglayerbridge.NewAgglayerbridge(bridgeAddr, ethClient)
 			require.NoError(t, err)
 
@@ -757,7 +993,7 @@ func TestTxnSenderField(t *testing.T) {
 				kind:           NonSovereignChain,
 				agglayerBridge: agglayerBridge,
 			}
-			appenderMap, err := buildAppender(ethClient, bridgeAddr, false, bridgeDeployment, logger)
+			appenderMap, err := buildAppender(t.Context(), ethClient, bridgeAddr, false, bridgeDeployment, logger)
 			require.NoError(t, err)
 			require.NotNil(t, appenderMap)
 
@@ -778,6 +1014,150 @@ func TestTxnSenderField(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractTxnSenderAndFrom(t *testing.T) {
+	bridgeAddr := common.HexToAddress("0x10")
+	txHash := common.HexToHash("0xabcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcd")
+
+	tests := []struct {
+		name                         string
+		logEvent                     *agglayerbridge.AgglayerbridgeBridgeEvent
+		responseDebugTrace           *Call
+		responseDebugTraceError      error
+		responseTransactionHash      *Transaction
+		responseTransactionHashError error
+		expectedTxnSender            common.Address
+		expectedFrom                 common.Address
+		expectErr                    string
+	}{
+		{
+			name: "messageLeaf: error eth_getTransactionByHash",
+			logEvent: &agglayerbridge.AgglayerbridgeBridgeEvent{
+				LeafType:           bridgeLeafTypeMessage,
+				DestinationNetwork: 1,
+				DestinationAddress: common.HexToAddress("0x30"),
+				Amount:             big.NewInt(100),
+			},
+			responseTransactionHashError: fmt.Errorf("RPC error"),
+			expectErr:                    "RPC error",
+		},
+		{
+			name: "assetLeaf: error can't find From from calls",
+			logEvent: &agglayerbridge.AgglayerbridgeBridgeEvent{
+				LeafType:           bridgeLeafTypeAsset,
+				DestinationNetwork: 1,
+				DestinationAddress: common.HexToAddress("0x30"),
+				Amount:             big.NewInt(100),
+			},
+			responseDebugTrace: &Call{
+				Calls: []Call{
+					{
+						To:    bridgeAddr,
+						From:  common.HexToAddress("0x20"),
+						Input: BridgeMessageMethodID,
+					},
+					{
+						To:    bridgeAddr,
+						From:  common.HexToAddress("0x25"),
+						Input: BridgeMessageMethodID,
+					},
+				},
+			},
+			expectErr: "failed to extract",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ethClient := mocks.NewEthClienter(t)
+			ctx := t.Context()
+			logger := logger.WithFields("module", "test")
+			ethClient.EXPECT().
+				Call(mock.Anything, "eth_getTransactionByHash", mock.Anything).
+				Return(tt.responseTransactionHashError).
+				Run(func(result any, method string, args ...any) {
+					arg, ok := result.(*Transaction)
+					require.True(t, ok)
+					if tt.responseTransactionHash != nil {
+						*arg = *tt.responseTransactionHash
+					}
+				}).
+				Maybe()
+			ethClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+				Run(func(result any, method string, args ...any) {
+					arg, ok := result.(*Call)
+					require.True(t, ok)
+					*arg = *tt.responseDebugTrace
+				}).Return(nil).
+				Maybe()
+
+			txnSender, from, err := ExtractTxnSenderAndFrom(ctx, ethClient,
+				bridgeAddr, txHash, tt.logEvent, logger)
+			if tt.expectErr != "" {
+				require.ErrorContains(t, err, tt.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedTxnSender, txnSender)
+				require.Equal(t, tt.expectedFrom, from)
+			}
+		})
+	}
+}
+
+func TestBridgeCallParams_String(t *testing.T) {
+	params := &bridgeCallParams{
+		LeafType:           1,
+		DestinationNetwork: 42,
+		DestinationAddress: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+		Amount:             big.NewInt(1000),
+		Token:              common.HexToAddress("0xbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"),
+	}
+	expectedStr := "LeafType: 1, DestinationNetwork: 42, DestinationAddress: 0x1234567890AbcdEF1234567890aBcdef12345678, Amount: 1000, Token: 0xbeEFdeaDBeefDeadBEeFDeAdbEeFDeaDbeefdEad"
+	require.Equal(t, expectedStr, params.String())
+
+	var nilParams *bridgeCallParams
+	require.Equal(t, "<nil>", nilParams.String())
+}
+
+func TestBridgeCallParams_Equal(t *testing.T) {
+	params := &bridgeCallParams{
+		LeafType:           1,
+		DestinationNetwork: 42,
+		DestinationAddress: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+		Amount:             big.NewInt(1000),
+		Token:              common.HexToAddress("0xbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"),
+	}
+	logEvent := &agglayerbridge.AgglayerbridgeBridgeEvent{
+		LeafType:           params.LeafType,
+		DestinationNetwork: params.DestinationNetwork,
+		DestinationAddress: params.DestinationAddress,
+		Amount:             params.Amount,
+	}
+	require.True(t, params.Equal(logEvent))
+}
+
+const bridgeAssetCallData = "0xcd58657900000000000000000000000000000000000000000000000000000000000000140000000000000000000000005480f3152748809495bd56c14eab4a622aa3a19b00000000000000000000000000000000000000000000000000b1a2bc2ec500000000000000000000000000002dc70fb75b88d2eb4715bc06e1595e6d97c34dff000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000000"
+const bridegeMessageCallData = "0x240ff3780000000000000000000000000000000000000000000000000000000000000001000000000000000000000000afb88881e53589f5e6eb1cc27e9207cc7f03023f0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000205dea582a050bb15ca16e0820c023b97f85553fb47d8a86c0c21a5d86bca2631f"
+
+func TestExtractParamFromCallData(t *testing.T) {
+	_, err := ExtractParamFromCallData([]byte{0x01, 0x02})
+	require.ErrorContains(t, err, "too short")
+
+	_, err = ExtractParamFromCallData([]byte{0x01, 0x02, 0x3, 0x4})
+	require.ErrorContains(t, err, "failed to get method")
+
+	calldata := common.FromHex(bridgeAssetCallData)
+	_, err = ExtractParamFromCallData(calldata)
+	require.NoError(t, err)
+
+	data, err := ExtractParamFromCallData(common.FromHex(bridegeMessageCallData))
+	require.NoError(t, err)
+	require.Equal(t, &bridgeCallParams{
+		LeafType:           1,
+		DestinationNetwork: 1,
+		DestinationAddress: common.HexToAddress("0xafb88881e53589f5e6eb1cc27e9207cc7f03023f"),
+		Amount:             big.NewInt(0),
+	}, data)
 }
 
 func strPtr(s string) *string {

--- a/bridgesync/migrations/bridgesync0011.sql
+++ b/bridgesync/migrations/bridgesync0011.sql
@@ -1,0 +1,15 @@
+-- +migrate Down
+
+-- +migrate Up
+UPDATE bridge
+SET from_address = NULL
+WHERE tx_hash IN (
+    SELECT b.tx_hash
+    FROM bridge b
+    JOIN claim c ON b.tx_hash = c.tx_hash
+);
+UPDATE bridge
+SET from_address = NULL
+WHERE tx_hash IN (
+    SELECT tx_hash FROM bridge GROUP BY tx_hash HAVING COUNT(*) > 1 
+);

--- a/bridgesync/migrations/migrations.go
+++ b/bridgesync/migrations/migrations.go
@@ -38,6 +38,9 @@ var mig0009 string
 //go:embed bridgesync0010.sql
 var mig0010 string
 
+//go:embed bridgesync0011.sql
+var mig0011 string
+
 func RunMigrations(dbPath string) error {
 	migrations := []types.Migration{
 		{
@@ -79,6 +82,10 @@ func RunMigrations(dbPath string) error {
 		{
 			ID:  "bridgesync0010",
 			SQL: mig0010,
+		},
+		{
+			ID:  "bridgesync0011",
+			SQL: mig0011,
 		},
 	}
 	migrations = append(migrations, treeMigrations.Migrations...)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -740,6 +740,7 @@ func runBridgeSyncL1IfNeeded(
 			log.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
+		log.Infof("txn_sender backfilling completed for L1 bridge sync")
 	}()
 
 	go bridgeSyncL1.Start(ctx)


### PR DESCRIPTION
cherry-pick: #1372
## 🔄 Changes Summary
- Cover all cases in MAINNET
- In case of find a event / calls that are not able to solve returns an error (avoid filling with wrong data)
- Upgrade in the background the wrong values in bridges From address
 

## ✅ Testing
- 🤖 **Automatic**: Unit Test
- 🖱️ **Manual**:Applied to mainnet sincronization with version `0.7.2` till block 23933203

## 🐞 Issues
- Closes #1356
- Closes #1346

## 🔗 Related PRs
- #1355


