### PR TITLE
feat: claude code

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -13,7 +13,8 @@ jobs:
       pull-requests: read
       issues: write
       id-token: write
-      actions: read
+      statuses: write
+      actions: write
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -21,3 +21,35 @@ jobs:
       - uses: anthropics/claude-code-action@63cff77972af4131bf3ccfa88a9f6d8207e78341 # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          track_progress: true
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            REVIEW this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+
+            Priority levels for feedback:
+            - 🔴 Required: Security issues, breaking changes, major bugs
+            - 🟡 Suggested: Code quality improvements, optimizations
+            - 🟢 Optional: Style preferences, alternative approaches
+
+            Also fill next template with a brief summary of the changes made in this PR:
+            ---
+            ## 🚀 What's New
+            [Provide a concise summary of the changes in this PR here.]
+            ## 🐛 Bug Fixes
+            [List any bug fixes made in this PR here, or state "None".]
+            ## 📋 Config Updates
+            [List any configuration changes made in this PR here with examples and default values, or state "None".]
+            ## ⚠️ Breaking Changes
+            [List any breaking changes introduced by this PR here, or state "None".]
+            ---
+
+            Use the MCP inline comment tool for specific code issues.
+            Use gh pr comment to post an overall summary.
+          claude_args: |
+            --model claude-sonnet-4-5-20250929

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -1,0 +1,23 @@
+name: Claude Interactive
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+jobs:
+  claude:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -9,8 +9,8 @@ jobs:
     if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
       issues: write
       id-token: write
       actions: read

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@63cff77972af4131bf3ccfa88a9f6d8207e78341 # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   pull-requests: read
   statuses: write
-  
+
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -29,12 +29,25 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: true
+          use_sticky_comment: true
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
             REVIEW this pull request with a focus on:
             - Code quality and best practices
             - Potential bugs or issues
             - Security implications
             - Performance considerations
+
+            Priority levels for feedback:
+            - 🔴 Required: Security issues, breaking changes, major bugs
+            - 🟡 Suggested: Code quality improvements, optimizations
+            - 🟢 Optional: Style preferences, alternative approaches
+
+            Use the MCP inline comment tool for specific code issues.
+            Use gh pr comment to post an overall summary.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(markdownlint-cli2:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
             --model claude-sonnet-4-5-20250929

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,9 +13,6 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    concurrency:
-      group: claude-review-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@63cff77972af4131bf3ccfa88a9f6d8207e78341 # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           track_progress: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,13 @@
 name: Claude Code Review
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize,reopened]
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+  
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -24,16 +30,11 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
             REVIEW this pull request with a focus on:
             - Code quality and best practices
             - Potential bugs or issues
             - Security implications
             - Performance considerations
-            Note: The PR branch is already checked out in the current working directory.
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model claude-sonnet-4-5-20250929

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -46,6 +46,16 @@ jobs:
             - 🟡 Suggested: Code quality improvements, optimizations
             - 🟢 Optional: Style preferences, alternative approaches
 
+            Also fill next template with a brief summary of the changes made in this PR:
+            ---
+            ## 🚀 What's New
+            [Provide a concise summary of the changes in this PR here.]
+            ## 📋 Config Updates
+            [List any configuration changes made in this PR here with examples and default values, or state "None".]
+            ## ⚠️ Breaking Changes
+            [List any breaking changes introduced by this PR here, or state "None".]
+            ---
+
             Use the MCP inline comment tool for specific code issues.
             Use gh pr comment to post an overall summary.
           claude_args: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 on:
   pull_request:
-    types: [opened, synchronize,reopened]
+    types: [opened, synchronize, reopened]
   workflow_dispatch: {}
 permissions:
   contents: read
@@ -29,7 +29,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           use_sticky_comment: true
           prompt: |
@@ -59,5 +58,4 @@ jobs:
             Use the MCP inline comment tool for specific code issues.
             Use gh pr comment to post an overall summary.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(markdownlint-cli2:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
             --model claude-sonnet-4-5-20250929

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,11 +13,12 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
   workflow_dispatch: {}
 permissions:
   contents: read
@@ -49,6 +49,8 @@ jobs:
             ---
             ## 🚀 What's New
             [Provide a concise summary of the changes in this PR here.]
+            ## 🐛 Bug Fixes
+            [List any bug fixes made in this PR here, or state "None".]
             ## 📋 Config Updates
             [List any configuration changes made in this PR here with examples and default values, or state "None".]
             ## ⚠️ Breaking Changes

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            REVIEW this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+            Note: The PR branch is already checked out in the current working directory.
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 🔄 Changes Summary
- Integration claude code to github action (follow up of PR #1456)
- Used next guide: [Claude Code GitHub Actions](https://code.claude.com/docs/en/github-actions)
- Example: https://github.com/akash0-real/ai-assistant-instructions/blob/main/.github-shared/workflows/claude-review.yml
- 
## Usage
- It review at PR creation or reopen
- You can invoce creating a comment with `@claude`


## 🔗 Related PRs
- #1456


