### PR TITLE
fix: cherry-pick #1471 Fix typo 'DelayBeetweenCertificates' 

### DIFF
--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -18,8 +18,8 @@ import (
 )
 
 type TriggerASAPConfig struct {
-	// DelayBeetweenCertificates is the delay to wait before sending a new certificate after the previous one is settled
-	DelayBeetweenCertificates types.Duration `mapstructure:"DelayBeetweenCertificates"`
+	// DelayBetweenCertificates is the delay to wait before sending a new certificate after the previous one is settled
+	DelayBetweenCertificates types.Duration `mapstructure:"DelayBetweenCertificates"`
 	// MinimumNewCertificateInterval is the minimum interval between two new certificates triggers
 	MinimumNewCertificateInterval types.Duration `mapstructure:"MinimumNewCertificateInterval"`
 	// OnNewL2Bridge indicates whether to trigger a new certificate when a new L2 bridge exit is detected
@@ -28,21 +28,21 @@ type TriggerASAPConfig struct {
 
 func NewTriggerASAPConfigDefault() *TriggerASAPConfig {
 	return &TriggerASAPConfig{
-		DelayBeetweenCertificates:     types.Duration{Duration: time.Second},
+		DelayBetweenCertificates:      types.Duration{Duration: time.Second},
 		MinimumNewCertificateInterval: types.Duration{Duration: time.Hour},
 	}
 }
 
 func (c *TriggerASAPConfig) String() string {
-	return fmt.Sprintf("DelayBeetweenCertificates: %s, MinimumNewCertificateInterval: %s, OnNewL2Bridge: %t",
-		c.DelayBeetweenCertificates.String(),
+	return fmt.Sprintf("DelayBetweenCertificates: %s, MinimumNewCertificateInterval: %s, OnNewL2Bridge: %t",
+		c.DelayBetweenCertificates.String(),
 		c.MinimumNewCertificateInterval.String(),
 		c.OnNewL2Bridge)
 }
 
 func (c *TriggerASAPConfig) Validate() error {
-	if c.DelayBeetweenCertificates.Duration < 0 {
-		return fmt.Errorf("DelayBeetweenCertificates cannot be negative")
+	if c.DelayBetweenCertificates.Duration < 0 {
+		return fmt.Errorf("DelayBetweenCertificates cannot be negative")
 	}
 	if c.MinimumNewCertificateInterval.Duration <= 0 {
 		return fmt.Errorf("MinimumNewCertificateInterval must be >= 0")

--- a/aggsender/config/config_test.go
+++ b/aggsender/config/config_test.go
@@ -166,3 +166,137 @@ func TestConfigString(t *testing.T) {
 	require.Contains(t, result, "RequireNoFEPBlockGap: false")
 	require.Contains(t, result, "RetriesToBuildAndSendCertificate: RetryPolicyConfig{Mode: delays")
 }
+
+func TestNewTriggerASAPConfigDefault(t *testing.T) {
+	t.Parallel()
+
+	config := NewTriggerASAPConfigDefault()
+
+	require.NotNil(t, config)
+	require.Equal(t, time.Second, config.DelayBetweenCertificates.Duration)
+	require.Equal(t, time.Hour, config.MinimumNewCertificateInterval.Duration)
+	require.False(t, config.OnNewL2Bridge)
+}
+
+func TestTriggerASAPConfigString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		config   TriggerASAPConfig
+		expected string
+	}{
+		{
+			name: "Default configuration",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(1 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(1 * time.Hour),
+				OnNewL2Bridge:                 false,
+			},
+			expected: "DelayBetweenCertificates: 1s, MinimumNewCertificateInterval: 1h0m0s, OnNewL2Bridge: false",
+		},
+		{
+			name: "Custom configuration with OnNewL2Bridge enabled",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(5 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(30 * time.Minute),
+				OnNewL2Bridge:                 true,
+			},
+			expected: "DelayBetweenCertificates: 5s, MinimumNewCertificateInterval: 30m0s, OnNewL2Bridge: true",
+		},
+		{
+			name: "Zero values",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(0),
+				MinimumNewCertificateInterval: types.NewDuration(1 * time.Millisecond),
+				OnNewL2Bridge:                 false,
+			},
+			expected: "DelayBetweenCertificates: 0s, MinimumNewCertificateInterval: 1ms, OnNewL2Bridge: false",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tc.config.String()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestTriggerASAPConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		config      TriggerASAPConfig
+		expectedErr string
+	}{
+		{
+			name: "Valid configuration",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(1 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(1 * time.Hour),
+				OnNewL2Bridge:                 true,
+			},
+		},
+		{
+			name: "Valid with zero DelayBetweenCertificates",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(0),
+				MinimumNewCertificateInterval: types.NewDuration(1 * time.Hour),
+				OnNewL2Bridge:                 false,
+			},
+		},
+		{
+			name: "Invalid negative DelayBetweenCertificates",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(-1 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(1 * time.Hour),
+				OnNewL2Bridge:                 false,
+			},
+			expectedErr: "DelayBetweenCertificates cannot be negative",
+		},
+		{
+			name: "Invalid zero MinimumNewCertificateInterval",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(1 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(0),
+				OnNewL2Bridge:                 false,
+			},
+			expectedErr: "MinimumNewCertificateInterval must be >= 0",
+		},
+		{
+			name: "Invalid negative MinimumNewCertificateInterval",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(1 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(-1 * time.Hour),
+				OnNewL2Bridge:                 false,
+			},
+			expectedErr: "MinimumNewCertificateInterval must be >= 0",
+		},
+		{
+			name: "Both fields with invalid values",
+			config: TriggerASAPConfig{
+				DelayBetweenCertificates:      types.NewDuration(-5 * time.Second),
+				MinimumNewCertificateInterval: types.NewDuration(-10 * time.Minute),
+				OnNewL2Bridge:                 true,
+			},
+			expectedErr: "DelayBetweenCertificates cannot be negative",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/aggsender/trigger/trigger_asap.go
+++ b/aggsender/trigger/trigger_asap.go
@@ -144,7 +144,7 @@ func (r *asapTrigger) OnIdle() {
 		r.log.Debugf("ASAP Trigger: trigger already running, skipping")
 		return
 	}
-	r.log.Debugf("ASAP Trigger: sending a trigger in %s", r.cfg.DelayBeetweenCertificates.String())
+	r.log.Debugf("ASAP Trigger: sending a trigger in %s", r.cfg.DelayBetweenCertificates.String())
 
 	go func() {
 		select {
@@ -155,7 +155,7 @@ func (r *asapTrigger) OnIdle() {
 			r.ch = nil
 			r.triggerRunning = false
 			return
-		case <-time.After(r.cfg.DelayBeetweenCertificates.Duration):
+		case <-time.After(r.cfg.DelayBetweenCertificates.Duration):
 			r.trigger("Idle", nil)
 		}
 	}()

--- a/aggsender/trigger/trigger_asap_test.go
+++ b/aggsender/trigger/trigger_asap_test.go
@@ -75,7 +75,7 @@ func TestASAPTrigger_Status(t *testing.T) {
 	require.NoError(t, err, "Failed to create ASAP trigger")
 
 	status := trigger.Status()
-	require.Equal(t, "ASAP Runner: cfg: DelayBeetweenCertificates: 1s, MinimumNewCertificateInterval: 1h0m0s, OnNewL2Bridge: false", status, "Unexpected status message")
+	require.Equal(t, "ASAP Runner: cfg: DelayBetweenCertificates: 1s, MinimumNewCertificateInterval: 1h0m0s, OnNewL2Bridge: false", status, "Unexpected status message")
 }
 
 func TestASAPTrigger_MinInterval(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -220,7 +220,7 @@ TriggerCertMode = "Auto"
 	# Percentage of epoch completion to trigger certificate sending
 	EpochNotificationPercentage = 50
 [AggSender.TriggerASAP]
-	DelayBeetweenCertificates = "1s"
+	DelayBetweenCertificates = "1s"
 	MinimumNewCertificateInterval = "5m"
 	OnNewL2Bridge = false
 

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -227,7 +227,7 @@ The `TriggerASAPConfig` structure configures the ASAP (As Soon As Possible) trig
 
 | Field Name                         | Type                | Description                                                                                                     |
 |------------------------------------|---------------------|-----------------------------------------------------------------------------------------------------------------|
-| DelayBeetweenCertificates          | Duration            | The delay to wait before sending a new certificate after the previous one is settled                            |
+| DelayBetweenCertificates          | Duration            | The delay to wait before sending a new certificate after the previous one is settled                            |
 | MinimumNewCertificateInterval      | Duration            | The minimum interval between two new certificate triggers (0 = no minimum interval)                             |
 
 Example:
@@ -235,11 +235,11 @@ Example:
 [AggSender]
     TriggerCertMode = "ASAP"
     [AggSender.TriggerASAP]
-        DelayBeetweenCertificates = "1s"
+        DelayBetweenCertificates = "1s"
         MinimumNewCertificateInterval = "1h"
 ```
 
-The ASAP trigger sends certificates as soon as possible after the last certificate reaches a final state (settled or in error). The `DelayBeetweenCertificates` parameter adds a configurable delay before sending, while `MinimumNewCertificateInterval` ensures a minimum time gap between certificate submissions to prevent excessive certificate generation.
+The ASAP trigger sends certificates as soon as possible after the last certificate reaches a final state (settled or in error). The `DelayBetweenCertificates` parameter adds a configurable delay before sending, while `MinimumNewCertificateInterval` ensures a minimum time gap between certificate submissions to prevent excessive certificate generation.
 
 ### Trigger Modes
 


### PR DESCRIPTION
Cherry-pick from `develop` #1471

## 🔄 Changes Summary
- Fix typo: `AggSender.TriggerASAP.DelayBeetweenCertificates`

## ⚠️ Breaking Changes
- Deprecated field ` `AggSender.TriggerASAP.DelayBeetweenCertificates` in favour of `DelayBetweenCertificates`
    DelayBetweenCertificates = "1s"
```
[AggSender.TriggerASAP]

```

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: [Optional: Enumerate config changes/provide snippet of changes]

## 🔗 Related PRs
- #1470

