### PR TITLE
feat: improve local e2e script to reuse existing temp dirs

### DIFF
--- a/aggsender/aggchainproofclient/aggchain_proof_client_test.go
+++ b/aggsender/aggchainproofclient/aggchain_proof_client_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	agglayerInteropTypesV1Proto "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
 	aggkitProverV1Proto "buf.build/gen/go/agglayer/provers/protocolbuffers/go/aggkit/prover/v1"
 	agglayer "github.com/agglayer/aggkit/agglayer/types"
 	aggkitProverMocks "github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
+	configtypes "github.com/agglayer/aggkit/config/types"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/tree"
@@ -18,6 +20,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGenerateAggchainProof_Exploratory(t *testing.T) {
+	t.Skip("exploratory test")
+	defaultTime := configtypes.NewDuration(300 * time.Second)
+	client, err := NewAggchainProofClient(&aggkitgrpc.ClientConfig{
+		URL:            "localhost:32800",
+		RequestTimeout: defaultTime,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	ctx := context.Background()
+	l1_rpc_endpoint := "http://127.0.0.1:32769"
+	l1client, err := aggkitgrpc.NewEthereumClient(l1_rpc_endpoint, defaultTime)
+	require.NoError(t, err)
+	blockNumber, err := l1client.BlockNumber(ctx)
+	require.NoError(t, err)
+	t.Logf("Current L1 block number: %d", blockNumber)
+
+	block, err := l1client.BlockByNumber(ctx, blockNumber)
+	require.NoError(t, err)
+	blockHash := block.Hash()
+	t.Logf("Current L1 block hash: %s", blockHash.Hex())
+	globalIndex := &agglayer.GlobalIndex{
+		MainnetFlag: true,
+		RollupIndex: 1,
+		LeafIndex:   1,
+	}
+	req := &types.AggchainProofRequest{
+		LastProvenBlock:    241,
+		RequestedEndBlock:  6841,
+		L1InfoTreeRootHash: blockHash,
+		L1InfoTreeLeaf: l1infotreesync.L1InfoTreeLeaf{
+			BlockNumber:       block.NumberU64(),
+			PreviousBlockHash: blockHash,
+		},
+		ImportedBridgeExitsWithBlockNumber: []*agglayer.ImportedBridgeExitWithBlockNumber{
+			{
+				BlockNumber: 241,
+				ImportedBridgeExit: &agglayer.ImportedBridgeExit{
+					GlobalIndex: globalIndex,
+				},
+			},
+		},
+		Unclaims: []*agglayer.Unclaim{
+			{
+				BlockNumber: 6841,
+				GlobalIndex: globalIndex,
+			},
+		},
+	}
+
+	result, err := client.GenerateAggchainProof(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	t.Logf("Received Aggchain Proof: %+v", result)
+}
 func TestGenerateAggchainProof_Success(t *testing.T) {
 	mockClient := aggkitProverMocks.NewAggchainProofServiceClient(t)
 	client := &AggchainProofClient{

--- a/aggsender/aggchainproofclient/aggchain_proof_client_test.go
+++ b/aggsender/aggchainproofclient/aggchain_proof_client_test.go
@@ -12,9 +12,12 @@ import (
 	aggkitProverMocks "github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	configtypes "github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/etherman"
+	ethermanconfig "github.com/agglayer/aggkit/etherman/config"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/tree"
+	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -31,15 +34,15 @@ func TestGenerateAggchainProof_Exploratory(t *testing.T) {
 	require.NotNil(t, client)
 	ctx := context.Background()
 	l1_rpc_endpoint := "http://127.0.0.1:32769"
-	l1client, err := aggkitgrpc.NewEthereumClient(l1_rpc_endpoint, defaultTime)
+	l1client, err := etherman.DialWithRetry(ctx, nil, &ethermanconfig.RPCClientConfig{URL: l1_rpc_endpoint})
 	require.NoError(t, err)
 	blockNumber, err := l1client.BlockNumber(ctx)
 	require.NoError(t, err)
 	t.Logf("Current L1 block number: %d", blockNumber)
 
-	block, err := l1client.BlockByNumber(ctx, blockNumber)
+	header, err := l1client.CustomHeaderByNumber(ctx, aggkittypes.NewBlockNumber(blockNumber))
 	require.NoError(t, err)
-	blockHash := block.Hash()
+	blockHash := header.Hash
 	t.Logf("Current L1 block hash: %s", blockHash.Hex())
 	globalIndex := &agglayer.GlobalIndex{
 		MainnetFlag: true,
@@ -51,7 +54,7 @@ func TestGenerateAggchainProof_Exploratory(t *testing.T) {
 		RequestedEndBlock:  6841,
 		L1InfoTreeRootHash: blockHash,
 		L1InfoTreeLeaf: l1infotreesync.L1InfoTreeLeaf{
-			BlockNumber:       block.NumberU64(),
+			BlockNumber:       header.Number,
 			PreviousBlockHash: blockHash,
 		},
 		ImportedBridgeExitsWithBlockNumber: []*agglayer.ImportedBridgeExitWithBlockNumber{

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -127,14 +127,16 @@ name_temp_kurtosis_dir() {
 # Clone Kurtosis CDK repo to temporary directory
 clone_kurtosis_repo() {
     local expected_commit="$1"
+    local dir
+    dir=$(name_temp_kurtosis_dir "$expected_commit")
 
-    TEMP_KURTOSIS_DIR=$(name_temp_kurtosis_dir "$expected_commit" )
-    if [ -d "$TEMP_KURTOSIS_DIR" ]; then
-        log_info "Temporary directory for Kurtosis already exists: $TEMP_KURTOSIS_DIR"
+    if [ -d "$dir" ]; then
+        log_info "Temporary directory for Kurtosis already exists: $dir"
         log_info "Reusing existing directory..."
-        echo "$TEMP_KURTOSIS_DIR"
+        echo "$dir"
         return
     fi
+    TEMP_KURTOSIS_DIR="$dir"
     mkdir -p "$TEMP_KURTOSIS_DIR"
     log_info "Cloning Kurtosis CDK repo to temporary directory..."
     log_info "Temporary directory: $TEMP_KURTOSIS_DIR"
@@ -167,13 +169,16 @@ name_temp_e2e_dir() {
 
 # Clone E2E repo to temporary directory
 clone_e2e_repo() {
-    TEMP_E2E_DIR=$(name_temp_e2e_dir "$E2E_REPO_URL")
-    if [ -d "$TEMP_E2E_DIR" ]; then
-        log_info "Temporary directory for E2E already exists: $TEMP_E2E_DIR"
+    local dir
+    dir=$(name_temp_e2e_dir "$E2E_REPO_URL")
+
+    if [ -d "$dir" ]; then
+        log_info "Temporary directory for E2E already exists: $dir"
         log_info "Reusing existing directory..."
-        echo "$TEMP_E2E_DIR"
+        echo "$dir"
         return
     fi
+    TEMP_E2E_DIR="$dir"
     mkdir -p "$TEMP_E2E_DIR"
     log_info "Cloning E2E test repo to temporary directory..."
     log_info "Temporary directory: $TEMP_E2E_DIR"

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -119,11 +119,23 @@ get_expected_kurtosis_commit() {
     echo "$commit"
 }
 
+name_temp_kurtosis_dir() {
+    local _commit="$1"
+    echo "${TMPDIR:-/tmp}/kurtosis_${_commit}"
+}
+
 # Clone Kurtosis CDK repo to temporary directory
 clone_kurtosis_repo() {
     local expected_commit="$1"
 
-    TEMP_KURTOSIS_DIR=$(mktemp -d)
+    TEMP_KURTOSIS_DIR=$(name_temp_kurtosis_dir "$expected_commit" )
+    if [ -d "$TEMP_KURTOSIS_DIR" ]; then
+        log_info "Temporary directory for Kurtosis already exists: $TEMP_KURTOSIS_DIR"
+        log_info "Reusing existing directory..."
+        echo "$TEMP_KURTOSIS_DIR"
+        return
+    fi
+    mkdir -p "$TEMP_KURTOSIS_DIR"
     log_info "Cloning Kurtosis CDK repo to temporary directory..."
     log_info "Temporary directory: $TEMP_KURTOSIS_DIR"
 
@@ -144,9 +156,25 @@ clone_kurtosis_repo() {
     echo "$TEMP_KURTOSIS_DIR"
 }
 
+name_temp_e2e_dir() {
+    local _e2e_repo_url="$1"
+    local _commit="${_e2e_repo_url##*@}"
+    if [ "$_commit" = "$_e2e_repo_url" ]; then
+        _commit="main"
+    fi
+    echo "${TMPDIR:-/tmp}/e2e_${_commit}"
+}
+
 # Clone E2E repo to temporary directory
 clone_e2e_repo() {
-    TEMP_E2E_DIR=$(mktemp -d)
+    TEMP_E2E_DIR=$(name_temp_e2e_dir "$E2E_REPO_URL")
+    if [ -d "$TEMP_E2E_DIR" ]; then
+        log_info "Temporary directory for E2E already exists: $TEMP_E2E_DIR"
+        log_info "Reusing existing directory..."
+        echo "$TEMP_E2E_DIR"
+        return
+    fi
+    mkdir -p "$TEMP_E2E_DIR"
     log_info "Cloning E2E test repo to temporary directory..."
     log_info "Temporary directory: $TEMP_E2E_DIR"
 
@@ -186,10 +214,13 @@ esac
 if [ "$KURTOSIS_REPO_PATH" = "-" ]; then
     log_info "Skipping Kurtosis setup (kurtosis_repo_path is '-')"
 elif [ -z "$KURTOSIS_REPO_PATH" ]; then
-    # No path provided, ask user if they want to clone (or auto-clone if --force)
-    if [ "$FORCE_CLONE" = true ]; then
+    EXPECTED_COMMIT=$(get_expected_kurtosis_commit)
+    DEFAULT_KURTOSIS_DIR=$(name_temp_kurtosis_dir "$EXPECTED_COMMIT")
+    if [ -d "$DEFAULT_KURTOSIS_DIR" ]; then
+        log_info "Found existing Kurtosis CDK repo at default location: $DEFAULT_KURTOSIS_DIR"
+        KURTOSIS_REPO_PATH="$DEFAULT_KURTOSIS_DIR"
+    elif [ "$FORCE_CLONE" = true ]; then
         log_info "No Kurtosis CDK repository path provided. Auto-cloning (--force enabled)..."
-        EXPECTED_COMMIT=$(get_expected_kurtosis_commit)
         KURTOSIS_REPO_PATH=$(clone_kurtosis_repo "$EXPECTED_COMMIT")
     else
         echo ""
@@ -198,7 +229,6 @@ elif [ -z "$KURTOSIS_REPO_PATH" ]; then
         echo ""
 
         if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-            EXPECTED_COMMIT=$(get_expected_kurtosis_commit)
             KURTOSIS_REPO_PATH=$(clone_kurtosis_repo "$EXPECTED_COMMIT")
         else
             log_info "Skipping Kurtosis setup"
@@ -344,8 +374,11 @@ fi
 if [ "$E2E_REPO_PATH" = "-" ]; then
     log_info "Skipping E2E tests (e2e_repo_path is '-')"
 elif [ -z "$E2E_REPO_PATH" ]; then
-    # No path provided, ask user if they want to clone (or auto-clone if --force)
-    if [ "$FORCE_CLONE" = true ]; then
+    DEFAULT_E2E_DIR=$(name_temp_e2e_dir "$E2E_REPO_URL")
+    if [ -d "$DEFAULT_E2E_DIR" ]; then
+        log_info "Found existing E2E repo at default location: $DEFAULT_E2E_DIR"
+        E2E_REPO_PATH="$DEFAULT_E2E_DIR"
+    elif [ "$FORCE_CLONE" = true ]; then
         log_info "No E2E test repository path provided. Auto-cloning (--force enabled)..."
         E2E_REPO_PATH=$(clone_e2e_repo)
     else


### PR DESCRIPTION
## 🔄 Changes Summary
- Use `${TMPDIR:-/tmp}` instead of hardcoded `/tmp` for temp directory paths
- Use deterministic temp directory names (based on commit hash / repo URL) instead of `mktemp -d`, so runs can reuse an already-cloned repo
- Extract `name_temp_kurtosis_dir` and `name_temp_e2e_dir` helper functions for computing the default temp paths
- For E2E dir, extract the commit from the repo URL (format: `repo@<commit>`), falling back to `main` if no `@` present
- If the default temp directory already exists when no path is provided, reuse it automatically without prompting

## ⚠️ Breaking Changes
- None

## ✅ Testing
- 🖱️ **Manual**: Run `./test/run-local-e2e.sh` twice — second run should reuse the existing cloned repos without re-cloning

## 📝 Notes
- Speeds up repeated local E2E runs significantly by skipping redundant clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)