### PR TITLE
fix: Error backfilling in case of same tx have multiples bridges 

### DIFF
--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -139,6 +139,7 @@ type RecordUpdate struct {
 	BlockPos  uint64
 	TxnSender common.Address
 	FromAddr  common.Address
+	ToAddr    common.Address
 }
 
 func (r *RecordUpdate) String() string {
@@ -305,7 +306,7 @@ func (b *BackfillTxnSender) worker(
 			Amount:             job.Record.Amount,
 		}
 		// Extract txn_sender from transaction hash
-		txnSender, fromAddr, err := b.extractData(ctx, job.Record.TxHash, logEvent)
+		txnSender, fromAddr, toAddr, err := b.extractData(ctx, job.Record.TxHash, logEvent)
 
 		result := TxnSenderResult{
 			Update: RecordUpdate{
@@ -313,6 +314,7 @@ func (b *BackfillTxnSender) worker(
 				BlockPos:  job.Record.BlockPos,
 				TxnSender: txnSender,
 				FromAddr:  fromAddr,
+				ToAddr:    toAddr,
 			},
 			Error: err,
 		}
@@ -327,18 +329,19 @@ func (b *BackfillTxnSender) worker(
 	}
 }
 
-// extractData extracts the transaction txn_sender and from_address
+// extractData extracts the transaction txn_sender, from_address and to_address
 func (b *BackfillTxnSender) extractData(ctx context.Context,
 	txHash common.Hash,
-	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) (txnSender common.Address, fromAddr common.Address, err error) {
+	logEvent *agglayerbridge.AgglayerbridgeBridgeEvent) (txnSender common.Address,
+	fromAddr common.Address, toAddr common.Address, err error) {
 	// Check if context is cancelled before making network call
 	select {
 	case <-ctx.Done():
-		return common.Address{}, common.Address{}, ctx.Err()
+		return common.Address{}, common.Address{}, common.Address{}, ctx.Err()
 	default:
 	}
-	txnSender, fromAddr, _, err = ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash, logEvent, b.log)
-	return txnSender, fromAddr, err
+	txnSender, fromAddr, toAddr, err = ExtractTxnAddresses(ctx, b.client, b.bridgeAddr, txHash, logEvent, b.log)
+	return txnSender, fromAddr, toAddr, err
 }
 
 // bulkUpdate performs a bulk update of multiple records
