### PR TITLE
fix: cherry-pick #1589 - add query exceeds max block range to ParseMaxRangeFromError (0.8)

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -14,6 +14,8 @@ var (
 	reExceededBlockRange = regexp.MustCompile(`exceeded maximum block range:\s*(\d+)`)
 	// Matches "eth_getLogs is limited to a 10,000 range" (number may contain comma thousands separators)
 	reEthGetLogsLimited = regexp.MustCompile(`eth_getLogs is limited to a\s+([\d,]+)\s+range`)
+	// Matches "query exceeds max block range 100000"
+	reQueryExceedsMaxBlockRange = regexp.MustCompile(`query exceeds max block range\s+(\d+)`)
 )
 
 // ParseMaxRangeFromError extracts the max range value from error message
@@ -23,7 +25,10 @@ var (
 //   - "eth_getLogs is limited to a 10,000 range"
 func ParseMaxRangeFromError(errMsg string) (uint64, bool) {
 	var matches []string
-	for _, re := range []*regexp.Regexp{reMaxRange, reExceededBlockRange, reEthGetLogsLimited} {
+	for _, re := range []*regexp.Regexp{reMaxRange,
+		reExceededBlockRange,
+		reEthGetLogsLimited,
+		reQueryExceedsMaxBlockRange} {
 		matches = re.FindStringSubmatch(errMsg)
 		if len(matches) >= maxRangeMatchGroups {
 			break

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -105,6 +105,18 @@ func TestParseMaxRangeFromError(t *testing.T) {
 			expectedMaxBlock:   100000,
 			expectedIsMaxRange: true,
 		},
+		{
+			name:               "query exceeds max block range",
+			errorMsg:           "query exceeds max block range 100000",
+			expectedMaxBlock:   100000,
+			expectedIsMaxRange: true,
+		},
+		{
+			name:               "query exceeds max block range embedded in longer message",
+			errorMsg:           "claimsync: FilterLogs error: query exceeds max block range 100000",
+			expectedMaxBlock:   100000,
+			expectedIsMaxRange: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 🔄 Changes Summary

Cherry-pick of #1589 (merged into release/0.10) into release/0.8.

- Added a new regex to `ParseMaxRangeFromError` (`common/errors.go`) to match the error format `query exceeds max block range <N>`, which was not covered by any of the existing patterns.
- Without this fix, the ClaimSyncer's RPC fallback path failed to detect this as a block-range limit error and returned immediately instead of retrying with chunked requests, causing:
  ```
  claimsync: FilterLogs error for globalIndex X [0, 963183]: query exceeds max block range 100000
  ```
- Added two unit tests for the new pattern in `common/errors_test.go`.

## ⚠️ Breaking Changes
None.

## 📋 Config Updates
None.

## ✅ Testing
- 🤖 **Automatic**: `go test ./common/... -run TestParseMaxRangeFromError`

## 🔗 Related PRs
- #1589 — original PR (merged into release/0.10)
- #1520 — feat: unset claims max log range (introduced the chunking logic that depends on `ParseMaxRangeFromError`)

## 📝 Notes
The existing regexes cover: `block range too large, max range: X`, `exceeded maximum block range: X`, and `eth_getLogs is limited to a X range`. The new format `query exceeds max block range X` is emitted by some RPC providers (observed in production with a 100000-block limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)