### PR TITLE
fix: debug trace bridge call matching

### DIFF
--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -616,6 +616,7 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 			}).Return(nil).Maybe()
 
@@ -682,12 +683,14 @@ func TestBackfillTxnSender_processBatch(t *testing.T) {
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 			}).Return(nil).Maybe()
 		mockClient.EXPECT().Call(mock.Anything, DebugTraceTxEndpoint, mock.Anything, mock.Anything).
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 			}).Return(nil).Maybe()
 
@@ -733,6 +736,7 @@ func TestBackfillTxnSender_extractTxnSender(t *testing.T) {
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 				arg.From = expectedSender
 				arg.To = common.HexToAddress("0x1234")
@@ -1054,6 +1058,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 				arg.From = common.HexToAddress(testAddress)
 				arg.To = common.HexToAddress("0x1234")
@@ -1134,6 +1139,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 				arg.From = common.HexToAddress(testAddress)
 				arg.To = common.HexToAddress("0x1234")
@@ -1292,6 +1298,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 			}).Return(nil).Maybe()
 
@@ -1400,6 +1407,7 @@ func TestBackfillTxnSender_processBatch_Comprehensive(t *testing.T) {
 			Run(func(result any, method string, args ...any) {
 				arg, ok := result.(*Call)
 				require.True(t, ok)
+				arg.Type = CallTypeCall
 				arg.Input = BridgeAssetMethodID
 				arg.From = common.HexToAddress(testAddress)
 				arg.To = common.HexToAddress("0x1234")

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -64,6 +64,23 @@ const (
 	bridgeLeafTypeAsset   = uint8(bridgesynctypes.LeafTypeAsset)
 )
 
+const (
+	// CallTypeCall is a callTracer CALL frame.
+	CallTypeCall = "CALL"
+	// CallTypeDelegateCall is a callTracer DELEGATECALL frame.
+	CallTypeDelegateCall = "DELEGATECALL"
+	// CallTypeStaticCall is a callTracer STATICCALL frame.
+	CallTypeStaticCall = "STATICCALL"
+	// CallTypeCallCode is a callTracer CALLCODE frame.
+	CallTypeCallCode = "CALLCODE"
+	// CallTypeCreate is a callTracer CREATE frame.
+	CallTypeCreate = "CREATE"
+	// CallTypeCreate2 is a callTracer CREATE2 frame.
+	CallTypeCreate2 = "CREATE2"
+	// CallTypeSelfDestruct is a callTracer SELFDESTRUCT frame.
+	CallTypeSelfDestruct = "SELFDESTRUCT"
+)
+
 func buildAppender(
 	ctx context.Context,
 	client aggkittypes.EthClienter,
@@ -522,6 +539,7 @@ func buildForwardLETEventHandler(contract *agglayerbridgel2.Agglayerbridgel2) fu
 }
 
 type Call struct {
+	Type  string            `json:"type"`
 	From  common.Address    `json:"from"`
 	To    common.Address    `json:"to"`
 	Value *rpctypes.ArgBig  `json:"value"`
@@ -554,7 +572,7 @@ func findCall(rootCall Call, targetAddr common.Address, callback func(Call) (boo
 			continue
 		}
 
-		if currentCall.To == targetAddr {
+		if currentCall.To == targetAddr && currentCall.Type == CallTypeCall {
 			if callback != nil {
 				found, err := callback(currentCall)
 				if err != nil {

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -268,7 +268,7 @@ func TestBuildAppender(t *testing.T) {
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*Call)
 			require.True(t, ok)
-			*arg = Call{To: bridgeAddr, Input: BridgeAssetMethodID}
+			*arg = Call{Type: CallTypeCall, To: bridgeAddr, Input: BridgeAssetMethodID}
 		}).
 		Return(nil).
 		Maybe()
@@ -423,6 +423,7 @@ func TestFindCall(t *testing.T) {
 
 	// Simple direct call
 	root := Call{
+		Type: CallTypeCall,
 		To:   bridgeAddr,
 		From: fromAddr,
 		Err:  nil,
@@ -434,6 +435,7 @@ func TestFindCall(t *testing.T) {
 
 	// Reverted call should be skipped
 	root = Call{
+		Type: CallTypeCall,
 		To:   bridgeAddr,
 		From: fromAddr,
 		Err:  strPtr("reverted"),
@@ -443,16 +445,19 @@ func TestFindCall(t *testing.T) {
 
 	// Nested call, only inner is not reverted
 	root = Call{
+		Type: CallTypeCall,
 		To:   common.HexToAddress("0x01"),
 		From: fromAddr,
 		Err:  nil,
 		Calls: []Call{
 			{
+				Type: CallTypeCall,
 				To:   bridgeAddr,
 				From: fromAddr,
 				Err:  nil,
 			},
 			{
+				Type: CallTypeCall,
 				To:   bridgeAddr,
 				From: fromAddr,
 				Err:  strPtr("reverted"),
@@ -465,6 +470,34 @@ func TestFindCall(t *testing.T) {
 	require.Equal(t, bridgeAddr, founds[0].To)
 }
 
+func TestFindCallSkipsNonCallFrameTypes(t *testing.T) {
+	bridgeAddr := common.HexToAddress("0x10")
+	fromAddr := common.HexToAddress("0x20")
+	logger := logger.WithFields("module", "test")
+
+	root := Call{
+		Type: CallTypeCall,
+		To:   common.HexToAddress("0x01"),
+		From: fromAddr,
+		Calls: []Call{
+			{Type: CallTypeDelegateCall, To: bridgeAddr, From: fromAddr},
+			{Type: CallTypeStaticCall, To: bridgeAddr, From: fromAddr},
+			{Type: CallTypeCallCode, To: bridgeAddr, From: fromAddr},
+			{To: bridgeAddr, From: fromAddr},
+		},
+	}
+
+	found, err := findCall(root, bridgeAddr, nil, logger)
+	require.ErrorContains(t, err, "not found")
+	require.Nil(t, found)
+
+	root.Calls = append(root.Calls, Call{Type: CallTypeCall, To: bridgeAddr, From: fromAddr})
+	found, err = findCall(root, bridgeAddr, nil, logger)
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.Equal(t, CallTypeCall, found[0].Type)
+}
+
 func TestFindCallWithMixedMethods(t *testing.T) {
 	bridgeAddr := common.HexToAddress("0x10")
 	fromAddr := common.HexToAddress("0x20")
@@ -475,23 +508,27 @@ func TestFindCallWithMixedMethods(t *testing.T) {
 	// Second call: claimAsset (recognized)
 	// Third call: claimMessage (recognized)
 	rootCall := Call{
+		Type: CallTypeCall,
 		To:   common.HexToAddress("0x01"),
 		From: fromAddr,
 		Err:  nil,
 		Calls: []Call{
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
 				Input: []byte{0x38, 0xb8, 0xfb, 0xbb}, // getProxiedTokensManager
 			},
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
 				Input: claimAssetEtrogMethodID, // claimAsset
 			},
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
@@ -527,17 +564,20 @@ func TestFindCallWithOnlyUnrecognizedMethods(t *testing.T) {
 
 	// Test case: Transaction with only unrecognized method calls
 	rootCall := Call{
+		Type: CallTypeCall,
 		To:   common.HexToAddress("0x01"),
 		From: fromAddr,
 		Err:  nil,
 		Calls: []Call{
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
 				Input: []byte{0x38, 0xb8, 0xfb, 0xbb}, // getProxiedTokensManager
 			},
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
@@ -586,11 +626,13 @@ func TestTxnSenderField(t *testing.T) {
 			name:           "bridgeEventSignature with TxnSender",
 			eventSignature: bridgeEventSignature,
 			callFrame: Call{
+				Type: CallTypeCall,
 				To:   common.HexToAddress("0x01"),
 				From: expectedTxnSender,
 				Err:  nil,
 				Calls: []Call{
 					{
+						Type:  CallTypeCall,
 						To:    bridgeAddr,
 						From:  expectedTxnSender,
 						Err:   nil,
@@ -755,13 +797,16 @@ func TestExtractTxnAddresses(t *testing.T) {
 				Amount:             big.NewInt(100),
 			},
 			responseDebugTrace: &Call{
+				Type: CallTypeCall,
 				Calls: []Call{
 					{
+						Type:  CallTypeCall,
 						To:    bridgeAddr,
 						From:  common.HexToAddress("0x20"),
 						Input: BridgeMessageMethodID,
 					},
 					{
+						Type:  CallTypeCall,
 						To:    bridgeAddr,
 						From:  common.HexToAddress("0x25"),
 						Input: BridgeMessageMethodID,
@@ -780,10 +825,12 @@ func TestExtractTxnAddresses(t *testing.T) {
 				Amount:             big.NewInt(100),
 			},
 			responseDebugTrace: &Call{
+				Type: CallTypeCall,
 				From: common.HexToAddress("0x3333333333333333333333333333333333333333"),
 				To:   common.HexToAddress("0x4444444444444444444444444444444444444444"),
 				Calls: []Call{
 					{
+						Type:  CallTypeCall,
 						To:    bridgeAddr,
 						From:  common.HexToAddress("0x50"),
 						Input: append(BridgeAssetMethodID, make([]byte, 100)...),

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -72,6 +72,7 @@ func TestBridgeEventE2E(t *testing.T) {
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
+			arg.Type = bridgesync.CallTypeCall
 			arg.Input = bridgesync.BridgeAssetMethodID
 		}).Return(nil)
 
@@ -218,6 +219,7 @@ func TestBridgeL1SyncerWithReorgDetector(t *testing.T) {
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
+			arg.Type = bridgesync.CallTypeCall
 			arg.Input = bridgesync.BridgeAssetMethodID
 		}).Return(nil).Maybe()
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)
@@ -404,6 +406,7 @@ func TestReorgWithSameHashEdgeCase(t *testing.T) {
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
+			arg.Type = bridgesync.CallTypeCall
 			arg.Input = bridgesync.BridgeAssetMethodID
 		}).Return(nil)
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)
@@ -520,6 +523,7 @@ func TestBridgeL1SyncerWithMultipleReorgs(t *testing.T) {
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*bridgesync.Call)
 			require.True(t, ok)
+			arg.Type = bridgesync.CallTypeCall
 			arg.Input = bridgesync.BridgeAssetMethodID
 		}).Return(nil)
 	ethClient := etherman.NewDefaultEthClient(client.Client(), rpcClient, ethClientConfig)

--- a/claimsync/claimcalldata_test.go
+++ b/claimsync/claimcalldata_test.go
@@ -26,7 +26,7 @@ type testCase struct {
 }
 
 func TestClaimCalldata(t *testing.T) {
-	testCases := []testCase{}
+	testCases := make([]testCase, 0, 46)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 	// Setup Docker L1

--- a/claimsync/downloader.go
+++ b/claimsync/downloader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strings"
 	goSync "sync"
 
@@ -63,6 +64,23 @@ const (
 
 	// methodIDLength is the length of the method ID in bytes
 	methodIDLength = 4
+)
+
+const (
+	// CallTypeCall is a callTracer CALL frame.
+	CallTypeCall = "CALL"
+	// CallTypeDelegateCall is a callTracer DELEGATECALL frame.
+	CallTypeDelegateCall = "DELEGATECALL"
+	// CallTypeStaticCall is a callTracer STATICCALL frame.
+	CallTypeStaticCall = "STATICCALL"
+	// CallTypeCallCode is a callTracer CALLCODE frame.
+	CallTypeCallCode = "CALLCODE"
+	// CallTypeCreate is a callTracer CREATE frame.
+	CallTypeCreate = "CREATE"
+	// CallTypeCreate2 is a callTracer CREATE2 frame.
+	CallTypeCreate2 = "CREATE2"
+	// CallTypeSelfDestruct is a callTracer SELFDESTRUCT frame.
+	CallTypeSelfDestruct = "SELFDESTRUCT"
 )
 
 // BridgeDeployment represents the type of bridge contract deployment (sovereign vs non-sovereign).
@@ -411,6 +429,7 @@ func NewPreferDetailedClaimLogsHook(logger aggkitcommon.Logger) sync.LogsHookFun
 }
 
 type Call struct {
+	Type  string            `json:"type"`
 	From  common.Address    `json:"from"`
 	To    common.Address    `json:"to"`
 	Value *rpctypes.ArgBig  `json:"value"`
@@ -446,7 +465,7 @@ func findCall(rootCall Call,
 			continue
 		}
 
-		if currentCall.To == targetAddr {
+		if currentCall.To == targetAddr && currentCall.Type == CallTypeCall {
 			if callback != nil {
 				found, err := callback(currentCall)
 				if err != nil {
@@ -513,23 +532,53 @@ func extractCallData(
 // - bridge: Target contract address.
 // - logger: Logger instance for debug logging.
 //
-// Returns an error if calldata isn't found.
+// Returns an error if calldata isn't found or if distinct matching calldata candidates are found.
 func setClaimCalldataFromRoot(
 	c *Claim,
 	rootCall *Call,
 	bridge common.Address,
 	logger aggkitcommon.Logger,
 ) error {
+	candidates := make([]Claim, 0, 1)
 	_, err := findCall(*rootCall, bridge,
 		func(call Call) (bool, error) {
 			// Skip reverted calls
 			if call.Err != nil {
 				return false, nil
 			}
-			return tryDecodeClaimCalldata(c, call.Input, logger)
+			candidate := *c
+			found, err := tryDecodeClaimCalldata(&candidate, call.Input, logger)
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				return false, nil
+			}
+			if !hasClaimCandidate(candidates, candidate) {
+				candidates = append(candidates, candidate)
+			}
+			return true, nil
 		}, logger)
+	if err != nil {
+		return err
+	}
 
-	return err
+	if len(candidates) != 1 {
+		return fmt.Errorf("ambiguous claim calldata for globalIndex %s: found %d matching bridge calls",
+			c.GlobalIndex.String(), len(candidates))
+	}
+
+	*c = candidates[0]
+	return nil
+}
+
+func hasClaimCandidate(candidates []Claim, candidate Claim) bool {
+	for _, existing := range candidates {
+		if reflect.DeepEqual(existing, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 // tryDecodeClaimCalldata attempts to find and decode the claim calldata from the provided input bytes.

--- a/claimsync/downloader_test.go
+++ b/claimsync/downloader_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +30,7 @@ func TestFindCall(t *testing.T) {
 
 	// Simple direct call
 	root := Call{
+		Type: CallTypeCall,
 		To:   bridgeAddr,
 		From: fromAddr,
 		Err:  nil,
@@ -40,6 +42,7 @@ func TestFindCall(t *testing.T) {
 
 	// Reverted root call must be skipped — returns ErrNotFound
 	root = Call{
+		Type: CallTypeCall,
 		To:   bridgeAddr,
 		From: fromAddr,
 		Err:  strPtr("reverted"),
@@ -49,16 +52,19 @@ func TestFindCall(t *testing.T) {
 
 	// Nested calls: one valid, one reverted — only valid is returned
 	root = Call{
+		Type: CallTypeCall,
 		To:   common.HexToAddress("0x01"),
 		From: fromAddr,
 		Err:  nil,
 		Calls: []Call{
 			{
+				Type: CallTypeCall,
 				To:   bridgeAddr,
 				From: fromAddr,
 				Err:  nil,
 			},
 			{
+				Type: CallTypeCall,
 				To:   bridgeAddr,
 				From: fromAddr,
 				Err:  strPtr("reverted"),
@@ -71,6 +77,34 @@ func TestFindCall(t *testing.T) {
 	require.Equal(t, bridgeAddr, founds[0].To)
 }
 
+func TestFindCallSkipsNonCallFrameTypes(t *testing.T) {
+	bridgeAddr := common.HexToAddress("0x10")
+	fromAddr := common.HexToAddress("0x20")
+	lg := logger.WithFields("module", "test")
+
+	root := Call{
+		Type: CallTypeCall,
+		To:   common.HexToAddress("0x01"),
+		From: fromAddr,
+		Calls: []Call{
+			{Type: CallTypeDelegateCall, To: bridgeAddr, From: fromAddr},
+			{Type: CallTypeStaticCall, To: bridgeAddr, From: fromAddr},
+			{Type: CallTypeCallCode, To: bridgeAddr, From: fromAddr},
+			{To: bridgeAddr, From: fromAddr},
+		},
+	}
+
+	found, err := findCall(root, bridgeAddr, nil, lg)
+	require.ErrorContains(t, err, "not found")
+	require.Nil(t, found)
+
+	root.Calls = append(root.Calls, Call{Type: CallTypeCall, To: bridgeAddr, From: fromAddr})
+	found, err = findCall(root, bridgeAddr, nil, lg)
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.Equal(t, CallTypeCall, found[0].Type)
+}
+
 func TestFindCallWithMixedMethods(t *testing.T) {
 	bridgeAddr := common.HexToAddress("0x10")
 	fromAddr := common.HexToAddress("0x20")
@@ -81,23 +115,27 @@ func TestFindCallWithMixedMethods(t *testing.T) {
 	//   2. claimAsset (recognized)
 	//   3. claimMessage (recognized)
 	rootCall := Call{
+		Type: CallTypeCall,
 		To:   common.HexToAddress("0x01"),
 		From: fromAddr,
 		Err:  nil,
 		Calls: []Call{
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
 				Input: []byte{0x38, 0xb8, 0xfb, 0xbb}, // unrecognized
 			},
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
 				Input: claimAssetEtrogMethodID,
 			},
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
@@ -127,17 +165,20 @@ func TestFindCallWithOnlyUnrecognizedMethods(t *testing.T) {
 	lg := logger.WithFields("module", "test")
 
 	rootCall := Call{
+		Type: CallTypeCall,
 		To:   common.HexToAddress("0x01"),
 		From: fromAddr,
 		Err:  nil,
 		Calls: []Call{
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
 				Input: []byte{0x38, 0xb8, 0xfb, 0xbb},
 			},
 			{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  fromAddr,
 				Err:   nil,
@@ -249,6 +290,143 @@ func TestTryDecodeClaimCalldata(t *testing.T) {
 	}
 }
 
+func TestSetClaimCalldataFromRootFiltersDelegateCall(t *testing.T) {
+	bridgeAddr := common.HexToAddress("0xb81d6e")
+	callerAddr := common.HexToAddress("0xca11e6")
+	lg := logger.WithFields("module", "test")
+
+	bridgeABI, err := agglayerbridge.AgglayerbridgeMetaData.GetAbi()
+	require.NoError(t, err)
+
+	globalIndex := big.NewInt(900)
+	originNetwork := uint32(69)
+	originAddress := common.HexToAddress("0xffaaffaa")
+	destinationAddress := common.HexToAddress("0x123456789")
+	amount := big.NewInt(3)
+
+	type variant struct {
+		proofLocal   [tree.DefaultHeight][common.HashLength]byte
+		proofRollup  [tree.DefaultHeight][common.HashLength]byte
+		proofLocalH  tree.Proof
+		proofRollupH tree.Proof
+		mer          common.Hash
+		rer          common.Hash
+		destNetwork  uint32
+		metadata     []byte
+	}
+
+	newVariant := func(proofLocalHex, proofRollupHex, merHex, rerHex string,
+		destNetwork uint32, metadata []byte) variant {
+		var v variant
+		v.proofLocal[5] = common.HexToHash(proofLocalHex)
+		v.proofLocalH[5] = common.HexToHash(proofLocalHex)
+		v.proofRollup[4] = common.HexToHash(proofRollupHex)
+		v.proofRollupH[4] = common.HexToHash(proofRollupHex)
+		v.mer = common.HexToHash(merHex)
+		v.rer = common.HexToHash(rerHex)
+		v.destNetwork = destNetwork
+		v.metadata = metadata
+		return v
+	}
+
+	claimFor := func(v variant) Claim {
+		return Claim{
+			GlobalIndex:         new(big.Int).Set(globalIndex),
+			OriginNetwork:       originNetwork,
+			OriginAddress:       originAddress,
+			DestinationAddress:  destinationAddress,
+			Amount:              new(big.Int).Set(amount),
+			MainnetExitRoot:     v.mer,
+			RollupExitRoot:      v.rer,
+			ProofLocalExitRoot:  v.proofLocalH,
+			ProofRollupExitRoot: v.proofRollupH,
+			DestinationNetwork:  v.destNetwork,
+			Metadata:            v.metadata,
+			GlobalExitRoot:      crypto.Keccak256Hash(v.mer.Bytes(), v.rer.Bytes()),
+		}
+	}
+
+	encode := func(v variant) []byte {
+		data, packErr := bridgeABI.Pack(
+			"claimAsset",
+			v.proofLocal,
+			v.proofRollup,
+			globalIndex,
+			v.mer,
+			v.rer,
+			originNetwork,
+			originAddress,
+			v.destNetwork,
+			destinationAddress,
+			amount,
+			v.metadata,
+		)
+		require.NoError(t, packErr)
+		return data
+	}
+
+	seed := func() Claim {
+		return Claim{
+			GlobalIndex:        new(big.Int).Set(globalIndex),
+			OriginNetwork:      originNetwork,
+			OriginAddress:      originAddress,
+			DestinationAddress: destinationAddress,
+			Amount:             new(big.Int).Set(amount),
+		}
+	}
+
+	legit := newVariant("0xbeef", "0xa1fa", "0x5ca1e", "0xdead", 0, []byte{})
+	malicious := newVariant("0xcafe", "0xbabe", "0xf00d", "0xb105", 42, []byte{0xde, 0xad, 0xbe, 0xef})
+	legitClaim := claimFor(legit)
+
+	legitFrame := Call{Type: CallTypeCall, To: bridgeAddr, Input: encode(legit)}
+	delegateFrame := Call{Type: CallTypeDelegateCall, To: bridgeAddr, Input: encode(malicious)}
+	maliciousCallFrame := Call{Type: CallTypeCall, To: bridgeAddr, Input: encode(malicious)}
+
+	t.Run("call wins regardless of sibling order", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			calls []Call
+		}{
+			{name: "delegate first", calls: []Call{delegateFrame, legitFrame}},
+			{name: "delegate last", calls: []Call{legitFrame, delegateFrame}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				actual := seed()
+				root := &Call{Type: CallTypeCall, To: callerAddr, Calls: tt.calls}
+				require.NoError(t, setClaimCalldataFromRoot(&actual, root, bridgeAddr, lg))
+				require.Equal(t, legitClaim, actual)
+			})
+		}
+	})
+
+	t.Run("delegate-only trace is ignored", func(t *testing.T) {
+		actual := seed()
+		root := &Call{Type: CallTypeCall, To: callerAddr, Calls: []Call{delegateFrame}}
+
+		require.ErrorContains(t, setClaimCalldataFromRoot(&actual, root, bridgeAddr, lg), "not found")
+		require.Equal(t, seed(), actual)
+	})
+
+	t.Run("duplicate identical calls are accepted", func(t *testing.T) {
+		actual := seed()
+		root := &Call{Type: CallTypeCall, To: callerAddr, Calls: []Call{legitFrame, legitFrame}}
+
+		require.NoError(t, setClaimCalldataFromRoot(&actual, root, bridgeAddr, lg))
+		require.Equal(t, legitClaim, actual)
+	})
+
+	t.Run("distinct matching calls are ambiguous", func(t *testing.T) {
+		actual := seed()
+		root := &Call{Type: CallTypeCall, To: callerAddr, Calls: []Call{legitFrame, maliciousCallFrame}}
+
+		require.ErrorContains(t, setClaimCalldataFromRoot(&actual, root, bridgeAddr, lg), "ambiguous claim calldata")
+		require.Equal(t, seed(), actual)
+	})
+}
+
 func TestBuildAppender(t *testing.T) {
 	bridgeAddr := common.HexToAddress("0x10")
 	blockNum := uint64(1)
@@ -287,6 +465,7 @@ func TestBuildAppender(t *testing.T) {
 			arg, ok := result.(*Call)
 			require.True(t, ok)
 			*arg = Call{
+				Type:  CallTypeCall,
 				To:    bridgeAddr,
 				From:  common.HexToAddress("0x01"),
 				Input: claimAssetInput,
@@ -643,7 +822,7 @@ func TestBuildClaimEventHandlerPreEtrog_OK(t *testing.T) {
 		Run(func(result any, method string, args ...any) {
 			arg, ok := result.(*Call)
 			require.True(t, ok)
-			*arg = Call{To: bridgeAddr, From: common.HexToAddress("0x01"), Input: claimAssetInput}
+			*arg = Call{Type: CallTypeCall, To: bridgeAddr, From: common.HexToAddress("0x01"), Input: claimAssetInput}
 		}).
 		Return(nil)
 


### PR DESCRIPTION
## 🔄 Changes Summary
- Filter debug trace call matching to actual `CALL` frames in `bridgesync` and `claimsync`, avoiding calldata extraction from `DELEGATECALL`, `STATICCALL`, `CALLCODE`, or missing-type frames.
- Add call tracer frame type constants and include the `type` field in decoded trace calls.
- Make claim calldata extraction reject ambiguous distinct matching bridge calls while accepting duplicate identical matches.
- Extend bridge and claim sync tests for call-frame filtering, ambiguous calldata, and updated mocked debug traces.

## ⚠️ Breaking Changes
- 🛠️ **Config**: None
- 🔌 **API/CLI**: None
- 🗑️ **Deprecated Features**: None

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: None

## ✅ Testing
- 🤖 **Automatic**: `go test ./bridgesync ./claimsync`
- 🖱️ **Manual**: Not run

## 🐞 Issues
- None

## 🔗 Related PRs
- None

## 📝 Notes
- The fix keeps debug trace traversal behavior but only treats canonical `CALL` frames to the bridge as extraction candidates, preventing delegate-call calldata from being selected as if it were a direct bridge call.