### PR TITLE
feat: add param SyncFromInBridges to bridgesyncer

### DIFF
--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -50,11 +50,11 @@ func (r RuntimeData) String() string {
 	return fmt.Sprintf("NetworkID: %d", r.NetworkID)
 }
 
-func (r RuntimeData) IsCompatible(storage RuntimeData) error {
+func (r RuntimeData) IsCompatible(storage RuntimeData) (*RuntimeData, error) {
 	if r.NetworkID != storage.NetworkID {
-		return fmt.Errorf("network ID mismatch: %d != %d", r.NetworkID, storage.NetworkID)
+		return nil, fmt.Errorf("network ID mismatch: %d != %d", r.NetworkID, storage.NetworkID)
 	}
-	return nil
+	return nil, nil
 }
 
 type AggSenderStorageMaintainer interface {

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -1255,7 +1255,7 @@ func Test_RuntimeData_IsCompatible(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.runtime.IsCompatible(tt.storage)
+			_, err := tt.runtime.IsCompatible(tt.storage)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/aggsender/query/aggchain_fep_rollup_query.go
+++ b/aggsender/query/aggchain_fep_rollup_query.go
@@ -72,7 +72,7 @@ func NewAggchainFEPQuerier(
 	l1Client aggkittypes.BaseEthereumClienter) (types.AggchainFEPRollupQuerier, error) {
 	if aggchainFEPAddr == aggkitcommon.ZeroAddress || aggsenderMode == types.PessimisticProofMode {
 		// its a PP network without AggchainFEP contract
-		logger.Info("aggchainProverFlow - AggchainFEP contract address is zero, using no-op querier")
+		logger.Infof("aggchainProverFlow - AggchainFEP contract address is zero, or mode (%s) is PessimisticProofMode, using no-op querier", aggsenderMode)
 		return &noOpAggchainFEPRollupQuerier{}, nil
 	}
 
@@ -96,7 +96,7 @@ func newAggchainFEPQuerier(
 			aggchainFEPAddr.String(), err)
 	}
 
-	logger.Info("aggchainProverFlow - AggchainFEP contract address is not zero, using real querier")
+	logger.Infof("aggchainProverFlow - AggchainFEP contract address is not zero, using real querier (%s)", aggchainFEPAddr.String())
 
 	return &aggchainFEPRollupQuerier{
 		startL2BlockNum:   startL2Block.Uint64(),

--- a/aggsender/query/aggchain_fep_rollup_query.go
+++ b/aggsender/query/aggchain_fep_rollup_query.go
@@ -72,7 +72,8 @@ func NewAggchainFEPQuerier(
 	l1Client aggkittypes.BaseEthereumClienter) (types.AggchainFEPRollupQuerier, error) {
 	if aggchainFEPAddr == aggkitcommon.ZeroAddress || aggsenderMode == types.PessimisticProofMode {
 		// its a PP network without AggchainFEP contract
-		logger.Infof("aggchainProverFlow - AggchainFEP contract address is zero, or mode (%s) is PessimisticProofMode, using no-op querier", aggsenderMode)
+		logger.Infof("aggchainProverFlow - AggchainFEP contract address is zero, or mode (%s) is "+
+			"PessimisticProofMode, using no-op querier", aggsenderMode)
 		return &noOpAggchainFEPRollupQuerier{}, nil
 	}
 
@@ -96,7 +97,8 @@ func newAggchainFEPQuerier(
 			aggchainFEPAddr.String(), err)
 	}
 
-	logger.Infof("aggchainProverFlow - AggchainFEP contract address is not zero, using real querier (%s)", aggchainFEPAddr.String())
+	logger.Infof("aggchainProverFlow - AggchainFEP contract address is not zero, using real querier (%s)",
+		aggchainFEPAddr.String())
 
 	return &aggchainFEPRollupQuerier{
 		startL2BlockNum:   startL2Block.Uint64(),

--- a/bridgeservice/types/types.go
+++ b/bridgeservice/types/types.go
@@ -99,8 +99,9 @@ type BridgeResponse struct {
 	// Position of the bridge event within the block
 	BlockPos uint64 `json:"block_pos" example:"1"`
 
-	// Address that initiated the transaction on bridge contract. It can be intermediary contract or EOA
-	FromAddress Address `json:"from_address" example:"0xabc1234567890abcdef1234567890abcdef1234"`
+	// Address that initiated the transaction on bridge contract. It can be intermediary contract or EOA.
+	// May be null if bridge was synced with SyncFromInBridges=false
+	FromAddress *Address `json:"from_address,omitempty" example:"0xabc1234567890abcdef1234567890abcdef1234"`
 
 	// Hash of the transaction that included the bridge event
 	TxHash Hash `json:"tx_hash" example:"0xdef4567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"`

--- a/bridgeservice/utils.go
+++ b/bridgeservice/utils.go
@@ -127,10 +127,17 @@ func NewBridgeResponse(bridge *bridgesync.Bridge, networkID uint32,
 		globalIndex = bridgesync.GenerateGlobalIndexForNetworkID(networkID, bridge.DepositCount)
 	}
 
+	// Convert FromAddress to pointer if not nil
+	var fromAddr *bridgetypes.Address
+	if bridge.FromAddress != nil {
+		addr := bridgetypes.Address(bridge.FromAddress.Hex())
+		fromAddr = &addr
+	}
+
 	return &bridgetypes.BridgeResponse{
 		BlockNum:           bridge.BlockNum,
 		BlockPos:           bridge.BlockPos,
-		FromAddress:        bridgetypes.Address(bridge.FromAddress.Hex()),
+		FromAddress:        fromAddr,
 		TxHash:             bridgetypes.Hash(bridge.TxHash.Hex()),
 		GlobalIndex:        globalIndex,
 		BlockTimestamp:     bridge.BlockTimestamp,

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -160,15 +160,27 @@ type TxnSenderResult struct {
 	Error  error
 }
 
+// missingFieldsCondition returns the SQL condition for records that still need backfilling.
+// When syncFromInBridges is false, from_address will intentionally remain NULL for asset events
+// sent through a router contract, so we only require txn_sender to be filled.
+// When syncFromInBridges is true, both txn_sender and from_address must be present.
+func (b *BackfillTxnSender) missingFieldsCondition() string {
+	if b.syncFromInBridges {
+		return "txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL"
+	}
+	return "txn_sender = '' OR txn_sender IS NULL"
+}
+
 // getRecordsNeedingBackfillCount returns the count of records that need txn_sender backfilling
 func (b *BackfillTxnSender) getRecordsNeedingBackfillCount(ctx context.Context, tableName string) (int, error) {
+	missingFieldsCond := b.missingFieldsCondition()
 	//nolint:gosec
 	query := fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM %s
-		WHERE (txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL)
+		WHERE (%s)
 		AND (source IS NULL OR (source != $1 AND source != $2))
-	`, tableName)
+	`, tableName, missingFieldsCond)
 
 	var count int
 	dbCtx, cancel := context.WithTimeout(ctx, b.dbTimeout)
@@ -189,14 +201,15 @@ func (b *BackfillTxnSender) getRecordsNeedingBackfill(
 	tableName string,
 	limit int,
 ) ([]RecordToBackfill, error) {
+	missingFieldsCond := b.missingFieldsCondition()
 	//nolint:gosec
 	query := fmt.Sprintf(`
 		SELECT *
 		FROM %s
-		WHERE (txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL)
+		WHERE (%s)
 		AND (source IS NULL OR (source != $1 AND source != $2))
 		LIMIT $3
-	`, tableName)
+	`, tableName, missingFieldsCond)
 
 	dbCtx, cancel := context.WithTimeout(ctx, b.dbTimeout)
 	defer cancel()

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -141,7 +141,7 @@ type RecordUpdate struct {
 	BlockNum  uint64
 	BlockPos  uint64
 	TxnSender common.Address
-	FromAddr  common.Address
+	FromAddr  *common.Address // nil means not available (e.g. syncFromInBridges=false for asset events)
 }
 
 func (r *RecordUpdate) String() string {
@@ -337,18 +337,15 @@ func (b *BackfillTxnSender) worker(
 // extractData extracts the transaction txn_sender and from_address
 func (b *BackfillTxnSender) extractData(ctx context.Context,
 	txHash common.Hash,
-	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) (txnSender common.Address, fromAddr common.Address, err error) {
+	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) (txnSender common.Address, fromAddr *common.Address, err error) {
 	// Check if context is cancelled before making network call
 	select {
 	case <-ctx.Done():
-		return common.Address{}, common.Address{}, ctx.Err()
+		return common.Address{}, nil, ctx.Err()
 	default:
 	}
-	txnSender, fromAddrPtr, _, err := ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash,
+	txnSender, fromAddr, _, err = ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash,
 		logEvent, b.log, b.syncFromInBridges)
-	if fromAddrPtr != nil {
-		fromAddr = *fromAddrPtr
-	}
 	return txnSender, fromAddr, err
 }
 
@@ -380,7 +377,7 @@ func (b *BackfillTxnSender) bulkUpdate(
 		}
 	}()
 
-	stmt, err := tx.PrepareContext(dbCtx, fmt.Sprintf(`
+	stmtWithFrom, err := tx.PrepareContext(dbCtx, fmt.Sprintf(`
 		UPDATE %s
 		SET
 			txn_sender = COALESCE(NULLIF(txn_sender, ''), ?),
@@ -388,15 +385,32 @@ func (b *BackfillTxnSender) bulkUpdate(
 		WHERE block_num = ? AND block_pos = ?;
 	`, tableName))
 	if err != nil {
-		return fmt.Errorf("failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement (with from_address): %w", err)
 	}
-	defer stmt.Close()
+	defer stmtWithFrom.Close()
+
+	stmtWithoutFrom, err := tx.PrepareContext(dbCtx, fmt.Sprintf(`
+		UPDATE %s
+		SET txn_sender = COALESCE(NULLIF(txn_sender, ''), ?)
+		WHERE block_num = ? AND block_pos = ?;
+	`, tableName))
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement (without from_address): %w", err)
+	}
+	defer stmtWithoutFrom.Close()
 
 	for _, update := range updates {
-		_, err := stmt.ExecContext(dbCtx, update.TxnSender.Hex(), update.FromAddr.Hex(), update.BlockNum, update.BlockPos)
-		if err != nil {
+		var execErr error
+		if update.FromAddr != nil {
+			_, execErr = stmtWithFrom.ExecContext(dbCtx,
+				update.TxnSender.Hex(), update.FromAddr.Hex(), update.BlockNum, update.BlockPos)
+		} else {
+			_, execErr = stmtWithoutFrom.ExecContext(dbCtx,
+				update.TxnSender.Hex(), update.BlockNum, update.BlockPos)
+		}
+		if execErr != nil {
 			return fmt.Errorf("failed to execute update for block %d pos %d: %w",
-				update.BlockNum, update.BlockPos, err)
+				update.BlockNum, update.BlockPos, execErr)
 		}
 	}
 

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -75,7 +75,7 @@ func (b *BackfillTxnSender) BackfillAll(ctx context.Context) error {
 //
 //nolint:unparam // tableName is kept for future extensibility
 func (b *BackfillTxnSender) backfillTable(ctx context.Context, tableName string) error {
-	b.log.Infof("Starting backfill for %s table", tableName)
+	b.log.Infof("Starting backfill for %s table, syncFromInBridges: %v", tableName, b.syncFromInBridges)
 
 	// Get total count of records that need backfilling
 	totalCount, err := b.getRecordsNeedingBackfillCount(ctx, tableName)

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -27,11 +27,12 @@ const (
 
 // BackfillTxnSender handles the backfilling of txn_sender field for bridge records
 type BackfillTxnSender struct {
-	db         *sql.DB
-	log        *log.Logger
-	client     types.EthClienter
-	bridgeAddr common.Address
-	dbTimeout  time.Duration
+	db                *sql.DB
+	log               *log.Logger
+	client            types.EthClienter
+	bridgeAddr        common.Address
+	dbTimeout         time.Duration
+	syncFromInBridges bool
 }
 
 // NewBackfillTxnSender creates a new instance of BackfillTxnSender
@@ -39,6 +40,7 @@ func NewBackfillTxnSender(
 	dbPath string,
 	client types.EthClienter,
 	bridgeAddr common.Address,
+	syncFromInBridges bool,
 	logger *log.Logger,
 ) (*BackfillTxnSender, error) {
 	database, err := db.NewSQLiteDB(dbPath)
@@ -47,11 +49,12 @@ func NewBackfillTxnSender(
 	}
 
 	return &BackfillTxnSender{
-		db:         database,
-		log:        logger,
-		client:     client,
-		bridgeAddr: bridgeAddr,
-		dbTimeout:  dbTimeout,
+		db:                database,
+		log:               logger,
+		client:            client,
+		bridgeAddr:        bridgeAddr,
+		dbTimeout:         dbTimeout,
+		syncFromInBridges: syncFromInBridges,
 	}, nil
 }
 
@@ -341,7 +344,8 @@ func (b *BackfillTxnSender) extractData(ctx context.Context,
 		return common.Address{}, common.Address{}, ctx.Err()
 	default:
 	}
-	txnSender, fromAddr, _, err = ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash, logEvent, b.log)
+	txnSender, fromAddr, _, err = ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash,
+		logEvent, b.log, b.syncFromInBridges)
 	return txnSender, fromAddr, err
 }
 

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -344,8 +344,11 @@ func (b *BackfillTxnSender) extractData(ctx context.Context,
 		return common.Address{}, common.Address{}, ctx.Err()
 	default:
 	}
-	txnSender, fromAddr, _, err = ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash,
+	txnSender, fromAddrPtr, _, err := ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash,
 		logEvent, b.log, b.syncFromInBridges)
+	if fromAddrPtr != nil {
+		fromAddr = *fromAddrPtr
+	}
 	return txnSender, fromAddr, err
 }
 

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -91,7 +91,7 @@ func TestBackfillTxnSender(t *testing.T) {
 
 	// Create backfill instance
 	logger := log.WithFields("module", "test")
-	backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+	backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 	require.NoError(t, err)
 	defer backfiller.Close()
 
@@ -121,7 +121,7 @@ func TestNewBackfillTxnSender(t *testing.T) {
 		logger := log.WithFields("module", "test")
 		bridgeAddr := common.HexToAddress("0x1234")
 
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, bridgeAddr, logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, bridgeAddr, true, logger)
 		require.NoError(t, err)
 		require.NotNil(t, backfiller)
 		require.Equal(t, bridgeAddr, backfiller.bridgeAddr)
@@ -139,7 +139,7 @@ func TestNewBackfillTxnSender(t *testing.T) {
 		logger := log.WithFields("module", "test")
 		bridgeAddr := common.HexToAddress("0x1234")
 
-		backfiller, err := NewBackfillTxnSender(invalidPath, mockClient, bridgeAddr, logger)
+		backfiller, err := NewBackfillTxnSender(invalidPath, mockClient, bridgeAddr, true, logger)
 		require.NoError(t, err) // sql.Open doesn't validate paths
 		require.NotNil(t, backfiller)
 
@@ -196,7 +196,7 @@ func TestBackfillTxnSender_BackfillAll(t *testing.T) {
 		// Create mock client
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -224,7 +224,7 @@ func TestBackfillTxnSender_BackfillAll(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -249,7 +249,7 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -298,7 +298,7 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -326,7 +326,7 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -349,7 +349,7 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -404,7 +404,7 @@ func TestBackfillTxnSender_getRecordsNeedingBackfillCount(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -499,7 +499,7 @@ func TestBackfillTxnSender_getRecordsNeedingBackfillCount(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -529,7 +529,7 @@ func TestBackfillTxnSender_getRecordsNeedingBackfillCount(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -585,7 +585,7 @@ func TestBackfillTxnSender_getRecordsNeedingBackfill(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -607,7 +607,7 @@ func TestBackfillTxnSender_getRecordsNeedingBackfill(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -631,7 +631,7 @@ func TestBackfillTxnSender_getRecordsNeedingBackfill(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -657,7 +657,7 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
@@ -689,7 +689,7 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -716,7 +716,7 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
@@ -761,7 +761,7 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -794,7 +794,7 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -851,7 +851,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -910,7 +910,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -941,7 +941,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -960,7 +960,7 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -993,7 +993,7 @@ func TestBackfillTxnSender_Close(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 
 		err = backfiller.Close()
@@ -1050,7 +1050,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1134,7 +1134,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1223,7 +1223,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1302,7 +1302,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1355,7 +1355,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1419,7 +1419,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1499,7 +1499,7 @@ func TestBackfillTxnSender_BackfillAll_WithDifferentRecordCounts(t *testing.T) {
 
 			mockClient := mocks.NewEthClienter(t)
 			logger := log.WithFields("module", "test")
-			backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+			backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 			require.NoError(t, err)
 			defer backfiller.Close()
 
@@ -1581,7 +1581,7 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1657,7 +1657,7 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 
 		mockClient := mocks.NewEthClienter(t)
 		logger := log.WithFields("module", "test")
-		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
 
@@ -1751,7 +1751,7 @@ func TestBackfillTxnSenderIntegration(t *testing.T) {
 
 	// Create backfill instance
 
-	backfiller, err := NewBackfillTxnSender(dbPath, client, common.HexToAddress("0x1234"), logger)
+	backfiller, err := NewBackfillTxnSender(dbPath, client, common.HexToAddress("0x1234"), true, logger)
 	require.NoError(t, err)
 	defer backfiller.Close()
 

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -646,6 +646,20 @@ func TestBackfillTxnSender_getRecordsNeedingBackfill(t *testing.T) {
 	})
 }
 
+func mockClientCallGetTransactionByHash(t *testing.T,
+	mockClient *mocks.EthClienter,
+	expectedTxHash common.Hash, fromAddress string, toAddress string) {
+	t.Helper()
+	mockClient.EXPECT().Call(mock.Anything, GetTransactionByHashEndpoint, mock.Anything).Run(func(result any, method string, args ...any) {
+		arg, ok := result.(*Transaction)
+		require.True(t, ok)
+		arg.FromRaw = fromAddress
+		arg.To = toAddress
+		arg.Hash = expectedTxHash.Hex()
+		arg.Input = common.Bytes2Hex(BridgeAssetMethodID)
+	}).Return(nil).Maybe()
+}
+
 func TestBackfillTxnSender_processBatch(t *testing.T) {
 	t.Run("successful processing", func(t *testing.T) {
 		tempDir := t.TempDir()
@@ -660,7 +674,11 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
@@ -692,8 +710,11 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
 		ctx := context.Background()
 		records := []RecordToBackfill{
 			{
@@ -719,13 +740,17 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
 				arg.Input = BridgeAssetMethodID
 			}).Return(nil).Maybe()
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
@@ -766,7 +791,11 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 		defer backfiller.Close()
 
 		expectedSender := common.HexToAddress(testAddress)
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
@@ -797,8 +826,11 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
 
 		txHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
 		sender, _, err := backfiller.extractData(t.Context(), txHash, &agglayerbridge.AgglayerbridgeBridgeEvent{
@@ -1053,8 +1085,11 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
@@ -1137,10 +1172,13 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
 		// Mock mixed results: first call succeeds, second fails
 
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
@@ -1150,7 +1188,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 			}).Return(nil).Once()
 
 		// Mock the second call to fail
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Once()
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Once()
 
 		records := []RecordToBackfill{
 			{
@@ -1226,9 +1264,12 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
 		// Mock all calls to fail
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
 		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("network error")).Maybe()
 
 		records := []RecordToBackfill{
@@ -1308,8 +1349,11 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		// Create a context that will be cancelled
 		cancelCtx, cancel := context.WithCancel(ctx)
-
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				time.Sleep(10 * time.Millisecond)
 				arg, ok := result.(*Call)
@@ -1422,8 +1466,11 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), true, logger)
 		require.NoError(t, err)
 		defer backfiller.Close()
-
-		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		// txReceipt To is not bridgeAddr, so must call debugTrace
+		mockClientCallGetTransactionByHash(t, mockClient,
+			common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+			testAddress, "0x0000000000000000000000000000000000000000000")
+		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -39,7 +39,7 @@ const (
 	// CurrentDBVersion represents the current version of the bridge syncer's database schema.
 	// It is used to ensure the database is reset if an upgrade requires a full resync.
 	// Increment this value whenever the database schema changes in a way that is not backward-compatible.
-	CurrentDBVersion = 2
+	CurrentDBVersion = 1
 )
 
 func (b BridgeSyncerID) String() string {

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -39,7 +39,7 @@ const (
 	// CurrentDBVersion represents the current version of the bridge syncer's database schema.
 	// It is used to ensure the database is reset if an upgrade requires a full resync.
 	// Increment this value whenever the database schema changes in a way that is not backward-compatible.
-	CurrentDBVersion = 1
+	CurrentDBVersion = 2
 )
 
 func (b BridgeSyncerID) String() string {
@@ -82,6 +82,7 @@ func NewL1(
 	rd ReorgDetector,
 	ethClient aggkittypes.EthClienter,
 	originNetwork uint32,
+	syncFromInBridges bool,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -92,6 +93,7 @@ func NewL1(
 		L1BridgeSyncer,
 		originNetwork,
 		false,
+		syncFromInBridges,
 	)
 }
 
@@ -103,6 +105,7 @@ func NewL2(
 	ethClient aggkittypes.EthClienter,
 	originNetwork uint32,
 	syncFullClaims bool,
+	syncFromInBridges bool,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -113,6 +116,7 @@ func NewL2(
 		L2BridgeSyncer,
 		originNetwork,
 		syncFullClaims,
+		syncFromInBridges,
 	)
 }
 
@@ -125,6 +129,7 @@ func newBridgeSync(
 	syncerID BridgeSyncerID,
 	networkID uint32,
 	syncFullClaims bool,
+	syncFromInBridges bool,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
 
@@ -177,7 +182,8 @@ func newBridgeSync(
 		return nil, fmt.Errorf("failed to resolve bridge deployment. Reason: %w", err)
 	}
 
-	appender, err := buildAppender(ctx, ethClient, processor, cfg.BridgeAddr, syncFullClaims, bridgeDeployment, logger)
+	appender, err := buildAppender(ctx, ethClient, processor, cfg.BridgeAddr, syncFullClaims,
+		syncFromInBridges, bridgeDeployment, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -206,9 +212,10 @@ func newBridgeSync(
 			}
 			ver := CurrentDBVersion
 			return BridgeSyncRuntimeData{
-				ChainID:   tmp.ChainID,
-				Addresses: tmp.Addresses,
-				DBVersion: &ver,
+				ChainID:           tmp.ChainID,
+				Addresses:         tmp.Addresses,
+				DBVersion:         &ver,
+				SyncFromInBridges: &syncFromInBridges,
 			}, nil
 		},
 		processor)

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -138,7 +138,7 @@ func newBridgeSync(
 		return nil, fmt.Errorf("failed to create binding for AgglayerBridge contract: %w", err)
 	}
 
-	logger.Infof("Bridge sync %s, syncing full claims: %t", syncerID.String(), syncFullClaims)
+	logger.Infof("Bridge sync %s, syncing full claims: %t, syncFromInBridges: %t", syncerID.String(), syncFullClaims, syncFromInBridges)
 
 	err = sanityCheckContract(logger, cfg.BridgeAddr, agglayerBridge)
 	if err != nil {

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -138,7 +138,8 @@ func newBridgeSync(
 		return nil, fmt.Errorf("failed to create binding for AgglayerBridge contract: %w", err)
 	}
 
-	logger.Infof("Bridge sync %s, syncing full claims: %t, syncFromInBridges: %t", syncerID.String(), syncFullClaims, syncFromInBridges)
+	logger.Infof("Bridge sync %s, syncing full claims: %t, syncFromInBridges: %t",
+		syncerID.String(), syncFullClaims, syncFromInBridges)
 
 	err = sanityCheckContract(logger, cfg.BridgeAddr, agglayerBridge)
 	if err != nil {

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testSyncFromInBridges = true
+
 func TestNewLx(t *testing.T) {
 	const (
 		syncBlockChunkSize         = uint64(100)
@@ -86,6 +88,7 @@ func TestNewLx(t *testing.T) {
 		mockReorgDetector,
 		mockEthClient,
 		originNetwork,
+		false,
 	)
 
 	require.NoError(t, err)
@@ -111,6 +114,7 @@ func TestNewLx(t *testing.T) {
 		mockEthClient,
 		originNetwork,
 		false,
+		testSyncFromInBridges,
 	)
 
 	require.NoError(t, err)
@@ -128,6 +132,7 @@ func TestNewLx(t *testing.T) {
 		mockEthClient,
 		originNetwork,
 		false,
+		testSyncFromInBridges,
 	)
 	require.Error(t, err)
 	require.Nil(t, l2BridgeSyncer)
@@ -330,6 +335,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		mockEthClient,
 		originNetwork,
 		false,
+		testSyncFromInBridges,
 	)
 	require.NoError(t, err)
 
@@ -499,6 +505,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		mockEthClient,
 		originNetwork,
 		false,
+		testSyncFromInBridges,
 	)
 	require.NoError(t, err)
 
@@ -703,6 +710,7 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 		mockEthClient,
 		originNetwork,
 		false,
+		testSyncFromInBridges,
 	)
 	require.NoError(t, err)
 
@@ -716,9 +724,12 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 	t.Run("get last root after processing bridge events", func(t *testing.T) {
 		bridgeEvents := []interface{}{
 			Event{Bridge: &Bridge{
-				BlockNum:           1,
-				BlockPos:           0,
-				FromAddress:        common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				BlockNum: 1,
+				BlockPos: 0,
+				FromAddress: func() *common.Address {
+					addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+					return &addr
+				}(),
 				TxHash:             common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
 				BlockTimestamp:     1234567890,
 				LeafType:           1,
@@ -731,9 +742,12 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 				DepositCount:       0,
 			}},
 			Event{Bridge: &Bridge{
-				BlockNum:           1,
-				BlockPos:           1,
-				FromAddress:        common.HexToAddress("0x5555555555555555555555555555555555555555"),
+				BlockNum: 1,
+				BlockPos: 1,
+				FromAddress: func() *common.Address {
+					addr := common.HexToAddress("0x5555555555555555555555555555555555555555")
+					return &addr
+				}(),
 				TxHash:             common.HexToHash("0x6666666666666666666666666666666666666666666666666666666666666666"),
 				BlockTimestamp:     1234567890,
 				LeafType:           1,
@@ -776,9 +790,12 @@ func TestBridgeSync_GetLastRoot(t *testing.T) {
 
 		bridgeEvents := []interface{}{
 			Event{Bridge: &Bridge{
-				BlockNum:           2,
-				BlockPos:           0,
-				FromAddress:        common.HexToAddress("0x9999999999999999999999999999999999999999"),
+				BlockNum: 2,
+				BlockPos: 0,
+				FromAddress: func() *common.Address {
+					addr := common.HexToAddress("0x9999999999999999999999999999999999999999")
+					return &addr
+				}(),
 				TxHash:             common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 				BlockTimestamp:     1234567891,
 				LeafType:           1,
@@ -874,6 +891,7 @@ func TestBridgeSync_SubscribeToSync(t *testing.T) {
 		mockEthClient,
 		originNetwork,
 		false,
+		testSyncFromInBridges,
 	)
 	require.NoError(t, err)
 

--- a/bridgesync/config.go
+++ b/bridgesync/config.go
@@ -2,11 +2,61 @@ package bridgesync
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/agglayer/aggkit/config/types"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+// SyncFromInBridgesMode represents the mode for FromAddress extraction
+type SyncFromInBridgesMode string
+
+const (
+	// SyncFromInBridgesTrue always extracts FromAddress using debug_traceTransaction
+	SyncFromInBridgesTrue SyncFromInBridgesMode = "true"
+	// SyncFromInBridgesFalse never extracts FromAddress
+	SyncFromInBridgesFalse SyncFromInBridgesMode = "false"
+	// SyncFromInBridgesAuto decides automatically based on whether BRIDGE component is active
+	SyncFromInBridgesAuto SyncFromInBridgesMode = "auto"
+)
+
+// UnmarshalText implements encoding.TextUnmarshaler
+func (m *SyncFromInBridgesMode) UnmarshalText(text []byte) error {
+	str := strings.ToLower(strings.TrimSpace(string(text)))
+	switch str {
+	case "true":
+		*m = SyncFromInBridgesTrue
+	case "false":
+		*m = SyncFromInBridgesFalse
+	case "auto":
+		*m = SyncFromInBridgesAuto
+	default:
+		return fmt.Errorf("invalid SyncFromInBridgesMode: %s (valid values: true, false, auto)", str)
+	}
+	return nil
+}
+
+// String returns the string representation
+func (m SyncFromInBridgesMode) String() string {
+	return string(m)
+}
+
+// Resolve converts the mode to a boolean, using the provided components list to resolve "auto"
+func (m SyncFromInBridgesMode) Resolve(hasBridgeComponent bool) bool {
+	switch m {
+	case SyncFromInBridgesTrue:
+		return true
+	case SyncFromInBridgesFalse:
+		return false
+	case SyncFromInBridgesAuto:
+		// If BRIDGE component is active, we need FromAddress extraction
+		return hasBridgeComponent
+	default:
+		// Default to false
+		return false
+	}
+}
 
 type Config struct {
 	// DBPath path of the DB
@@ -33,6 +83,14 @@ type Config struct {
 	// DBQueryTimeout is the timeout for database operations (queries, transactions)
 	// This is separate from HTTP timeouts to allow database operations more time when needed
 	DBQueryTimeout types.Duration `mapstructure:"DBQueryTimeout"`
+	// SyncFromInBridges controls whether to extract FromAddress for bridge Asset events.
+	// Possible values:
+	//   - "true": always extracts FromAddress using debug_traceTransaction (requires archive node)
+	//   - "false": never extracts FromAddress (no archive node needed)
+	//   - "auto": automatically decides based on whether BRIDGE component is active
+	// Note: TxnSender and ToAddress are always extracted via standard eth_getTransactionByHash.
+	// Default: "auto"
+	SyncFromInBridges SyncFromInBridgesMode `mapstructure:"SyncFromInBridges"`
 }
 
 // Validate checks if the configuration is valid

--- a/bridgesync/config.go
+++ b/bridgesync/config.go
@@ -98,5 +98,12 @@ func (c Config) Validate() error {
 	if err := c.BlockFinality.Validate(); err != nil {
 		return fmt.Errorf("invalid BlockFinality configuration: %w", err)
 	}
+	// Validate SyncFromInBridges
+	switch c.SyncFromInBridges {
+	case SyncFromInBridgesTrue, SyncFromInBridgesFalse, SyncFromInBridgesAuto, "":
+		// Valid values, including empty (will use default)
+	default:
+		return fmt.Errorf("invalid SyncFromInBridges value: %s (valid values: true, false, auto)", c.SyncFromInBridges)
+	}
 	return nil
 }

--- a/bridgesync/config_test.go
+++ b/bridgesync/config_test.go
@@ -7,6 +7,245 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSyncFromInBridgesMode_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      SyncFromInBridgesMode
+		expectedError string
+	}{
+		{
+			name:          "true lowercase",
+			input:         "true",
+			expected:      SyncFromInBridgesTrue,
+			expectedError: "",
+		},
+		{
+			name:          "true uppercase",
+			input:         "TRUE",
+			expected:      SyncFromInBridgesTrue,
+			expectedError: "",
+		},
+		{
+			name:          "true mixed case",
+			input:         "TrUe",
+			expected:      SyncFromInBridgesTrue,
+			expectedError: "",
+		},
+		{
+			name:          "true with whitespace",
+			input:         "  true  ",
+			expected:      SyncFromInBridgesTrue,
+			expectedError: "",
+		},
+		{
+			name:          "false lowercase",
+			input:         "false",
+			expected:      SyncFromInBridgesFalse,
+			expectedError: "",
+		},
+		{
+			name:          "false uppercase",
+			input:         "FALSE",
+			expected:      SyncFromInBridgesFalse,
+			expectedError: "",
+		},
+		{
+			name:          "false mixed case",
+			input:         "FaLsE",
+			expected:      SyncFromInBridgesFalse,
+			expectedError: "",
+		},
+		{
+			name:          "false with whitespace",
+			input:         "  false  ",
+			expected:      SyncFromInBridgesFalse,
+			expectedError: "",
+		},
+		{
+			name:          "auto lowercase",
+			input:         "auto",
+			expected:      SyncFromInBridgesAuto,
+			expectedError: "",
+		},
+		{
+			name:          "auto uppercase",
+			input:         "AUTO",
+			expected:      SyncFromInBridgesAuto,
+			expectedError: "",
+		},
+		{
+			name:          "auto mixed case",
+			input:         "AuTo",
+			expected:      SyncFromInBridgesAuto,
+			expectedError: "",
+		},
+		{
+			name:          "auto with whitespace",
+			input:         "  auto  ",
+			expected:      SyncFromInBridgesAuto,
+			expectedError: "",
+		},
+		{
+			name:          "invalid value",
+			input:         "invalid",
+			expected:      "",
+			expectedError: "invalid SyncFromInBridgesMode: invalid (valid values: true, false, auto)",
+		},
+		{
+			name:          "empty string",
+			input:         "",
+			expected:      "",
+			expectedError: "invalid SyncFromInBridgesMode:  (valid values: true, false, auto)",
+		},
+		{
+			name:          "numeric value",
+			input:         "1",
+			expected:      "",
+			expectedError: "invalid SyncFromInBridgesMode: 1 (valid values: true, false, auto)",
+		},
+		{
+			name:          "yes value",
+			input:         "yes",
+			expected:      "",
+			expectedError: "invalid SyncFromInBridgesMode: yes (valid values: true, false, auto)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mode SyncFromInBridgesMode
+			err := mode.UnmarshalText([]byte(tt.input))
+
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, mode)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestSyncFromInBridgesMode_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     SyncFromInBridgesMode
+		expected string
+	}{
+		{
+			name:     "true mode",
+			mode:     SyncFromInBridgesTrue,
+			expected: "true",
+		},
+		{
+			name:     "false mode",
+			mode:     SyncFromInBridgesFalse,
+			expected: "false",
+		},
+		{
+			name:     "auto mode",
+			mode:     SyncFromInBridgesAuto,
+			expected: "auto",
+		},
+		{
+			name:     "empty mode",
+			mode:     SyncFromInBridgesMode(""),
+			expected: "",
+		},
+		{
+			name:     "invalid mode",
+			mode:     SyncFromInBridgesMode("invalid"),
+			expected: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mode.String()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSyncFromInBridgesMode_Resolve(t *testing.T) {
+	tests := []struct {
+		name               string
+		mode               SyncFromInBridgesMode
+		hasBridgeComponent bool
+		expected           bool
+	}{
+		{
+			name:               "true mode with bridge component",
+			mode:               SyncFromInBridgesTrue,
+			hasBridgeComponent: true,
+			expected:           true,
+		},
+		{
+			name:               "true mode without bridge component",
+			mode:               SyncFromInBridgesTrue,
+			hasBridgeComponent: false,
+			expected:           true,
+		},
+		{
+			name:               "false mode with bridge component",
+			mode:               SyncFromInBridgesFalse,
+			hasBridgeComponent: true,
+			expected:           false,
+		},
+		{
+			name:               "false mode without bridge component",
+			mode:               SyncFromInBridgesFalse,
+			hasBridgeComponent: false,
+			expected:           false,
+		},
+		{
+			name:               "auto mode with bridge component",
+			mode:               SyncFromInBridgesAuto,
+			hasBridgeComponent: true,
+			expected:           true,
+		},
+		{
+			name:               "auto mode without bridge component",
+			mode:               SyncFromInBridgesAuto,
+			hasBridgeComponent: false,
+			expected:           false,
+		},
+		{
+			name:               "invalid mode with bridge component",
+			mode:               SyncFromInBridgesMode("invalid"),
+			hasBridgeComponent: true,
+			expected:           false,
+		},
+		{
+			name:               "invalid mode without bridge component",
+			mode:               SyncFromInBridgesMode("invalid"),
+			hasBridgeComponent: false,
+			expected:           false,
+		},
+		{
+			name:               "empty mode with bridge component",
+			mode:               SyncFromInBridgesMode(""),
+			hasBridgeComponent: true,
+			expected:           false,
+		},
+		{
+			name:               "empty mode without bridge component",
+			mode:               SyncFromInBridgesMode(""),
+			hasBridgeComponent: false,
+			expected:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mode.Resolve(tt.hasBridgeComponent)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -21,6 +260,38 @@ func TestConfig_Validate(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name: "valid config with SyncFromInBridges true",
+			config: Config{
+				BlockFinality:     aggkittypes.SafeBlock,
+				SyncFromInBridges: SyncFromInBridgesTrue,
+			},
+			expectedError: "",
+		},
+		{
+			name: "valid config with SyncFromInBridges false",
+			config: Config{
+				BlockFinality:     aggkittypes.SafeBlock,
+				SyncFromInBridges: SyncFromInBridgesFalse,
+			},
+			expectedError: "",
+		},
+		{
+			name: "valid config with SyncFromInBridges auto",
+			config: Config{
+				BlockFinality:     aggkittypes.SafeBlock,
+				SyncFromInBridges: SyncFromInBridgesAuto,
+			},
+			expectedError: "",
+		},
+		{
+			name: "valid config with empty SyncFromInBridges",
+			config: Config{
+				BlockFinality:     aggkittypes.SafeBlock,
+				SyncFromInBridges: "",
+			},
+			expectedError: "",
+		},
+		{
 			name: "invalid config with invalid BlockFinality",
 			config: Config{
 				BlockFinality: aggkittypes.BlockNumberFinality{
@@ -29,6 +300,22 @@ func TestConfig_Validate(t *testing.T) {
 				},
 			},
 			expectedError: "invalid BlockFinality configuration:",
+		},
+		{
+			name: "invalid config with invalid SyncFromInBridges",
+			config: Config{
+				BlockFinality:     aggkittypes.SafeBlock,
+				SyncFromInBridges: "invalid_value",
+			},
+			expectedError: "invalid SyncFromInBridges value:",
+		},
+		{
+			name: "invalid config with numeric SyncFromInBridges",
+			config: Config{
+				BlockFinality:     aggkittypes.SafeBlock,
+				SyncFromInBridges: "123",
+			},
+			expectedError: "invalid SyncFromInBridges value:",
 		},
 	}
 

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -226,6 +226,11 @@ func ExtractTxnAddresses(ctx context.Context,
 				txHash.Hex(), err)
 	}
 
+	// If extraction returned zero address, treat as nil (NULL in database)
+	if fromAddrValue == (common.Address{}) {
+		return txnSender, nil, toAddr, nil
+	}
+
 	return txnSender, &fromAddrValue, toAddr, nil
 }
 

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -71,9 +71,10 @@ var (
 )
 
 const (
-	// debugTraceTxEndpoint is the name of the debug method used to trace a transaction.
-	debugTraceTxEndpoint = "debug_traceTransaction"
-
+	// DebugTraceTxEndpoint is the name of the debug method used to trace a transaction.
+	DebugTraceTxEndpoint = "debug_traceTransaction"
+	//GetTransactionByHashEndpoint is the name of the method used to get transaction details by hash.
+	GetTransactionByHashEndpoint = "eth_getTransactionByHash"
 	// callTracerType is the name of the call tracer
 	callTracerType = "callTracer"
 
@@ -160,7 +161,7 @@ func RPCTransactionByHash(client aggkittypes.EthClienter,
 	txHash common.Hash) (*Transaction, error) {
 	// Use client.Call to fetch transaction details using eth_getTransactionByHash
 	var tx Transaction
-	err := client.Call(&tx, "eth_getTransactionByHash", txHash.Hex())
+	err := client.Call(&tx, GetTransactionByHashEndpoint, txHash.Hex())
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch transaction by hash: %w", err)
 	}
@@ -799,7 +800,7 @@ func findCall(rootCall Call, targetAddr common.Address, callback func(Call) (boo
 // extractRootCall extracts the root call for a transaction using debug_traceTransaction.
 func extractRootCall(client aggkittypes.RPCClienter, contractAddr common.Address, txHash common.Hash) (*Call, error) {
 	rootCall := &Call{To: contractAddr}
-	err := client.Call(rootCall, debugTraceTxEndpoint, txHash, tracerCfg{Tracer: callTracerType})
+	err := client.Call(rootCall, DebugTraceTxEndpoint, txHash, tracerCfg{Tracer: callTracerType})
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -177,28 +177,29 @@ func ExtractTxnAddresses(ctx context.Context,
 	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent,
 	logger *logger.Logger,
 	syncFromInBridges bool) (txnSender common.Address, fromAddr *common.Address, toAddr common.Address, err error) {
+	tx, err := RPCTransactionByHash(client, txHash)
+	if err != nil {
+		return common.Address{}, nil, common.Address{},
+			fmt.Errorf("extractTxnAddresses: failed to extract txn sender from tx_hash:%s: %w", txHash.Hex(), err)
+	}
 	// For Message events, FromAddress comes from OriginAddress (no tracing needed)
 	if logEvent.LeafType == bridgeLeafTypeMessage {
-		tx, err := RPCTransactionByHash(client, txHash)
-		if err != nil {
-			return common.Address{}, nil, common.Address{},
-				fmt.Errorf("extractTxnAddresses: failed to extract txn sender from tx_hash:%s: %w", txHash.Hex(), err)
-		}
 		txnSender = tx.From()
 		toAddr = tx.ToAddress()
 		originAddr := logEvent.OriginAddress
 		return txnSender, &originAddr, toAddr, nil
 	}
+	// This is a improvement: if the tx is directely sent to the bridge
+	// we use the txSender as the from address without doing the expensive debug_traceTransaction,
+	if tx.ToAddress() == bridgeAddr {
+		txnSender = tx.From()
+		toAddr = tx.ToAddress()
+		return txnSender, &txnSender, toAddr, nil
+	}
 
 	// FromAddress extraction for Asset events requires debug_traceTransaction
 	if !syncFromInBridges {
 		// Skip expensive extraction - leave FromAddress as nil (will be stored as NULL)
-		// For this case, get TxnSender and ToAddress from standard RPC
-		tx, err := RPCTransactionByHash(client, txHash)
-		if err != nil {
-			return common.Address{}, nil, common.Address{},
-				fmt.Errorf("extractTxnAddresses: failed to extract txn info from tx_hash:%s: %w", txHash.Hex(), err)
-		}
 		txnSender = tx.From()
 		toAddr = tx.ToAddress()
 		logger.Debugf("Skipping FromAddress extraction for tx %s (SyncFromInBridges=false)", txHash.Hex())

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -73,7 +73,7 @@ var (
 const (
 	// DebugTraceTxEndpoint is the name of the debug method used to trace a transaction.
 	DebugTraceTxEndpoint = "debug_traceTransaction"
-	//GetTransactionByHashEndpoint is the name of the method used to get transaction details by hash.
+	// GetTransactionByHashEndpoint is the name of the method used to get transaction details by hash.
 	GetTransactionByHashEndpoint = "eth_getTransactionByHash"
 	// callTracerType is the name of the call tracer
 	callTracerType = "callTracer"

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -176,54 +176,57 @@ func ExtractTxnAddresses(ctx context.Context,
 	txHash common.Hash,
 	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent,
 	logger *logger.Logger,
-	syncFromInBridges bool) (txnSender common.Address, fromAddr common.Address, toAddr common.Address, err error) {
+	syncFromInBridges bool) (txnSender common.Address, fromAddr *common.Address, toAddr common.Address, err error) {
 	// For Message events, FromAddress comes from OriginAddress (no tracing needed)
 	if logEvent.LeafType == bridgeLeafTypeMessage {
 		tx, err := RPCTransactionByHash(client, txHash)
 		if err != nil {
-			return common.Address{}, common.Address{}, common.Address{},
+			return common.Address{}, nil, common.Address{},
 				fmt.Errorf("extractTxnAddresses: failed to extract txn sender from tx_hash:%s: %w", txHash.Hex(), err)
 		}
 		txnSender = tx.From()
 		toAddr = tx.ToAddress()
-		return txnSender, logEvent.OriginAddress, toAddr, nil
+		originAddr := logEvent.OriginAddress
+		return txnSender, &originAddr, toAddr, nil
 	}
-
-	// For Asset events, we can always get TxnSender and ToAddress from standard RPC
-	tx, err := RPCTransactionByHash(client, txHash)
-	if err != nil {
-		return common.Address{}, common.Address{}, common.Address{},
-			fmt.Errorf("extractTxnAddresses: failed to extract txn info from tx_hash:%s: %w", txHash.Hex(), err)
-	}
-	txnSender = tx.From()
-	toAddr = tx.ToAddress()
 
 	// FromAddress extraction for Asset events requires debug_traceTransaction
 	if !syncFromInBridges {
-		// Skip expensive extraction - leave FromAddress as zero (will be stored as NULL)
+		// Skip expensive extraction - leave FromAddress as nil (will be stored as NULL)
+		// For this case, get TxnSender and ToAddress from standard RPC
+		tx, err := RPCTransactionByHash(client, txHash)
+		if err != nil {
+			return common.Address{}, nil, common.Address{},
+				fmt.Errorf("extractTxnAddresses: failed to extract txn info from tx_hash:%s: %w", txHash.Hex(), err)
+		}
+		txnSender = tx.From()
+		toAddr = tx.ToAddress()
 		logger.Debugf("Skipping FromAddress extraction for tx %s (SyncFromInBridges=false)", txHash.Hex())
-		return txnSender, common.Address{}, toAddr, nil
+		return txnSender, nil, toAddr, nil
 	}
 
 	// Extract FromAddress via debug_traceTransaction for Asset events
-	foundCalls, _, err := extractCallData(client, bridgeAddr, txHash, logger, func(c Call) (bool, error) {
+	// When syncFromInBridges==true, use the original behavior (get txnSender and toAddr from rootCall)
+	foundCalls, rootCall, err := extractCallData(client, bridgeAddr, txHash, logger, func(c Call) (bool, error) {
 		if logEvent.LeafType == bridgeLeafTypeAsset {
 			return bytes.HasPrefix(c.Input, BridgeAssetMethodID), nil
 		}
 		return false, nil
 	})
 	if err != nil {
-		return common.Address{}, common.Address{}, common.Address{},
+		return common.Address{}, nil, common.Address{},
 			fmt.Errorf("extractTxnAddresses:failed to extract bridge event data (tx hash: %s): %w", txHash, err)
 	}
-	fromAddr, err = ExtractFromAddrFromCalls(foundCalls, logEvent)
+	txnSender = rootCall.From
+	toAddr = rootCall.To
+	fromAddrValue, err := ExtractFromAddrFromCalls(foundCalls, logEvent)
 	if err != nil {
-		return common.Address{}, common.Address{}, common.Address{},
+		return common.Address{}, nil, common.Address{},
 			fmt.Errorf("extractTxnAddresses: failed to extract fromAddr from tx_hash:%s calls: %w",
 				txHash.Hex(), err)
 	}
 
-	return txnSender, fromAddr, toAddr, nil
+	return txnSender, &fromAddrValue, toAddr, nil
 }
 
 type bridgeCallParams struct {
@@ -390,16 +393,10 @@ func buildBridgeEventHandler(
 			return fmt.Errorf("failed to extract bridge event data (tx hash: %s): %w", l.TxHash, err)
 		}
 
-		// Convert fromAddress to pointer for nullable field
-		var fromAddrPtr *common.Address
-		if fromAddress != (common.Address{}) {
-			fromAddrPtr = &fromAddress
-		}
-
 		b.Events = append(b.Events, Event{Bridge: &Bridge{
 			BlockNum:           b.Num,
 			BlockPos:           uint64(l.Index),
-			FromAddress:        fromAddrPtr,
+			FromAddress:        fromAddress,
 			TxHash:             l.TxHash,
 			BlockTimestamp:     b.Timestamp,
 			LeafType:           bridgeEvent.LeafType,

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -90,6 +90,7 @@ func buildAppender(
 	querier BridgeQuerier,
 	bridgeAddr common.Address,
 	syncFullClaims bool,
+	syncFromInBridges bool,
 	bridgeDeployment *bridgeDeployment,
 	logger *logger.Logger,
 ) (sync.LogAppenderMap, error) {
@@ -102,7 +103,7 @@ func buildAppender(
 
 	// Add event handlers for the bridge contract
 	appender[bridgeEventSignature] = buildBridgeEventHandler(
-		ctx, bridgeDeployment.agglayerBridge, bridgeAddr, client, logger)
+		ctx, bridgeDeployment.agglayerBridge, bridgeAddr, client, syncFromInBridges, logger)
 	appender[claimEventSignaturePreEtrog] = buildClaimEventHandlerPreEtrog(
 		legacyBridge, client, bridgeAddr, syncFullClaims, logger)
 	appender[claimEventSignature] = buildClaimEventHandler(ctx, bridgeDeployment.agglayerBridge, client, querier,
@@ -166,16 +167,17 @@ func RPCTransactionByHash(client aggkittypes.EthClienter,
 	return &tx, nil
 }
 
-// ExtractTxnAddresses extracts the txn_sender, from address, and to address from the transaction trace.
+// ExtractTxnAddresses extracts the txn_sender, from address, and to address.
+// When syncFromInBridges is false, only extracts txnSender and toAddr using standard RPC,
+// and returns zero address for fromAddr (avoids expensive debug_traceTransaction).
 func ExtractTxnAddresses(ctx context.Context,
 	client aggkittypes.EthClienter,
 	bridgeAddr common.Address,
 	txHash common.Hash,
 	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent,
-	logger *logger.Logger) (txnSender common.Address, fromAddr common.Address, toAddr common.Address, err error) {
-	// If event is a message, fromAddr is log.origin_address
-	// so we only need the txn_sender that can be obtained from hash_receipt
-	// and toAddr from the transaction receipt (same source as txn_sender)
+	logger *logger.Logger,
+	syncFromInBridges bool) (txnSender common.Address, fromAddr common.Address, toAddr common.Address, err error) {
+	// For Message events, FromAddress comes from OriginAddress (no tracing needed)
 	if logEvent.LeafType == bridgeLeafTypeMessage {
 		tx, err := RPCTransactionByHash(client, txHash)
 		if err != nil {
@@ -186,7 +188,25 @@ func ExtractTxnAddresses(ctx context.Context,
 		toAddr = tx.ToAddress()
 		return txnSender, logEvent.OriginAddress, toAddr, nil
 	}
-	foundCalls, rootCall, err := extractCallData(client, bridgeAddr, txHash, logger, func(c Call) (bool, error) {
+
+	// For Asset events, we can always get TxnSender and ToAddress from standard RPC
+	tx, err := RPCTransactionByHash(client, txHash)
+	if err != nil {
+		return common.Address{}, common.Address{}, common.Address{},
+			fmt.Errorf("extractTxnAddresses: failed to extract txn info from tx_hash:%s: %w", txHash.Hex(), err)
+	}
+	txnSender = tx.From()
+	toAddr = tx.ToAddress()
+
+	// FromAddress extraction for Asset events requires debug_traceTransaction
+	if !syncFromInBridges {
+		// Skip expensive extraction - leave FromAddress as zero (will be stored as NULL)
+		logger.Debugf("Skipping FromAddress extraction for tx %s (SyncFromInBridges=false)", txHash.Hex())
+		return txnSender, common.Address{}, toAddr, nil
+	}
+
+	// Extract FromAddress via debug_traceTransaction for Asset events
+	foundCalls, _, err := extractCallData(client, bridgeAddr, txHash, logger, func(c Call) (bool, error) {
 		if logEvent.LeafType == bridgeLeafTypeAsset {
 			return bytes.HasPrefix(c.Input, BridgeAssetMethodID), nil
 		}
@@ -196,8 +216,6 @@ func ExtractTxnAddresses(ctx context.Context,
 		return common.Address{}, common.Address{}, common.Address{},
 			fmt.Errorf("extractTxnAddresses:failed to extract bridge event data (tx hash: %s): %w", txHash, err)
 	}
-	txnSender = rootCall.From
-	toAddr = rootCall.To
 	fromAddr, err = ExtractFromAddrFromCalls(foundCalls, logEvent)
 	if err != nil {
 		return common.Address{}, common.Address{}, common.Address{},
@@ -353,6 +371,7 @@ func buildBridgeEventHandler(
 	contract *agglayerbridge.Agglayerbridge,
 	bridgeAddr common.Address,
 	client aggkittypes.EthClienter,
+	syncFromInBridges bool,
 	logger *logger.Logger,
 ) func(*sync.EVMBlock, types.Log) error {
 	return func(b *sync.EVMBlock, l types.Log) error {
@@ -364,16 +383,23 @@ func buildBridgeEventHandler(
 			"DestinationNetwork: %d, DestinationAddress: %s, DepositCount: %d, Amount: %s, ",
 			bridgeEvent.LeafType, bridgeEvent.OriginNetwork, bridgeEvent.OriginAddress.Hex(), bridgeEvent.DestinationNetwork,
 			bridgeEvent.DestinationAddress.Hex(), bridgeEvent.DepositCount, bridgeEvent.Amount.String())
+
 		txnSender, fromAddress, toAddress, err := ExtractTxnAddresses(ctx, client, bridgeAddr, l.TxHash,
-			bridgeEvent, logger)
+			bridgeEvent, logger, syncFromInBridges)
 		if err != nil {
 			return fmt.Errorf("failed to extract bridge event data (tx hash: %s): %w", l.TxHash, err)
+		}
+
+		// Convert fromAddress to pointer for nullable field
+		var fromAddrPtr *common.Address
+		if fromAddress != (common.Address{}) {
+			fromAddrPtr = &fromAddress
 		}
 
 		b.Events = append(b.Events, Event{Bridge: &Bridge{
 			BlockNum:           b.Num,
 			BlockPos:           uint64(l.Index),
-			FromAddress:        fromAddress,
+			FromAddress:        fromAddrPtr,
 			TxHash:             l.TxHash,
 			BlockTimestamp:     b.Timestamp,
 			LeafType:           bridgeEvent.LeafType,

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -1158,6 +1158,11 @@ func TestExtractTxnAddresses(t *testing.T) {
 	bridgeAddr := common.HexToAddress("0x10")
 	txHash := common.HexToHash("0xabcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcd")
 
+	// Helper function to create address pointers
+	addrPtr := func(addr common.Address) *common.Address {
+		return &addr
+	}
+
 	tests := []struct {
 		name                         string
 		logEvent                     *agglayerbridge.AgglayerbridgeBridgeEvent
@@ -1166,7 +1171,7 @@ func TestExtractTxnAddresses(t *testing.T) {
 		responseTransactionHash      *Transaction
 		responseTransactionHashError error
 		expectedTxnSender            common.Address
-		expectedFrom                 common.Address
+		expectedFrom                 *common.Address
 		expectedTo                   common.Address
 		expectErr                    string
 	}{
@@ -1195,7 +1200,7 @@ func TestExtractTxnAddresses(t *testing.T) {
 				To:      "0x2222222222222222222222222222222222222222",
 			},
 			expectedTxnSender: common.HexToAddress("0x1111111111111111111111111111111111111111"),
-			expectedFrom:      common.HexToAddress("0x40"),
+			expectedFrom:      addrPtr(common.HexToAddress("0x40")),
 			expectedTo:        common.HexToAddress("0x2222222222222222222222222222222222222222"),
 		},
 		{
@@ -1243,7 +1248,7 @@ func TestExtractTxnAddresses(t *testing.T) {
 				},
 			},
 			expectedTxnSender: common.HexToAddress("0x3333333333333333333333333333333333333333"),
-			expectedFrom:      common.HexToAddress("0x50"),
+			expectedFrom:      addrPtr(common.HexToAddress("0x50")),
 			expectedTo:        common.HexToAddress("0x4444444444444444444444444444444444444444"),
 		},
 	}

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -41,7 +41,7 @@ func TestExtractTxnAddressesExploratory(t *testing.T) {
 	require.NoError(t, err)
 	logger := logger.WithFields("module", "test")
 	bn := big.NewInt(0).SetUint64(22770713)
-	handler := buildBridgeEventHandler(ctx, agglayerBridge, bridgeAddr, ethClient, logger)
+	handler := buildBridgeEventHandler(ctx, agglayerBridge, bridgeAddr, ethClient, true, logger)
 	filterQuery := ethereum.FilterQuery{
 		Addresses: []common.Address{bridgeAddr},
 		FromBlock: bn,
@@ -709,7 +709,7 @@ func TestBuildAppender(t *testing.T) {
 			if tt.buildQuerierMockFunc != nil {
 				querierMock = tt.buildQuerierMockFunc()
 			}
-			appenderMap, err := buildAppender(t.Context(), ethClient, querierMock, bridgeAddr, false, bridgeDeployment, logger)
+			appenderMap, err := buildAppender(t.Context(), ethClient, querierMock, bridgeAddr, false, true, bridgeDeployment, logger)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 				require.NotNil(t, appenderMap)
@@ -1131,7 +1131,7 @@ func TestTxnSenderField(t *testing.T) {
 				kind:           NonSovereignChain,
 				agglayerBridge: agglayerBridge,
 			}
-			appenderMap, err := buildAppender(t.Context(), ethClient, querierMock, bridgeAddr, false, bridgeDeployment, logger)
+			appenderMap, err := buildAppender(t.Context(), ethClient, querierMock, bridgeAddr, false, true, bridgeDeployment, logger)
 			require.NoError(t, err)
 			require.NotNil(t, appenderMap)
 
@@ -1272,7 +1272,7 @@ func TestExtractTxnAddresses(t *testing.T) {
 				Maybe()
 
 			txnSender, from, to, err := ExtractTxnAddresses(ctx, ethClient,
-				bridgeAddr, txHash, tt.logEvent, logger)
+				bridgeAddr, txHash, tt.logEvent, logger, true)
 			if tt.expectErr != "" {
 				require.ErrorContains(t, err, tt.expectErr)
 			} else {

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -256,8 +256,13 @@ func TestBuildAppender(t *testing.T) {
 	require.NoError(t, err)
 
 	ethClient := mocks.NewEthClienter(t)
+	// txReceipt To is not bridgeAddr, so must call debugTrace
+	mockClientCallGetTransactionByHash(t, ethClient,
+		common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+		testAddress, "0x0000000000000000000000000000000000000000000")
+
 	ethClient.EXPECT().
-		Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+		Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*Call)
 			require.True(t, ok)
@@ -1105,7 +1110,7 @@ func TestTxnSenderField(t *testing.T) {
 				Maybe()
 
 			ethClient.EXPECT().
-				Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+				Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 				Run(func(result any, method string, args ...any) {
 					arg, ok := result.(*Call)
 					require.True(t, ok)
@@ -1268,7 +1273,7 @@ func TestExtractTxnAddresses(t *testing.T) {
 					}
 				}).
 				Maybe()
-			ethClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).
+			ethClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 				Run(func(result any, method string, args ...any) {
 					arg, ok := result.(*Call)
 					require.True(t, ok)

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -31,6 +31,8 @@ var (
 	}
 )
 
+const testSyncFromInBridges = true
+
 func TestBridgeEventE2E(t *testing.T) {
 	const (
 		blockTime    = time.Millisecond * 10
@@ -185,7 +187,7 @@ func TestBridgeL1SyncerWithReorgDetector(t *testing.T) {
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)
 
 	// Create the bridge syncer with reorg detector
-	syncer, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rd, ethClient, originNetwork)
+	syncer, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rd, ethClient, originNetwork, testSyncFromInBridges)
 	require.NoError(t, err)
 	require.NotNil(t, syncer)
 	require.Equal(t, originNetwork, syncer.OriginNetwork())
@@ -362,7 +364,7 @@ func TestReorgWithSameHashEdgeCase(t *testing.T) {
 			arg.Input = bridgesync.BridgeAssetMethodID
 		}).Return(nil)
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)
-	syncer, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rd, ethClient, originNetwork)
+	syncer, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rd, ethClient, originNetwork, testSyncFromInBridges)
 	require.NoError(t, err)
 	require.NotNil(t, syncer)
 
@@ -474,7 +476,7 @@ func TestBridgeL1SyncerWithMultipleReorgs(t *testing.T) {
 		}).Return(nil)
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)
 	// Create the bridge syncer with reorg detector
-	syncer, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rd, ethClient, originNetwork)
+	syncer, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rd, ethClient, originNetwork, testSyncFromInBridges)
 	require.NoError(t, err)
 	require.NotNil(t, syncer)
 	require.Equal(t, originNetwork, syncer.OriginNetwork())

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -33,6 +33,20 @@ var (
 
 const testSyncFromInBridges = true
 
+func mockClientCallGetTransactionByHash(t *testing.T,
+	mockClient *mocks.RPCClienter,
+	expectedTxHash common.Hash, fromAddress string, toAddress string) {
+	t.Helper()
+	mockClient.EXPECT().Call(mock.Anything, bridgesync.GetTransactionByHashEndpoint, mock.Anything).Run(func(result any, method string, args ...any) {
+		arg, ok := result.(*bridgesync.Transaction)
+		require.True(t, ok)
+		arg.FromRaw = fromAddress
+		arg.To = toAddress
+		arg.Hash = expectedTxHash.Hex()
+		arg.Input = common.Bytes2Hex(bridgesync.BridgeAssetMethodID)
+	}).Return(nil).Maybe()
+}
+
 func TestBridgeEventE2E(t *testing.T) {
 	const (
 		blockTime    = time.Millisecond * 10
@@ -40,7 +54,13 @@ func TestBridgeEventE2E(t *testing.T) {
 	)
 
 	rpcClient := mocks.NewRPCClienter(t)
-	rpcClient.EXPECT().Call(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+
+	// txReceipt To is not bridgeAddr, so must call debugTrace
+	mockClientCallGetTransactionByHash(t, rpcClient,
+		common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+		"0x0000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000")
+
+	rpcClient.EXPECT().Call(mock.Anything, bridgesync.DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
@@ -178,12 +198,17 @@ func TestBridgeL1SyncerWithReorgDetector(t *testing.T) {
 		DBQueryTimeout:                     cfgtypes.NewDuration(5 * time.Second),
 	}
 	rpcClient := mocks.NewRPCClienter(t)
-	rpcClient.EXPECT().Call(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	// txReceipt To is not bridgeAddr, so must call debugTrace
+	mockClientCallGetTransactionByHash(t, rpcClient,
+		common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+		"0x0000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000")
+
+	rpcClient.EXPECT().Call(mock.Anything, bridgesync.DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
 			arg.Input = bridgesync.BridgeAssetMethodID
-		}).Return(nil)
+		}).Return(nil).Maybe()
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)
 
 	// Create the bridge syncer with reorg detector
@@ -357,7 +382,12 @@ func TestReorgWithSameHashEdgeCase(t *testing.T) {
 		DBQueryTimeout:                     cfgtypes.NewDuration(5 * time.Second),
 	}
 	rpcClient := mocks.NewRPCClienter(t)
-	rpcClient.EXPECT().Call(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	// txReceipt To is not bridgeAddr, so must call debugTrace
+	mockClientCallGetTransactionByHash(t, rpcClient,
+		common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+		"0x0000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000")
+
+	rpcClient.EXPECT().Call(mock.Anything, bridgesync.DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
@@ -468,6 +498,11 @@ func TestBridgeL1SyncerWithMultipleReorgs(t *testing.T) {
 		DBQueryTimeout:                     cfgtypes.NewDuration(5 * time.Second),
 	}
 	rpcClient := mocks.NewRPCClienter(t)
+	// txReceipt To is not bridgeAddr, so must call debugTrace
+	mockClientCallGetTransactionByHash(t, rpcClient,
+		common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+		"0x0000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000")
+
 	rpcClient.EXPECT().Call(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)

--- a/bridgesync/leaf_data.go
+++ b/bridgesync/leaf_data.go
@@ -39,7 +39,8 @@ func (l LeafData) ToBridge(
 	blockNum, blockPos, blockTimestamp uint64,
 	depositCount uint32,
 	txnHash common.Hash,
-	txnSender, fromAddr common.Address) Bridge {
+	txnSender common.Address,
+	fromAddr *common.Address) Bridge {
 	return Bridge{
 		BlockNum:           blockNum,
 		BlockPos:           blockPos,

--- a/bridgesync/migrations/migrations.go
+++ b/bridgesync/migrations/migrations.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/agglayer/aggkit/db"
+	dbmigrations "github.com/agglayer/aggkit/db/migrations"
 	"github.com/agglayer/aggkit/db/types"
 	treemigrations "github.com/agglayer/aggkit/tree/migrations"
 )
@@ -46,11 +47,14 @@ func init() {
 }
 
 func RunMigrations(dbPath string) error {
+	baseMigrations := dbmigrations.GetBaseMigrations()
 	// Allocate slice with exact capacity to avoid reallocations when combining migrations
-	total := len(migrations) + len(treemigrations.Migrations)
+	total := len(baseMigrations) + len(migrations) + len(treemigrations.Migrations)
 
 	combined := make([]types.Migration, 0, total)
 	// Copy migrations
+
+	combined = append(combined, baseMigrations...)
 	combined = append(combined, migrations...)
 	combined = append(combined, treemigrations.Migrations...)
 

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -169,8 +169,8 @@ func TestMigration0002(t *testing.T) {
 		DepositCount       uint32   `meddler:"deposit_count"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
-		FromAddress        string   `meddler:"from_address"`
-		TxnSender          string   `meddler:"txn_sender"`
+		FromAddress        *string  `meddler:"from_address"`
+		TxnSender          *string  `meddler:"txn_sender"`
 	}
 
 	err = meddler.QueryRow(db, &bridge,
@@ -518,8 +518,8 @@ func TestMigration0006(t *testing.T) {
 		DepositCount       uint32   `meddler:"deposit_count"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
-		FromAddress        string   `meddler:"from_address"`
-		TxnSender          string   `meddler:"txn_sender"`
+		FromAddress        *string  `meddler:"from_address"`
+		TxnSender          *string  `meddler:"txn_sender"`
 	}
 
 	// Test that we can query the txn_sender column after migration
@@ -527,7 +527,8 @@ func TestMigration0006(t *testing.T) {
 		`SELECT * FROM bridge WHERE block_pos = 0`)
 	require.NoError(t, err)
 	require.NotNil(t, bridgeWithTxnSender)
-	require.Equal(t, "", bridgeWithTxnSender.TxnSender) // Should have default empty string value
+	require.NotNil(t, bridgeWithTxnSender.TxnSender)
+	require.Equal(t, "", *bridgeWithTxnSender.TxnSender) // Should have default empty string value
 	require.Equal(t, "0x1111", bridgeWithTxnSender.OriginAddress)
 
 	// Test the second record
@@ -544,15 +545,16 @@ func TestMigration0006(t *testing.T) {
 		DepositCount       uint32   `meddler:"deposit_count"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
-		FromAddress        string   `meddler:"from_address"`
-		TxnSender          string   `meddler:"txn_sender"`
+		FromAddress        *string  `meddler:"from_address"`
+		TxnSender          *string  `meddler:"txn_sender"`
 	}
 
 	err = meddler.QueryRow(database, &bridgeWithTxnSender2,
 		`SELECT * FROM bridge WHERE block_pos = 1`)
 	require.NoError(t, err)
 	require.NotNil(t, bridgeWithTxnSender2)
-	require.Equal(t, "", bridgeWithTxnSender2.TxnSender) // Should have default empty string value
+	require.NotNil(t, bridgeWithTxnSender2.TxnSender)
+	require.Equal(t, "", *bridgeWithTxnSender2.TxnSender) // Should have default empty string value
 	require.Equal(t, "0x4444", bridgeWithTxnSender2.OriginAddress)
 
 	// Test that we can insert new records with txn_sender values
@@ -590,15 +592,16 @@ func TestMigration0006(t *testing.T) {
 		DepositCount       uint32   `meddler:"deposit_count"`
 		BlockTimestamp     uint64   `meddler:"block_timestamp"`
 		TxHash             string   `meddler:"tx_hash"`
-		FromAddress        string   `meddler:"from_address"`
-		TxnSender          string   `meddler:"txn_sender"`
+		FromAddress        *string  `meddler:"from_address"`
+		TxnSender          *string  `meddler:"txn_sender"`
 	}
 
 	err = meddler.QueryRow(database, &bridgeWithCustomTxnSender,
 		`SELECT * FROM bridge WHERE block_pos = 2`)
 	require.NoError(t, err)
 	require.NotNil(t, bridgeWithCustomTxnSender)
-	require.Equal(t, "0xAAAA", bridgeWithCustomTxnSender.TxnSender)
+	require.NotNil(t, bridgeWithCustomTxnSender.TxnSender)
+	require.Equal(t, "0xAAAA", *bridgeWithCustomTxnSender.TxnSender)
 	require.Equal(t, "0x7777", bridgeWithCustomTxnSender.OriginAddress)
 
 	// Test migration 0006 DOWN (DROP COLUMN) by manually executing the SQL

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -1911,15 +1911,10 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 			archivedBridge := archivedBridges[0]
 			txnHash = archivedBridge.TxHash
 			txnSender = archivedBridge.TxnSender
-			// Only restore FromAddress if it was set in archive
-			if archivedBridge.FromAddress != nil {
-				fromAddrPtr = archivedBridge.FromAddress
-			} else {
-				// FromAddress was NULL in archive (synced with SyncFromInBridges=false)
-				p.log.Debugf("Archived bridge has NULL FromAddress, keeping it NULL for restored bridge")
-			}
+			// It copy the fromAddr pointer, it could be nil
+			fromAddrPtr = archivedBridge.FromAddress
 		} else if len(archivedBridges) > 1 {
-			p.log.Debugf("multiple archived bridges found that match forward LET leaf %s;"+
+			p.log.Warnf("multiple archived bridges found that match forward LET leaf %s;"+
 				"cannot set txnSender and fromAddr fields to the bridge", leaf.String())
 		}
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -638,7 +638,7 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 	}
 	if storage.SyncFromInBridges == nil {
 		// If store doesn't have this field means that is 'true' by default,
-		if !*b.SyncFromInBridges {
+		if b.SyncFromInBridges != nil && !*b.SyncFromInBridges {
 			log.Warnf("Database created without SyncFromInBridges field, assuming true. " +
 				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress.",
 			)
@@ -986,8 +986,10 @@ func (p *processor) buildBridgesFilterClause(depositCount *uint64, networkIDs []
 	if fromAddress != "" && common.IsHexAddress(fromAddress) {
 		// Only match non-NULL from_address values with the specified address
 		// NULL values will not match this filter (intentional - explicit filtering)
-		clauses = append(clauses, fmt.Sprintf("from_address = $%d", paramIndex))
-		args = append(args, strings.ToUpper(fromAddress))
+		// Use UPPER for case-insensitive comparison (addresses stored in checksum format)
+		clauses = append(clauses, fmt.Sprintf("UPPER(from_address) = UPPER($%d)", paramIndex))
+		args = append(args, fromAddress)
+		paramIndex++
 	}
 
 	if len(clauses) > 0 {

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -600,6 +600,7 @@ type BridgeSyncRuntimeData struct {
 	// DBVersion tracks the database schema version for compatibility validation
 	DBVersion *int
 	// SyncFromInBridges tracks if FromAddress extraction was enabled for this database
+	// By default is true
 	SyncFromInBridges *bool
 }
 
@@ -617,38 +618,51 @@ func (b BridgeSyncRuntimeData) String() string {
 	return res
 }
 
-func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) error {
+func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*BridgeSyncRuntimeData, error) {
+	// First check the basic runtimedata compatibility using the existing logic in sync.RuntimeData
 	tmp := sync.RuntimeData{
 		ChainID:   b.ChainID,
 		Addresses: b.Addresses,
 	}
-	if err := tmp.IsCompatible(sync.RuntimeData{ChainID: storage.ChainID, Addresses: storage.Addresses}); err != nil {
-		return err
+	if _, err := tmp.IsCompatible(sync.RuntimeData{ChainID: storage.ChainID, Addresses: storage.Addresses}); err != nil {
+		return nil, err
 	}
+	// Check database schema version compatibility, this is to introduce
+	// changes beyond migration mechanism.
+	// You can control that the data in DB is invalid and need to be deleted
+	// or, in the future, you can create a way to update it.
 	if storage.DBVersion == nil || *storage.DBVersion != *b.DBVersion {
-		return fmt.Errorf("database schema version mismatch (current: %v, stored: %v). "+
+		return nil, fmt.Errorf("database schema version mismatch (current: %v, stored: %v). "+
 			"Drop BridgeL1Sync and BridgeL2Sync databases and restart",
 			b.DBVersion, storage.DBVersion)
 	}
-
+	if storage.SyncFromInBridges == nil {
+		// If store doesn't have this field means that is 'true' by default,
+		if !*b.SyncFromInBridges {
+			log.Warnf("Database created without SyncFromInBridges field, assuming true. " +
+				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress.",
+			)
+		}
+		// we update storage with current value
+		return &b, nil
+	}
 	// Validate SyncFromInBridges compatibility
-	if storage.SyncFromInBridges != nil && b.SyncFromInBridges != nil {
-		// false → true: FORBIDDEN (missing FromAddress cannot be recovered)
-		if !*storage.SyncFromInBridges && *b.SyncFromInBridges {
-			return fmt.Errorf("incompatible SyncFromInBridges configuration: " +
-				"cannot enable FromAddress sync on database created without it. " +
-				"Database config: false, Current config: true",
-			)
-		}
-		// true → false: ALLOWED (log warning about inconsistent data)
-		if *storage.SyncFromInBridges && !*b.SyncFromInBridges {
-			log.Warnf("SyncFromInBridges changed from true to false. " +
-				"Existing bridges have FromAddress, new bridges will not.",
-			)
-		}
+
+	// false → true: FORBIDDEN (missing FromAddress cannot be recovered)
+	if !*storage.SyncFromInBridges && *b.SyncFromInBridges {
+		return nil, fmt.Errorf("incompatible SyncFromInBridges configuration: " +
+			"cannot enable FromAddress sync on database created without it. " +
+			"Database config: false, Current config: true",
+		)
+	}
+	// true → false: ALLOWED (log warning about inconsistent data)
+	if *storage.SyncFromInBridges && !*b.SyncFromInBridges {
+		log.Warnf("SyncFromInBridges changed from true to false. " +
+			"Existing bridges have FromAddress, new bridges will not.",
+		)
 	}
 
-	return nil
+	return nil, nil
 }
 
 type BridgeQuerier interface {

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -1637,7 +1637,8 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 				Hash:  event.Bridge.Hash(),
 			}); err != nil {
 				if errors.Is(err, tree.ErrInvalidIndex) {
-					p.halt(fmt.Sprintf("error adding leaf to the exit tree: %v", err))
+					p.halt(fmt.Sprintf("error adding leaf %d in block %d to the exit tree: %v",
+						event.Bridge.DepositCount, block.Num, err))
 				}
 				return sync.ErrInconsistentState
 			}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -136,22 +136,22 @@ const (
 
 // Bridge is the representation of a bridge event
 type Bridge struct {
-	BlockNum           uint64         `meddler:"block_num"`
-	BlockPos           uint64         `meddler:"block_pos"`
-	FromAddress        common.Address `meddler:"from_address,address"`
-	TxHash             common.Hash    `meddler:"tx_hash,hash"`
-	BlockTimestamp     uint64         `meddler:"block_timestamp"`
-	LeafType           uint8          `meddler:"leaf_type"`
-	OriginNetwork      uint32         `meddler:"origin_network"`
-	OriginAddress      common.Address `meddler:"origin_address"`
-	DestinationNetwork uint32         `meddler:"destination_network"`
-	DestinationAddress common.Address `meddler:"destination_address"`
-	Amount             *big.Int       `meddler:"amount,bigint"`
-	Metadata           []byte         `meddler:"metadata"`
-	DepositCount       uint32         `meddler:"deposit_count"`
-	TxnSender          common.Address `meddler:"txn_sender,address"`
-	Source             BridgeSource   `meddler:"source"`
-	ToAddress          common.Address `meddler:"to_address,address"`
+	BlockNum           uint64          `meddler:"block_num"`
+	BlockPos           uint64          `meddler:"block_pos"`
+	FromAddress        *common.Address `meddler:"from_address,address"`
+	TxHash             common.Hash     `meddler:"tx_hash,hash"`
+	BlockTimestamp     uint64          `meddler:"block_timestamp"`
+	LeafType           uint8           `meddler:"leaf_type"`
+	OriginNetwork      uint32          `meddler:"origin_network"`
+	OriginAddress      common.Address  `meddler:"origin_address"`
+	DestinationNetwork uint32          `meddler:"destination_network"`
+	DestinationAddress common.Address  `meddler:"destination_address"`
+	Amount             *big.Int        `meddler:"amount,bigint"`
+	Metadata           []byte          `meddler:"metadata"`
+	DepositCount       uint32          `meddler:"deposit_count"`
+	TxnSender          common.Address  `meddler:"txn_sender,address"`
+	Source             BridgeSource    `meddler:"source"`
+	ToAddress          common.Address  `meddler:"to_address,address"`
 }
 
 func (b *Bridge) String() string {
@@ -159,11 +159,15 @@ func (b *Bridge) String() string {
 	if b.Amount != nil {
 		amountStr = b.Amount.String()
 	}
+	fromAddrStr := nilStr
+	if b.FromAddress != nil {
+		fromAddrStr = b.FromAddress.String()
+	}
 	return fmt.Sprintf("Bridge{BlockNum: %d, BlockPos: %d, FromAddress: %s, TxHash: %s, "+
 		"BlockTimestamp: %d, LeafType: %d, OriginNetwork: %d, OriginAddress: %s, "+
 		"DestinationNetwork: %d, DestinationAddress: %s, Amount: %s, Metadata: %x, "+
 		"DepositCount: %d, TxnSender: %s, Source: %s, ToAddress: %s}",
-		b.BlockNum, b.BlockPos, b.FromAddress.String(), b.TxHash.String(),
+		b.BlockNum, b.BlockPos, fromAddrStr, b.TxHash.String(),
 		b.BlockTimestamp, b.LeafType, b.OriginNetwork, b.OriginAddress.String(),
 		b.DestinationNetwork, b.DestinationAddress.String(), amountStr, b.Metadata,
 		b.DepositCount, b.TxnSender.String(), b.Source, b.ToAddress.String())
@@ -595,6 +599,8 @@ type BridgeSyncRuntimeData struct {
 	Addresses []common.Address
 	// DBVersion tracks the database schema version for compatibility validation
 	DBVersion *int
+	// SyncFromInBridges tracks if FromAddress extraction was enabled for this database
+	SyncFromInBridges *bool
 }
 
 func (b BridgeSyncRuntimeData) String() string {
@@ -603,7 +609,10 @@ func (b BridgeSyncRuntimeData) String() string {
 		res += addr.String() + ", "
 	}
 	if b.DBVersion != nil {
-		res += fmt.Sprintf("DBVersion: %d", *b.DBVersion)
+		res += fmt.Sprintf("DBVersion: %d, ", *b.DBVersion)
+	}
+	if b.SyncFromInBridges != nil {
+		res += fmt.Sprintf("SyncFromInBridges: %t", *b.SyncFromInBridges)
 	}
 	return res
 }
@@ -621,6 +630,24 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) error
 			"Drop BridgeL1Sync and BridgeL2Sync databases and restart",
 			b.DBVersion, storage.DBVersion)
 	}
+
+	// Validate SyncFromInBridges compatibility
+	if storage.SyncFromInBridges != nil && b.SyncFromInBridges != nil {
+		// false → true: FORBIDDEN (missing FromAddress cannot be recovered)
+		if !*storage.SyncFromInBridges && *b.SyncFromInBridges {
+			return fmt.Errorf("incompatible SyncFromInBridges configuration: " +
+				"cannot enable FromAddress sync on database created without it. " +
+				"Database config: false, Current config: true",
+			)
+		}
+		// true → false: ALLOWED (log warning about inconsistent data)
+		if *storage.SyncFromInBridges && !*b.SyncFromInBridges {
+			log.Warnf("SyncFromInBridges changed from true to false. " +
+				"Existing bridges have FromAddress, new bridges will not.",
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -926,7 +953,9 @@ func (p *processor) buildBridgesFilterClause(depositCount *uint64, networkIDs []
 	}
 
 	if fromAddress != "" && common.IsHexAddress(fromAddress) {
-		clauses = append(clauses, fmt.Sprintf("UPPER(from_address) LIKE '%s'", fromAddress))
+		// Only match non-NULL from_address values with the specified address
+		// NULL values will not match this filter (intentional - explicit filtering)
+		clauses = append(clauses, fmt.Sprintf("from_address = '%s'", strings.ToUpper(fromAddress)))
 	}
 
 	if len(clauses) > 0 {
@@ -1798,8 +1827,9 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 		}
 
 		var (
-			txnHash             = event.TxnHash
-			txnSender, fromAddr common.Address
+			txnHash     = event.TxnHash
+			txnSender   common.Address
+			fromAddrPtr *common.Address
 		)
 
 		// let's see if we have exactly one archived bridge that matches the forward LET leaf
@@ -1812,7 +1842,13 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 			archivedBridge := archivedBridges[0]
 			txnHash = archivedBridge.TxHash
 			txnSender = archivedBridge.TxnSender
-			fromAddr = archivedBridge.FromAddress
+			// Only restore FromAddress if it was set in archive
+			if archivedBridge.FromAddress != nil {
+				fromAddrPtr = archivedBridge.FromAddress
+			} else {
+				// FromAddress was NULL in archive (synced with SyncFromInBridges=false)
+				p.log.Debugf("Archived bridge has NULL FromAddress, keeping it NULL for restored bridge")
+			}
 		} else if len(archivedBridges) > 1 {
 			p.log.Debugf("multiple archived bridges found that match forward LET leaf %s;"+
 				"cannot set txnSender and fromAddr fields to the bridge", leaf.String())
@@ -1826,7 +1862,7 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 			newDepositCount,
 			txnHash,
 			txnSender,
-			fromAddr,
+			fromAddrPtr,
 		)
 
 		// insert the new bridge leaf into the local exit tree

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -2005,7 +2005,7 @@ func (p *processor) GetTotalNumberOfRecordsWithParams(ctx context.Context, table
 	count := 0
 	// Safe: tableName is validated by regex, whereClause contains only SQL placeholders ($1, $2, etc.)
 	// constructed internally, and actual values are passed via args parameter
-	query := fmt.Sprintf("SELECT COUNT(*) AS count FROM %s%s;", tableName, whereClause)
+	query := "SELECT COUNT(*) AS count FROM " + tableName + whereClause + ";"
 	err := p.db.QueryRowContext(dbCtx, query, args...).Scan(&count)
 	if err != nil {
 		return 0, err

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -989,7 +989,6 @@ func (p *processor) buildBridgesFilterClause(depositCount *uint64, networkIDs []
 		// Use UPPER for case-insensitive comparison (addresses stored in checksum format)
 		clauses = append(clauses, fmt.Sprintf("UPPER(from_address) = UPPER($%d)", paramIndex))
 		args = append(args, fromAddress)
-		paramIndex++
 	}
 
 	if len(clauses) > 0 {

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -911,9 +911,10 @@ func (p *processor) GetBridgesPaged(
 	ctx context.Context, pageNumber, pageSize uint32,
 	depositCount *uint64, networkIDs []uint32, fromAddress string,
 ) ([]*Bridge, int, error) {
-	whereClause := p.buildBridgesFilterClause(depositCount, networkIDs, fromAddress)
+	whereClause, whereArgs := p.buildBridgesFilterClause(depositCount, networkIDs, fromAddress)
 	orderByClause := "deposit_count DESC"
-	bridgesCount, err := p.GetTotalNumberOfRecords(ctx, bridgeTableName, whereClause)
+
+	bridgesCount, err := p.GetTotalNumberOfRecordsWithParams(ctx, bridgeTableName, whereClause, whereArgs)
 	if err != nil {
 		return []*Bridge{}, 0, err
 	}
@@ -927,14 +928,16 @@ func (p *processor) GetBridgesPaged(
 		return nil, 0, err
 	}
 
-	rows, err := p.queryPaged(ctx, p.db, offset, pageSize, bridgeTableName, orderByClause, whereClause)
+	rows, err := p.queryPagedWithParams(ctx, p.db, offset, pageSize, bridgeTableName,
+		orderByClause, whereClause, whereArgs)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			p.log.Debugf("no bridges were found for provided parameters (pageNumber=%d, pageSize=%d, where clause=%s)",
 				pageNumber, pageSize, whereClause)
 			return nil, bridgesCount, nil
 		}
-		p.log.Errorf("GetBridgesPaged: queryPaged failed for pageNumber=%d, pageSize=%d: %v", pageNumber, pageSize, err)
+		p.log.Errorf("GetBridgesPaged: queryPagedWithParams failed for pageNumber=%d, pageSize=%d: %v",
+			pageNumber, pageSize, err)
 		return nil, 0, err
 	}
 
@@ -946,7 +949,8 @@ func (p *processor) GetBridgesPaged(
 
 	bridges := []*Bridge{}
 	if err = meddler.ScanAll(rows, &bridges); err != nil {
-		p.log.Errorf("GetBridgesPaged: meddler.ScanAll failed for pageNumber=%d, pageSize=%d: %v", pageNumber, pageSize, err)
+		p.log.Errorf("GetBridgesPaged: meddler.ScanAll failed for pageNumber=%d, pageSize=%d: %v",
+			pageNumber, pageSize, err)
 		return nil, 0, err
 	}
 
@@ -955,27 +959,41 @@ func (p *processor) GetBridgesPaged(
 
 // buildBridgesFilterClause builds the WHERE clause for the bridges table
 // based on the provided depositCount, networkIDs, fromAddress and globalIndex
-func (p *processor) buildBridgesFilterClause(depositCount *uint64, networkIDs []uint32, fromAddress string) string {
+// Returns the WHERE clause with placeholders and the corresponding arguments for parameterized queries
+func (p *processor) buildBridgesFilterClause(depositCount *uint64, networkIDs []uint32,
+	fromAddress string) (string, []interface{}) {
 	const clauseCapacity = 3
 	clauses := make([]string, 0, clauseCapacity)
+	args := make([]interface{}, 0, clauseCapacity)
+	paramIndex := 1
+
 	if depositCount != nil {
-		clauses = append(clauses, fmt.Sprintf("deposit_count = %d", *depositCount))
+		clauses = append(clauses, fmt.Sprintf("deposit_count = $%d", paramIndex))
+		args = append(args, *depositCount)
+		paramIndex++
 	}
 
 	if len(networkIDs) > 0 {
-		clauses = append(clauses, buildNetworkIDsFilter(networkIDs, "destination_network"))
+		placeholders := make([]string, len(networkIDs))
+		for i, id := range networkIDs {
+			placeholders[i] = fmt.Sprintf("$%d", paramIndex)
+			args = append(args, id)
+			paramIndex++
+		}
+		clauses = append(clauses, fmt.Sprintf("destination_network IN (%s)", strings.Join(placeholders, ", ")))
 	}
 
 	if fromAddress != "" && common.IsHexAddress(fromAddress) {
 		// Only match non-NULL from_address values with the specified address
 		// NULL values will not match this filter (intentional - explicit filtering)
-		clauses = append(clauses, fmt.Sprintf("from_address = '%s'", strings.ToUpper(fromAddress)))
+		clauses = append(clauses, fmt.Sprintf("from_address = $%d", paramIndex))
+		args = append(args, strings.ToUpper(fromAddress))
 	}
 
 	if len(clauses) > 0 {
-		return " WHERE " + strings.Join(clauses, " AND ")
+		return " WHERE " + strings.Join(clauses, " AND "), args
 	}
-	return ""
+	return "", nil
 }
 
 func (p *processor) GetClaimsPaged(
@@ -1319,6 +1337,43 @@ func (p *processor) queryPaged(ctx context.Context, tx dbtypes.Querier,
 		ORDER BY %s
 		LIMIT $1 OFFSET $2;
 	`, table, whereClause, orderByClause), pageSize, offset)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return rows, nil
+}
+
+// queryPagedWithParams returns a paged result from the given table with parameterized WHERE clause
+// to prevent SQL injection attacks
+func (p *processor) queryPagedWithParams(ctx context.Context, tx dbtypes.Querier,
+	offset, pageSize uint32,
+	table, orderByClause, whereClause string,
+	whereArgs []interface{},
+) (*sql.Rows, error) {
+	// Create a context with database timeout
+	dbCtx, _ := p.withDatabaseTimeout(ctx)
+
+	// Build the query with placeholders for pagination
+	// whereArgs already contains placeholders starting from $1
+	// We need to adjust LIMIT and OFFSET to use the next available placeholders
+	nextParam := len(whereArgs) + 1
+	query := fmt.Sprintf(`
+		SELECT *
+		FROM %s
+		%s
+		ORDER BY %s
+		LIMIT $%d OFFSET $%d;
+	`, table, whereClause, orderByClause, nextParam, nextParam+1)
+
+	// Combine WHERE args with pagination args
+	args := make([]interface{}, 0, len(whereArgs)+2) //nolint:mnd
+	args = append(args, whereArgs...)
+	args = append(args, pageSize, offset)
+
+	rows, err := tx.QueryContext(dbCtx, query, args...)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, db.ErrNotFound
@@ -1926,6 +1981,27 @@ func (p *processor) GetTotalNumberOfRecords(ctx context.Context, tableName, wher
 	err := p.db.QueryRowContext(dbCtx, fmt.Sprintf(
 		`SELECT COUNT(*) AS count FROM %s%s;`, tableName, whereClause,
 	)).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// GetTotalNumberOfRecordsWithParams returns the total number of records with parameterized WHERE clause
+func (p *processor) GetTotalNumberOfRecordsWithParams(ctx context.Context, tableName,
+	whereClause string, args []interface{}) (int, error) {
+	if !tableNameRegex.MatchString(tableName) {
+		return 0, fmt.Errorf("invalid table name '%s' provided", tableName)
+	}
+
+	// Create a context with database timeout
+	dbCtx, cancel := p.withDatabaseTimeout(ctx)
+	defer cancel()
+
+	count := 0
+	query := `SELECT COUNT(*) AS count FROM ` + tableName + whereClause + ";"
+	err := p.db.QueryRowContext(dbCtx, query, args...).Scan(&count)
 	if err != nil {
 		return 0, err
 	}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -1990,6 +1990,8 @@ func (p *processor) GetTotalNumberOfRecords(ctx context.Context, tableName, wher
 }
 
 // GetTotalNumberOfRecordsWithParams returns the total number of records with parameterized WHERE clause
+// Note: whereClause must be constructed internally using parameterized placeholders ($1, $2, etc.)
+// and should never contain user input directly concatenated into the string.
 func (p *processor) GetTotalNumberOfRecordsWithParams(ctx context.Context, tableName,
 	whereClause string, args []interface{}) (int, error) {
 	if !tableNameRegex.MatchString(tableName) {
@@ -2001,7 +2003,9 @@ func (p *processor) GetTotalNumberOfRecordsWithParams(ctx context.Context, table
 	defer cancel()
 
 	count := 0
-	query := `SELECT COUNT(*) AS count FROM ` + tableName + whereClause + ";"
+	// Safe: tableName is validated by regex, whereClause contains only SQL placeholders ($1, $2, etc.)
+	// constructed internally, and actual values are passed via args parameter
+	query := fmt.Sprintf("SELECT COUNT(*) AS count FROM %s%s;", tableName, whereClause)
 	err := p.db.QueryRowContext(dbCtx, query, args...).Scan(&count)
 	if err != nil {
 		return 0, err

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -627,6 +627,10 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 	if _, err := tmp.IsCompatible(sync.RuntimeData{ChainID: storage.ChainID, Addresses: storage.Addresses}); err != nil {
 		return nil, err
 	}
+	if b.DBVersion == nil || b.SyncFromInBridges == nil {
+		return nil, errors.New("invalid runtime data: missing DBVersion or SyncFromInBridges field (internal error)")
+	}
+
 	// Check database schema version compatibility, this is to introduce
 	// changes beyond migration mechanism.
 	// You can control that the data in DB is invalid and need to be deleted
@@ -1913,7 +1917,7 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 			archivedBridge := archivedBridges[0]
 			txnHash = archivedBridge.TxHash
 			txnSender = archivedBridge.TxnSender
-			// It copy the fromAddr pointer, it could be nil
+			// It copies the fromAddr pointer, which could be nil
 			fromAddrPtr = archivedBridge.FromAddress
 		} else if len(archivedBridges) > 1 {
 			p.log.Warnf("multiple archived bridges found that match forward LET leaf %s;"+

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -637,7 +637,8 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 			b.DBVersion, storage.DBVersion)
 	}
 	if storage.SyncFromInBridges == nil {
-		// If store doesn't have this field means that is 'true' by default,
+		// If storage doesn't have this field, the database was created before this field existed,
+		// so we assume 'true' by default (historical behavior).
 		if b.SyncFromInBridges != nil && !*b.SyncFromInBridges {
 			log.Warnf("Database created without SyncFromInBridges field, assuming true. " +
 				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress.",

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -643,9 +643,10 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 	if storage.SyncFromInBridges == nil {
 		// If storage doesn't have this field, the database was created before this field existed,
 		// so we assume 'true' by default (historical behavior).
-		if b.SyncFromInBridges != nil && !*b.SyncFromInBridges {
+		if !*b.SyncFromInBridges {
 			log.Warnf("Database created without SyncFromInBridges field, assuming true. " +
-				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress.",
+				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress." +
+				"Also a background process is going to fill the missing FromAddress",
 			)
 		}
 		// we update storage with current value

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -627,9 +627,6 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 	if _, err := tmp.IsCompatible(sync.RuntimeData{ChainID: storage.ChainID, Addresses: storage.Addresses}); err != nil {
 		return nil, err
 	}
-	if b.DBVersion == nil || b.SyncFromInBridges == nil {
-		return nil, errors.New("invalid runtime data: missing DBVersion or SyncFromInBridges field (internal error)")
-	}
 
 	// Check database schema version compatibility, this is to introduce
 	// changes beyond migration mechanism.
@@ -640,13 +637,16 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 			"Drop BridgeL1Sync and BridgeL2Sync databases and restart",
 			b.DBVersion, storage.DBVersion)
 	}
+	if b.SyncFromInBridges == nil {
+		return nil, errors.New("invalid runtime data: missing SyncFromInBridges field (internal error)")
+	}
+
 	if storage.SyncFromInBridges == nil {
 		// If storage doesn't have this field, the database was created before this field existed,
 		// so we assume 'true' by default (historical behavior).
-		if !*b.SyncFromInBridges {
+		if b.SyncFromInBridges != nil && !*b.SyncFromInBridges {
 			log.Warnf("Database created without SyncFromInBridges field, assuming true. " +
-				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress." +
-				"Also a background process is going to fill the missing FromAddress",
+				"Current config has SyncFromInBridges set to false, new bridges will not have FromAddress.",
 			)
 		}
 		// we update storage with current value
@@ -656,10 +656,9 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 
 	// false → true: FORBIDDEN (missing FromAddress cannot be recovered)
 	if !*storage.SyncFromInBridges && *b.SyncFromInBridges {
-		return nil, fmt.Errorf("incompatible SyncFromInBridges configuration: " +
-			"cannot enable FromAddress sync on database created without it. " +
-			"Database config: false, Current config: true",
-		)
+		log.Warnf("SyncFromInBridges changed from false to true. " +
+			"The missing FromAddress are going to be filled by a background " +
+			"process, but it might take a while")
 	}
 	// true → false: ALLOWED (log warning about inconsistent data)
 	if *storage.SyncFromInBridges && !*b.SyncFromInBridges {

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2180,7 +2180,7 @@ func TestBridgeSyncRuntimeData_IsCompatible(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.current.IsCompatible(tt.storage)
+			_, err := tt.current.IsCompatible(tt.storage)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2120,9 +2120,10 @@ func TestBridgeSyncRuntimeData_IsCompatible(t *testing.T) {
 		{
 			name: "compatible versions",
 			current: BridgeSyncRuntimeData{
-				ChainID:   1,
-				Addresses: []common.Address{common.HexToAddress("0x123")},
-				DBVersion: intPtr(1),
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(true),
 			},
 			storage: BridgeSyncRuntimeData{
 				ChainID:   1,
@@ -2134,9 +2135,10 @@ func TestBridgeSyncRuntimeData_IsCompatible(t *testing.T) {
 		{
 			name: "incompatible versions - different DB versions",
 			current: BridgeSyncRuntimeData{
-				ChainID:   1,
-				Addresses: []common.Address{common.HexToAddress("0x123")},
-				DBVersion: intPtr(2),
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(2),
+				SyncFromInBridges: boolPtr(true),
 			},
 			storage: BridgeSyncRuntimeData{
 				ChainID:   1,
@@ -2164,9 +2166,10 @@ func TestBridgeSyncRuntimeData_IsCompatible(t *testing.T) {
 		{
 			name: "incompatible versions - different addresses",
 			current: BridgeSyncRuntimeData{
-				ChainID:   1,
-				Addresses: []common.Address{common.HexToAddress("0x123")},
-				DBVersion: intPtr(1),
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(true),
 			},
 			storage: BridgeSyncRuntimeData{
 				ChainID:   1,
@@ -2778,6 +2781,10 @@ func intPtr(i int) *int {
 
 func uint64Ptr(i uint64) *uint64 {
 	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 func TestProcessor_ErrorPathLogging(t *testing.T) {

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -2179,6 +2179,70 @@ func TestBridgeSyncRuntimeData_IsCompatible(t *testing.T) {
 			expectError: true,
 			errorMsg:    "addresses[0] mismatch: 0x0000000000000000000000000000000000000123 != 0x0000000000000000000000000000000000000456",
 		},
+		{
+			name: "storage no flag SyncFromInBridges -> false: ok",
+			current: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(false),
+			},
+			storage: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: nil, // Previous DB to this version
+			},
+			expectError: false,
+		},
+		{
+			name: "storage no flag SyncFromInBridges -> true: ok",
+			current: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(true),
+			},
+			storage: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: nil, // Previous DB to this version
+			},
+			expectError: false,
+		},
+		{
+			name: "storage SyncFromInBridges false -> true: ok",
+			current: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(true),
+			},
+			storage: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(false),
+			},
+			expectError: false,
+		},
+		{
+			name: "storage SyncFromInBridges true -> false: ok",
+			current: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(false),
+			},
+			storage: BridgeSyncRuntimeData{
+				ChainID:           1,
+				Addresses:         []common.Address{common.HexToAddress("0x123")},
+				DBVersion:         intPtr(1),
+				SyncFromInBridges: boolPtr(true),
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -1008,13 +1008,34 @@ func TestGetBridgesPaged(t *testing.T) {
 	fromBlock := uint64(1)
 	toBlock := uint64(10)
 	bridges := []*Bridge{
-		{DepositCount: 0, BlockNum: 1, Amount: big.NewInt(1), DestinationNetwork: 10, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")},
-		{DepositCount: 1, BlockNum: 2, Amount: big.NewInt(1), DestinationNetwork: 10, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")},
-		{DepositCount: 2, BlockNum: 3, Amount: big.NewInt(1), DestinationNetwork: 20, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")},
-		{DepositCount: 3, BlockNum: 4, Amount: big.NewInt(1), DestinationNetwork: 30, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")},
-		{DepositCount: 4, BlockNum: 5, Amount: big.NewInt(1), DestinationNetwork: 30, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")},
-		{DepositCount: 5, BlockNum: 6, Amount: big.NewInt(1), DestinationNetwork: 30, FromAddress: common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")},
-		{DepositCount: 6, BlockNum: 7, Amount: big.NewInt(1), DestinationNetwork: 50, FromAddress: common.HexToAddress("0xd34aaF64b29273B7D567FCFc40544c014EEe9970")},
+		{DepositCount: 0, BlockNum: 1, Amount: big.NewInt(1), DestinationNetwork: 10, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
+		{DepositCount: 1, BlockNum: 2, Amount: big.NewInt(1), DestinationNetwork: 10, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
+		{DepositCount: 2, BlockNum: 3, Amount: big.NewInt(1), DestinationNetwork: 20, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
+		{DepositCount: 3, BlockNum: 4, Amount: big.NewInt(1), DestinationNetwork: 30, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
+		{DepositCount: 4, BlockNum: 5, Amount: big.NewInt(1), DestinationNetwork: 30, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
+		{DepositCount: 5, BlockNum: 6, Amount: big.NewInt(1), DestinationNetwork: 30, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xE34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
+		{DepositCount: 6, BlockNum: 7, Amount: big.NewInt(1), DestinationNetwork: 50, FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0xd34aaF64b29273B7D567FCFc40544c014EEe9970")
+			return &addr
+		}()},
 	}
 
 	path := path.Join(t.TempDir(), "bridgesyncGetBridgesPaged.sqlite")
@@ -2981,11 +3002,14 @@ func createTestProcessor(t *testing.T, dbName string) *processor {
 // createTestBridge creates a test Bridge event
 func createTestBridge(blockNum uint64, blockPos int) *Bridge {
 	return &Bridge{
-		BlockNum:           blockNum,
-		BlockPos:           uint64(blockPos),
-		BlockTimestamp:     1234567890,
-		TxHash:             common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
-		FromAddress:        common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		BlockNum:       blockNum,
+		BlockPos:       uint64(blockPos),
+		BlockTimestamp: 1234567890,
+		TxHash:         common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+		FromAddress: func() *common.Address {
+			addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+			return &addr
+		}(),
 		LeafType:           1,
 		OriginNetwork:      1,
 		OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
@@ -6066,7 +6090,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			DepositCount:       20,
 			TxHash:             archivedTxHash,
 			TxnSender:          archivedTxnSender,
-			FromAddress:        archivedFromAddr,
+			FromAddress:        &archivedFromAddr,
 			// Don't set Source - bridge_archive table doesn't have this column
 		}
 		// Insert manually to avoid Source field
@@ -6167,7 +6191,10 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			DepositCount:       30,
 			TxHash:             common.HexToHash("0xfirst111"),
 			TxnSender:          common.HexToAddress("0x1111111111111111111111111111111111111111"),
-			FromAddress:        common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			FromAddress: func() *common.Address {
+				addr := common.HexToAddress("0x2222222222222222222222222222222222222222")
+				return &addr
+			}(),
 		}
 
 		archivedBridge2 := &Bridge{
@@ -6183,7 +6210,10 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			DepositCount:       31,
 			TxHash:             common.HexToHash("0xsecond222"),
 			TxnSender:          common.HexToAddress("0x3333333333333333333333333333333333333333"),
-			FromAddress:        common.HexToAddress("0x4444444444444444444444444444444444444444"),
+			FromAddress: func() *common.Address {
+				addr := common.HexToAddress("0x4444444444444444444444444444444444444444")
+				return &addr
+			}(),
 		}
 
 		// Insert both archived bridges manually (to avoid Source column)
@@ -6520,7 +6550,8 @@ func calculateExpectedRootAfterForwardLET(t *testing.T, initialDepositCount uint
 	for i, leaf := range leaves {
 		// Try to get archived bridge info if available
 		var txHash common.Hash
-		var txnSender, fromAddr common.Address
+		var txnSender common.Address
+		var fromAddr *common.Address
 		if archived, found := archivedByLeaf[i]; found {
 			txHash = archived.TxHash
 			txnSender = archived.TxnSender

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -5946,7 +5946,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 		require.Equal(t, initialDepositCount+1, bridge.DepositCount)
 		require.Equal(t, event.TxnHash, bridge.TxHash)
 		require.Equal(t, aggkitcommon.ZeroAddress, bridge.TxnSender)
-		require.Equal(t, aggkitcommon.ZeroAddress, bridge.FromAddress)
+		require.Nil(t, bridge.FromAddress)
 		require.Equal(t, BridgeSourceForwardLET, bridge.Source)
 
 		// Verify: ForwardLET event was inserted
@@ -6140,7 +6140,8 @@ func TestHandleForwardLETEvent(t *testing.T) {
 		bridge := bridges[0]
 		require.Equal(t, archivedTxHash, bridge.TxHash, "Should use archived tx hash")
 		require.Equal(t, archivedTxnSender, bridge.TxnSender, "Should use archived txn sender")
-		require.Equal(t, archivedFromAddr, bridge.FromAddress, "Should use archived from address")
+		require.NotNil(t, bridge.FromAddress)
+		require.Equal(t, archivedFromAddr, *bridge.FromAddress, "Should use archived from address")
 		require.Equal(t, BridgeSourceForwardLET, bridge.Source)
 	})
 
@@ -6255,7 +6256,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 		bridge := bridges[0]
 		require.Equal(t, event.TxnHash, bridge.TxHash, "Should use event's tx hash when multiple archived bridges match")
 		require.Equal(t, common.Address{}, bridge.TxnSender, "TxnSender should be empty with multiple matches")
-		require.Equal(t, common.Address{}, bridge.FromAddress, "FromAddress should be empty with multiple matches")
+		require.Nil(t, bridge.FromAddress, "FromAddress should be nil with multiple matches")
 		require.Equal(t, BridgeSourceForwardLET, bridge.Source)
 	})
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -756,11 +756,11 @@ func runBridgeSyncL1IfNeeded(
 	// Run txn_sender backfilling in a separate goroutine
 	wg.Add(1)
 	go func() {
-		if err := runTxnSenderBackfill(ctx, cfg, l1Client, components, bridgesync.L1BridgeSyncer, wg); err != nil {
-			log.Errorf("txn_sender backfilling failed: %v", err)
+		logger := log.WithFields("module", "tx-sender-backfill-"+bridgesync.L1BridgeSyncer.String())
+		if err := runTxnSenderBackfill(ctx, cfg, l1Client, components, bridgesync.L1BridgeSyncer, logger, wg); err != nil {
+			logger.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
-		log.Infof("txn_sender backfilling completed for L1 bridge sync")
 	}()
 
 	go bridgeSyncL1.Start(ctx)
@@ -813,8 +813,9 @@ func runBridgeSyncL2IfNeeded(
 	// Run txn_sender backfilling in a separate goroutine
 	wg.Add(1)
 	go func() {
-		if err := runTxnSenderBackfill(ctx, cfg, l2Client, components, bridgesync.L2BridgeSyncer, wg); err != nil {
-			log.Errorf("txn_sender backfilling failed: %v", err)
+		logger := log.WithFields("module", "tx-sender-backfill-"+bridgesync.L2BridgeSyncer.String())
+		if err := runTxnSenderBackfill(ctx, cfg, l2Client, components, bridgesync.L2BridgeSyncer, logger, wg); err != nil {
+			logger.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
 	}()
@@ -930,23 +931,24 @@ func runTxnSenderBackfill(
 	client aggkittypes.EthClienter,
 	components []string,
 	syncerID bridgesync.BridgeSyncerID,
+	logger *log.Logger,
 	wg *sync.WaitGroup,
 ) error {
 	// Only run backfilling if we have a database path configured
 	if cfg.DBPath == "" {
-		log.Debug("No database path configured, skipping txn_sender backfilling")
+		logger.Debug("No database path configured, skipping txn_sender backfilling")
 		return nil
 	}
 
 	// Defer WaitGroup Done to ensure cleanup on exit
 	defer wg.Done()
 
-	log.Infof("Starting txn_sender backfilling process for %s", syncerID.String())
+	logger.Infof("Starting txn_sender backfilling process for %s", syncerID.String())
 
 	// Resolve SyncFromInBridges mode based on components
 	hasBridgeComponent := isNeeded([]string{aggkitcommon.BRIDGE}, components)
 	syncFromInBridges := cfg.SyncFromInBridges.Resolve(hasBridgeComponent)
-	log.Infof("SyncFromInBridges syncer: %s,  mode: %s, resolved to: %t (BRIDGE component active: %t)",
+	logger.Infof("SyncFromInBridges syncer: %s,  mode: %s, resolved to: %t (BRIDGE component active: %t)",
 		syncerID.String(),
 		cfg.SyncFromInBridges, syncFromInBridges, hasBridgeComponent)
 
@@ -956,7 +958,7 @@ func runTxnSenderBackfill(
 		client,
 		cfg.BridgeAddr,
 		syncFromInBridges,
-		log.WithFields("module", "tx-sender-backfill-"+syncerID.String()),
+		logger,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create backfill instance: %w", err)
@@ -968,16 +970,16 @@ func runTxnSenderBackfill(
 	if err := backfiller.BackfillAll(ctx); err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Err() != nil {
-			log.Infof("txn_sender backfilling cancelled: %v", ctx.Err())
+			logger.Infof("txn_sender backfilling cancelled: %v", ctx.Err())
 			return nil // Don't treat cancellation as an error
 		}
-		log.Errorf("txn_sender backfilling failed: %v", err)
+		logger.Errorf("txn_sender backfilling failed: %v", err)
 		// Don't fail the entire process, just log the error and continue
 		return err
 	}
 
 	duration := time.Since(start)
-	log.Infof("txn_sender backfilling completed in %v", duration)
+	logger.Infof("txn_sender backfilling for %s completed in %v", syncerID.String(), duration)
 
 	return nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,6 +83,7 @@ func start(cliCtx *cli.Context) error {
 	if cfg.Prometheus.Enabled {
 		prometheus.Init()
 	}
+	log.Debugf("Components to run: %v", components)
 	l1Client := runL1ClientIfNeeded(cliCtx.Context, cfg.L1NetworkConfig.RPC)
 	l2Client := runL2ClientIfNeeded(cliCtx.Context, components, cfg.Common.L2RPC)
 	reorgDetectorL1, errChanL1 := runReorgDetectorL1IfNeeded(cliCtx.Context, components, l1Client, &cfg.ReorgDetectorL1)
@@ -755,7 +756,7 @@ func runBridgeSyncL1IfNeeded(
 	// Run txn_sender backfilling in a separate goroutine
 	wg.Add(1)
 	go func() {
-		if err := runTxnSenderBackfill(ctx, cfg, l1Client, components, wg); err != nil {
+		if err := runTxnSenderBackfill(ctx, cfg, l1Client, components, bridgesync.L1BridgeSyncer, wg); err != nil {
 			log.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
@@ -812,7 +813,7 @@ func runBridgeSyncL2IfNeeded(
 	// Run txn_sender backfilling in a separate goroutine
 	wg.Add(1)
 	go func() {
-		if err := runTxnSenderBackfill(ctx, cfg, l2Client, components, wg); err != nil {
+		if err := runTxnSenderBackfill(ctx, cfg, l2Client, components, bridgesync.L2BridgeSyncer, wg); err != nil {
 			log.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
@@ -928,6 +929,7 @@ func runTxnSenderBackfill(
 	cfg bridgesync.Config,
 	client aggkittypes.EthClienter,
 	components []string,
+	syncerID bridgesync.BridgeSyncerID,
 	wg *sync.WaitGroup,
 ) error {
 	// Only run backfilling if we have a database path configured
@@ -939,12 +941,13 @@ func runTxnSenderBackfill(
 	// Defer WaitGroup Done to ensure cleanup on exit
 	defer wg.Done()
 
-	log.Info("Starting txn_sender backfilling process")
+	log.Infof("Starting txn_sender backfilling process for %s", syncerID.String())
 
 	// Resolve SyncFromInBridges mode based on components
 	hasBridgeComponent := isNeeded([]string{aggkitcommon.BRIDGE}, components)
 	syncFromInBridges := cfg.SyncFromInBridges.Resolve(hasBridgeComponent)
-	log.Infof("SyncFromInBridges mode: %s, resolved to: %t (BRIDGE component active: %t)",
+	log.Infof("SyncFromInBridges syncer: %s,  mode: %s, resolved to: %t (BRIDGE component active: %t)",
+		syncerID.String(),
 		cfg.SyncFromInBridges, syncFromInBridges, hasBridgeComponent)
 
 	// Create backfill instance
@@ -953,7 +956,7 @@ func runTxnSenderBackfill(
 		client,
 		cfg.BridgeAddr,
 		syncFromInBridges,
-		log.WithFields("module", "tx-sender-backfill"),
+		log.WithFields("module", "tx-sender-backfill-"+syncerID.String()),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create backfill instance: %w", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -734,12 +734,19 @@ func runBridgeSyncL1IfNeeded(
 		log.Fatalf("invalid BridgeL1Sync config: %v", err)
 	}
 
+	// Resolve SyncFromInBridges mode based on components
+	hasBridgeComponent := isNeeded([]string{aggkitcommon.BRIDGE}, components)
+	syncFromInBridges := cfg.SyncFromInBridges.Resolve(hasBridgeComponent)
+	log.Infof("BridgeL1Sync SyncFromInBridges mode: %s, resolved to: %t (BRIDGE component active: %t)",
+		cfg.SyncFromInBridges, syncFromInBridges, hasBridgeComponent)
+
 	bridgeSyncL1, err := bridgesync.NewL1(
 		ctx,
 		cfg,
 		reorgDetectorL1,
 		l1Client,
 		rollupID,
+		syncFromInBridges,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -748,7 +755,7 @@ func runBridgeSyncL1IfNeeded(
 	// Run txn_sender backfilling in a separate goroutine
 	wg.Add(1)
 	go func() {
-		if err := runTxnSenderBackfill(ctx, cfg, l1Client, wg); err != nil {
+		if err := runTxnSenderBackfill(ctx, cfg, l1Client, components, wg); err != nil {
 			log.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
@@ -783,6 +790,12 @@ func runBridgeSyncL2IfNeeded(
 		return nil
 	}
 
+	// Resolve SyncFromInBridges mode based on components
+	hasBridgeComponent := isNeeded([]string{aggkitcommon.BRIDGE}, components)
+	syncFromInBridges := cfg.SyncFromInBridges.Resolve(hasBridgeComponent)
+	log.Infof("BridgeL2Sync SyncFromInBridges mode: %s, resolved to: %t (BRIDGE component active: %t)",
+		cfg.SyncFromInBridges, syncFromInBridges, hasBridgeComponent)
+
 	bridgeSyncL2, err := bridgesync.NewL2(
 		ctx,
 		cfg,
@@ -790,6 +803,7 @@ func runBridgeSyncL2IfNeeded(
 		l2Client,
 		rollupID,
 		fullClaimsNeeded,
+		syncFromInBridges,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)
@@ -798,7 +812,7 @@ func runBridgeSyncL2IfNeeded(
 	// Run txn_sender backfilling in a separate goroutine
 	wg.Add(1)
 	go func() {
-		if err := runTxnSenderBackfill(ctx, cfg, l2Client, wg); err != nil {
+		if err := runTxnSenderBackfill(ctx, cfg, l2Client, components, wg); err != nil {
 			log.Errorf("txn_sender backfilling failed: %v", err)
 			// Don't fail the entire process, just log the error and continue
 		}
@@ -913,6 +927,7 @@ func runTxnSenderBackfill(
 	ctx context.Context,
 	cfg bridgesync.Config,
 	client aggkittypes.EthClienter,
+	components []string,
 	wg *sync.WaitGroup,
 ) error {
 	// Only run backfilling if we have a database path configured
@@ -926,11 +941,18 @@ func runTxnSenderBackfill(
 
 	log.Info("Starting txn_sender backfilling process")
 
+	// Resolve SyncFromInBridges mode based on components
+	hasBridgeComponent := isNeeded([]string{aggkitcommon.BRIDGE}, components)
+	syncFromInBridges := cfg.SyncFromInBridges.Resolve(hasBridgeComponent)
+	log.Infof("SyncFromInBridges mode: %s, resolved to: %t (BRIDGE component active: %t)",
+		cfg.SyncFromInBridges, syncFromInBridges, hasBridgeComponent)
+
 	// Create backfill instance
 	backfiller, err := bridgesync.NewBackfillTxnSender(
 		cfg.DBPath,
 		client,
 		cfg.BridgeAddr,
+		syncFromInBridges,
 		log.WithFields("module", "tx-sender-backfill"),
 	)
 	if err != nil {

--- a/config/default.go
+++ b/config/default.go
@@ -162,6 +162,7 @@ MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
 DBQueryTimeout = "{{defaultDBQueryTimeout}}"
+SyncFromInBridges = "auto"
 
 [BridgeL2Sync]
 DBPath = "{{PathRWData}}/bridgel2sync.sqlite"
@@ -174,6 +175,7 @@ MaxRetryAttemptsAfterError = -1
 WaitForNewBlocksPeriod = "3s"
 RequireStorageContentCompatibility = {{RequireStorageContentCompatibility}}
 DBQueryTimeout = "{{defaultDBQueryTimeout}}"
+SyncFromInBridges = "auto"
 
 [L2GERSync]
 DBPath = "{{PathRWData}}/l2gersync.sqlite"

--- a/db/compatibility/compatibility_db_contents.go
+++ b/db/compatibility/compatibility_db_contents.go
@@ -82,7 +82,8 @@ func (s *CompatibilityCheck[T]) Check(ctx context.Context, tx types.Querier) err
 		return fmt.Errorf("compatibilityCheck: error reading value from storage. Err: %w", err)
 	}
 	// Compare data
-	if err = runtimeData.IsCompatible(storageData); err != nil {
+	newData, err := runtimeData.IsCompatible(storageData)
+	if err != nil {
 		if s.RequireStorageContentCompatibility {
 			return fmt.Errorf("compatibilityCheck: data on DB is [%s] != runtime [%s]. Err: %w",
 				storageData.String(), runtimeData.String(), err)
@@ -91,6 +92,12 @@ func (s *CompatibilityCheck[T]) Check(ctx context.Context, tx types.Querier) err
 				storageData.String(), runtimeData.String(), err)
 			return nil
 		}
+	}
+	// If newData is not nil, update the storage
+	if newData != nil {
+		s.Logger.Infof("compatibilityCheck: updating DB from [%s] to [%s]",
+			storageData.String(), (*newData).String())
+		return s.Storage.SetCompatibilityData(ctx, tx, *newData)
 	}
 	s.Logger.Infof("compatibilityCheck: data in DB[%s] is compatible with [%s]",
 		storageData.String(), runtimeData.String())

--- a/db/compatibility/compatibility_db_contents_test.go
+++ b/db/compatibility/compatibility_db_contents_test.go
@@ -15,11 +15,11 @@ type testBindData struct {
 	a int
 }
 
-func (t testBindData) IsCompatible(storage testBindData) error {
+func (t testBindData) IsCompatible(storage testBindData) (*testBindData, error) {
 	if t.a != storage.a {
-		return fmt.Errorf("a mismatch: %d != %d", t.a, storage.a)
+		return nil, fmt.Errorf("a mismatch: %d != %d", t.a, storage.a)
 	}
-	return nil
+	return nil, nil
 }
 func (t testBindData) String() string {
 	return fmt.Sprintf("a: %d", t.a)

--- a/db/compatibility/helper_storage.go
+++ b/db/compatibility/helper_storage.go
@@ -82,5 +82,10 @@ func (s *KeyValueToCompatibilityStorage[T]) SetCompatibilityData(ctx context.Con
 	if err != nil {
 		return fmt.Errorf("compatibilityCheck: fails to marshal runtime data. Err: %w", err)
 	}
-	return s.KVStorage.InsertValue(tx, s.OwnerName, compatibilityContentKey, string(dataStr))
+	_, err = s.KVStorage.GetValue(tx, s.OwnerName, compatibilityContentKey)
+	if err != nil && errors.Is(err, db.ErrNotFound) {
+		return s.KVStorage.InsertValue(tx, s.OwnerName, compatibilityContentKey, string(dataStr))
+	} else {
+		return s.KVStorage.UpdateValue(tx, s.OwnerName, compatibilityContentKey, string(dataStr))
+	}
 }

--- a/db/compatibility/helper_storage_test.go
+++ b/db/compatibility/helper_storage_test.go
@@ -1,0 +1,307 @@
+package compatibility
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agglayer/aggkit/db"
+	dbmocks "github.com/agglayer/aggkit/db/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testOwnerName = "test_owner"
+)
+
+type testData struct {
+	Value  string `json:"value"`
+	Number int    `json:"number"`
+}
+
+func TestNewKeyValueToCompatibilityStorage(t *testing.T) {
+	kvStorageMock := dbmocks.NewKeyValueStorager(t)
+
+	storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+	require.NotNil(t, storage)
+	require.Equal(t, kvStorageMock, storage.KVStorage)
+	require.Equal(t, testOwnerName, storage.OwnerName)
+}
+
+func TestKeyValueToCompatibilityStorage_GetCompatibilityData(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("No data stored returns false with no error", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return("", db.ErrNotFound).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.NoError(t, err)
+		require.False(t, exists)
+		require.Equal(t, testData{}, data)
+	})
+
+	t.Run("Data exists and is valid returns true with unmarshaled data", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		expectedData := testData{Value: "test", Number: 42}
+		jsonData, err := json.Marshal(expectedData)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return(string(jsonData), nil).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, expectedData, data)
+	})
+
+	t.Run("Invalid JSON data returns error", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return("invalid json", nil).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fails to unmarshal runtime data")
+		require.False(t, exists)
+		require.Equal(t, testData{}, data)
+	})
+
+	t.Run("Storage error other than ErrNotFound returns error", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		expectedErr := errors.New("storage error")
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return("", expectedErr).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+		require.False(t, exists)
+		require.Equal(t, testData{}, data)
+	})
+}
+
+func TestKeyValueToCompatibilityStorage_SetCompatibilityData(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("First time storing data uses InsertValue", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		dataToStore := testData{Value: "new", Number: 123}
+		jsonData, err := json.Marshal(dataToStore)
+		require.NoError(t, err)
+
+		// First GetValue returns ErrNotFound
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return("", db.ErrNotFound).Once()
+		// Then InsertValue is called
+		kvStorageMock.EXPECT().InsertValue(nil, testOwnerName, compatibilityContentKey, string(jsonData)).
+			Return(nil).Once()
+
+		err = storage.SetCompatibilityData(ctx, nil, dataToStore)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Updating existing data uses UpdateValue", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		dataToStore := testData{Value: "updated", Number: 456}
+		jsonData, err := json.Marshal(dataToStore)
+		require.NoError(t, err)
+
+		// GetValue returns existing data (not ErrNotFound)
+		existingData := testData{Value: "old", Number: 999}
+		existingJSON, err := json.Marshal(existingData)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return(string(existingJSON), nil).Once()
+		// Then UpdateValue is called
+		kvStorageMock.EXPECT().UpdateValue(nil, testOwnerName, compatibilityContentKey, string(jsonData)).
+			Return(nil).Once()
+
+		err = storage.SetCompatibilityData(ctx, nil, dataToStore)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("InsertValue error is returned", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		dataToStore := testData{Value: "test", Number: 789}
+		expectedErr := errors.New("insert error")
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return("", db.ErrNotFound).Once()
+		kvStorageMock.EXPECT().InsertValue(nil, testOwnerName, compatibilityContentKey, string([]byte(`{"value":"test","number":789}`))).
+			Return(expectedErr).Once()
+
+		err := storage.SetCompatibilityData(ctx, nil, dataToStore)
+
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("UpdateValue error is returned", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		dataToStore := testData{Value: "test", Number: 321}
+		expectedErr := errors.New("update error")
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return(`{"value":"old","number":1}`, nil).Once()
+		kvStorageMock.EXPECT().UpdateValue(nil, testOwnerName, compatibilityContentKey, string([]byte(`{"value":"test","number":321}`))).
+			Return(expectedErr).Once()
+
+		err := storage.SetCompatibilityData(ctx, nil, dataToStore)
+
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+	})
+}
+
+func TestKeyValueToCompatibilityStorage_SetCompatibilityData_MarshalError(t *testing.T) {
+	// Test with a type that cannot be marshaled (e.g., contains a channel)
+	type unmarshalableData struct {
+		Channel chan int
+	}
+
+	ctx := context.Background()
+	kvStorageMock := dbmocks.NewKeyValueStorager(t)
+	storage := NewKeyValueToCompatibilityStorage[unmarshalableData](kvStorageMock, testOwnerName)
+
+	dataToStore := unmarshalableData{Channel: make(chan int)}
+
+	err := storage.SetCompatibilityData(ctx, nil, dataToStore)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fails to marshal runtime data")
+}
+
+func TestKeyValueToCompatibilityStorage_WithTransaction(t *testing.T) {
+	ctx := context.Background()
+	mockTx := dbmocks.NewQuerier(t)
+
+	t.Run("GetCompatibilityData with transaction", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		expectedData := testData{Value: "txtest", Number: 100}
+		jsonData, err := json.Marshal(expectedData)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(mockTx, testOwnerName, compatibilityContentKey).
+			Return(string(jsonData), nil).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, mockTx)
+
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, expectedData, data)
+	})
+
+	t.Run("SetCompatibilityData with transaction", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[testData](kvStorageMock, testOwnerName)
+
+		dataToStore := testData{Value: "txtransaction", Number: 200}
+		jsonData, err := json.Marshal(dataToStore)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(mockTx, testOwnerName, compatibilityContentKey).
+			Return("", db.ErrNotFound).Once()
+		kvStorageMock.EXPECT().InsertValue(mockTx, testOwnerName, compatibilityContentKey, string(jsonData)).
+			Return(nil).Once()
+
+		err = storage.SetCompatibilityData(ctx, mockTx, dataToStore)
+
+		require.NoError(t, err)
+	})
+}
+
+func TestKeyValueToCompatibilityStorage_WithDifferentTypes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Works with string type", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[string](kvStorageMock, testOwnerName)
+
+		expectedData := "test string"
+		jsonData, err := json.Marshal(expectedData)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return(string(jsonData), nil).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, expectedData, data)
+	})
+
+	t.Run("Works with int type", func(t *testing.T) {
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[int](kvStorageMock, testOwnerName)
+
+		expectedData := 42
+		jsonData, err := json.Marshal(expectedData)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return(string(jsonData), nil).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, expectedData, data)
+	})
+
+	t.Run("Works with nested struct type", func(t *testing.T) {
+		type nestedStruct struct {
+			Inner testData
+			Name  string
+		}
+
+		kvStorageMock := dbmocks.NewKeyValueStorager(t)
+		storage := NewKeyValueToCompatibilityStorage[nestedStruct](kvStorageMock, testOwnerName)
+
+		expectedData := nestedStruct{
+			Inner: testData{Value: "inner", Number: 99},
+			Name:  "nested",
+		}
+		jsonData, err := json.Marshal(expectedData)
+		require.NoError(t, err)
+
+		kvStorageMock.EXPECT().GetValue(nil, testOwnerName, compatibilityContentKey).
+			Return(string(jsonData), nil).Once()
+
+		exists, data, err := storage.GetCompatibilityData(ctx, nil)
+
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, expectedData, data)
+	})
+}

--- a/db/compatibility/types/comparer.go
+++ b/db/compatibility/types/comparer.go
@@ -5,5 +5,7 @@ import "fmt"
 type CompatibilityComparer[T any] interface {
 	// IsCompatible returns an error if the data in storage is not compatible
 	fmt.Stringer
-	IsCompatible(storage T) error
+	// IsCompatible returns an error if the data in storage is not compatible with the runtime data
+	// and return a new T to be stored into DB (if !=nil)
+	IsCompatible(storage T) (*T, error)
 }

--- a/db/compatibility/types/comparer.go
+++ b/db/compatibility/types/comparer.go
@@ -3,7 +3,6 @@ package types
 import "fmt"
 
 type CompatibilityComparer[T any] interface {
-	// IsCompatible returns an error if the data in storage is not compatible
 	fmt.Stringer
 	// IsCompatible returns an error if the data in storage is not compatible with the runtime data
 	// and return a new T to be stored into DB (if !=nil)

--- a/db/key_value_storage_test.go
+++ b/db/key_value_storage_test.go
@@ -1,0 +1,332 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/db/types"
+	"github.com/agglayer/aggkit/log"
+	"github.com/russross/meddler"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testOwner = "test_owner"
+	testKey   = "test_key"
+	testValue = "test_value"
+)
+
+func TestNewKeyValueStorage(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "test.sqlite")
+	db, err := NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	kv := NewKeyValueStorage(db)
+	require.NotNil(t, kv)
+	require.Equal(t, db, kv.DB)
+}
+
+func TestKeyValueStorage_InsertValue(t *testing.T) {
+	logger := log.WithFields("test", "key_value_storage")
+	dbPath := path.Join(t.TempDir(), "test.sqlite")
+	db, err := NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = RunMigrationsDB(logger, db, []types.Migration{})
+	require.NoError(t, err)
+
+	kv := NewKeyValueStorage(db)
+	owner := testOwner
+	key := testKey
+	value := testValue
+
+	t.Run("Insert with tx nil", func(t *testing.T) {
+		err := kv.InsertValue(nil, owner, key, value)
+		require.NoError(t, err)
+
+		// Verify the value was inserted
+		retrievedValue, err := kv.GetValue(nil, owner, key)
+		require.NoError(t, err)
+		require.Equal(t, value, retrievedValue)
+	})
+
+	t.Run("Insert duplicate key returns error", func(t *testing.T) {
+		// Try to insert the same key again
+		err := kv.InsertValue(nil, owner, key, "another_value")
+		require.Error(t, err)
+	})
+
+	t.Run("Insert with transaction", func(t *testing.T) {
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		newKey := "test_key_tx"
+		newValue := "test_value_tx"
+		err = kv.InsertValue(tx, owner, newKey, newValue)
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		// Verify the value was inserted
+		retrievedValue, err := kv.GetValue(nil, owner, newKey)
+		require.NoError(t, err)
+		require.Equal(t, newValue, retrievedValue)
+	})
+
+	t.Run("Insert sets updated_at timestamp", func(t *testing.T) {
+		fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+		originalTimeFunc := funcTimeNow
+		funcTimeNow = func() time.Time { return fixedTime }
+		defer func() { funcTimeNow = originalTimeFunc }()
+
+		testKey := "time_test_key"
+		err := kv.InsertValue(nil, owner, testKey, "value")
+		require.NoError(t, err)
+
+		// Query the database directly to check the timestamp
+		var data kvRow
+		err = meddler.QueryRow(db, &data, "SELECT * FROM key_value WHERE owner = $1 and key = $2 LIMIT 1;",
+			owner, testKey)
+		require.NoError(t, err)
+		require.Equal(t, fixedTime.Unix(), data.UpdatedAt)
+	})
+}
+
+func TestKeyValueStorage_GetValue(t *testing.T) {
+	logger := log.WithFields("test", "key_value_storage")
+	dbPath := path.Join(t.TempDir(), "test.sqlite")
+	db, err := NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = RunMigrationsDB(logger, db, []types.Migration{})
+	require.NoError(t, err)
+
+	kv := NewKeyValueStorage(db)
+	owner := testOwner
+	key := testKey
+	value := testValue
+
+	t.Run("Get non-existent key returns ErrNotFound", func(t *testing.T) {
+		_, err := kv.GetValue(nil, owner, "non_existent_key")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("Get existing value with tx nil", func(t *testing.T) {
+		err := kv.InsertValue(nil, owner, key, value)
+		require.NoError(t, err)
+
+		retrievedValue, err := kv.GetValue(nil, owner, key)
+		require.NoError(t, err)
+		require.Equal(t, value, retrievedValue)
+	})
+
+	t.Run("Get value with transaction", func(t *testing.T) {
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		retrievedValue, err := kv.GetValue(tx, owner, key)
+		require.NoError(t, err)
+		require.Equal(t, value, retrievedValue)
+	})
+
+	t.Run("Get value returns ErrNotFound when DB returns sql.ErrNoRows", func(t *testing.T) {
+		_, err := kv.GetValue(nil, owner, "missing_key")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("Get value with nil DB returns error", func(t *testing.T) {
+		kvNilDB := &KeyValueStorage{DB: nil}
+		_, err := kvNilDB.GetValue(nil, owner, key)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tx is nil and kv.DB is nil")
+	})
+}
+
+func TestKeyValueStorage_UpdateValue(t *testing.T) {
+	logger := log.WithFields("test", "key_value_storage")
+	dbPath := path.Join(t.TempDir(), "test.sqlite")
+	db, err := NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = RunMigrationsDB(logger, db, []types.Migration{})
+	require.NoError(t, err)
+
+	kv := NewKeyValueStorage(db)
+	owner := testOwner
+	key := testKey
+	value := testValue
+
+	t.Run("Update inserts new key-value when not exists", func(t *testing.T) {
+		newKey := "update_test_key"
+		err := kv.UpdateValue(nil, owner, newKey, value)
+		require.NoError(t, err)
+
+		// Verify the value was inserted
+		retrievedValue, err := kv.GetValue(nil, owner, newKey)
+		require.NoError(t, err)
+		require.Equal(t, value, retrievedValue)
+	})
+
+	t.Run("Update updates existing key-value", func(t *testing.T) {
+		// First insert
+		err := kv.InsertValue(nil, owner, key, value)
+		require.NoError(t, err)
+
+		// Update the value
+		newValue := "updated_value"
+		err = kv.UpdateValue(nil, owner, key, newValue)
+		require.NoError(t, err)
+
+		// Verify the value was updated
+		retrievedValue, err := kv.GetValue(nil, owner, key)
+		require.NoError(t, err)
+		require.Equal(t, newValue, retrievedValue)
+	})
+
+	t.Run("Update with transaction", func(t *testing.T) {
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		txKey := "tx_update_key"
+		err = kv.UpdateValue(tx, owner, txKey, value)
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		// Verify the value was updated
+		retrievedValue, err := kv.GetValue(nil, owner, txKey)
+		require.NoError(t, err)
+		require.Equal(t, value, retrievedValue)
+	})
+
+	t.Run("Update sets updated_at timestamp", func(t *testing.T) {
+		// Insert initial value with old timestamp
+		oldTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+		originalTimeFunc := funcTimeNow
+		funcTimeNow = func() time.Time { return oldTime }
+
+		timeKey := "time_update_key"
+		err := kv.InsertValue(nil, owner, timeKey, "old_value")
+		require.NoError(t, err)
+
+		// Update with new timestamp
+		newTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+		funcTimeNow = func() time.Time { return newTime }
+		defer func() { funcTimeNow = originalTimeFunc }()
+
+		err = kv.UpdateValue(nil, owner, timeKey, "new_value")
+		require.NoError(t, err)
+
+		// Query the database directly to check the timestamp
+		var data kvRow
+		err = meddler.QueryRow(db, &data, "SELECT * FROM key_value WHERE owner = $1 and key = $2 LIMIT 1;",
+			owner, timeKey)
+		require.NoError(t, err)
+		require.Equal(t, newTime.Unix(), data.UpdatedAt)
+		require.Equal(t, "new_value", data.Value)
+	})
+
+	t.Run("Update multiple times preserves latest value", func(t *testing.T) {
+		multiKey := "multi_update_key"
+
+		// First update (insert)
+		err := kv.UpdateValue(nil, owner, multiKey, "value1")
+		require.NoError(t, err)
+
+		// Second update
+		err = kv.UpdateValue(nil, owner, multiKey, "value2")
+		require.NoError(t, err)
+
+		// Third update
+		err = kv.UpdateValue(nil, owner, multiKey, "value3")
+		require.NoError(t, err)
+
+		// Verify final value
+		retrievedValue, err := kv.GetValue(nil, owner, multiKey)
+		require.NoError(t, err)
+		require.Equal(t, "value3", retrievedValue)
+	})
+}
+
+func TestKeyValueStorage_TransactionRollback(t *testing.T) {
+	logger := log.WithFields("test", "key_value_storage")
+	dbPath := path.Join(t.TempDir(), "test.sqlite")
+	db, err := NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = RunMigrationsDB(logger, db, []types.Migration{})
+	require.NoError(t, err)
+
+	kv := NewKeyValueStorage(db)
+	owner := "test_owner"
+
+	t.Run("InsertValue rollback does not persist data", func(t *testing.T) {
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		key := "rollback_insert_key"
+		err = kv.InsertValue(tx, owner, key, "value")
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		// Verify the value was not persisted
+		_, err = kv.GetValue(nil, owner, key)
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("UpdateValue rollback does not persist data", func(t *testing.T) {
+		key := "rollback_update_key"
+
+		// Insert initial value
+		err := kv.InsertValue(nil, owner, key, "original")
+		require.NoError(t, err)
+
+		// Start transaction and update
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		err = kv.UpdateValue(tx, owner, key, "updated")
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		// Verify the value was not updated
+		retrievedValue, err := kv.GetValue(nil, owner, key)
+		require.NoError(t, err)
+		require.Equal(t, "original", retrievedValue)
+	})
+}
+
+func TestReturnErrNotFound(t *testing.T) {
+	t.Run("Returns ErrNotFound for sql.ErrNoRows", func(t *testing.T) {
+		err := ReturnErrNotFound(sql.ErrNoRows)
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("Returns original error for other errors", func(t *testing.T) {
+		originalErr := errors.New("some other error")
+		err := ReturnErrNotFound(originalErr)
+		require.Equal(t, originalErr, err)
+	})
+
+	t.Run("Returns nil for nil error", func(t *testing.T) {
+		err := ReturnErrNotFound(nil)
+		require.NoError(t, err)
+	})
+}

--- a/db/meddler.go
+++ b/db/meddler.go
@@ -228,22 +228,46 @@ type AddressMeddler struct{}
 
 // PreRead is called before a Scan operation for fields that have the AddressMeddler
 func (b AddressMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err error) {
+	// Check if this is a nullable field (**common.Address)
+	_, ok := fieldAddr.(**common.Address)
+	if ok {
+		// Return **string to handle NULL values properly
+		return new(*string), nil
+	}
 	// give a pointer to a byte buffer to grab the raw data
 	return new(string), nil
 }
 
 // PostRead is called after a Scan operation for fields that have the AddressMeddler
 func (b AddressMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
+	// Handle **string case (nullable field)
+	if rawAddrPtr, ok := scanTarget.(**string); ok {
+		addrPtrPtr, ok := fieldPtr.(**common.Address)
+		if !ok {
+			return errors.New("fieldPtr is not **common.Address for **string scanTarget")
+		}
+		if rawAddrPtr == nil || *rawAddrPtr == nil || **rawAddrPtr == "" {
+			*addrPtrPtr = nil
+			return nil
+		}
+		addr := common.HexToAddress(**rawAddrPtr)
+		*addrPtrPtr = &addr
+		return nil
+	}
+
+	// Handle *string case (non-nullable field)
 	ptr, ok := scanTarget.(*string)
 	if !ok {
-		return errors.New("scanTarget is not *string")
+		return errors.New("scanTarget is not *string or **string")
 	}
 	if ptr == nil {
 		return errors.New("AddressMeddler.PostRead: nil pointer")
 	}
+
+	// Handle regular pointer (non-nullable field)
 	field, ok := fieldPtr.(*common.Address)
 	if !ok {
-		return errors.New("fieldPtr is not common.Address")
+		return errors.New("fieldPtr is not *common.Address")
 	}
 	*field = common.HexToAddress(*ptr)
 	return nil
@@ -251,9 +275,17 @@ func (b AddressMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
 
 // PreWrite is called before an Insert or Update operation for fields that have the AddressMeddler
 func (b AddressMeddler) PreWrite(fieldPtr interface{}) (saveValue interface{}, err error) {
+	// Handle pointer to common.Address (nullable field)
+	if addrPtr, ok := fieldPtr.(*common.Address); ok {
+		if addrPtr == nil {
+			return nil, nil
+		}
+		return addrPtr.Hex(), nil
+	}
+	// Handle common.Address (non-nullable field)
 	field, ok := fieldPtr.(common.Address)
 	if !ok {
-		return nil, errors.New("fieldPtr is not common.Address")
+		return nil, errors.New("fieldPtr is not common.Address or *common.Address")
 	}
 	return field.Hex(), nil
 }

--- a/db/meddler_test.go
+++ b/db/meddler_test.go
@@ -2,10 +2,14 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 
+	tree "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
+	sqlite "github.com/mattn/go-sqlite3"
 	"github.com/russross/meddler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,6 +112,775 @@ func TestMeddlerHashpostReadDoublePtrBadParams(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSQLiteErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		err          error
+		expectSQLite bool
+		expectedCode sqlite.ErrNo
+	}{
+		{
+			name:         "direct sqlite error",
+			err:          sqlite.Error{Code: sqlite.ErrConstraint},
+			expectSQLite: true,
+			expectedCode: sqlite.ErrConstraint,
+		},
+		{
+			name:         "non-sqlite error",
+			err:          errors.New("generic error"),
+			expectSQLite: false,
+		},
+		{
+			name:         "nil error",
+			err:          nil,
+			expectSQLite: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sqliteErr, ok := SQLiteErr(tt.err)
+			require.Equal(t, tt.expectSQLite, ok)
+			if tt.expectSQLite {
+				require.NotNil(t, sqliteErr)
+				if tt.expectedCode != 0 {
+					require.Equal(t, tt.expectedCode, sqliteErr.Code)
+				}
+			}
+		})
+	}
+}
+
+func TestSliceToSlicePtrs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "empty int slice",
+			input:    []int{},
+			expected: []*int{},
+		},
+		{
+			name:     "int slice with values",
+			input:    []int{1, 2, 3},
+			expected: []*int{},
+		},
+		{
+			name:     "string slice",
+			input:    []string{"a", "b", "c"},
+			expected: []*string{},
+		},
+		{
+			name:     "empty string slice",
+			input:    []string{},
+			expected: []*string{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := SliceToSlicePtrs(tt.input)
+			require.NotNil(t, result)
+
+			// Verify the result type matches expected pointer slice type
+			switch v := tt.input.(type) {
+			case []int:
+				ptrs, ok := result.([]*int)
+				require.True(t, ok, "result should be []*int")
+				require.Equal(t, len(v), len(ptrs))
+				for i, val := range v {
+					require.Equal(t, val, *ptrs[i])
+				}
+			case []string:
+				ptrs, ok := result.([]*string)
+				require.True(t, ok, "result should be []*string")
+				require.Equal(t, len(v), len(ptrs))
+				for i, val := range v {
+					require.Equal(t, val, *ptrs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSlicePtrsToSlice(t *testing.T) {
+	t.Parallel()
+
+	// Create test data
+	i1, i2, i3 := 1, 2, 3
+	s1, s2, s3 := "a", "b", "c"
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "empty int pointer slice",
+			input:    []*int{},
+			expected: []int{},
+		},
+		{
+			name:     "int pointer slice with values",
+			input:    []*int{&i1, &i2, &i3},
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "string pointer slice",
+			input:    []*string{&s1, &s2, &s3},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "empty string pointer slice",
+			input:    []*string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := SlicePtrsToSlice(tt.input)
+			require.NotNil(t, result)
+
+			// Verify the result matches expected
+			switch expected := tt.expected.(type) {
+			case []int:
+				actual, ok := result.([]int)
+				require.True(t, ok, "result should be []int")
+				require.Equal(t, expected, actual)
+			case []string:
+				actual, ok := result.([]string)
+				require.True(t, ok, "result should be []string")
+				require.Equal(t, expected, actual)
+			}
+		})
+	}
+}
+
+func TestBigIntMeddler_PreRead(t *testing.T) {
+	t.Parallel()
+
+	b := BigIntMeddler{}
+	scanTarget, err := b.PreRead(nil)
+	require.NoError(t, err)
+	require.NotNil(t, scanTarget)
+
+	_, ok := scanTarget.(*string)
+	require.True(t, ok, "scanTarget should be *string")
+}
+
+func TestBigIntMeddler_PostRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		scanTarget  interface{}
+		fieldPtr    interface{}
+		expected    *big.Int
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:       "valid big int string",
+			scanTarget: func() *string { s := "12345"; return &s }(),
+			fieldPtr:   new(*big.Int),
+			expected:   big.NewInt(12345),
+		},
+		{
+			name:       "zero value",
+			scanTarget: func() *string { s := "0"; return &s }(),
+			fieldPtr:   new(*big.Int),
+			expected:   big.NewInt(0),
+		},
+		{
+			name:       "large number",
+			scanTarget: func() *string { s := "999999999999999999999999"; return &s }(),
+			fieldPtr:   new(*big.Int),
+			expected:   func() *big.Int { i, _ := new(big.Int).SetString("999999999999999999999999", 10); return i }(),
+		},
+		{
+			name:        "invalid scan target type",
+			scanTarget:  "not a pointer",
+			fieldPtr:    new(*big.Int),
+			expectError: true,
+			errorMsg:    "scanTarget is not *string",
+		},
+		{
+			name:        "nil scan target",
+			scanTarget:  (*string)(nil),
+			fieldPtr:    new(*big.Int),
+			expectError: true,
+			errorMsg:    "nil pointer",
+		},
+		{
+			name:        "invalid field pointer type",
+			scanTarget:  func() *string { s := "123"; return &s }(),
+			fieldPtr:    new(string),
+			expectError: true,
+			errorMsg:    "fieldPtr is not *big.Int",
+		},
+		{
+			name:        "invalid number string",
+			scanTarget:  func() *string { s := "not a number"; return &s }(),
+			fieldPtr:    new(*big.Int),
+			expectError: true,
+			errorMsg:    "SetString failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := BigIntMeddler{}
+			err := b.PostRead(tt.fieldPtr, tt.scanTarget)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				field, ok := tt.fieldPtr.(**big.Int)
+				require.True(t, ok)
+				require.Equal(t, tt.expected.String(), (*field).String())
+			}
+		})
+	}
+}
+
+func TestBigIntMeddler_PreWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		fieldPtr    interface{}
+		expected    interface{}
+		expectError bool
+	}{
+		{
+			name:     "valid big int",
+			fieldPtr: big.NewInt(12345),
+			expected: "12345",
+		},
+		{
+			name:     "zero value",
+			fieldPtr: big.NewInt(0),
+			expected: "0",
+		},
+		{
+			name:     "negative value",
+			fieldPtr: big.NewInt(-999),
+			expected: "-999",
+		},
+		{
+			name:     "large number",
+			fieldPtr: func() *big.Int { i, _ := new(big.Int).SetString("999999999999999999999999", 10); return i }(),
+			expected: "999999999999999999999999",
+		},
+		{
+			name:        "invalid type",
+			fieldPtr:    "not a big int",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := BigIntMeddler{}
+			saveValue, err := b.PreWrite(tt.fieldPtr)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "fieldPtr is not *big.Int")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, saveValue)
+			}
+		})
+	}
+}
+
+func TestMerkleProofMeddler_PreRead(t *testing.T) {
+	t.Parallel()
+
+	m := MerkleProofMeddler{}
+	scanTarget, err := m.PreRead(nil)
+	require.NoError(t, err)
+	require.NotNil(t, scanTarget)
+
+	_, ok := scanTarget.(*string)
+	require.True(t, ok, "scanTarget should be *string")
+}
+
+func TestMerkleProofMeddler_PostRead(t *testing.T) {
+	t.Parallel()
+
+	// Create a valid proof string with 32 hashes
+	validHashes := make([]string, tree.DefaultHeight)
+	for i := range validHashes {
+		validHashes[i] = fmt.Sprintf("0x%064d", i)
+	}
+	validProofString := func() *string {
+		s := "" + validHashes[0]
+		for i := 1; i < len(validHashes); i++ {
+			s += "," + validHashes[i]
+		}
+		return &s
+	}()
+
+	tests := []struct {
+		name        string
+		scanTarget  interface{}
+		fieldPtr    interface{}
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:       "valid proof",
+			scanTarget: validProofString,
+			fieldPtr:   new(tree.Proof),
+		},
+		{
+			name:        "invalid scan target type",
+			scanTarget:  "not a pointer",
+			fieldPtr:    new(tree.Proof),
+			expectError: true,
+			errorMsg:    "scanTarget is not *string",
+		},
+		{
+			name:        "nil scan target",
+			scanTarget:  (*string)(nil),
+			fieldPtr:    new(tree.Proof),
+			expectError: true,
+			errorMsg:    "nil pointer",
+		},
+		{
+			name:        "invalid field pointer type",
+			scanTarget:  validProofString,
+			fieldPtr:    new(string),
+			expectError: true,
+			errorMsg:    "fieldPtr is not tree.Proof",
+		},
+		{
+			name:        "wrong number of hashes",
+			scanTarget:  func() *string { s := "0x123,0x456"; return &s }(),
+			fieldPtr:    new(tree.Proof),
+			expectError: true,
+			errorMsg:    "unexpected len of hashes",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := MerkleProofMeddler{}
+			err := m.PostRead(tt.fieldPtr, tt.scanTarget)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				field, ok := tt.fieldPtr.(*tree.Proof)
+				require.True(t, ok)
+				require.NotNil(t, field)
+			}
+		})
+	}
+}
+
+func TestMerkleProofMeddler_PreWrite(t *testing.T) {
+	t.Parallel()
+
+	// Create a valid proof
+	var proof tree.Proof
+	for i := range proof {
+		proof[i] = common.HexToHash(fmt.Sprintf("0x%064d", i))
+	}
+
+	tests := []struct {
+		name        string
+		fieldPtr    interface{}
+		expectError bool
+	}{
+		{
+			name:     "valid proof",
+			fieldPtr: proof,
+		},
+		{
+			name:        "invalid type",
+			fieldPtr:    "not a proof",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := MerkleProofMeddler{}
+			saveValue, err := m.PreWrite(tt.fieldPtr)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "fieldPtr is not tree.Proof")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, saveValue)
+				str, ok := saveValue.(string)
+				require.True(t, ok)
+				require.NotEmpty(t, str)
+			}
+		})
+	}
+}
+
+func TestHashMeddler_PreRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		fieldAddr       interface{}
+		expectedType    string
+		expectedIsNil   bool
+		expectDoublePtr bool
+	}{
+		{
+			name:            "nullable hash field",
+			fieldAddr:       new(*common.Hash),
+			expectedType:    "**string",
+			expectDoublePtr: true,
+		},
+		{
+			name:         "non-nullable hash field",
+			fieldAddr:    new(common.Hash),
+			expectedType: "*string",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := HashMeddler{}
+			scanTarget, err := h.PreRead(tt.fieldAddr)
+			require.NoError(t, err)
+			require.NotNil(t, scanTarget)
+
+			if tt.expectDoublePtr {
+				_, ok := scanTarget.(**string)
+				require.True(t, ok, "scanTarget should be **string")
+			} else {
+				_, ok := scanTarget.(*string)
+				require.True(t, ok, "scanTarget should be *string")
+			}
+		})
+	}
+}
+
+func TestHashMeddler_PostRead(t *testing.T) {
+	t.Parallel()
+
+	hex := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	hash := common.HexToHash(hex)
+
+	tests := []struct {
+		name        string
+		scanTarget  interface{}
+		fieldPtr    interface{}
+		expected    *common.Hash
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:       "valid hash",
+			scanTarget: func() *string { s := hex; return &s }(),
+			fieldPtr:   new(common.Hash),
+			expected:   &hash,
+		},
+		{
+			name:       "nullable hash with value",
+			scanTarget: func() **string { s := hex; ps := &s; return &ps }(),
+			fieldPtr:   new(*common.Hash),
+			expected:   &hash,
+		},
+		{
+			name:       "nullable hash with nil",
+			scanTarget: func() **string { var ps *string; return &ps }(),
+			fieldPtr:   new(*common.Hash),
+			expected:   nil,
+		},
+		{
+			name:       "nullable hash with empty string",
+			scanTarget: func() **string { s := ""; ps := &s; return &ps }(),
+			fieldPtr:   new(*common.Hash),
+			expected:   nil,
+		},
+		{
+			name:        "invalid scan target",
+			scanTarget:  123,
+			fieldPtr:    new(common.Hash),
+			expectError: true,
+			errorMsg:    "scanTarget is not *string",
+		},
+		{
+			name:        "invalid field pointer",
+			scanTarget:  func() *string { s := hex; return &s }(),
+			fieldPtr:    new(string),
+			expectError: true,
+			errorMsg:    "fieldPtr is not *common.Hash",
+		},
+		{
+			name:        "double ptr invalid field pointer",
+			scanTarget:  func() **string { s := hex; ps := &s; return &ps }(),
+			fieldPtr:    new(string),
+			expectError: true,
+			errorMsg:    "fieldPtr is not **common.Hash",
+		},
+	}
+
+	//nolint:dupl // Similar test structure by design for different types
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := HashMeddler{}
+			err := h.PostRead(tt.fieldPtr, tt.scanTarget)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				if hashPtrPtr, ok := tt.fieldPtr.(**common.Hash); ok {
+					if tt.expected == nil {
+						require.Nil(t, *hashPtrPtr)
+					} else {
+						require.NotNil(t, *hashPtrPtr)
+						require.Equal(t, *tt.expected, **hashPtrPtr)
+					}
+				} else if hashPtr, ok := tt.fieldPtr.(*common.Hash); ok {
+					require.Equal(t, *tt.expected, *hashPtr)
+				}
+			}
+		})
+	}
+}
+
+func TestAddressMeddler_PreRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		fieldAddr       interface{}
+		expectDoublePtr bool
+	}{
+		{
+			name:            "nullable address field",
+			fieldAddr:       new(*common.Address),
+			expectDoublePtr: true,
+		},
+		{
+			name:      "non-nullable address field",
+			fieldAddr: new(common.Address),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := AddressMeddler{}
+			scanTarget, err := a.PreRead(tt.fieldAddr)
+			require.NoError(t, err)
+			require.NotNil(t, scanTarget)
+
+			if tt.expectDoublePtr {
+				_, ok := scanTarget.(**string)
+				require.True(t, ok, "scanTarget should be **string")
+			} else {
+				_, ok := scanTarget.(*string)
+				require.True(t, ok, "scanTarget should be *string")
+			}
+		})
+	}
+}
+
+func TestAddressMeddler_PostRead(t *testing.T) {
+	t.Parallel()
+
+	addrHex := "0x1234567890123456789012345678901234567890"
+	addr := common.HexToAddress(addrHex)
+
+	tests := []struct {
+		name        string
+		scanTarget  interface{}
+		fieldPtr    interface{}
+		expected    *common.Address
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:       "valid address",
+			scanTarget: func() *string { s := addrHex; return &s }(),
+			fieldPtr:   new(common.Address),
+			expected:   &addr,
+		},
+		{
+			name:       "nullable address with value",
+			scanTarget: func() **string { s := addrHex; ps := &s; return &ps }(),
+			fieldPtr:   new(*common.Address),
+			expected:   &addr,
+		},
+		{
+			name:       "nullable address with nil",
+			scanTarget: func() **string { var ps *string; return &ps }(),
+			fieldPtr:   new(*common.Address),
+			expected:   nil,
+		},
+		{
+			name:       "nullable address with empty string",
+			scanTarget: func() **string { s := ""; ps := &s; return &ps }(),
+			fieldPtr:   new(*common.Address),
+			expected:   nil,
+		},
+		{
+			name:        "invalid scan target type",
+			scanTarget:  123,
+			fieldPtr:    new(common.Address),
+			expectError: true,
+			errorMsg:    "scanTarget is not *string or **string",
+		},
+		{
+			name:        "nil scan target pointer",
+			scanTarget:  (*string)(nil),
+			fieldPtr:    new(common.Address),
+			expectError: true,
+			errorMsg:    "nil pointer",
+		},
+		{
+			name:        "invalid field pointer type",
+			scanTarget:  func() *string { s := addrHex; return &s }(),
+			fieldPtr:    new(string),
+			expectError: true,
+			errorMsg:    "fieldPtr is not *common.Address",
+		},
+		{
+			name:        "double ptr invalid field pointer",
+			scanTarget:  func() **string { s := addrHex; ps := &s; return &ps }(),
+			fieldPtr:    new(string),
+			expectError: true,
+			errorMsg:    "fieldPtr is not **common.Address",
+		},
+	}
+
+	//nolint:dupl // Similar test structure by design for different types
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := AddressMeddler{}
+			err := a.PostRead(tt.fieldPtr, tt.scanTarget)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				if addrPtrPtr, ok := tt.fieldPtr.(**common.Address); ok {
+					if tt.expected == nil {
+						require.Nil(t, *addrPtrPtr)
+					} else {
+						require.NotNil(t, *addrPtrPtr)
+						require.Equal(t, *tt.expected, **addrPtrPtr)
+					}
+				} else if addrPtr, ok := tt.fieldPtr.(*common.Address); ok {
+					require.Equal(t, *tt.expected, *addrPtr)
+				}
+			}
+		})
+	}
+}
+
+func TestAddressMeddler_PreWrite(t *testing.T) {
+	t.Parallel()
+
+	addrHex := "0x1234567890123456789012345678901234567890"
+	addr := common.HexToAddress(addrHex)
+
+	tests := []struct {
+		name        string
+		fieldPtr    interface{}
+		expected    interface{}
+		expectError bool
+	}{
+		{
+			name:     "valid address",
+			fieldPtr: addr,
+			expected: addr.Hex(),
+		},
+		{
+			name:     "valid address pointer",
+			fieldPtr: &addr,
+			expected: addr.Hex(),
+		},
+		{
+			name:     "nil address pointer",
+			fieldPtr: (*common.Address)(nil),
+			expected: nil,
+		},
+		{
+			name:        "invalid type",
+			fieldPtr:    "not an address",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := AddressMeddler{}
+			saveValue, err := a.PreWrite(tt.fieldPtr)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "fieldPtr is not common.Address")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, saveValue)
+			}
+		})
+	}
+}
+
 func createExampleDB(t *testing.T) *sql.DB {
 	t.Helper()
 	dbPath := ":memory:"
@@ -123,12 +896,12 @@ func createExampleDB(t *testing.T) *sql.DB {
 	`)
 	require.NoError(t, err, "failed to create table")
 	_, err = db.Exec(`
-	INSERT INTO certificate_info (height, certificate_id,finalized_l1_info_tree_root) 
+	INSERT INTO certificate_info (height, certificate_id,finalized_l1_info_tree_root)
 	VALUES (0,'0xbeef', NULL);
 `)
 	require.NoError(t, err, "failed to insert null data")
 	_, err = db.Exec(`
-		INSERT INTO certificate_info (height,certificate_id, finalized_l1_info_tree_root) 
+		INSERT INTO certificate_info (height,certificate_id, finalized_l1_info_tree_root)
 		VALUES (1, '0xbeef','0x1234567890123456789012345678901234567890');
 	`)
 	require.NoError(t, err, "failed to insert data")

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -64,7 +64,18 @@ func RunMigrationsDBExtended(logger aggkitcommon.Logger,
 	fullmigrations := migrationsParam
 	// In case of partial execution we ignore the base migrations
 	if maxMigrations == NoLimitMigrations {
-		fullmigrations = append(fullmigrations, migrations.GetBaseMigrations()...)
+		baseMigrations := migrations.GetBaseMigrations()
+		found := false
+		// If the base migration is included we skip adding twice
+		for _, m := range migrationsParam {
+			if m.ID == baseMigrations[0].ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			fullmigrations = append(fullmigrations, baseMigrations...)
+		}
 	} else {
 		migrate.SetIgnoreUnknown(true)
 	}

--- a/multidownloader/state.go
+++ b/multidownloader/state.go
@@ -109,7 +109,13 @@ func (s *State) ExtendPendingRange(
 
 // GetHighestBlockNumberPendingToSync returns the highest block number that is pending to be synced
 func (s *State) GetHighestBlockNumberPendingToSync() (uint64, aggkittypes.BlockNumberFinality) {
-	return s.Pending.GetHighestBlockNumber()
+	// TODO: Change this for a more elegant way of determining that it's fully synced
+	bn, tag := s.Pending.GetHighestBlockNumber()
+	// If bn = 0 is zero means that there are no pending segments
+	if bn == 0 {
+		bn, tag = s.Synced.GetHighestBlockNumber()
+	}
+	return bn, tag
 }
 
 // IsAvailable checks if the given LogQuery is fully available in the synced segments

--- a/multidownloader/storage/compatibility_runtime.go
+++ b/multidownloader/storage/compatibility_runtime.go
@@ -15,12 +15,12 @@ type DBRuntimeData struct {
 func (r DBRuntimeData) String() string {
 	return fmt.Sprintf("NetworkID: %d, DataVersion: %d", r.NetworkID, r.DataVersion)
 }
-func (r DBRuntimeData) IsCompatible(storage DBRuntimeData) error {
+func (r DBRuntimeData) IsCompatible(storage DBRuntimeData) (*DBRuntimeData, error) {
 	if r.NetworkID != storage.NetworkID {
-		return fmt.Errorf("network ID mismatch: expected: %d != storage: %d", r.NetworkID, storage.NetworkID)
+		return nil, fmt.Errorf("network ID mismatch: expected: %d != storage: %d", r.NetworkID, storage.NetworkID)
 	}
 	if r.DataVersion != storage.DataVersion {
-		return fmt.Errorf("data version mismatch: expected: %d != storage: %d", r.DataVersion, storage.DataVersion)
+		return nil, fmt.Errorf("data version mismatch: expected: %d != storage: %d", r.DataVersion, storage.DataVersion)
 	}
-	return nil
+	return nil, nil
 }

--- a/multidownloader/storage/compatibility_runtime_test.go
+++ b/multidownloader/storage/compatibility_runtime_test.go
@@ -44,7 +44,7 @@ func TestDBRuntimeDataIsCompatible(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := sut.IsCompatible(tt.storage)
+			_, err := sut.IsCompatible(tt.storage)
 			if tt.expectError == "" {
 				require.NoError(t, err)
 			} else {

--- a/multidownloader/sync/runtimedata.go
+++ b/multidownloader/sync/runtimedata.go
@@ -21,17 +21,17 @@ func (r RuntimeData) String() string {
 	return res
 }
 
-func (r RuntimeData) IsCompatible(other RuntimeData) error {
+func (r RuntimeData) IsCompatible(other RuntimeData) (*RuntimeData, error) {
 	if r.ChainID != other.ChainID {
-		return fmt.Errorf("chain ID mismatch: %d != %d", r.ChainID, other.ChainID)
+		return nil, fmt.Errorf("chain ID mismatch: %d != %d", r.ChainID, other.ChainID)
 	}
 	if len(r.Addresses) != len(other.Addresses) {
-		return fmt.Errorf("addresses len mismatch: %d != %d", len(r.Addresses), len(other.Addresses))
+		return nil, fmt.Errorf("addresses len mismatch: %d != %d", len(r.Addresses), len(other.Addresses))
 	}
 	for i, addr := range r.Addresses {
 		if addr != other.Addresses[i] {
-			return fmt.Errorf("addresses[%d] mismatch: %s != %s", i, addr.String(), other.Addresses[i].String())
+			return nil, fmt.Errorf("addresses[%d] mismatch: %s != %s", i, addr.String(), other.Addresses[i].String())
 		}
 	}
-	return nil
+	return nil, nil
 }

--- a/multidownloader/sync/runtimedata_test.go
+++ b/multidownloader/sync/runtimedata_test.go
@@ -149,8 +149,9 @@ func TestRuntimeData_IsCompatible_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.data1.IsCompatible(tt.data2)
+			result, err := tt.data1.IsCompatible(tt.data2)
 			require.NoError(t, err)
+			require.Nil(t, result)
 		})
 	}
 }
@@ -210,8 +211,9 @@ func TestRuntimeData_IsCompatible_ChainIDMismatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.data1.IsCompatible(tt.data2)
+			result, err := tt.data1.IsCompatible(tt.data2)
 			require.Error(t, err)
+			require.Nil(t, result)
 			require.Contains(t, err.Error(), "chain ID mismatch")
 		})
 	}
@@ -300,8 +302,9 @@ func TestRuntimeData_IsCompatible_AddressesLenMismatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.data1.IsCompatible(tt.data2)
+			result, err := tt.data1.IsCompatible(tt.data2)
 			require.Error(t, err)
+			require.Nil(t, result)
 			require.Contains(t, err.Error(), "addresses len mismatch")
 		})
 	}
@@ -412,8 +415,9 @@ func TestRuntimeData_IsCompatible_AddressMismatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.data1.IsCompatible(tt.data2)
+			result, err := tt.data1.IsCompatible(tt.data2)
 			require.Error(t, err)
+			require.Nil(t, result)
 			require.Contains(t, err.Error(), "addresses")
 			require.Contains(t, err.Error(), "mismatch")
 		})
@@ -431,8 +435,9 @@ func TestRuntimeData_IsCompatible_ErrorPrecedence(t *testing.T) {
 			Addresses: []common.Address{common.HexToAddress("0x456")},
 		}
 
-		err := data1.IsCompatible(data2)
+		result, err := data1.IsCompatible(data2)
 		require.Error(t, err)
+		require.Nil(t, result)
 		require.Contains(t, err.Error(), "chain ID mismatch")
 	})
 
@@ -449,8 +454,9 @@ func TestRuntimeData_IsCompatible_ErrorPrecedence(t *testing.T) {
 			},
 		}
 
-		err := data1.IsCompatible(data2)
+		result, err := data1.IsCompatible(data2)
 		require.Error(t, err)
+		require.Nil(t, result)
 		require.Contains(t, err.Error(), "addresses len mismatch")
 	})
 }
@@ -466,8 +472,9 @@ func TestRuntimeData_IsCompatible_NilAddresses(t *testing.T) {
 			Addresses: nil,
 		}
 
-		err := data1.IsCompatible(data2)
+		result, err := data1.IsCompatible(data2)
 		require.NoError(t, err)
+		require.Nil(t, result)
 	})
 
 	t.Run("one nil, one empty", func(t *testing.T) {
@@ -480,8 +487,9 @@ func TestRuntimeData_IsCompatible_NilAddresses(t *testing.T) {
 			Addresses: []common.Address{},
 		}
 
-		err := data1.IsCompatible(data2)
+		result, err := data1.IsCompatible(data2)
 		require.NoError(t, err)
+		require.Nil(t, result)
 	})
 
 	t.Run("nil vs non-empty", func(t *testing.T) {
@@ -494,8 +502,9 @@ func TestRuntimeData_IsCompatible_NilAddresses(t *testing.T) {
 			Addresses: []common.Address{common.HexToAddress("0x123")},
 		}
 
-		err := data1.IsCompatible(data2)
+		result, err := data1.IsCompatible(data2)
 		require.Error(t, err)
+		require.Nil(t, result)
 		require.Contains(t, err.Error(), "addresses len mismatch")
 	})
 }

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -63,19 +63,19 @@ func (r RuntimeData) String() string {
 	return res
 }
 
-func (r RuntimeData) IsCompatible(other RuntimeData) error {
+func (r RuntimeData) IsCompatible(other RuntimeData) (*RuntimeData, error) {
 	if r.ChainID != other.ChainID {
-		return fmt.Errorf("chain ID mismatch: %d != %d", r.ChainID, other.ChainID)
+		return nil, fmt.Errorf("chain ID mismatch: %d != %d", r.ChainID, other.ChainID)
 	}
 	if len(r.Addresses) != len(other.Addresses) {
-		return fmt.Errorf("addresses len mismatch: %d != %d", len(r.Addresses), len(other.Addresses))
+		return nil, fmt.Errorf("addresses len mismatch: %d != %d", len(r.Addresses), len(other.Addresses))
 	}
 	for i, addr := range r.Addresses {
 		if addr != other.Addresses[i] {
-			return fmt.Errorf("addresses[%d] mismatch: %s != %s", i, addr.String(), other.Addresses[i].String())
+			return nil, fmt.Errorf("addresses[%d] mismatch: %s != %s", i, addr.String(), other.Addresses[i].String())
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 type processorInterface interface {

--- a/sync/evmdriver_test.go
+++ b/sync/evmdriver_test.go
@@ -440,3 +440,505 @@ func TestEVMDriver_GetCompletionPercentage(t *testing.T) {
 	sut := &EVMDriver{}
 	require.Nil(t, sut.GetCompletionPercentage(), "expected GetCompletionPercentage to return nil for legacy syncer")
 }
+
+func TestRuntimeData_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     RuntimeData
+		expected string
+	}{
+		{
+			name: "empty addresses",
+			data: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{},
+			},
+			expected: "ChainID: 1, Addresses: ",
+		},
+		{
+			name: "single address",
+			data: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			expected: "ChainID: 1, Addresses: 0x0000000000000000000000000000000000000123, ",
+		},
+		{
+			name: "two addresses",
+			data: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+					common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				},
+			},
+			expected: "ChainID: 1, Addresses: 0x1234567890AbcdEF1234567890aBcdef12345678, 0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD, ",
+		},
+		{
+			name: "multiple addresses",
+			data: RuntimeData{
+				ChainID: 42,
+				Addresses: []common.Address{
+					common.HexToAddress("0x123"),
+					common.HexToAddress("0x456"),
+					common.HexToAddress("0x789"),
+				},
+			},
+			expected: "ChainID: 42, Addresses: 0x0000000000000000000000000000000000000123, 0x0000000000000000000000000000000000000456, 0x0000000000000000000000000000000000000789, ",
+		},
+		{
+			name: "zero chain ID",
+			data: RuntimeData{
+				ChainID:   0,
+				Addresses: []common.Address{common.HexToAddress("0xabc")},
+			},
+			expected: "ChainID: 0, Addresses: 0x0000000000000000000000000000000000000aBc, ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.data.String()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRuntimeData_IsCompatible_Success(t *testing.T) {
+	tests := []struct {
+		name  string
+		data1 RuntimeData
+		data2 RuntimeData
+	}{
+		{
+			name: "identical data with single address",
+			data1: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			data2: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+		},
+		{
+			name: "identical data with two addresses",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+					common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+					common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				},
+			},
+		},
+		{
+			name: "identical data with multiple addresses",
+			data1: RuntimeData{
+				ChainID: 42,
+				Addresses: []common.Address{
+					common.HexToAddress("0x123"),
+					common.HexToAddress("0x456"),
+					common.HexToAddress("0x789"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 42,
+				Addresses: []common.Address{
+					common.HexToAddress("0x123"),
+					common.HexToAddress("0x456"),
+					common.HexToAddress("0x789"),
+				},
+			},
+		},
+		{
+			name: "both have empty addresses",
+			data1: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{},
+			},
+			data2: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{},
+			},
+		},
+		{
+			name: "zero chain ID with matching data",
+			data1: RuntimeData{
+				ChainID:   0,
+				Addresses: []common.Address{common.HexToAddress("0x789")},
+			},
+			data2: RuntimeData{
+				ChainID:   0,
+				Addresses: []common.Address{common.HexToAddress("0x789")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.data1.IsCompatible(tt.data2)
+			require.NoError(t, err)
+			require.Nil(t, result)
+		})
+	}
+}
+
+func TestRuntimeData_IsCompatible_ChainIDMismatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		data1    RuntimeData
+		data2    RuntimeData
+		chainID1 uint64
+		chainID2 uint64
+	}{
+		{
+			name: "different chain IDs with same address",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 2,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				},
+			},
+			chainID1: 1,
+			chainID2: 2,
+		},
+		{
+			name: "chain ID 0 vs 1",
+			data1: RuntimeData{
+				ChainID:   0,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			data2: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			chainID1: 0,
+			chainID2: 1,
+		},
+		{
+			name: "large chain ID difference",
+			data1: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			data2: RuntimeData{
+				ChainID:   999999,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			chainID1: 1,
+			chainID2: 999999,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.data1.IsCompatible(tt.data2)
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.Contains(t, err.Error(), "chain ID mismatch")
+		})
+	}
+}
+
+func TestRuntimeData_IsCompatible_AddressesLenMismatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		data1 RuntimeData
+		data2 RuntimeData
+	}{
+		{
+			name: "data1 has more addresses",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+					common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				},
+			},
+		},
+		{
+			name: "data2 has more addresses",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+					common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				},
+			},
+		},
+		{
+			name: "data1 empty, data2 has addresses",
+			data1: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{},
+			},
+			data2: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+		},
+		{
+			name: "data1 has addresses, data2 empty",
+			data1: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{common.HexToAddress("0x123")},
+			},
+			data2: RuntimeData{
+				ChainID:   1,
+				Addresses: []common.Address{},
+			},
+		},
+		{
+			name: "large difference in address count",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x111"),
+					common.HexToAddress("0x222"),
+					common.HexToAddress("0x333"),
+					common.HexToAddress("0x444"),
+					common.HexToAddress("0x555"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x111"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.data1.IsCompatible(tt.data2)
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.Contains(t, err.Error(), "addresses len mismatch")
+		})
+	}
+}
+
+func TestRuntimeData_IsCompatible_AddressMismatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		data1 RuntimeData
+		data2 RuntimeData
+		index int
+	}{
+		{
+			name: "single address mismatch",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				},
+			},
+			index: 0,
+		},
+		{
+			name: "first address differs",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x123"),
+					common.HexToAddress("0x456"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x789"),
+					common.HexToAddress("0x456"),
+				},
+			},
+			index: 0,
+		},
+		{
+			name: "second address differs",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x123"),
+					common.HexToAddress("0x456"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x123"),
+					common.HexToAddress("0x789"),
+				},
+			},
+			index: 1,
+		},
+		{
+			name: "middle address differs in longer list",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x111"),
+					common.HexToAddress("0x222"),
+					common.HexToAddress("0x333"),
+					common.HexToAddress("0x444"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x111"),
+					common.HexToAddress("0x222"),
+					common.HexToAddress("0x999"),
+					common.HexToAddress("0x444"),
+				},
+			},
+			index: 2,
+		},
+		{
+			name: "last address differs",
+			data1: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x111"),
+					common.HexToAddress("0x222"),
+					common.HexToAddress("0x333"),
+				},
+			},
+			data2: RuntimeData{
+				ChainID: 1,
+				Addresses: []common.Address{
+					common.HexToAddress("0x111"),
+					common.HexToAddress("0x222"),
+					common.HexToAddress("0x999"),
+				},
+			},
+			index: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.data1.IsCompatible(tt.data2)
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.Contains(t, err.Error(), "addresses")
+			require.Contains(t, err.Error(), "mismatch")
+		})
+	}
+}
+
+func TestRuntimeData_IsCompatible_ErrorPrecedence(t *testing.T) {
+	t.Run("chain ID mismatch takes precedence over address differences", func(t *testing.T) {
+		data1 := RuntimeData{
+			ChainID:   1,
+			Addresses: []common.Address{common.HexToAddress("0x123")},
+		}
+		data2 := RuntimeData{
+			ChainID:   2,
+			Addresses: []common.Address{common.HexToAddress("0x456")},
+		}
+
+		result, err := data1.IsCompatible(data2)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "chain ID mismatch")
+	})
+
+	t.Run("length mismatch checked before address comparison", func(t *testing.T) {
+		data1 := RuntimeData{
+			ChainID:   1,
+			Addresses: []common.Address{common.HexToAddress("0x123")},
+		}
+		data2 := RuntimeData{
+			ChainID: 1,
+			Addresses: []common.Address{
+				common.HexToAddress("0x456"),
+				common.HexToAddress("0x789"),
+			},
+		}
+
+		result, err := data1.IsCompatible(data2)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "addresses len mismatch")
+	})
+}
+
+func TestRuntimeData_IsCompatible_NilAddresses(t *testing.T) {
+	t.Run("both nil addresses", func(t *testing.T) {
+		data1 := RuntimeData{
+			ChainID:   1,
+			Addresses: nil,
+		}
+		data2 := RuntimeData{
+			ChainID:   1,
+			Addresses: nil,
+		}
+
+		result, err := data1.IsCompatible(data2)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("one nil, one empty", func(t *testing.T) {
+		data1 := RuntimeData{
+			ChainID:   1,
+			Addresses: nil,
+		}
+		data2 := RuntimeData{
+			ChainID:   1,
+			Addresses: []common.Address{},
+		}
+
+		result, err := data1.IsCompatible(data2)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("nil vs non-empty", func(t *testing.T) {
+		data1 := RuntimeData{
+			ChainID:   1,
+			Addresses: nil,
+		}
+		data2 := RuntimeData{
+			ChainID:   1,
+			Addresses: []common.Address{common.HexToAddress("0x123")},
+		}
+
+		result, err := data1.IsCompatible(data2)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "addresses len mismatch")
+	})
+}

--- a/sync/evmdriver_test.go
+++ b/sync/evmdriver_test.go
@@ -579,6 +579,17 @@ func TestRuntimeData_IsCompatible_Success(t *testing.T) {
 				Addresses: []common.Address{common.HexToAddress("0x789")},
 			},
 		},
+		{
+			name: "zero chain ID with matching data",
+			data1: RuntimeData{
+				ChainID:   0,
+				Addresses: []common.Address{common.HexToAddress("0x789")},
+			},
+			data2: RuntimeData{
+				ChainID:   0,
+				Addresses: []common.Address{common.HexToAddress("0x789")},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -210,7 +210,7 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 		RequireStorageContentCompatibility: true,
 		DBQueryTimeout:                     cfgtypes.NewDuration(defaultDBQueryTimeout),
 	}
-	bridgeL1Sync, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rdL1, testClient, originNetwork)
+	bridgeL1Sync, err := bridgesync.NewL1(ctx, bridgeSyncCfg, rdL1, testClient, originNetwork, true)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -341,7 +341,7 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig, l1Setup *L1Environment) *L2En
 		RequireStorageContentCompatibility: true,
 		DBQueryTimeout:                     cfgtypes.NewDuration(defaultDBQueryTimeout),
 	}
-	bridgeL2Sync, err := bridgesync.NewL2(ctx, bridgeSyncCfg, rdL2, testClient, originNetwork, false)
+	bridgeL2Sync, err := bridgesync.NewL2(ctx, bridgeSyncCfg, rdL2, testClient, originNetwork, false, false)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)


### PR DESCRIPTION
## 🔄 Changes Summary
This PR adds a new configuration parameter SyncFromInBridges to the bridge syncer that controls whether to extract the FromAddress field for bridge Asset events using `debug_traceTransaction`. 

The parameter supports three modes: "true" (always extract using debug_traceTransaction), "false" (never extract), and "auto" (decide based on BRIDGE component activation). 

**This allows nodes without archive capability to sync bridge events** without the expensive debug tracing operation, while maintaining backward compatibility.

Also improve the case `SyncFromInBridges==true` (bridgeService) using txReceipt in case of direct call to bridge SC 

**INTERNAL CHANGE**: The compatibility store checker (that validate that contents of DB is compatible with current execution) can update data on DB

## ⚠️ Breaking Changes
None

## 📋 Config Updates
New configuration parameter added to both BridgeL1Sync and BridgeL2Sync
```
[BridgeL1Sync]
SyncFromInBridges = "auto"

[BridgeL2Sync]
SyncFromInBridges = "auto"
```
- `"true"`: Always extracts FromAddress (requires archive node with debug_traceTransaction)
- `"false"`: Never extracts FromAddress (stores NULL, no archive node needed)
- `"auto"`: Automatically decides based on whether BRIDGE component is active

## ✅ Testing
- 🤖 **Automatic**: e2e tests
- 🖱️ **Manual**: manullay syncer a sepolia network

## 🐞 Issues
- Closes #1485

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
