### PR TITLE
feat: add configurable unset-claims log range chunking

### DIFF
--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -139,6 +139,9 @@ type Config struct {
 	CommitteeOverride query.CommitteeOverride `mapstructure:"CommitteeOverride"`
 	// AgglayerBridgeL2Addr is the address of the bridge L2 sovereign contract on L2 sovereign chain
 	AgglayerBridgeL2Addr ethCommon.Address `mapstructure:"AgglayerBridgeL2Addr"`
+	// UnsetClaimsMaxLogBlockRange is the proactive max block range for eth_getLogs queries when fetching unset claims.
+	// 0 means disabled.
+	UnsetClaimsMaxLogBlockRange uint64 `mapstructure:"UnsetClaimsMaxLogBlockRange"`
 	// BlockFinalityForL1InfoTree indicates the block finality to use when querying for L1InfoRoot to use
 	BlockFinalityForL1InfoTree aggkittypes.BlockNumberFinality `jsonschema:"enum=LatestBlock, enum=SafeBlock, enum=PendingBlock, enum=FinalizedBlock, enum=EarliestBlock" mapstructure:"BlockFinalityForL1InfoTree"` //nolint:lll
 	// TriggerCertMode is the mode used to trigger certificate sending

--- a/aggsender/flows/builder_flow_factory.go
+++ b/aggsender/flows/builder_flow_factory.go
@@ -51,6 +51,7 @@ func NewBuilderFlow(
 			true, // fullClaims required (with calldata)
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
+			cfg.UnsetClaimsMaxLogBlockRange,
 			cfg.GlobalExitRootL1Addr,
 			cfg.BlockFinalityForL1InfoTree,
 		)
@@ -100,6 +101,7 @@ func NewBuilderFlow(
 			true, // full claims required (with calldata)
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
+			cfg.UnsetClaimsMaxLogBlockRange,
 			cfg.GlobalExitRootL1Addr,
 			cfg.BlockFinalityForL1InfoTree,
 		)
@@ -167,6 +169,7 @@ func CreateCommonFlowComponents(
 	fullClaimsRequired bool,
 	requireCommitteeMembershipCheck bool,
 	agglayerBridgeL2Addr ethCommon.Address,
+	unsetClaimsMaxLogBlockRange uint64,
 	globalExitRootL1Addr ethCommon.Address,
 	blockFinalityForL1InfoTree aggkittypes.BlockNumberFinality,
 ) (*CommonFlowComponents, error) {
@@ -181,7 +184,11 @@ func CreateCommonFlowComponents(
 		return nil, err
 	}
 
-	agglayerBridgeL2Reader, err := bridgesync.NewAgglayerBridgeL2Reader(agglayerBridgeL2Addr, l2Client)
+	agglayerBridgeL2Reader, err := bridgesync.NewAgglayerBridgeL2ReaderWithMaxLogBlockRange(
+		agglayerBridgeL2Addr,
+		l2Client,
+		unsetClaimsMaxLogBlockRange,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create bridge L2 sovereign reader: %w", err)
 	}

--- a/aggsender/flows/verifier_flow_factory.go
+++ b/aggsender/flows/verifier_flow_factory.go
@@ -37,6 +37,7 @@ func NewVerifierFlow(
 			true, // full claims are (eventually) needed in validator mode
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
+			cfg.UnsetClaimsMaxLogBlockRange,
 			cfg.GlobalExitRootL1Addr,
 			cfg.BlockFinalityForL1InfoTree,
 		)
@@ -67,6 +68,7 @@ func NewVerifierFlow(
 			true, // full claims are (eventually) needed in validator mode
 			cfg.RequireCommitteeMembershipCheck,
 			cfg.AgglayerBridgeL2Addr,
+			cfg.UnsetClaimsMaxLogBlockRange,
 			cfg.GlobalExitRootL1Addr,
 			cfg.BlockFinalityForL1InfoTree,
 		)

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	RequireCommitteeMembershipCheck bool `mapstructure:"RequireCommitteeMembershipCheck"`
 	// AgglayerBridgeL2Addr is the address of the bridge L2 sovereign contract on L2 sovereign chain
 	AgglayerBridgeL2Addr ethCommon.Address `mapstructure:"AgglayerBridgeL2Addr"`
+	// UnsetClaimsMaxLogBlockRange is the proactive max block range for eth_getLogs queries when fetching unset claims.
+	// 0 means disabled.
+	UnsetClaimsMaxLogBlockRange uint64 `mapstructure:"UnsetClaimsMaxLogBlockRange"`
 	// GlobalExitRootL1Addr is the address of the GlobalExitRootManager contract on L1
 	GlobalExitRootL1Addr ethCommon.Address `mapstructure:"GlobalExitRootL1Addr"`
 	// BlockFinalityForL1InfoTree indicates the block finality to use when querying for L1InfoRoot to use

--- a/bridgesync/agglayer_bridge_l2_reader.go
+++ b/bridgesync/agglayer_bridge_l2_reader.go
@@ -17,7 +17,8 @@ import (
 // AgglayerBridgeL2Reader provides functionality to read and interact with the AggLayer Bridge L2 contract.
 // It encapsulates the contract instance and provides methods to query bridge-related data from the L2 chain.
 type AgglayerBridgeL2Reader struct {
-	agglayerBridgeL2 *agglayerbridgel2.Agglayerbridgel2
+	agglayerBridgeL2            *agglayerbridgel2.Agglayerbridgel2
+	unsetClaimsMaxLogBlockRange uint64
 }
 
 // NewAgglayerBridgeL2Reader creates a new instance of AgglayerBridgeL2Reader.
@@ -34,11 +35,25 @@ func NewAgglayerBridgeL2Reader(
 	bridgeAddr common.Address,
 	l2Client aggkittypes.BaseEthereumClienter,
 ) (*AgglayerBridgeL2Reader, error) {
+	return NewAgglayerBridgeL2ReaderWithMaxLogBlockRange(bridgeAddr, l2Client, 0)
+}
+
+// NewAgglayerBridgeL2ReaderWithMaxLogBlockRange creates a new instance of AgglayerBridgeL2Reader
+// with an optional proactive max block range for unset claims eth_getLogs queries.
+func NewAgglayerBridgeL2ReaderWithMaxLogBlockRange(
+	bridgeAddr common.Address,
+	l2Client aggkittypes.BaseEthereumClienter,
+	unsetClaimsMaxLogBlockRange uint64,
+) (*AgglayerBridgeL2Reader, error) {
 	agglayerBridgeL2Contract, err := agglayerbridgel2.NewAgglayerbridgel2(bridgeAddr, l2Client)
 	if err != nil {
 		return nil, err
 	}
-	return &AgglayerBridgeL2Reader{agglayerBridgeL2: agglayerBridgeL2Contract}, nil
+
+	return &AgglayerBridgeL2Reader{
+		agglayerBridgeL2:            agglayerBridgeL2Contract,
+		unsetClaimsMaxLogBlockRange: unsetClaimsMaxLogBlockRange,
+	}, nil
 }
 
 // GetUnsetClaimsForBlockRange retrieves all unset claims (unclaims) within a specified block range.
@@ -60,26 +75,41 @@ func (r *AgglayerBridgeL2Reader) GetUnsetClaimsForBlockRange(ctx context.Context
 		return nil, fmt.Errorf("invalid block range: fromBlock(%d) > toBlock(%d)", fromBlock, toBlock)
 	}
 
+	if r.unsetClaimsMaxLogBlockRange > 0 && toBlock-fromBlock >= r.unsetClaimsMaxLogBlockRange {
+		return r.getUnsetClaimsInChunks(ctx, fromBlock, toBlock, r.unsetClaimsMaxLogBlockRange)
+	}
+
+	return r.fetchUnsetClaimsWithFallbackChunking(ctx, fromBlock, toBlock)
+}
+
+func (r *AgglayerBridgeL2Reader) fetchUnsetClaimsWithFallbackChunking(ctx context.Context,
+	fromBlock, toBlock uint64) ([]types.Unclaim, error) {
+
 	unclaims, err := r.fetchUnsetClaims(ctx, fromBlock, toBlock)
 	if err != nil {
 		// Check if error is due to block range being too large
 		maxRange, isMaxRangeErr := aggkitcommon.ParseMaxRangeFromError(err.Error())
 		if isMaxRangeErr {
-			log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
-			return aggkitcommon.ChunkedRangeQuery(
-				ctx, fromBlock, toBlock, maxRange,
-				r.fetchUnsetClaims,
-				func(all, chunk []types.Unclaim) []types.Unclaim {
-					return append(all, chunk...)
-				},
-				make([]types.Unclaim, 0),
-			)
+			return r.getUnsetClaimsInChunks(ctx, fromBlock, toBlock, maxRange)
 		}
 
 		return nil, err
 	}
 
 	return unclaims, nil
+}
+
+func (r *AgglayerBridgeL2Reader) getUnsetClaimsInChunks(ctx context.Context,
+	fromBlock, toBlock, maxRange uint64) ([]types.Unclaim, error) {
+	log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
+	return aggkitcommon.ChunkedRangeQuery(
+		ctx, fromBlock, toBlock, maxRange,
+		r.fetchUnsetClaimsWithFallbackChunking,
+		func(all, chunk []types.Unclaim) []types.Unclaim {
+			return append(all, chunk...)
+		},
+		make([]types.Unclaim, 0),
+	)
 }
 
 // fetchUnsetClaims performs the actual event filtering for a given block range

--- a/bridgesync/agglayer_bridge_l2_reader.go
+++ b/bridgesync/agglayer_bridge_l2_reader.go
@@ -84,7 +84,6 @@ func (r *AgglayerBridgeL2Reader) GetUnsetClaimsForBlockRange(ctx context.Context
 
 func (r *AgglayerBridgeL2Reader) fetchUnsetClaimsWithFallbackChunking(ctx context.Context,
 	fromBlock, toBlock uint64) ([]types.Unclaim, error) {
-
 	unclaims, err := r.fetchUnsetClaims(ctx, fromBlock, toBlock)
 	if err != nil {
 		// Check if error is due to block range being too large

--- a/bridgesync/agglayer_bridge_l2_reader_test.go
+++ b/bridgesync/agglayer_bridge_l2_reader_test.go
@@ -76,7 +76,8 @@ func TestAgglayerBridgeL2Reader_GetUnsetClaimsForBlockRange_ProactiveChunkingByC
 
 		var ranges [][2]uint64
 		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Run(func(args mock.Arguments) {
-			q := args.Get(1).(ethereum.FilterQuery)
+			q, ok := args.Get(1).(ethereum.FilterQuery)
+			require.True(t, ok)
 			require.NotNil(t, q.FromBlock)
 			require.NotNil(t, q.ToBlock)
 			ranges = append(ranges, [2]uint64{q.FromBlock.Uint64(), q.ToBlock.Uint64()})

--- a/bridgesync/agglayer_bridge_l2_reader_test.go
+++ b/bridgesync/agglayer_bridge_l2_reader_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agglayer/aggkit/etherman"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	mocksethclient "github.com/agglayer/aggkit/types/mocks"
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
@@ -62,6 +63,42 @@ func TestNewAgglayerBridgeL2Reader(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAgglayerBridgeL2Reader_GetUnsetClaimsForBlockRange_ProactiveChunkingByConfig(t *testing.T) {
+	ctx := context.Background()
+	bridgeAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	t.Run("configured max proactively chunks range", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2ReaderWithMaxLogBlockRange(bridgeAddr, mockClient, 1000)
+		require.NoError(t, err)
+
+		var ranges [][2]uint64
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Run(func(args mock.Arguments) {
+			q := args.Get(1).(ethereum.FilterQuery)
+			require.NotNil(t, q.FromBlock)
+			require.NotNil(t, q.ToBlock)
+			ranges = append(ranges, [2]uint64{q.FromBlock.Uint64(), q.ToBlock.Uint64()})
+		}).Times(3)
+
+		unclaims, err := reader.GetUnsetClaimsForBlockRange(ctx, 0, 2500)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+		require.Equal(t, [][2]uint64{{0, 999}, {1000, 1999}, {2000, 2500}}, ranges)
+	})
+
+	t.Run("zero configured max keeps current non-proactive behavior", func(t *testing.T) {
+		mockClient := mocksethclient.NewBaseEthereumClienter(t)
+		reader, err := NewAgglayerBridgeL2ReaderWithMaxLogBlockRange(bridgeAddr, mockClient, 0)
+		require.NoError(t, err)
+
+		mockClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Once()
+
+		unclaims, err := reader.GetUnsetClaimsForBlockRange(ctx, 0, 2500)
+		require.NoError(t, err)
+		require.NotNil(t, unclaims)
+	})
 }
 
 func TestAgglayerBridgeL2Reader_GetUnsetClaimsForBlockRange_WithMockedClient(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -71,6 +71,8 @@ func TestLoadDefaultConfig(t *testing.T) {
 	require.Equal(t, cfg.Validator.AgglayerClient.GRPC.MinConnectTimeout, cfg.AggSender.AgglayerClient.GRPC.MinConnectTimeout)
 	require.Equal(t, cfg.Validator.AgglayerClient.GRPC.Retry.MaxAttempts, cfg.AggSender.AgglayerClient.GRPC.Retry.MaxAttempts)
 	require.Equal(t, cfg.AggSender.RollupManagerAddr, cfg.Validator.LerQuerier.RollupManagerAddr)
+	require.Equal(t, uint64(0), cfg.AggSender.UnsetClaimsMaxLogBlockRange)
+	require.Equal(t, cfg.AggSender.UnsetClaimsMaxLogBlockRange, cfg.Validator.UnsetClaimsMaxLogBlockRange)
 	require.Equal(t, aggsendertypes.AutoMode, cfg.AggSender.Mode)
 	require.Equal(t, aggsendertypes.AutoMode, cfg.Validator.Mode)
 	require.Equal(t, cfg.AggSender.StorageRetainCertificatesPolicy.String(), "retain all certificates, keep history: true")

--- a/config/default.go
+++ b/config/default.go
@@ -216,6 +216,8 @@ MaxL2BlockNumber = 0
 StopOnFinishedSendingAllCertificates = false
 RequireCommitteeMembershipCheck = false
 AgglayerBridgeL2Addr = "{{L2Config.BridgeAddr}}"
+# Max block range per eth_getLogs call for unset-claims queries. 0 disables proactive chunking.
+UnsetClaimsMaxLogBlockRange = 0
 BlockFinalityForL1InfoTree = "FinalizedBlock"
 TriggerCertMode = "Auto"
 [AggSender.TriggerEpochBased]
@@ -306,6 +308,8 @@ DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
 Mode = "{{AggSender.Mode}}"
 RequireCommitteeMembershipCheck = {{AggSender.RequireCommitteeMembershipCheck}}
 AgglayerBridgeL2Addr = "{{L2Config.BridgeAddr}}"
+# Max block range per eth_getLogs call for unset-claims queries. 0 disables proactive chunking.
+UnsetClaimsMaxLogBlockRange = {{AggSender.UnsetClaimsMaxLogBlockRange}}
 GlobalExitRootL1Addr = "{{L1Config.polygonZkEVMGlobalExitRootAddress}}"
 BlockFinalityForL1InfoTree = "{{AggSender.BlockFinalityForL1InfoTree}}"
 [Validator.ServerConfig]


### PR DESCRIPTION
## 🔄 Changes Summary
- Add a new config knob `UnsetClaimsMaxLogBlockRange` to both AggSender and Validator config.
- Proactively chunk unset-claims `eth_getLogs` queries in `AgglayerBridgeL2Reader` when the configured range is exceeded.
- Keep existing error-driven fallback chunking behavior for compatibility with provider-specific failures.
- Plumb the new config through flow factories so certificate validation uses the configured chunking behavior.

## ⚠️ Breaking Changes
- 🛠️ **Config**: None (default is `0`, which preserves current behavior)
- 🔌 **API/CLI**: None
- 🗑️ **Deprecated Features**: None

## 📋 Config Updates
- Added:
  - `[AggSender] UnsetClaimsMaxLogBlockRange = 0`
  - `[Validator] UnsetClaimsMaxLogBlockRange = {{AggSender.UnsetClaimsMaxLogBlockRange}}`
- `0` disables proactive chunking and keeps legacy behavior.

## ✅ Testing
- 🤖 **Automatic**:
  - `go test ./aggsender/config ./aggsender/validator ./aggsender/flows ./bridgesync ./config`
- 🖱️ **Manual**:
  - None
## 🐞 Issues
- Closes #[issue-number]

## 🔗 Related PRs
- N/A

## 📝 Notes
- This change is focused on unset-claims log queries used by validator/aggsender flows.
- It avoids dependence on provider-specific error message parsing by chunking proactively when configured.