### PR TITLE
fix: #1468-Error if there are 2 injected GER in the same block

### DIFF
--- a/aggsender/query/ger_query.go
+++ b/aggsender/query/ger_query.go
@@ -84,13 +84,9 @@ func (g *gerDataQuerier) GetInjectedGERsProofs(
 			}
 		}
 
-		if injectedGER.BlockPosition == nil {
-			return nil, fmt.Errorf("block position for GER %s is undefined", ger.String())
-		}
-
 		proofs[ger] = &agglayertypes.ProvenInsertedGERWithBlockNumber{
 			BlockNumber: injectedGER.BlockNum,
-			LogIndex:    *injectedGER.BlockPosition,
+			LogIndex:    injectedGER.BlockPosition,
 			ProvenInsertedGERLeaf: agglayertypes.ProvenInsertedGER{
 				ProofGERToL1Root: &agglayertypes.MerkleProof{Root: finalizedL1InfoTreeRootHash, Proof: proof},
 				L1Leaf: &agglayertypes.L1InfoTreeLeaf{

--- a/aggsender/query/ger_query_test.go
+++ b/aggsender/query/ger_query_test.go
@@ -46,9 +46,8 @@ func Test_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "success",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				blockPos := uint64(0)
 				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]l2gersync.GlobalExitRootInfo{
-					common.HexToHash("0x1"): {GlobalExitRoot: common.HexToHash("0x1"), BlockNum: 111, BlockPosition: &blockPos},
+					common.HexToHash("0x1"): {GlobalExitRoot: common.HexToHash("0x1"), BlockNum: 111, BlockPosition: 0},
 				}, nil)
 				mockL1InfoTreeQuery.EXPECT().GetProofForGER(ctx, common.HexToHash("0x1"), common.HexToHash("0x2")).Return(
 					&l1infotreesync.L1InfoTreeLeaf{
@@ -89,14 +88,13 @@ func Test_GetInjectedGERsProofs(t *testing.T) {
 		{
 			name: "success with removed GER (dummy info and proof)",
 			mockFn: func(mockChainGERReader *mocks.ChainGERReader, mockL1InfoTreeQuery *mocks.L1InfoTreeDataQuerier) {
-				blockPos := uint64(5)
 				gerHash := common.HexToHash("0xabc123")
 				mockChainGERReader.EXPECT().GetInjectedGERsForRange(ctx, uint64(1), uint64(10)).Return(map[common.Hash]l2gersync.GlobalExitRootInfo{
 					gerHash: {
 						GlobalExitRoot:  gerHash,
 						L1InfoTreeIndex: math.MaxUint32,
 						BlockNum:        222,
-						BlockPosition:   &blockPos,
+						BlockPosition:   5,
 						Removed:         true,
 					},
 				}, nil)

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -30,6 +30,14 @@ func RunMigrations(dbPath string, migrations []types.Migration) error {
 	return RunMigrationsDB(log.GetDefaultLogger(), db, migrations)
 }
 
+func RunMigrationsDown(dbPath string, migrations []types.Migration, maxMigrations int) error {
+	db, err := NewSQLiteDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("error creating DB %w", err)
+	}
+	return RunMigrationsDBExtended(log.GetDefaultLogger(), db, migrations, migrate.Down, maxMigrations)
+}
+
 func RunMigrationsDB(logger aggkitcommon.Logger, db *sql.DB, migrationsParam []types.Migration) error {
 	return RunMigrationsDBExtended(logger, db, migrationsParam, migrate.Up, NoLimitMigrations)
 }

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -27,6 +27,11 @@ func RunMigrations(dbPath string, migrations []types.Migration) error {
 	if err != nil {
 		return fmt.Errorf("error creating DB %w", err)
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.GetDefaultLogger().Errorf("error closing DB: %w", err)
+		}
+	}()
 	return RunMigrationsDB(log.GetDefaultLogger(), db, migrations)
 }
 
@@ -35,6 +40,11 @@ func RunMigrationsDown(dbPath string, migrations []types.Migration, maxMigration
 	if err != nil {
 		return fmt.Errorf("error creating DB %w", err)
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.GetDefaultLogger().Errorf("error closing DB: %w", err)
+		}
+	}()
 	return RunMigrationsDBExtended(log.GetDefaultLogger(), db, migrations, migrate.Down, maxMigrations)
 }
 

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -531,7 +531,7 @@ CREATE TABLE IF NOT EXISTS rollback_table (
 	})
 
 	t.Run("returns error with invalid db path", func(t *testing.T) {
-		dbPath := "/nonexistent/directory/test.sqlite"
+		dbPath := filepath.Join(t.TempDir(), "nonexistent", "directory", "test.sqlite")
 		migrations := []types.Migration{
 			{
 				ID:     "0001",

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/agglayer/aggkit/db/types"
@@ -44,7 +45,7 @@ CREATE TABLE IF NOT EXISTS test_table (
 
 	t.Run("returns error with invalid db path", func(t *testing.T) {
 		// Use an invalid path (directory that doesn't exist)
-		dbPath := "/nonexistent/directory/test.sqlite"
+		dbPath := filepath.Join(t.TempDir(), "nonexistent", "test.sqlite")
 		migrations := []types.Migration{}
 
 		err := RunMigrations(dbPath, migrations)

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -1,0 +1,481 @@
+package db
+
+import (
+	"path"
+	"testing"
+
+	"github.com/agglayer/aggkit/db/types"
+	"github.com/agglayer/aggkit/log"
+	migrate "github.com/rubenv/sql-migrate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMigrations(t *testing.T) {
+	t.Run("successfully runs migrations with file path", func(t *testing.T) {
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS test_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS test_table (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);`,
+			},
+		}
+
+		err := RunMigrations(dbPath, migrations)
+		require.NoError(t, err)
+
+		// Verify database was created and migration was applied
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Check that the table exists
+		var tableName string
+		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='test_table'").Scan(&tableName)
+		require.NoError(t, err)
+		require.Equal(t, "test_table", tableName)
+	})
+
+	t.Run("returns error with invalid db path", func(t *testing.T) {
+		// Use an invalid path (directory that doesn't exist)
+		dbPath := "/nonexistent/directory/test.sqlite"
+		migrations := []types.Migration{}
+
+		err := RunMigrations(dbPath, migrations)
+		require.Error(t, err)
+	})
+}
+
+func TestRunMigrationsDB(t *testing.T) {
+	t.Run("successfully runs migrations on existing db connection", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS users;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    username TEXT NOT NULL
+);`,
+			},
+		}
+
+		err = RunMigrationsDB(logger, db, migrations)
+		require.NoError(t, err)
+
+		// Verify the migration was applied
+		var tableName string
+		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='users'").Scan(&tableName)
+		require.NoError(t, err)
+		require.Equal(t, "users", tableName)
+	})
+
+	t.Run("runs with empty migrations list", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		err = RunMigrationsDB(logger, db, []types.Migration{})
+		require.NoError(t, err)
+	})
+}
+
+func TestRunMigrationsDBExtended(t *testing.T) {
+	t.Run("successfully runs migrations up with no limit", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS products;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);`,
+			},
+			{
+				ID:     "0002",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS orders;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS orders (
+    id INTEGER PRIMARY KEY,
+    product_id INTEGER
+);`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify both tables were created
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('products', 'orders')").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+	})
+
+	t.Run("successfully runs migrations up with limit", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS table1;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS table1 (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+			{
+				ID:     "0002",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS table2;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS table2 (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		// Run only 1 migration
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, 1)
+		require.NoError(t, err)
+
+		// Verify only first table was created
+		var table1Exists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='table1'").Scan(&table1Exists)
+		require.NoError(t, err)
+		require.True(t, table1Exists)
+
+		var table2Exists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='table2'").Scan(&table2Exists)
+		require.NoError(t, err)
+		require.False(t, table2Exists)
+	})
+
+	t.Run("successfully runs migrations down", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS temp_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS temp_table (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		// First run migration up
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify table exists
+		var tableExists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='temp_table'").Scan(&tableExists)
+		require.NoError(t, err)
+		require.True(t, tableExists)
+
+		// Run migration down
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Down, 1)
+		require.NoError(t, err)
+
+		// Verify table was dropped
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='temp_table'").Scan(&tableExists)
+		require.NoError(t, err)
+		require.False(t, tableExists)
+	})
+
+	t.Run("successfully replaces db prefix placeholder", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "prefix_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS /*dbprefix*/custom_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS /*dbprefix*/custom_table (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify table with prefix was created
+		var tableName string
+		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='prefix_custom_table'").Scan(&tableName)
+		require.NoError(t, err)
+		require.Equal(t, "prefix_custom_table", tableName)
+	})
+
+	t.Run("handles empty prefix", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS no_prefix_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS no_prefix_table (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify table was created
+		var tableName string
+		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='no_prefix_table'").Scan(&tableName)
+		require.NoError(t, err)
+		require.Equal(t, "no_prefix_table", tableName)
+	})
+
+	t.Run("returns error on invalid SQL", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+INVALID SQL STATEMENT;
+-- +migrate Up
+CREATE INVALID TABLE SYNTAX;`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.Error(t, err)
+	})
+
+	t.Run("handles closed database connection", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+
+		// Close the database before running migrations
+		db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS test;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS test (id INTEGER);`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.Error(t, err)
+	})
+
+	t.Run("runs multiple migrations with different prefixes", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "module_a_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS module_a_data;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS module_a_data (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+			{
+				ID:     "0001",
+				Prefix: "module_b_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS module_b_data;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS module_b_data (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify both tables with different prefixes were created
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('module_a_data', 'module_b_data')").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+	})
+}
+
+func TestMigrationConstants(t *testing.T) {
+	t.Run("constants have expected values", func(t *testing.T) {
+		require.Equal(t, "-- +migrate Up", UpDownSeparator)
+		require.Equal(t, "/*dbprefix*/", dbPrefixReplacer)
+		require.Equal(t, 0, NoLimitMigrations)
+	})
+}
+
+func TestRunMigrationsWithBaseMigrations(t *testing.T) {
+	t.Run("includes base migrations when no limit is set", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		customMigrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "custom_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS custom_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS custom_table (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		// Run with NoLimitMigrations to include base migrations
+		err = RunMigrationsDBExtended(logger, db, customMigrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify both custom table and base key_value table exist
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('custom_table', 'key_value')").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+	})
+
+	t.Run("excludes base migrations when limit is set", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		customMigrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "custom_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS custom_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS custom_table (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		// Run with limit to exclude base migrations
+		err = RunMigrationsDBExtended(logger, db, customMigrations, migrate.Up, 1)
+		require.NoError(t, err)
+
+		// Verify custom table exists
+		var customExists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='custom_table'").Scan(&customExists)
+		require.NoError(t, err)
+		require.True(t, customExists)
+
+		// Verify base key_value table does NOT exist (base migrations were excluded)
+		var baseExists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='key_value'").Scan(&baseExists)
+		require.NoError(t, err)
+		require.False(t, baseExists)
+	})
+}
+
+func TestMigrationIDFormatting(t *testing.T) {
+	t.Run("migration ID is correctly formatted with prefix", func(t *testing.T) {
+		logger := log.WithFields("test", "migrations")
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "my_prefix_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS test;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS test (id INTEGER);`,
+			},
+		}
+
+		err = RunMigrationsDBExtended(logger, db, migrations, migrate.Up, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Query the migrations table to verify the ID format
+		var migrationID string
+		err = db.QueryRow("SELECT id FROM gorp_migrations WHERE id LIKE 'my_prefix_%'").Scan(&migrationID)
+		require.NoError(t, err)
+		require.Equal(t, "my_prefix_0001", migrationID)
+	})
+}

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -479,3 +479,163 @@ CREATE TABLE IF NOT EXISTS test (id INTEGER);`,
 		require.Equal(t, "my_prefix_0001", migrationID)
 	})
 }
+
+func TestRunMigrationsDown(t *testing.T) {
+	t.Run("successfully runs migrations down with file path", func(t *testing.T) {
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS rollback_table;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS rollback_table (
+    id INTEGER PRIMARY KEY,
+    data TEXT
+);`,
+			},
+		}
+
+		// First run migrations up
+		err := RunMigrations(dbPath, migrations)
+		require.NoError(t, err)
+
+		// Verify table exists
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		var tableName string
+		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='rollback_table'").Scan(&tableName)
+		require.NoError(t, err)
+		require.Equal(t, "rollback_table", tableName)
+
+		// Close the database before running migrations down
+		db.Close()
+
+		// Run migrations down
+		err = RunMigrationsDown(dbPath, migrations, 1)
+		require.NoError(t, err)
+
+		// Reopen database and verify table was dropped
+		db, err = NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		var tableExists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='rollback_table'").Scan(&tableExists)
+		require.NoError(t, err)
+		require.False(t, tableExists)
+	})
+
+	t.Run("returns error with invalid db path", func(t *testing.T) {
+		dbPath := "/nonexistent/directory/test.sqlite"
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS test;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS test (id INTEGER);`,
+			},
+		}
+
+		err := RunMigrationsDown(dbPath, migrations, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("runs down migrations with max limit", func(t *testing.T) {
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS table_one;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS table_one (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+			{
+				ID:     "0002",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS table_two;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS table_two (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		// First run all migrations up
+		err := RunMigrations(dbPath, migrations)
+		require.NoError(t, err)
+
+		// Verify both tables exist
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('table_one', 'table_two')").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+		db.Close()
+
+		// Run down with limit of 1 migration
+		err = RunMigrationsDown(dbPath, migrations, 1)
+		require.NoError(t, err)
+
+		// Reopen and verify only the most recent migration was rolled back
+		db, err = NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		var table1Exists, table2Exists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='table_one'").Scan(&table1Exists)
+		require.NoError(t, err)
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='table_two'").Scan(&table2Exists)
+		require.NoError(t, err)
+
+		// table_one should still exist, table_two should be gone (rolled back in reverse order)
+		require.True(t, table1Exists)
+		require.False(t, table2Exists)
+	})
+
+	t.Run("runs down with no limit using NoLimitMigrations constant", func(t *testing.T) {
+		dbPath := path.Join(t.TempDir(), "test.sqlite")
+		migrations := []types.Migration{
+			{
+				ID:     "0001",
+				Prefix: "test_",
+				SQL: `-- +migrate Down
+DROP TABLE IF EXISTS full_rollback;
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS full_rollback (
+    id INTEGER PRIMARY KEY
+);`,
+			},
+		}
+
+		// First run migration up
+		err := RunMigrations(dbPath, migrations)
+		require.NoError(t, err)
+
+		// Run down with NoLimitMigrations
+		err = RunMigrationsDown(dbPath, migrations, NoLimitMigrations)
+		require.NoError(t, err)
+
+		// Verify table was dropped
+		db, err := NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		var tableExists bool
+		err = db.QueryRow("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='full_rollback'").Scan(&tableExists)
+		require.NoError(t, err)
+		require.False(t, tableExists)
+	})
+}

--- a/l2gersync/evm_downloader_legacy.go
+++ b/l2gersync/evm_downloader_legacy.go
@@ -198,7 +198,7 @@ func (d *downloaderLegacy) getGERsFromIndex(
 
 		// For the legacy downloader, we cannot determine the block position,
 		// because we are querying the global exit root map we don't have a real block position,
-		// to avoid conflicts we set it to the same as l1infotreeindex
+		// to avoid conflicts we set it to the same as L1InfoTreeIndex
 		gers = append(gers, newGlobalExitRootInfo(info.GlobalExitRoot, i, blockNum, uint64(i)))
 	}
 

--- a/l2gersync/evm_downloader_legacy.go
+++ b/l2gersync/evm_downloader_legacy.go
@@ -197,8 +197,8 @@ func (d *downloaderLegacy) getGERsFromIndex(
 		}
 
 		// For the legacy downloader, we cannot determine the block position,
-		// because we are querying the global exit root map
-		gers = append(gers, newLegacyGlobalExitRootInfo(info.GlobalExitRoot, i, blockNum))
+		// because we are querying the global exit root map. We use 0 as the default block position.
+		gers = append(gers, newGlobalExitRootInfo(info.GlobalExitRoot, i, blockNum, 0))
 	}
 
 	return gers, nil

--- a/l2gersync/evm_downloader_legacy.go
+++ b/l2gersync/evm_downloader_legacy.go
@@ -197,8 +197,9 @@ func (d *downloaderLegacy) getGERsFromIndex(
 		}
 
 		// For the legacy downloader, we cannot determine the block position,
-		// because we are querying the global exit root map. We use 0 as the default block position.
-		gers = append(gers, newGlobalExitRootInfo(info.GlobalExitRoot, i, blockNum, 0))
+		// because we are querying the global exit root map we don't have a real block position,
+		// to avoid conflicts we set it to the same as l1infotreeindex
+		gers = append(gers, newGlobalExitRootInfo(info.GlobalExitRoot, i, blockNum, uint64(i)))
 	}
 
 	return gers, nil

--- a/l2gersync/migrations/l2gersync0005.sql
+++ b/l2gersync/migrations/l2gersync0005.sql
@@ -1,24 +1,25 @@
 
 -- +migrate Down
+
 CREATE TABLE IF NOT EXISTS imported_global_exit_root (
     block_num INTEGER PRIMARY KEY REFERENCES block (num) ON DELETE CASCADE,
+    block_pos INTEGER,
     global_exit_root VARCHAR NOT NULL,
     l1_info_tree_index INTEGER NOT NULL
 );
 
-INSERT INTO imported_global_exit_root (block_num, global_exit_root, l1_info_tree_index)
-SELECT v2.block_num, v2.global_exit_root, v2.l1_info_tree_index
-FROM imported_global_exit_root_v2 v2
-JOIN (
-    SELECT block_num, MIN(block_pos) AS min_pos
-    FROM imported_global_exit_root_v2
-    GROUP BY block_num
-) pick
-ON pick.block_num = v2.block_num AND pick.min_pos = v2.block_pos;
+INSERT INTO imported_global_exit_root (block_num, block_pos, global_exit_root, l1_info_tree_index)
+SELECT
+    block_num,
+    block_pos,
+    global_exit_root,
+    l1_info_tree_index
+FROM imported_global_exit_root_v2;
 
 DROP TABLE IF EXISTS imported_global_exit_root_v2;
 
 -- +migrate Up
+
 CREATE TABLE
 	IF NOT EXISTS imported_global_exit_root_v2 (
 		block_num INTEGER NOT NULL,
@@ -37,7 +38,7 @@ INSERT INTO imported_global_exit_root_v2 (
 )
 SELECT
     block_num,
-    0 AS block_pos,
+    COALESCE(block_pos, 0) AS block_pos,
     global_exit_root,
     l1_info_tree_index
 FROM imported_global_exit_root;

--- a/l2gersync/migrations/l2gersync0005.sql
+++ b/l2gersync/migrations/l2gersync0005.sql
@@ -1,0 +1,45 @@
+
+-- +migrate Down
+CREATE TABLE IF NOT EXISTS imported_global_exit_root (
+    block_num INTEGER PRIMARY KEY REFERENCES block (num) ON DELETE CASCADE,
+    global_exit_root VARCHAR NOT NULL,
+    l1_info_tree_index INTEGER NOT NULL
+);
+
+INSERT INTO imported_global_exit_root (block_num, global_exit_root, l1_info_tree_index)
+SELECT v2.block_num, v2.global_exit_root, v2.l1_info_tree_index
+FROM imported_global_exit_root_v2 v2
+JOIN (
+    SELECT block_num, MIN(block_pos) AS min_pos
+    FROM imported_global_exit_root_v2
+    GROUP BY block_num
+) pick
+ON pick.block_num = v2.block_num AND pick.min_pos = v2.block_pos;
+
+DROP TABLE IF EXISTS imported_global_exit_root_v2;
+
+-- +migrate Up
+CREATE TABLE
+	IF NOT EXISTS imported_global_exit_root_v2 (
+		block_num INTEGER NOT NULL,
+        block_pos INTEGER NOT NULL,
+		global_exit_root VARCHAR NOT NULL,
+		l1_info_tree_index INTEGER NOT NULL,
+        PRIMARY KEY (block_num, block_pos),
+        FOREIGN KEY (block_num) REFERENCES block(num) ON DELETE CASCADE
+	);
+
+INSERT INTO imported_global_exit_root_v2 (
+    block_num,
+    block_pos,
+    global_exit_root,
+    l1_info_tree_index
+)
+SELECT
+    block_num,
+    0 AS block_pos,
+    global_exit_root,
+    l1_info_tree_index
+FROM imported_global_exit_root;
+
+DROP TABLE imported_global_exit_root;

--- a/l2gersync/migrations/migrations.go
+++ b/l2gersync/migrations/migrations.go
@@ -19,24 +19,36 @@ var mig003 string
 //go:embed l2gersync0004.sql
 var mig004 string
 
+//go:embed l2gersync0005.sql
+var mig005 string
+
+var migrationsL2gersync []types.Migration = []types.Migration{
+	{
+		ID:  "l2gersync0001",
+		SQL: mig001,
+	},
+	{
+		ID:  "l2gersync0002",
+		SQL: mig002,
+	},
+	{
+		ID:  "l2gersync0003",
+		SQL: mig003,
+	},
+	{
+		ID:  "l2gersync0004",
+		SQL: mig004,
+	},
+	{
+		ID:  "l2gersync0005",
+		SQL: mig005,
+	},
+}
+
 func RunMigrations(dbPath string) error {
-	migrations := []types.Migration{
-		{
-			ID:  "l2gersync0001",
-			SQL: mig001,
-		},
-		{
-			ID:  "l2gersync0002",
-			SQL: mig002,
-		},
-		{
-			ID:  "l2gersync0003",
-			SQL: mig003,
-		},
-		{
-			ID:  "l2gersync0004",
-			SQL: mig004,
-		},
-	}
-	return db.RunMigrations(dbPath, migrations)
+	return db.RunMigrations(dbPath, migrationsL2gersync)
+}
+
+func RunMigrationsDown(dbPath string, maxMigrations int) error {
+	return db.RunMigrationsDown(dbPath, migrationsL2gersync, maxMigrations)
 }

--- a/l2gersync/migrations/migrations.go
+++ b/l2gersync/migrations/migrations.go
@@ -46,9 +46,17 @@ var migrationsL2gersync []types.Migration = []types.Migration{
 }
 
 func RunMigrations(dbPath string) error {
-	return db.RunMigrations(dbPath, migrationsL2gersync)
+	return RunMigrationsWithList(dbPath, migrationsL2gersync)
 }
 
-func RunMigrationsDown(dbPath string, maxMigrations int) error {
-	return db.RunMigrationsDown(dbPath, migrationsL2gersync, maxMigrations)
+func RunMigrationsWithList(dbPath string, migrations []types.Migration) error {
+	originMigrations := make([]types.Migration, len(migrations))
+	copy(originMigrations, migrations)
+	return db.RunMigrations(dbPath, originMigrations)
+}
+
+func RunMigrationsDown(dbPath string, migrations []types.Migration, maxMigrations int) error {
+	originMigrations := make([]types.Migration, len(migrations))
+	copy(originMigrations, migrations)
+	return db.RunMigrationsDown(dbPath, originMigrations, maxMigrations)
 }

--- a/l2gersync/migrations/migrations_test.go
+++ b/l2gersync/migrations/migrations_test.go
@@ -138,6 +138,7 @@ func TestMigration0005(t *testing.T) {
 	require.NoError(t, err)
 	testDB, err = db.NewSQLiteDB(dbPath)
 	require.NoError(t, err)
+	defer testDB.Close()
 	var importedGERV1 struct {
 		BlockNum        uint64 `meddler:"block_num"`
 		GlobalExitRoot  string `meddler:"global_exit_root"`

--- a/l2gersync/migrations/migrations_test.go
+++ b/l2gersync/migrations/migrations_test.go
@@ -21,13 +21,9 @@ import (
 
 func TestMigration0001(t *testing.T) {
 	dbPath := path.Join(t.TempDir(), "l2gersyncTest0001.sqlite")
-	originMigrations := make([]types.Migration, len(migrationsL2gersync))
-	copy(originMigrations, migrationsL2gersync)
-	defer func() {
-		migrationsL2gersync = originMigrations
-	}()
-	migrationsL2gersync = migrationsL2gersync[:1] // only first migration
-	err := RunMigrations(dbPath)
+
+	migrationsTo1 := migrationsL2gersync[:1] // only first migration
+	err := RunMigrationsWithList(dbPath, migrationsTo1)
 	require.NoError(t, err)
 	db, err := db.NewSQLiteDB(dbPath)
 	require.NoError(t, err)
@@ -79,16 +75,11 @@ func getKeysFromListMigrations(migs []types.Migration) []string {
 }
 
 func TestMigration0005(t *testing.T) {
-	originMigrations := make([]types.Migration, len(migrationsL2gersync))
-	copy(originMigrations, migrationsL2gersync)
-	defer func() {
-		migrationsL2gersync = originMigrations
-	}()
-	migrationsL2gersync = migrationsL2gersync[:4] // migration to 'l2gersync0004' (previous to 0005)
+	migrationsTo4 := migrationsL2gersync[:4] // migration to 'l2gersync0004' (previous to 0005)
 	log.Debugf("Total migrations till 0004: %d, %+v", len(migrationsL2gersync), getKeysFromListMigrations(migrationsL2gersync))
 	dbPath := path.Join(t.TempDir(), "l2gersyncTest0005.sqlite")
 
-	err := RunMigrations(dbPath)
+	err := RunMigrationsWithList(dbPath, migrationsTo4)
 	require.NoError(t, err)
 	testDB, err := db.NewSQLiteDB(dbPath)
 	require.NoError(t, err)
@@ -112,9 +103,9 @@ func TestMigration0005(t *testing.T) {
 	require.NoError(t, err)
 	testDB.Close()
 	// Now execute migration 5
-	migrationsL2gersync = originMigrations[:5]
-	log.Debugf("Total migrations including mig0005 test: %d, %+v", len(migrationsL2gersync), getKeysFromListMigrations(migrationsL2gersync))
-	err = RunMigrations(dbPath)
+	migrationsTo5 := migrationsL2gersync[:5]
+	log.Debugf("Total migrations including mig0005 test: %d, %+v", len(migrationsTo5), getKeysFromListMigrations(migrationsTo5))
+	err = RunMigrationsWithList(dbPath, migrationsTo5)
 	require.NoError(t, err)
 	testDB, err = db.NewSQLiteDB(dbPath)
 	require.NoError(t, err)
@@ -142,9 +133,8 @@ func TestMigration0005(t *testing.T) {
 	require.Equal(t, uint32(2), importedGER.L1InfoTreeIndex)
 	testDB.Close()
 	// Now execute migration down to 4
-	migrationsL2gersync = originMigrations[:5]
-	log.Debugf("Total migration down 1 step: %d, %+v", len(migrationsL2gersync), getKeysFromListMigrations(migrationsL2gersync))
-	err = RunMigrationsDown(dbPath, 1)
+	log.Debugf("Total migration down 1 step: %d, %+v", len(migrationsTo5), getKeysFromListMigrations(migrationsTo5))
+	err = RunMigrationsDown(dbPath, migrationsTo5, 1)
 	require.NoError(t, err)
 	testDB, err = db.NewSQLiteDB(dbPath)
 	require.NoError(t, err)

--- a/l2gersync/migrations/migrations_test.go
+++ b/l2gersync/migrations/migrations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/db/migrations"
 	"github.com/agglayer/aggkit/db/types"
+	"github.com/agglayer/aggkit/log"
 	_ "github.com/mattn/go-sqlite3"
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/russross/meddler"
@@ -20,7 +21,12 @@ import (
 
 func TestMigration0001(t *testing.T) {
 	dbPath := path.Join(t.TempDir(), "l2gersyncTest0001.sqlite")
-
+	originMigrations := make([]types.Migration, len(migrationsL2gersync))
+	copy(originMigrations, migrationsL2gersync)
+	defer func() {
+		migrationsL2gersync = originMigrations
+	}()
+	migrationsL2gersync = migrationsL2gersync[:1] // only first migration
 	err := RunMigrations(dbPath)
 	require.NoError(t, err)
 	db, err := db.NewSQLiteDB(dbPath)
@@ -63,6 +69,95 @@ func TestMigration0001(t *testing.T) {
 	require.Equal(t, uint64(1), importedGER.BlockNum)
 	require.Equal(t, "0x1", importedGER.GlobalExitRoot)
 	require.Equal(t, uint32(2), importedGER.L1InfoTreeIndex)
+}
+func getKeysFromListMigrations(migs []types.Migration) []string {
+	keys := make([]string, 0, len(migs))
+	for _, m := range migs {
+		keys = append(keys, m.ID)
+	}
+	return keys
+}
+
+func TestMigration0005(t *testing.T) {
+	originMigrations := make([]types.Migration, len(migrationsL2gersync))
+	copy(originMigrations, migrationsL2gersync)
+	defer func() {
+		migrationsL2gersync = originMigrations
+	}()
+	migrationsL2gersync = migrationsL2gersync[:4] // migration to 'l2gersync0004' (previous to 0005)
+	log.Debugf("Total migrations till 0004: %d, %+v", len(migrationsL2gersync), getKeysFromListMigrations(migrationsL2gersync))
+	dbPath := path.Join(t.TempDir(), "l2gersyncTest0005.sqlite")
+
+	err := RunMigrations(dbPath)
+	require.NoError(t, err)
+	testDB, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	ctx := context.Background()
+	tx, err := testDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(`
+		INSERT INTO block (num) VALUES (1);
+
+		INSERT INTO imported_global_exit_root (
+			block_num,
+			global_exit_root,
+			l1_info_tree_index
+		) VALUES (1, '0x1', '2');
+	`)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+	testDB.Close()
+	// Now execute migration 5
+	migrationsL2gersync = originMigrations[:5]
+	log.Debugf("Total migrations including mig0005 test: %d, %+v", len(migrationsL2gersync), getKeysFromListMigrations(migrationsL2gersync))
+	err = RunMigrations(dbPath)
+	require.NoError(t, err)
+	testDB, err = db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+
+	var block struct {
+		Num uint64 `meddler:"num"`
+	}
+	err = meddler.QueryRow(testDB, &block, `SELECT * FROM block WHERE num = 1;`)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	require.Equal(t, uint64(1), block.Num)
+
+	var importedGER struct {
+		BlockNum        uint64 `meddler:"block_num"`
+		BlockPos        uint64 `meddler:"block_pos"`
+		GlobalExitRoot  string `meddler:"global_exit_root"`
+		L1InfoTreeIndex uint32 `meddler:"l1_info_tree_index"`
+	}
+	err = meddler.QueryRow(testDB, &importedGER, `SELECT * FROM imported_global_exit_root_v2`)
+	require.NoError(t, err)
+	require.NotNil(t, importedGER)
+	require.Equal(t, uint64(1), importedGER.BlockNum)
+	require.Equal(t, uint64(0), importedGER.BlockPos)
+	require.Equal(t, "0x1", importedGER.GlobalExitRoot)
+	require.Equal(t, uint32(2), importedGER.L1InfoTreeIndex)
+	testDB.Close()
+	// Now execute migration down to 4
+	migrationsL2gersync = originMigrations[:5]
+	log.Debugf("Total migration down 1 step: %d, %+v", len(migrationsL2gersync), getKeysFromListMigrations(migrationsL2gersync))
+	err = RunMigrationsDown(dbPath, 1)
+	require.NoError(t, err)
+	testDB, err = db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	var importedGERV1 struct {
+		BlockNum        uint64 `meddler:"block_num"`
+		GlobalExitRoot  string `meddler:"global_exit_root"`
+		L1InfoTreeIndex uint32 `meddler:"l1_info_tree_index"`
+	}
+	err = meddler.QueryRow(testDB, &importedGERV1, `SELECT * FROM imported_global_exit_root`)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), importedGERV1.BlockNum)
+	require.Equal(t, "0x1", importedGERV1.GlobalExitRoot)
+	require.Equal(t, uint32(2), importedGERV1.L1InfoTreeIndex)
 }
 
 func TestMigrations_UpDown(t *testing.T) {

--- a/l2gersync/processor.go
+++ b/l2gersync/processor.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	deleteGERSql = "DELETE FROM imported_global_exit_root WHERE global_exit_root = $1;"
+	deleteGERSql = "DELETE FROM imported_global_exit_root_v2 WHERE global_exit_root = $1;"
 )
 
 type BlockNum struct {
@@ -50,17 +50,6 @@ func newGlobalExitRootInfo(
 		L1InfoTreeIndex: l1InfoTreeIndex,
 		BlockNum:        blockNum,
 		BlockPosition:   &blockPosition,
-	}
-}
-
-// newLegacyGlobalExitRootInfo creates a new GlobalExitRootInfo instance without block position
-func newLegacyGlobalExitRootInfo(
-	globalExitRoot ethcommon.Hash, l1InfoTreeIndex uint32, blockNum uint64) *GlobalExitRootInfo {
-	return &GlobalExitRootInfo{
-		GlobalExitRoot:  globalExitRoot,
-		L1InfoTreeIndex: l1InfoTreeIndex,
-		BlockNum:        blockNum,
-		BlockPosition:   nil,
 	}
 }
 
@@ -133,12 +122,12 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	return nil
 }
 
-// handleGEREvent either inserts or removes the global exit root entry from `imported_global_exit_root` table,
+// handleGEREvent either inserts or removes the global exit root entry from `imported_global_exit_root_v2` table,
 func (p *processor) handleGEREvent(tx dbtypes.Txer, gerInfo *GlobalExitRootInfo, eventType GEREventType) error {
 	switch eventType {
 	case GEREventTypeInsert:
 		// Insert the global exit root into the database
-		if err := meddler.Insert(tx, "imported_global_exit_root", gerInfo); err != nil {
+		if err := meddler.Insert(tx, "imported_global_exit_root_v2", gerInfo); err != nil {
 			return fmt.Errorf("failed to insert imported global exit root (value=%x, block=%d): %w",
 				gerInfo.GlobalExitRoot, gerInfo.BlockNum, err)
 		}
@@ -182,11 +171,11 @@ func (p *processor) GetLastProcessedBlock(ctx context.Context) (uint64, error) {
 	return block.Num, nil
 }
 
-// getLatestL1InfoTreeIndex retrieves the highest L1InfoTreeIndex recorded in the imported_global_exit_root table
+// getLatestL1InfoTreeIndex retrieves the highest L1InfoTreeIndex recorded in the imported_global_exit_root_v2 table
 func (p *processor) getLatestL1InfoTreeIndex() (uint32, error) {
 	var latestGERInfo GlobalExitRootInfo
 	err := meddler.QueryRow(p.database, &latestGERInfo,
-		`SELECT l1_info_tree_index FROM imported_global_exit_root
+		`SELECT l1_info_tree_index FROM imported_global_exit_root_v2
 			ORDER BY l1_info_tree_index DESC LIMIT 1;`)
 	if err != nil {
 		return 0, db.ReturnErrNotFound(err)
@@ -241,7 +230,7 @@ func (p *processor) GetFirstGERAfterL1InfoTreeIndex(
 	e := GlobalExitRootInfo{}
 	err := meddler.QueryRow(p.database, &e, `
 		SELECT l1_info_tree_index, block_num, global_exit_root, block_pos
-		FROM imported_global_exit_root
+		FROM imported_global_exit_root_v2
 		WHERE l1_info_tree_index >= $1
 		ORDER BY l1_info_tree_index ASC LIMIT 1;
 	`, l1InfoTreeIndex)
@@ -268,7 +257,7 @@ func (p *processor) GetInjectedGERsForRange(
 
 	err := meddler.QueryAll(p.database, &results, `
 		SELECT global_exit_root, l1_info_tree_index, block_num, block_pos
-		FROM imported_global_exit_root
+		FROM imported_global_exit_root_v2
 		WHERE block_num >= $1 AND block_num <= $2;
 	`, fromBlock, toBlock)
 	if err != nil {

--- a/l2gersync/processor.go
+++ b/l2gersync/processor.go
@@ -29,7 +29,7 @@ type GlobalExitRootInfo struct {
 	GlobalExitRoot  ethcommon.Hash `meddler:"global_exit_root,hash"`
 	L1InfoTreeIndex uint32         `meddler:"l1_info_tree_index"`
 	BlockNum        uint64         `meddler:"block_num"`
-	BlockPosition   *uint64        `meddler:"block_pos"`
+	BlockPosition   uint64         `meddler:"block_pos"`
 	Removed         bool           `meddler:"-"`
 }
 
@@ -49,7 +49,7 @@ func newGlobalExitRootInfo(
 		GlobalExitRoot:  globalExitRoot,
 		L1InfoTreeIndex: l1InfoTreeIndex,
 		BlockNum:        blockNum,
-		BlockPosition:   &blockPosition,
+		BlockPosition:   blockPosition,
 	}
 }
 
@@ -142,12 +142,12 @@ func (p *processor) handleGEREvent(tx dbtypes.Txer, gerInfo *GlobalExitRootInfo,
 		removeEvent := &RemoveGEREvent{
 			GlobalExitRoot: gerInfo.GlobalExitRoot,
 			BlockNum:       gerInfo.BlockNum,
-			BlockPos:       *gerInfo.BlockPosition,
+			BlockPos:       gerInfo.BlockPosition,
 			CreatedAt:      uint64(time.Now().Unix()),
 		}
 		if err := meddler.Insert(tx, "remove_ger_events", removeEvent); err != nil {
 			return fmt.Errorf("failed to insert remove GER event (value=%x, block=%d, pos=%d): %w",
-				gerInfo.GlobalExitRoot, gerInfo.BlockNum, *gerInfo.BlockPosition, err)
+				gerInfo.GlobalExitRoot, gerInfo.BlockNum, gerInfo.BlockPosition, err)
 		}
 	}
 

--- a/l2gersync/processor_test.go
+++ b/l2gersync/processor_test.go
@@ -42,6 +42,25 @@ func TestProcessBlock(t *testing.T) {
 		expectedErr   string
 	}{
 		{
+			name: "Multiple GERs in same block",
+			blocks: []sync.Block{
+				{
+					Num: 1,
+					Events: []any{
+						&Event{
+							GERInfo:   newGlobalExitRootInfo(common.HexToHash("0x1111"), 10, 1, 0),
+							EventType: GEREventTypeInsert,
+						},
+						&Event{
+							GERInfo:   newGlobalExitRootInfo(common.HexToHash("0x2222"), 11, 1, 1),
+							EventType: GEREventTypeInsert,
+						},
+					},
+				},
+			},
+			expectedIndex: 11,
+		},
+		{
 			name: "Add GERInfo",
 			blocks: []sync.Block{
 				{

--- a/l2gersync/processor_test.go
+++ b/l2gersync/processor_test.go
@@ -188,14 +188,11 @@ func TestProcessor_GetInjectedGERsForRange(t *testing.T) {
 
 	ctx := context.Background()
 
-	blockPosition := uint64(0)
-	blockPosition1 := uint64(1)
-	blockPosition2 := uint64(2)
 	makeGERs := func() []*GlobalExitRootInfo {
 		return []*GlobalExitRootInfo{
-			{GlobalExitRoot: common.HexToHash("0x1234"), BlockPosition: &blockPosition},
-			{GlobalExitRoot: common.HexToHash("0x5678"), BlockPosition: &blockPosition1},
-			{GlobalExitRoot: common.HexToHash("0x9876"), BlockPosition: &blockPosition2},
+			{GlobalExitRoot: common.HexToHash("0x1234"), BlockPosition: 0},
+			{GlobalExitRoot: common.HexToHash("0x5678"), BlockPosition: 1},
+			{GlobalExitRoot: common.HexToHash("0x9876"), BlockPosition: 2},
 		}
 	}
 
@@ -244,14 +241,13 @@ func TestProcessor_GetInjectedGERsForRange(t *testing.T) {
 	t.Run("returns only non-removed GERs", func(t *testing.T) {
 		t.Parallel()
 
-		blockPosition3 := uint64(3)
 		gerList := makeGERs()
 		allBlocks := []sync.Block{
 			{Num: 93, Events: []any{&Event{GERInfo: gerList[0]}}},
 			{Num: 94, Events: []any{&Event{GERInfo: gerList[1]}}},
 			{Num: 95, Events: []any{&Event{GERInfo: gerList[2]}}},
 			{Num: 96, Events: []any{&Event{
-				GERInfo:   &GlobalExitRootInfo{GlobalExitRoot: gerList[2].GlobalExitRoot, BlockPosition: &blockPosition3},
+				GERInfo:   &GlobalExitRootInfo{GlobalExitRoot: gerList[2].GlobalExitRoot, BlockPosition: 3},
 				EventType: GEREventTypeRemove,
 			}}},
 		}


### PR DESCRIPTION

## 🔄 Changes Summary
This PR introduces support for handling multiple GER (Global Exit Root) injections within the same block by migrating from the `imported_global_exit_root` table to a new `imported_global_exit_root_v2` table that includes a `block_pos` column to track the position of each GER within a block. This prevents primary key conflicts when multiple GERs are injected in the same block.
- The legacy downloader set as blockPosition the l1infotreeIndex to avoid duplications
- 

## 🐞 Issues
- Fixes #1468 - Error when there are 2 or more injected GERs in the same block
- Changes primary key from `block_num` alone to composite key (`block_num`, `block_pos`)
- Updates all queries to use the new `imported_global_exit_root_v2` table

## 📋 Config Updates
None

## ✅ Testing
- 🤖 **Automatic**:


## ⚠️ Breaking Changes
-None


