### PR TITLE
feat: add L2NetworkConfig with optional InitialLER override

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -144,7 +144,7 @@ func start(cliCtx *cli.Context) error {
 
 	l1BridgeSync := runBridgeSyncL1IfNeeded(ctx, components, cfg.BridgeL1Sync, reorgDetectorL1,
 		l1Client, MainnetID, &backfillWg)
-	initialLER, err := GetInitialLER(cfg.AggSender.RollupCreationBlockL1, rollupDataQuerier)
+	initialLER, err := GetInitialLER(cfg.L2NetworkConfig.InitialLER, cfg.AggSender.RollupCreationBlockL1, rollupDataQuerier)
 	if err != nil {
 		return fmt.Errorf("failed to get initial local exit root: %w", err)
 	}
@@ -802,8 +802,12 @@ func resolveL1BridgeConfig(cfg *bridgesync.Config, components []string, logprefi
 }
 
 func GetInitialLER(
+	initialLEROverride *common.Hash,
 	rollupCreationBlockL1 uint64,
 	rollupDataQuerier *ethermanquierier.RollupDataQuerier) (*common.Hash, error) {
+	if initialLEROverride != nil {
+		return initialLEROverride, nil
+	}
 	if rollupDataQuerier == nil {
 		return nil, nil
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -144,10 +144,12 @@ func start(cliCtx *cli.Context) error {
 
 	l1BridgeSync := runBridgeSyncL1IfNeeded(ctx, components, cfg.BridgeL1Sync, reorgDetectorL1,
 		l1Client, MainnetID, &backfillWg)
-	initialLER, err := GetInitialLER(cfg.L2NetworkConfig.InitialLER, cfg.AggSender.RollupCreationBlockL1, rollupDataQuerier)
+	initialLER, err := GetInitialLER(cfg.L2NetworkConfig.InitialLER,
+		cfg.AggSender.RollupCreationBlockL1, rollupDataQuerier)
 	if err != nil {
 		return fmt.Errorf("failed to get initial local exit root: %w", err)
 	}
+	log.Infof("Initial Local Exit Root (LER): %s", initialLER.Hex())
 
 	if isNeeded([]string{
 		aggkitcommon.AGGSENDER, aggkitcommon.AGGSENDERVALIDATOR, aggkitcommon.AGGCHAINPROOFGEN,

--- a/config/config.go
+++ b/config/config.go
@@ -258,6 +258,9 @@ type Config struct {
 	// L1NetworkConfig represents the L1 network config and contains RPC URL alongside L1 contract addresses.
 	L1NetworkConfig ethermanconfig.L1NetworkConfig
 
+	// L2NetworkConfig holds configuration specific to the L2 network.
+	L2NetworkConfig ethermanconfig.L2NetworkConfig
+
 	// REST contains the configuration settings for the REST service in the Aggkit
 	REST common.RESTConfig
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,6 +81,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 	cfgL2Multidownloader.BlockFinality = aggkittypes.LatestBlock
 	cfgL2Multidownloader.Enabled = false
 	require.Equal(t, cfgL2Multidownloader, cfg.L2Multidownloader)
+	require.Nil(t, cfg.L2NetworkConfig.InitialLER)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -125,6 +125,57 @@ func newCliContextConfigFlag(t *testing.T, values ...string) *cli.Context {
 	return cli.NewContext(nil, flagSet, nil)
 }
 
+func TestL2NetworkConfigInitialLER(t *testing.T) {
+	specificHash := "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd"
+	zeroHash := "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+	tests := []struct {
+		name          string
+		toml          string
+		expectNil     bool
+		expectedValue string
+	}{
+		{
+			name: "InitialLER set to a specific hash",
+			toml: `
+[L2NetworkConfig]
+InitialLER = "` + specificHash + `"
+`,
+			expectNil:     false,
+			expectedValue: specificHash,
+		},
+		{
+			name: "InitialLER set to zero hash is valid and not nil",
+			toml: `
+[L2NetworkConfig]
+InitialLER = "` + zeroHash + `"
+`,
+			expectNil:     false,
+			expectedValue: zeroHash,
+		},
+		{
+			name:      "InitialLER not set returns nil",
+			toml:      ``,
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadFileFromString(tt.toml, ConfigType)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+
+			if tt.expectNil {
+				require.Nil(t, cfg.L2NetworkConfig.InitialLER)
+			} else {
+				require.NotNil(t, cfg.L2NetworkConfig.InitialLER)
+				require.Equal(t, tt.expectedValue, cfg.L2NetworkConfig.InitialLER.Hex())
+			}
+		})
+	}
+}
+
 func TestLoadConfigWithDeprecatedFields(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "ut_config")
 	require.NoError(t, err)

--- a/config/default.go
+++ b/config/default.go
@@ -84,6 +84,11 @@ BlocksChunkSize = {{L1Config.BlocksChunkSize}}
 		BackoffMultiplier = 2.0
 		HashFromJSON = true
 
+[L2NetworkConfig]
+# InitialLER: optional override for the initial Local Exit Root (0x000...000 is a valid value).
+# If not set, the value is queried from the RollupManager contract on L1.
+# InitialLER =
+
 [ReorgDetectorL1]
 DBPath = "{{PathRWData}}/reorgdetectorl1.sqlite"
 FinalizedBlock = "FinalizedBlock"

--- a/etherman/config/network.go
+++ b/etherman/config/network.go
@@ -26,6 +26,14 @@ type CommonConfig struct {
 	L2RPC RPCClientConfig `mapstructure:"L2RPC"`
 }
 
+// L2NetworkConfig holds configuration specific to the L2 network
+type L2NetworkConfig struct {
+	// InitialLER is an optional override for the initial Local Exit Root.
+	// If set, the RollupManager contract is not queried for the initial LER.
+	// Note: 0x000...000 is a valid value. Omit this field to use the contract.
+	InitialLER *gethcommon.Hash `mapstructure:"InitialLER"`
+}
+
 // L1NetworkConfig represents the configuration of the network used in L1
 type L1NetworkConfig struct {
 	// RPC client configuration for the L1 network


### PR DESCRIPTION
## 🚀 What's New
The call to get the initial **Local Exit Root** from the contract requires an archive node. Using the configurable `InitialLER`, we can skip this call.

Introduces a new `[L2NetworkConfig]` section in the top-level config to hold L2-specific settings. The first field, `InitialLER`, allows operators to override the initial Local Exit Root without querying the RollupManager contract on L1, and so, let to use an archive-node.

- New `L2NetworkConfig` struct in `etherman/config/network.go`
- New `[L2NetworkConfig]` section in the main `Config` and `default.go`
- `GetInitialLER` in `cmd/run.go` accepts an optional override; if non-nil, the contract call is skipped
- Logs the resolved initial LER on startup

## 🐛 Bug Fixes
None.

## 📋 Config Updates
New optional field under `[L2NetworkConfig]`:

```toml
[L2NetworkConfig]
# InitialLER: optional override for the initial Local Exit Root (0x000...000 is a valid value).
# If not set, the value is queried from the RollupManager contract on L1.
# InitialLER = "0xaabbccdd..."
```

Default: not set (field absent → contract is queried as before).

## ⚠️ Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)