@@ -373,7 +376,8 @@ func (b *BackfillTxnSender) bulkUpdate(
 		UPDATE %s
 		SET
 			txn_sender = COALESCE(NULLIF(txn_sender, ''), ?),
-			from_address = COALESCE(NULLIF(from_address, ''), ?)
+			from_address = COALESCE(NULLIF(from_address, ''), ?),
+			to_address = COALESCE(NULLIF(to_address, ''), ?)
 		WHERE block_num = ? AND block_pos = ?;
 	`, tableName))
 	if err != nil {
@@ -382,7 +386,8 @@ func (b *BackfillTxnSender) bulkUpdate(
 	defer stmt.Close()
 
 	for _, update := range updates {
-		_, err := stmt.ExecContext(dbCtx, update.TxnSender.Hex(), update.FromAddr.Hex(), update.BlockNum, update.BlockPos)
+		_, err := stmt.ExecContext(dbCtx, update.TxnSender.Hex(),
+			update.FromAddr.Hex(), update.ToAddr.Hex(), update.BlockNum, update.BlockPos)
 		if err != nil {
 			return fmt.Errorf("failed to execute update for block %d pos %d: %w",
 				update.BlockNum, update.BlockPos, err)

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -124,9 +124,9 @@ type RecordToBackfill struct {
 	BlockTimestamp     uint64         `meddler:"block_timestamp"`
 	LeafType           uint8          `meddler:"leaf_type"`
 	OriginNetwork      uint32         `meddler:"origin_network"`
-	OriginAddress      common.Address `meddler:"origin_address,address"`
+	OriginAddress      common.Address `meddler:"origin_address"`
 	DestinationNetwork uint32         `meddler:"destination_network"`
-	DestinationAddress common.Address `meddler:"destination_address,address"`
+	DestinationAddress common.Address `meddler:"destination_address"`
 	Amount             *big.Int       `meddler:"amount,bigint"`
 	Metadata           []byte         `meddler:"metadata"`
 	DepositCount       uint32         `meddler:"deposit_count"`

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -29,7 +29,7 @@ const testAddress = "0x1111111111111111111111111111111111111111"
 
 // newTestBridge creates a Bridge with default test values using the given block position and tx hash.
 // Both TxnSender and FromAddress are set to testAddress (non-empty hex strings via AddressMeddler).
-// Use a SQL UPDATE to set txn_sender = '' after inserting if the record needs to trigger backfill.
+// Use a SQL UPDATE to set txn_sender = ” after inserting if the record needs to trigger backfill.
 func newTestBridge(blockNum, blockPos uint64, txHash string) *Bridge {
 	return &Bridge{
 		BlockNum:           blockNum,
@@ -654,7 +654,7 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 			}).Return(nil).Maybe()
 
 		txHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-		sender, _, err := backfiller.extractData(t.Context(), txHash,
+		sender, _, _, err := backfiller.extractData(t.Context(), txHash,
 			&agglayerbridge.AgglayerbridgeBridgeEvent{
 				LeafType: bridgeLeafTypeAsset,
 			})
@@ -679,7 +679,7 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
 
 		txHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-		sender, _, err := backfiller.extractData(t.Context(), txHash, &agglayerbridge.AgglayerbridgeBridgeEvent{
+		sender, _, _, err := backfiller.extractData(t.Context(), txHash, &agglayerbridge.AgglayerbridgeBridgeEvent{
 			LeafType: bridgeLeafTypeAsset,
 		})
 		require.Error(t, err)

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -2,8 +2,10 @@ package bridgesync
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -17,12 +19,35 @@ import (
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/russross/meddler"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 // testAddress is a constant test address used throughout the tests
 const testAddress = "0x1111111111111111111111111111111111111111"
+
+// newTestBridge creates a Bridge with default test values using the given block position and tx hash.
+// Both TxnSender and FromAddress are set to testAddress (non-empty hex strings via AddressMeddler).
+// Use a SQL UPDATE to set txn_sender = '' after inserting if the record needs to trigger backfill.
+func newTestBridge(blockNum, blockPos uint64, txHash string) *Bridge {
+	return &Bridge{
+		BlockNum:           blockNum,
+		BlockPos:           blockPos,
+		LeafType:           1,
+		OriginNetwork:      1,
+		OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		DestinationNetwork: 2,
+		DestinationAddress: common.HexToAddress("0x0987654321098765432109876543210987654321"),
+		Amount:             big.NewInt(1e18),
+		Metadata:           []byte{},
+		DepositCount:       1,
+		TxHash:             common.HexToHash(txHash),
+		BlockTimestamp:     1234567890,
+		FromAddress:        common.HexToAddress(testAddress),
+		TxnSender:          common.HexToAddress(testAddress),
+	}
+}
 
 func TestBackfillTxnSender(t *testing.T) {
 	// Create temporary database
@@ -49,21 +74,8 @@ func TestBackfillTxnSender(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(`
-		INSERT INTO bridge (
-			block_num, block_pos, leaf_type,
-			origin_network, origin_address,
-			destination_network, destination_address, amount, metadata, deposit_count,
-			tx_hash, block_timestamp, from_address, txn_sender
-		) VALUES (
-			1, 0, 1, 
-			1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', ''
-		)
-	`)
-	require.NoError(t, err)
+	require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+		"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
 
 	// Insert test claim record
 	_, err = tx.Exec(`
@@ -83,6 +95,9 @@ func TestBackfillTxnSender(t *testing.T) {
 	require.NoError(t, err)
 
 	err = tx.Commit()
+	require.NoError(t, err)
+
+	_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 	require.NoError(t, err)
 
 	// Create mock client
@@ -175,21 +190,13 @@ func TestBackfillTxnSender_BackfillAll(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES (
-				1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-				'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-				1234567890, '0x1111111111111111111111111111111111111111', ''
-			)
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 		require.NoError(t, err)
 
 		// Create mock client
@@ -200,6 +207,7 @@ func TestBackfillTxnSender_BackfillAll(t *testing.T) {
 		defer backfiller.Close()
 
 		// Mock the extractTxnSender function behavior (via eth_getTransactionByHash)
+		// leaf_type=1 = bridgeLeafTypeMessage, so RPCTransactionByHash is used
 		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			// Simulate the transaction structure that would be returned
 			tx, ok := args.Get(0).(*Transaction)
@@ -278,21 +286,13 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES (
-				1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-				'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-				1234567890, '0x1111111111111111111111111111111111111111', ''
-			)
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -302,6 +302,7 @@ func TestBackfillTxnSender_backfillTable(t *testing.T) {
 		defer backfiller.Close()
 
 		// Mock the extractTxnSender function behavior (via eth_getTransactionByHash)
+		// leaf_type=1 = bridgeLeafTypeMessage, so RPCTransactionByHash is used
 		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			tx, ok := args.Get(0).(*Transaction)
 			if !ok {
@@ -384,21 +385,13 @@ func TestBackfillTxnSender_getRecordsNeedingBackfillCount(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES (
-				1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-				'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-				1234567890, '0x1111111111111111111111111111111111111111', ''
-			)
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -459,21 +452,13 @@ func TestBackfillTxnSender_getRecordsNeedingBackfill(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES (
-				1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-				'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-				1234567890, '0x1111111111111111111111111111111111111111', ''
-			)
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -725,21 +710,13 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES (
-				1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-				'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-				1234567890, '0x1111111111111111111111111111111111111111', ''
-			)
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -781,24 +758,15 @@ func TestBackfillTxnSender_bulkUpdateTxnSender(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES
-			(1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', ''),
-			(1, 1, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', '')
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 1,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -917,28 +885,17 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES
-			(1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', ''),
-			(1, 1, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891',
-			1234567890, '0x1111111111111111111111111111111111111111', ''),
-			(1, 2, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567892',
-			1234567890, '0x1111111111111111111111111111111111111111', '')
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 1,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891")))
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 2,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567892")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1005,24 +962,15 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES
-			(1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', ''),
-			(1, 1, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891',
-			1234567890, '0x1111111111111111111111111111111111111111', '')
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 1,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1094,24 +1042,15 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES
-			(1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', ''),
-			(1, 1, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891',
-			1234567890, '0x1111111111111111111111111111111111111111', '')
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 1,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1122,7 +1061,6 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		// Mock all calls to fail
 		mockClient.EXPECT().Call(mock.Anything, debugTraceTxEndpoint, mock.Anything, mock.Anything).Return(errors.New("error")).Maybe()
-		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(errors.New("network error")).Maybe()
 
 		records := []RecordToBackfill{
 			{
@@ -1173,24 +1111,15 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1)`)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(`
-			INSERT INTO bridge (
-				block_num, block_pos, leaf_type, origin_network, origin_address,
-				destination_network, destination_address, amount, metadata, deposit_count,
-				tx_hash, block_timestamp, from_address, txn_sender
-			) VALUES
-			(1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-			1234567890, '0x1111111111111111111111111111111111111111', ''),
-			(1, 1, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891',
-			1234567890, '0x1111111111111111111111111111111111111111', '')
-		`)
-		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")))
+		require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 1,
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891")))
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1286,19 +1215,8 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 
 		// Insert records into database
 		for i := 0; i < largeBatchSize; i++ {
-			_, err = tx.Exec(fmt.Sprintf(`
-				INSERT INTO bridge (
-					block_num, block_pos, leaf_type, origin_network, origin_address,
-					destination_network, destination_address, amount, metadata, deposit_count,
-					tx_hash, block_timestamp, from_address, txn_sender
-				) VALUES (
-					1, %d, 1, 1, '0x1234567890123456789012345678901234567890',
-					2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-					'', 1, '0x%064x',
-					1234567890, '0x1111111111111111111111111111111111111111', ''
-				)
-			`, i, i))
-			require.NoError(t, err)
+			require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, uint64(i),
+				fmt.Sprintf("0x%064x", i))))
 
 			records[i] = RecordToBackfill{
 				BlockNum: 1,
@@ -1308,6 +1226,9 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 		}
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = ''")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1372,22 +1293,14 @@ func TestBackfillTxnSender_BackfillAll_WithDifferentRecordCounts(t *testing.T) {
 
 			// Insert multiple records
 			for i := 0; i < tc.recordCount; i++ {
-				_, err = tx.Exec(fmt.Sprintf(`
-					INSERT INTO bridge (
-						block_num, block_pos, leaf_type, origin_network, origin_address,
-						destination_network, destination_address, amount, metadata, deposit_count,
-						tx_hash, block_timestamp, from_address, txn_sender
-					) VALUES (
-						1, %d, 1, 1, '0x1234567890123456789012345678901234567890',
-						2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-						'', 1, '0x%064x',
-						1234567890, '0x1111111111111111111111111111111111111111', ''
-					)
-				`, i, i))
-				require.NoError(t, err)
+				require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, uint64(i),
+					fmt.Sprintf("0x%064x", i))))
 			}
 
 			err = tx.Commit()
+			require.NoError(t, err)
+
+			_, err = database.Exec("UPDATE bridge SET txn_sender = ''")
 			require.NoError(t, err)
 
 			mockClient := mocks.NewEthClienter(t)
@@ -1397,6 +1310,7 @@ func TestBackfillTxnSender_BackfillAll_WithDifferentRecordCounts(t *testing.T) {
 			defer backfiller.Close()
 
 			// Mock successful extractions for all records
+			// leaf_type=1 = bridgeLeafTypeMessage, so RPCTransactionByHash is used
 			mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 				tx, ok := args.Get(0).(*Transaction)
 				if !ok {
@@ -1454,22 +1368,14 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 		// Insert records that will be processed in multiple batches
 		totalRecords := 250 // This will create 3 batches with default batch size of 100
 		for i := 0; i < totalRecords; i++ {
-			_, err = tx.Exec(fmt.Sprintf(`
-				INSERT INTO bridge (
-					block_num, block_pos, leaf_type, origin_network, origin_address,
-					destination_network, destination_address, amount, metadata, deposit_count,
-					tx_hash, block_timestamp, from_address, txn_sender
-				) VALUES (
-					1, %d, 1, 1, '0x1234567890123456789012345678901234567890',
-					2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-					'', 1, '0x%064x',
-					1234567890, '0x1111111111111111111111111111111111111111', ''
-				)
-			`, i, i))
-			require.NoError(t, err)
+			require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, uint64(i),
+				fmt.Sprintf("0x%064x", i))))
 		}
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = ''")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1479,8 +1385,7 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 		defer backfiller.Close()
 
 		// Mock successful extractions for all records
-		// Note: The mock setup is complex, so we'll test with all successful calls
-		// and verify the batch processing works correctly
+		// leaf_type=1 = bridgeLeafTypeMessage, so RPCTransactionByHash is used
 		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			tx, ok := args.Get(0).(*Transaction)
 			if !ok {
@@ -1530,22 +1435,14 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 		// Insert records for multiple batches
 		totalRecords := 250
 		for i := 0; i < totalRecords; i++ {
-			_, err = tx.Exec(fmt.Sprintf(`
-				INSERT INTO bridge (
-					block_num, block_pos, leaf_type, origin_network, origin_address,
-					destination_network, destination_address, amount, metadata, deposit_count,
-					tx_hash, block_timestamp, from_address, txn_sender
-				) VALUES (
-					1, %d, 1, 1, '0x1234567890123456789012345678901234567890',
-					2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-					'', 1, '0x%064x',
-					1234567890, '0x1111111111111111111111111111111111111111', ''
-				)
-			`, i, i))
-			require.NoError(t, err)
+			require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, uint64(i),
+				fmt.Sprintf("0x%064x", i))))
 		}
 
 		err = tx.Commit()
+		require.NoError(t, err)
+
+		_, err = database.Exec("UPDATE bridge SET txn_sender = ''")
 		require.NoError(t, err)
 
 		mockClient := mocks.NewEthClienter(t)
@@ -1558,6 +1455,7 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 		cancelCtx, cancel := context.WithCancel(ctx)
 
 		// Mock calls with some delay
+		// leaf_type=1 = bridgeLeafTypeMessage, so RPCTransactionByHash is used
 		var callCount int64
 		mockClient.On("Call", mock.Anything, "eth_getTransactionByHash", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			count := atomic.AddInt64(&callCount, 1)
@@ -1585,6 +1483,192 @@ func TestBackfillTxnSender_MultipleBatches(t *testing.T) {
 		require.NoError(t, err)
 		require.Greater(t, processedCount, 0)
 		require.Less(t, processedCount, totalRecords)
+	})
+}
+
+func TestBackfillTxnSender_getRecordsNeedingBackfill_Cases(t *testing.T) {
+	filledAddr := common.HexToAddress("0xAAAABBBBCCCCDDDDEEEEFFFFAAAABBBBCCCCDDDD")
+
+	// setup creates a fresh migrated DB and a BackfillTxnSender.
+	setup := func(t *testing.T) (*BackfillTxnSender, *sql.DB, context.Context) {
+		t.Helper()
+		tempDir := t.TempDir()
+		dbPath := filepath.Join(tempDir, "test.db")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		database, err := db.NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { database.Close() })
+		mockClient := mocks.NewEthClienter(t)
+		logger := log.WithFields("module", "test")
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		require.NoError(t, err)
+		t.Cleanup(func() { backfiller.Close() })
+		return backfiller, database, context.Background()
+	}
+
+	insertBlock := func(t *testing.T, sqlDB *sql.DB, num uint64) {
+		t.Helper()
+		_, err := sqlDB.Exec("INSERT INTO block (num) VALUES (?)", num)
+		require.NoError(t, err)
+	}
+
+	// newBridge creates a Bridge with both txn_sender and from_address set to filledAddr,
+	// so it does NOT need backfill by default. Tests can UPDATE fields afterward.
+	newBridge := func(blockNum, blockPos uint64) *Bridge {
+		return &Bridge{
+			BlockNum:           blockNum,
+			BlockPos:           blockPos,
+			TxHash:             common.HexToHash(fmt.Sprintf("0x%064x", blockNum*1000+blockPos)),
+			BlockTimestamp:     1234567890,
+			LeafType:           1,
+			OriginNetwork:      1,
+			OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+			DestinationNetwork: 2,
+			DestinationAddress: common.HexToAddress("0x0987654321098765432109876543210987654321"),
+			Amount:             big.NewInt(1e18),
+			DepositCount:       uint32(blockNum*10 + blockPos),
+			FromAddress:        filledAddr,
+			TxnSender:          filledAddr,
+		}
+	}
+
+	// insertBridge uses meddler.Insert to match the format used by the processor in production.
+	insertBridge := func(t *testing.T, sqlDB *sql.DB, bridge *Bridge) {
+		t.Helper()
+		dbtx, err := sqlDB.Begin()
+		require.NoError(t, err)
+		require.NoError(t, meddler.Insert(dbtx, bridgeTableName, bridge))
+		require.NoError(t, dbtx.Commit())
+	}
+
+	t.Run("empty database returns no records", func(t *testing.T) {
+		backfiller, _, ctx := setup(t)
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Empty(t, records)
+	})
+
+	t.Run("null txn_sender triggers retrieval", func(t *testing.T) {
+		backfiller, sqlDB, ctx := setup(t)
+		insertBlock(t, sqlDB, 1)
+		insertBridge(t, sqlDB, newBridge(1, 0))
+		_, err := sqlDB.Exec("UPDATE bridge SET txn_sender = NULL WHERE block_num = 1 AND block_pos = 0")
+		require.NoError(t, err)
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		require.Equal(t, uint64(1), records[0].BlockNum)
+		require.Nil(t, records[0].TxnSender)
+	})
+
+	t.Run("empty txn_sender triggers retrieval", func(t *testing.T) {
+		backfiller, sqlDB, ctx := setup(t)
+		insertBlock(t, sqlDB, 1)
+		insertBridge(t, sqlDB, newBridge(1, 0))
+		_, err := sqlDB.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
+		require.NoError(t, err)
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+	})
+
+	t.Run("null from_address triggers retrieval", func(t *testing.T) {
+		backfiller, sqlDB, ctx := setup(t)
+		insertBlock(t, sqlDB, 1)
+		insertBridge(t, sqlDB, newBridge(1, 0))
+		_, err := sqlDB.Exec("UPDATE bridge SET from_address = NULL WHERE block_num = 1 AND block_pos = 0")
+		require.NoError(t, err)
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		require.Nil(t, records[0].FromAddress)
+	})
+
+	t.Run("empty from_address triggers retrieval", func(t *testing.T) {
+		backfiller, sqlDB, ctx := setup(t)
+		insertBlock(t, sqlDB, 1)
+		insertBridge(t, sqlDB, newBridge(1, 0))
+		_, err := sqlDB.Exec("UPDATE bridge SET from_address = '' WHERE block_num = 1 AND block_pos = 0")
+		require.NoError(t, err)
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+	})
+
+	t.Run("record with both fields populated is excluded", func(t *testing.T) {
+		// meddler.Insert stores non-zero address-codec fields as non-empty hex strings,
+		// so a freshly inserted bridge with filledAddr for both fields is excluded.
+		backfiller, sqlDB, ctx := setup(t)
+		insertBlock(t, sqlDB, 1)
+		insertBridge(t, sqlDB, newBridge(1, 0))
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Empty(t, records)
+	})
+
+	t.Run("limit is respected", func(t *testing.T) {
+		backfiller, sqlDB, ctx := setup(t)
+		for i := uint64(1); i <= 3; i++ {
+			insertBlock(t, sqlDB, i)
+			insertBridge(t, sqlDB, newBridge(i, 0))
+		}
+		_, err := sqlDB.Exec("UPDATE bridge SET txn_sender = NULL")
+		require.NoError(t, err)
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 2)
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+	})
+
+	t.Run("context cancelled returns error", func(t *testing.T) {
+		backfiller, sqlDB, _ := setup(t)
+		insertBlock(t, sqlDB, 1)
+		insertBridge(t, sqlDB, newBridge(1, 0))
+		_, err := sqlDB.Exec("UPDATE bridge SET txn_sender = NULL WHERE block_num = 1 AND block_pos = 0")
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err = backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.Error(t, err)
+	})
+
+	t.Run("mixed records - only those needing backfill returned", func(t *testing.T) {
+		backfiller, sqlDB, ctx := setup(t)
+		for i := uint64(1); i <= 3; i++ {
+			insertBlock(t, sqlDB, i)
+			insertBridge(t, sqlDB, newBridge(i, 0))
+		}
+		// Block 1: needs backfill (empty txn_sender)
+		_, err := sqlDB.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1")
+		require.NoError(t, err)
+		// Block 2: needs backfill (NULL from_address)
+		_, err = sqlDB.Exec("UPDATE bridge SET from_address = NULL WHERE block_num = 2")
+		require.NoError(t, err)
+		// Block 3: both fields populated → excluded
+
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+
+		blockNums := []uint64{records[0].BlockNum, records[1].BlockNum}
+		require.ElementsMatch(t, []uint64{1, 2}, blockNums)
+	})
+
+	t.Run("database error returns error", func(t *testing.T) {
+		backfiller, _, _ := setup(t)
+		backfiller.db.Close()
+
+		ctx := context.Background()
+		_, err := backfiller.getRecordsNeedingBackfill(ctx, bridgeTableName, 10)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to query records needing backfill")
 	})
 }
 
@@ -1619,21 +1703,13 @@ func TestBackfillTxnSenderIntegration(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(`
-		INSERT INTO bridge (
-			block_num, block_pos, leaf_type, origin_network, origin_address,
-			destination_network, destination_address, amount, metadata, deposit_count,
-			tx_hash, block_timestamp, from_address, txn_sender
-		) VALUES (
-			1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
-			2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
-			'', 1, '0x0000000000000000000000000000000000000000000000000000000000000000',
-			1234567890, '0x1111111111111111111111111111111111111111', ''
-		)
-	`)
-	require.NoError(t, err)
+	require.NoError(t, meddler.Insert(tx, bridgeTableName, newTestBridge(1, 0,
+		"0x0000000000000000000000000000000000000000000000000000000000000000")))
 
 	err = tx.Commit()
+	require.NoError(t, err)
+
+	_, err = database.Exec("UPDATE bridge SET txn_sender = '' WHERE block_num = 1 AND block_pos = 0")
 	require.NoError(t, err)
 
 	// Create real client

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -29,7 +29,7 @@ const testAddress = "0x1111111111111111111111111111111111111111"
 
 // newTestBridge creates a Bridge with default test values using the given block position and tx hash.
 // Both TxnSender and FromAddress are set to testAddress (non-empty hex strings via AddressMeddler).
-// Use a SQL UPDATE to set txn_sender = ” after inserting if the record needs to trigger backfill.
+// Use a SQL UPDATE to set txn_sender = '' (empty string) or txn_sender = NULL after inserting if the record needs to trigger backfill.
 func newTestBridge(blockNum, blockPos uint64, txHash string) *Bridge {
 	return &Bridge{
 		BlockNum:           blockNum,

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -29,7 +29,8 @@ const testAddress = "0x1111111111111111111111111111111111111111"
 
 // newTestBridge creates a Bridge with default test values using the given block position and tx hash.
 // Both TxnSender and FromAddress are set to testAddress (non-empty hex strings via AddressMeddler).
-// Use a SQL UPDATE to set txn_sender = '' (empty string) or txn_sender = NULL after inserting if the record needs to trigger backfill.
+// Use a SQL UPDATE to set txn_sender = ” (empty string) or txn_sender = NULL after inserting
+// if the record needs to trigger backfill.
 func newTestBridge(blockNum, blockPos uint64, txHash string) *Bridge {
 	return &Bridge{
 		BlockNum:           blockNum,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229
 	github.com/0xPolygon/zkevm-ethtx-manager v0.2.17
 	github.com/agglayer/go_signer v0.0.7
-	github.com/ethereum/go-ethereum v1.16.7
+	github.com/ethereum/go-ethereum v1.16.9
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/hermeznetwork/tracerr v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/ethereum/c-kzg-4844/v2 v2.1.5 h1:aVtoLK5xwJ6c5RiqO8g8ptJ5KU+2Hdquf6G3
 github.com/ethereum/c-kzg-4844/v2 v2.1.5/go.mod h1:u59hRTTah4Co6i9fDWtiCjTrblJv0UwsqZKCc0GfgUs=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
-github.com/ethereum/go-ethereum v1.16.7 h1:qeM4TvbrWK0UC0tgkZ7NiRsmBGwsjqc64BHo20U59UQ=
-github.com/ethereum/go-ethereum v1.16.7/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
+github.com/ethereum/go-ethereum v1.16.9 h1:UTJ93yoXD7BEMWg+9lSZ8/Zvf0oZfy2ZUmv0Gn0ZclE=
+github.com/ethereum/go-ethereum v1.16.9/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=


### PR DESCRIPTION

## 🔄 Changes Summary
- 💎 In case of filling a row that `to_address` is NULL is also updated
- 🐞backfill process is reading wrongly field `DestinationAddress` and `OriginAddress` of `bridge` table that produce an error extracting `from_address`, `txn_sender` and `to_address`

## 🛡️Security
-  Bump `github.com/ethereum/go-ethereum` to fix vulnerability **GO-2026-4511**: 
```
- Vulnerability #1: GO-2026-4511
    Go Ethereum Improperly Validates the ECIES Public Key in RLPx Handshake in
    github.com/ethereum/go-ethereum
  More info: https://pkg.go.dev/vuln/GO-2026-4511
  Module: github.com/ethereum/go-ethereum
    Found in: github.com/ethereum/go-ethereum@v1.16.7
    Fixed in: github.com/ethereum/go-ethereum@v1.16.9
```
## ✅ Testing
- 🖱️ **Manual**: Synchronizing mainnet bridges

## 🐞 Issues
- Closes #1514

