### PR TITLE
fix: revert golangci lint in makefile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: v2.4.0
+          version: v2.7.2
           args: --timeout=30m

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ check-curl: ## Check if curl is installed
 # Check for Golangci-lint
 .PHONY: check-golangci-lint
 check-golangci-lint:
-	@which golangci-lint-v2 > /dev/null || (echo "Error: golangci-lint-v2 is not installed. Please install it: https://github.com/golangci/golangci-lint" && exit 1)
+	@which golangci-lint > /dev/null || (echo "Error: golangci-lint is not installed. Please install it: https://github.com/golangci/golangci-lint" && exit 1)
 
 # Check for Swag
 .PHONY: check-swag
@@ -98,7 +98,7 @@ test-unit: ## Runs the unit tests
 
 .PHONY: lint
 lint: ## Runs the linter
-	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/golangci-lint-v2 run --timeout 5m
+	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/golangci-lint run --timeout 5m
 
 .PHONY: generate-swagger-docs
 generate-swagger-docs: ## Generates the swagger docs


### PR DESCRIPTION
## 🔄 Changes Summary
The PR reverts the changes made in Makefile for make lint command, introduced through #1435. The change was insisting that the `golangci-lint` is installed as `golangci-lint-v2`, which is wrong.

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
N/A

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
