### PR TITLE
chore: skip claude if dependabot

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## 🔄 Changes Summary
PR of **dependabot** are failing because: 
```
Trigger result: true
Preparing with mode: tag for event: pull_request
Actor type: Bot
Error: Prepare step failed with error: Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
Error: Process completed with exit code 1.
```
This PR also have issue with claude-review because the content is not identical to `develop` 

> 
>GitHub requires that workflow files are not modified in pull requests for certain token/permissions operations; >they must be byte-for-byte identical to the default branch version for the workflow to run securely.
