### PR TITLE
fix: typo in certificate function names

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -237,7 +237,7 @@ func (a *AggSender) Info() types.AggsenderInfo {
 	return res
 }
 
-func (a *AggSender) ForceTriggerCertitificate() {
+func (a *AggSender) ForceTriggerCertificate() {
 	a.certificateSendTrigger.ForceTriggerEvent()
 }
 

--- a/aggsender/mocks/mock_aggsender_interface.go
+++ b/aggsender/mocks/mock_aggsender_interface.go
@@ -20,34 +20,34 @@ func (_m *AggsenderInterface) EXPECT() *AggsenderInterface_Expecter {
 	return &AggsenderInterface_Expecter{mock: &_m.Mock}
 }
 
-// ForceTriggerCertitificate provides a mock function with no fields
-func (_m *AggsenderInterface) ForceTriggerCertitificate() {
+// ForceTriggerCertificate provides a mock function with no fields
+func (_m *AggsenderInterface) ForceTriggerCertificate() {
 	_m.Called()
 }
 
-// AggsenderInterface_ForceTriggerCertitificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForceTriggerCertitificate'
-type AggsenderInterface_ForceTriggerCertitificate_Call struct {
+// AggsenderInterface_ForceTriggerCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForceTriggerCertificate'
+type AggsenderInterface_ForceTriggerCertificate_Call struct {
 	*mock.Call
 }
 
-// ForceTriggerCertitificate is a helper method to define mock.On call
-func (_e *AggsenderInterface_Expecter) ForceTriggerCertitificate() *AggsenderInterface_ForceTriggerCertitificate_Call {
-	return &AggsenderInterface_ForceTriggerCertitificate_Call{Call: _e.mock.On("ForceTriggerCertitificate")}
+// ForceTriggerCertificate is a helper method to define mock.On call
+func (_e *AggsenderInterface_Expecter) ForceTriggerCertificate() *AggsenderInterface_ForceTriggerCertificate_Call {
+	return &AggsenderInterface_ForceTriggerCertificate_Call{Call: _e.mock.On("ForceTriggerCertificate")}
 }
 
-func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) Run(run func()) *AggsenderInterface_ForceTriggerCertitificate_Call {
+func (_c *AggsenderInterface_ForceTriggerCertificate_Call) Run(run func()) *AggsenderInterface_ForceTriggerCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) Return() *AggsenderInterface_ForceTriggerCertitificate_Call {
+func (_c *AggsenderInterface_ForceTriggerCertificate_Call) Return() *AggsenderInterface_ForceTriggerCertificate_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *AggsenderInterface_ForceTriggerCertitificate_Call) RunAndReturn(run func()) *AggsenderInterface_ForceTriggerCertitificate_Call {
+func (_c *AggsenderInterface_ForceTriggerCertificate_Call) RunAndReturn(run func()) *AggsenderInterface_ForceTriggerCertificate_Call {
 	_c.Run(run)
 	return _c
 }

--- a/aggsender/rpc/aggsender_rpc.go
+++ b/aggsender/rpc/aggsender_rpc.go
@@ -15,7 +15,7 @@ type AggsenderStorer interface {
 
 type AggsenderInterface interface {
 	Info() types.AggsenderInfo
-	ForceTriggerCertitificate()
+	ForceTriggerCertificate()
 }
 
 // AggsenderRPC is the RPC interface for the aggsender
@@ -45,11 +45,11 @@ func (b *AggsenderRPC) Status() (interface{}, rpc.Error) {
 	return info, nil
 }
 
-// TriggerCertitificate forces the publication of an epoch event to trigger certificate creation
+// TriggerCertificate forces the publication of an epoch event to trigger certificate creation
 // curl -X POST http://localhost:5576/ "Content-Type: application/json" \
-// -d '{"method":"aggsender_triggerCertitificate", "params":[], "id":1}'
-func (b *AggsenderRPC) TriggerCertitificate() (interface{}, rpc.Error) {
-	b.aggsender.ForceTriggerCertitificate()
+// -d '{"method":"aggsender_triggerCertificate", "params":[], "id":1}'
+func (b *AggsenderRPC) TriggerCertificate() (interface{}, rpc.Error) {
+	b.aggsender.ForceTriggerCertificate()
 	return nil, nil
 }
 

--- a/aggsender/rpc/aggsender_rpc_test.go
+++ b/aggsender/rpc/aggsender_rpc_test.go
@@ -16,10 +16,10 @@ func TestAggsenderRPCStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
-func TestAggsenderRPCTriggerCertitificate(t *testing.T) {
+func TestAggsenderRPCTriggerCertificate(t *testing.T) {
 	testData := newAggsenderData(t)
-	testData.mockAggsender.EXPECT().ForceTriggerCertitificate().Return()
-	res, err := testData.sut.TriggerCertitificate()
+	testData.mockAggsender.EXPECT().ForceTriggerCertificate().Return()
+	res, err := testData.sut.TriggerCertificate()
 	require.NoError(t, err)
 	require.Nil(t, res)
 }


### PR DESCRIPTION
## 🔄 Changes Summary

This pull request corrects a consistent typo in the spelling of "Certificate" across the `aggsender` package, updating both method names and related references. The changes ensure naming consistency throughout the codebase, including interfaces, implementations, mocks, RPC handlers, and tests.
