### PR TITLE
fix: cherry-pick #1490, #1557 and timeout adjustments into release/0.9

### DIFF
--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -2,6 +2,7 @@ package chaingersender
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -228,11 +229,15 @@ func (c *EVMChainGERSender) submitTransaction(
 
 	// Add the transaction to the transaction manager
 	id, err := c.ethTxMan.Add(ctx, targetAddr, common.Big0, txInput, c.gasOffset, nil)
-	if err != nil {
+	if err == nil {
+		c.logger.Infof("%s GER transaction submitted with ID: %s. GER: %s", action, id.Hex(), ger.Hex())
+	} else if !errors.Is(err, ethtxmanager.ErrAlreadyExists) {
 		return fmt.Errorf("failed to add %s GER transaction: %w", action, err)
 	}
+	if err != nil {
+		c.logger.Infof("%s GER transaction already exists in monitoring DB with ID: %s. GER: %s", action, id.Hex(), ger.Hex())
+	}
 
-	c.logger.Infof("%s GER transaction submitted with ID: %s. GER: %s", action, id.Hex(), ger.Hex())
 	c.logger.Debugf("monitoring every %s", c.waitPeriodMonitorTx)
 
 	// Monitor the transaction status

--- a/aggoracle/chaingersender/evm_test.go
+++ b/aggoracle/chaingersender/evm_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	"github.com/0xPolygon/zkevm-ethtx-manager/types"
 	"github.com/agglayer/aggkit/aggoracle/mocks"
 	"github.com/agglayer/aggkit/log"
@@ -392,6 +393,16 @@ func TestEVMChainGERSender_SubmitTransaction(t *testing.T) {
 			resultReturn:    &types.MonitoredTxResult{},
 			resultReturnErr: errors.New("result error"),
 			expectedErr:     "result error",
+		},
+		{
+			name:            "ErrAlreadyExists is not an error - monitoring continues until mined",
+			funcName:        "testFunction",
+			action:          "test",
+			addReturnTxID:   txID,
+			addReturnErr:    ethtxmanager.ErrAlreadyExists,
+			resultReturn:    &types.MonitoredTxResult{Status: types.MonitoredTxStatusMined, MinedAtBlockNumber: big.NewInt(123)},
+			resultReturnErr: nil,
+			expectedErr:     "",
 		},
 	}
 

--- a/config/default.go
+++ b/config/default.go
@@ -42,7 +42,7 @@ PathRWData = "/tmp/aggkit"
 RequireStorageContentCompatibility = true
 GenerateAggchainProofTimeout = "1h"
 # Default database query timeout
-defaultDBQueryTimeout = "60s"
+defaultDBQueryTimeout = "5m"
 [L2RPC]
 	Mode = "basic"
 	URL = "{{L2URL}}"
@@ -147,8 +147,8 @@ MaxRequestsPerIPAndSecond = 10
 [REST]
 Host = "0.0.0.0"
 Port = 5577
-ReadTimeout = "2s"
-WriteTimeout = "2s"
+ReadTimeout = "5m"
+WriteTimeout = "5m"
 MaxRequestsPerIPAndSecond = 10
 
 [BridgeL1Sync]

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	buf.build/gen/go/agglayer/provers/protocolbuffers/go v1.36.10-20251103121356-e8eff0e259e6.1
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.12
 	github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229
-	github.com/0xPolygon/zkevm-ethtx-manager v0.2.17
+	github.com/0xPolygon/zkevm-ethtx-manager v0.2.18
 	github.com/agglayer/go_signer v0.0.7
 	github.com/ethereum/go-ethereum v1.16.9
 	github.com/gin-gonic/gin v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229 h1:6YhqNQVcXkoxq
 github.com/0xPolygon/cdk-rpc v0.0.0-20250213125803-179882ad6229/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
 github.com/0xPolygon/zkevm-ethtx-manager v0.2.17 h1:iCDfJk/3HUMRHD5A7n2/39PuXXGAHYXE1qdYcrLC+QQ=
 github.com/0xPolygon/zkevm-ethtx-manager v0.2.17/go.mod h1:AmLGLIk9qrf1EGqZrgjBc3YGn+0Dc7Ee2KVLuiTBY7g=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.18 h1:V/ZLtWUSqsakcF7NxyOaLSJik+ANTn07l0hpO95mqW0=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.18/go.mod h1:AmLGLIk9qrf1EGqZrgjBc3YGn+0Dc7Ee2KVLuiTBY7g=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7 h1:KJM1QlNZdZjNRS+ajPauD4uG+uaYgItaL+96Om3f8aI=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7/go.mod h1:exl+KHnTN6Y8HG4nSUXni4qKbAug0HjJqpebMSgl72k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
## Summary
- cherry-pick #1490 handling for already-monitored GER transactions and its unit test
- update zkevm-ethtx-manager to v0.2.18 for ErrAlreadyExists support
- apply the REST and DB timeout adjustments

## Testing
- go test -v ./aggoracle/chaingersender
- go test -v ./config/...