### PR TITLE
fix: block range error parsing (exceeded maximum block range:)

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -2,14 +2,13 @@ package common
 
 import (
 	"regexp"
-	"strings"
 )
 
 const maxRangeMatchGroups = 2
 
 var (
-	// Matches "max range: 1000" or "max range:1000"
-	reMaxRange = regexp.MustCompile(`max range:\s*(\d+)`)
+	// Matches "block range too large, max range: 1000"
+	reMaxRange = regexp.MustCompile(`block range too large, max range:\s*(\d+)`)
 	// Matches "exceeded maximum block range: 5000"
 	reExceededBlockRange = regexp.MustCompile(`exceeded maximum block range:\s*(\d+)`)
 )
@@ -20,13 +19,11 @@ var (
 //   - "exceeded maximum block range: 5000"
 func ParseMaxRangeFromError(errMsg string) (uint64, bool) {
 	var matches []string
-
-	if strings.Contains(errMsg, "block range too large") {
-		matches = reMaxRange.FindStringSubmatch(errMsg)
-	} else if strings.Contains(errMsg, "exceeded maximum block range") {
-		matches = reExceededBlockRange.FindStringSubmatch(errMsg)
-	} else {
-		return 0, false
+	for _, re := range []*regexp.Regexp{reMaxRange, reExceededBlockRange} {
+		matches = re.FindStringSubmatch(errMsg)
+		if len(matches) >= maxRangeMatchGroups {
+			break
+		}
 	}
 
 	if len(matches) < maxRangeMatchGroups {

--- a/common/errors.go
+++ b/common/errors.go
@@ -7,16 +7,28 @@ import (
 
 const maxRangeMatchGroups = 2
 
-var re = regexp.MustCompile(`max range:\s*(\d+)`)
+var (
+	// Matches "max range: 1000" or "max range:1000"
+	reMaxRange = regexp.MustCompile(`max range:\s*(\d+)`)
+	// Matches "exceeded maximum block range: 5000"
+	reExceededBlockRange = regexp.MustCompile(`exceeded maximum block range:\s*(\d+)`)
+)
 
 // ParseMaxRangeFromError extracts the max range value from error message
-// Expected format: "block range too large, max range: 1000"
+// Expected formats:
+//   - "block range too large, max range: 1000"
+//   - "exceeded maximum block range: 5000"
 func ParseMaxRangeFromError(errMsg string) (uint64, bool) {
-	if !strings.Contains(errMsg, "block range too large") {
+	var matches []string
+
+	if strings.Contains(errMsg, "block range too large") {
+		matches = reMaxRange.FindStringSubmatch(errMsg)
+	} else if strings.Contains(errMsg, "exceeded maximum block range") {
+		matches = reExceededBlockRange.FindStringSubmatch(errMsg)
+	} else {
 		return 0, false
 	}
 
-	matches := re.FindStringSubmatch(errMsg)
 	if len(matches) < maxRangeMatchGroups {
 		return 0, false
 	}

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -63,6 +63,24 @@ func TestParseMaxRangeFromError(t *testing.T) {
 			expectedMaxBlock:   0,
 			expectedIsMaxRange: false,
 		},
+		{
+			name:               "exceeded maximum block range format",
+			errorMsg:           "exceeded maximum block range: 5000",
+			expectedMaxBlock:   5000,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "exceeded maximum block range with no spaces",
+			errorMsg:           "exceeded maximum block range:1000",
+			expectedMaxBlock:   1000,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "exceeded maximum block range with extra spaces",
+			errorMsg:           "exceeded maximum block range:   2500",
+			expectedMaxBlock:   2500,
+			expectedIsMaxRange: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 🔄 Changes Summary
-  Update parsing function `ParseMaxRangeFromError` to admit a new error: `exceeded maximum block range:` that appears using as RPC *immutable geth*

## ✅ Testing
- 🤖 **Automatic**: unittest

## 🐞 Issues
- Closes #1412

## 🔗 Related PRs
- #1387 


