### PR TITLE
feat: force to dont run claimsyncer to see if e2e-go fails

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -983,7 +983,9 @@ func runClaimSyncL2IfNeeded(
 	}
 
 	log.Infof("Starting ClaimSyncL2 (autoStart=%t)", *cfg.AutoStart.Resolved)
-	go res.Start(ctx)
+	log.Warnf("***TESTING NO RUN CLAIM SYNC L2***")
+	// TODO: Uncomment this line
+	//go res.Start(ctx)
 	return res
 }
 


### PR DESCRIPTION
## 🔄 Changes Summary
- The code have a intentional bug that is no running `claimsyncer` so all e2e must fail. But **e2e-go** is green.

Running locally also fails as expected: 
```
make e2e-go
(...)
        /home/jesteban/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/net/http/transport.go:1947 +0x174f
FAIL    github.com/agglayer/aggkit/test/e2e     1829.222s
=== RUN   TestLoadEnv_InvalidEnvName
--- PASS: TestLoadEnv_InvalidEnvName (0.00s)
=== RUN   TestFindEnvsDir
--- PASS: TestFindEnvsDir (0.00s)
PASS
ok      github.com/agglayer/aggkit/test/e2e/envs        0.006s
FAIL
make: *** [Makefile:110: test-e2e] Error 1
```
