### PR TITLE
fix: expose metrics for validator

### DIFF
--- a/aggsender/aggsender_validator.go
+++ b/aggsender/aggsender_validator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/agglayer/aggkit/agglayer"
+	"github.com/agglayer/aggkit/aggsender/metrics"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/aggsender/validator"
 	v1 "github.com/agglayer/aggkit/aggsender/validator/proto/v1"
@@ -56,6 +57,7 @@ func NewAggsenderValidator(ctx context.Context,
 	}, nil
 }
 func (a *AggsenderValidator) Start(ctx context.Context) {
+	metrics.Register()
 	a.validatorService.Start(ctx)
 }
 


### PR DESCRIPTION
## 🔄 Changes Summary
- Fix #1510 
This PR exposes metrics for the validator component by adding a call to `metrics.Register()` in the `AggsenderValidator.Start()` method, ensuring that validator-related Prometheus metrics (error counts, invalid signatures, validation time) are properly registered when the validator service starts.

## 🐞 Issues
- Closes #1510

## 🔗 Related PRs
- cherry-pick to 0.8: #1512 
- cherry-pick to 0.9: #1513

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
