### PR TITLE
fix: treat an existing monitored GER update tx as expected (#1479)

### DIFF
--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -2,6 +2,7 @@ package chaingersender
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -228,11 +229,11 @@ func (c *EVMChainGERSender) submitTransaction(
 
 	// Add the transaction to the transaction manager
 	id, err := c.ethTxMan.Add(ctx, targetAddr, common.Big0, txInput, c.gasOffset, nil)
-	if err != nil {
+	if err == nil {
+		c.logger.Infof("%s GER transaction submitted with ID: %s", action, id.Hex())
+	} else if !errors.Is(err, ethtxmanager.ErrAlreadyExists) {
 		return fmt.Errorf("failed to add %s GER transaction: %w", action, err)
 	}
-
-	c.logger.Infof("%s GER transaction submitted with ID: %s", action, id.Hex())
 
 	// Monitor the transaction status
 	for {


### PR DESCRIPTION
## 🔄 Changes Summary
- Neither fail nor log anything if a GER update tx is already monitored by the ethtxmanager.

## 🐞 Issues
- Closes #1479

## 🔗 Related PRs
- depends on https://github.com/0xPolygon/zkevm-ethtx-manager/pull/134

