### PR TITLE
chore: bump go to 1.25.7 (fix vulnerability)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.language == 'go' }}
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.6
+          go-version: 1.25.7
 
       - name: Verify Go version
         if: ${{ matrix.language == 'go' }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,5 +14,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.25.6
+           go-version-input: 1.25.7
            go-package: ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.6
+          go-version: 1.25.7
 
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -59,7 +59,7 @@ jobs:
   build-aggkit-image:
     uses: ./.github/workflows/build-aggkit-image.yml
     with:
-      go-version: 1.25.6
+      go-version: 1.25.7
       docker-image-name: aggkit
 
   read-aggkit-args:
@@ -157,7 +157,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.6
+          go-version: 1.25.7
       - name: Build Aggsender Find Imported Bridge
         run: make build-tools
       - name: Upload Binary

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.6]
+        go-version: [1.25.7]
         goarch: ["amd64"]
     runs-on: amd-runner-2204
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # STAGE 1: Build binary
 # ================================
-FROM golang:1.25.6-alpine AS builder
+FROM golang:1.25.7-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache gcc musl-dev make sqlite-dev git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agglayer/aggkit
 
-go 1.25.6
+go 1.25.7
 
 require (
 	buf.build/gen/go/agglayer/agglayer/grpc/go v1.5.1-20251003171624-441244f9c27c.2


### PR DESCRIPTION
## 🔄 Changes Summary
Bump go to 1.25.7

```
Vulnerability #1: GO-2026-4337
    Unexpected session resumption in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4337
  Standard library
    Found in: crypto/tls@go1.25.6
    Fixed in: crypto/tls@go1.25.7
    Example traces found:
Error:       #1: prometheus/prometheus.go:39:13: prometheus.Init calls sync.Once.Do, which eventually calls tls.Conn.Handshake
Error:       #2: pprof/pprof.go:66:33: pprof.StartProfilingHTTPServer calls http.Server.Serve, which eventually calls tls.Conn.HandshakeContext
Error:       #3: bridgeservice/client/client.go:368:29: client.Client.doRequest calls io.ReadAll, which eventually calls tls.Conn.Read
Error:       #4: version.go:20:13: aggkit.PrintVersion calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #5: bridgeservice/client/client.go:362:30: client.Client.doRequest calls http.Client.Do, which eventually calls tls.Dialer.DialContext

Your code is affected by 1 vulnerability from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
```

