### PR TITLE
fix: expose metrics for validator (#1511)

### DIFF
--- a/aggsender/aggsender_validator.go
+++ b/aggsender/aggsender_validator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/agglayer/aggkit/agglayer"
+	"github.com/agglayer/aggkit/aggsender/metrics"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/aggsender/validator"
 	v1 "github.com/agglayer/aggkit/aggsender/validator/proto/v1"
@@ -56,6 +57,7 @@ func NewAggsenderValidator(ctx context.Context,
 	}, nil
 }
 func (a *AggsenderValidator) Start(ctx context.Context) {
+	metrics.Register()
 	a.validatorService.Start(ctx)
 }
 


### PR DESCRIPTION
cherry-pick PR #1511 from `develop`

## 🔄 Changes Summary
- Fix #1510  This PR exposes metrics for the validator component by adding a call to `metrics.Register()` in the `AggsenderValidator.Start()` method, ensuring that validator-related Prometheus metrics (error counts, invalid signatures, validation time) are properly registered when the validator service starts.

## 🐞 Issues
- Closes #1511

## 🔗 Related PRs
- [Optional: Enumerate related pull requests]

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]

## 🔄 Changes Summary
- [Brief description of what was added, fixed, or changed in this PR]

## ⚠️ Breaking Changes
- 🛠️ **Config**: [Optional: Changes to TOML config]
- 🔌 **API/CLI**: [Optional: Breaking interface changes]
- 🗑️ **Deprecated Features**: [Optional: Removed features]

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: [Optional: Enumerate config changes/provide snippet of changes]

## ✅ Testing
- 🤖 **Automatic**: [Optional: Enumerate E2E tests]
- 🖱️ **Manual**: [Optional: Steps to verify]

## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- #1511 
- #1512

## 📝 Notes
- [Optional: design decisions, tradeoffs, or TODOs]
