### PR TITLE
feat: cherry-pick: configurable batch block header retrieval via RPCClientConfig

### DIFF
--- a/bridgeservice/client/client.go
+++ b/bridgeservice/client/client.go
@@ -134,7 +134,7 @@ func (c *Client) GetBridges(ctx context.Context, params GetBridgesParams) (*type
 		query.Set("from_address", *params.FromAddress)
 	}
 	if len(params.NetworkIDs) > 0 {
-		var ids []string
+		ids := make([]string, 0, len(params.NetworkIDs))
 		for _, id := range params.NetworkIDs {
 			ids = append(ids, strconv.FormatUint(uint64(id), 10))
 		}
@@ -160,7 +160,7 @@ func (c *Client) GetClaims(ctx context.Context, params GetClaimsParams) (*types.
 		query.Set("page_size", strconv.FormatUint(uint64(*params.PageSize), 10))
 	}
 	if len(params.NetworkIDs) > 0 {
-		var ids []string
+		ids := make([]string, 0, len(params.NetworkIDs))
 		for _, id := range params.NetworkIDs {
 			ids = append(ids, strconv.FormatUint(uint64(id), 10))
 		}

--- a/claimsync/claimsync_test.go
+++ b/claimsync/claimsync_test.go
@@ -3,12 +3,15 @@ package claimsync
 import (
 	"context"
 	"math/big"
+	"os"
 	"path"
 	"testing"
 	"time"
 
 	claimsynctypes "github.com/agglayer/aggkit/claimsync/types"
 	configtypes "github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/etherman"
+	ethermanconfig "github.com/agglayer/aggkit/etherman/config"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/agglayer/aggkit/test/contracts/claimmock"
@@ -17,6 +20,34 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetLastBlockNumByGlobalIndexFromRPC_Exploratory(t *testing.T) {
+	t.Skip("This test is exploratory. Set the L2URL environment variable to run it.")
+	l2URL := os.Getenv("L2URL")
+	if l2URL == "" {
+		t.Skip("L2URL environment variable not set")
+	}
+	claimSyncer := &ClaimSync{
+		logger: log.WithFields("test", "TestGetLastBlockNumByGlobalIndexFromRPC_Exploratory"),
+	}
+	claimSyncer.cfg.BridgeAddr = common.HexToAddress("0x1348947e282138d8f377b467f7d9c2eb0f335d1f")
+	ctx := context.Background()
+	cfgEthClient := ethermanconfig.RPCClientConfig{
+		URL:  l2URL,
+		Mode: "basic",
+	}
+	ethClient, err := etherman.NewRPCClient(ctx, log.WithFields("test", "TestGetLastBlockNumByGlobalIndexFromRPC_Exploratory"), cfgEthClient)
+	require.NoError(t, err)
+	claimSyncer.ethClient = ethClient
+
+	globalIndex, ok := big.NewInt(0).SetString("18446744073710677822", 10)
+	require.True(t, ok)
+
+	block, found_, err := claimSyncer.GetLatestBlockNumByGlobalIndexFromRPC(ctx, globalIndex, &aggkittypes.LatestBlock)
+	require.NoError(t, err)
+	require.True(t, found_)
+	log.Infof("Block number for global index %s: %d", globalIndex.String(), block)
+}
 
 // TestClaimSyncerWaitUntilSetNextRequiredBlock verifies the deferred start behavior of ClaimSyncer:
 // it must not begin syncing until an explicit starting block is provided via SetNextRequiredBlock.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,9 +58,11 @@ func TestLoadDefaultConfig(t *testing.T) {
 			MaxBackoff:        types.NewDuration(10 * time.Second),
 			BackoffMultiplier: 2.0,
 		},
-		Mode:         ethermanconfig.RPCModeBasic,
-		HashFromJSON: true,
+		Mode:                      ethermanconfig.RPCModeBasic,
+		HashFromJSON:              true,
+		BatchBlockHeaderRetrieval: true,
 	}, cfg.Common.L2RPC)
+	require.True(t, cfg.L1NetworkConfig.RPC.BatchBlockHeaderRetrieval)
 	require.Equal(t, cfg.Profiling.ProfilingEnabled, false)
 	require.Equal(t, cfg.Profiling.ProfilingHost, "localhost")
 	require.Equal(t, cfg.Profiling.ProfilingPort, 6060)

--- a/config/default.go
+++ b/config/default.go
@@ -52,6 +52,7 @@ defaultDBQueryTimeout = "5m"
 	MaxBackoff = "10s"
 	BackoffMultiplier = 2.0
 	HashFromJSON = true
+	BatchBlockHeaderRetrieval = true
 `
 
 // DefaultValues is the default configuration
@@ -83,6 +84,7 @@ BlocksChunkSize = {{L1Config.BlocksChunkSize}}
 		MaxBackoff = "10s"
 		BackoffMultiplier = 2.0
 		HashFromJSON = true
+		BatchBlockHeaderRetrieval = true
 
 [L2NetworkConfig]
 # InitialLER: optional override for the initial Local Exit Root (0x000...000 is a valid value).

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -133,3 +133,44 @@ Example:
 ```
 
 When rate limiting is enabled, if the number of requests exceeds `NumRequests` within the specified `Interval`, the system will wait until the next interval before allowing more requests. This helps prevent overwhelming the system with too many requests in a short period.
+
+## RPCClientConfig
+
+`RPCClientConfig` configures the JSON-RPC client used to connect to Ethereum nodes. It is used in multiple places, notably `[L1NetworkConfig.RPC]` (L1 node) and `[Common.L2RPC]` (L2 node).
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `URL` | `string` | — | JSON-RPC endpoint URL |
+| `Mode` | `string` | `""` | Client mode: `""` or `"basic"` for standard nodes, `"op"` for Optimism nodes |
+| `HashFromJSON` | `bool` | `false` | When `true`, fetches block hashes via JSON-RPC (`eth_getBlockByNumber`). When `false`, computes them locally from the RLP-encoded header (go-ethereum default). Enable this for nodes where RLP hashing does not match the canonical block hash |
+| `BatchBlockHeaderRetrieval` | `bool` | `true` | When `true`, uses JSON-RPC batch requests to fetch block headers in bulk (faster). Disable if the node does not support batch calls |
+| `RetryMode` | `string` | `"backoff"` | Retry strategy: `"backoff"` for exponential backoff, `"delays"` for fixed delay list, `""` for no retries |
+| `MaxRetries` | `int` | `5` | Maximum number of retry attempts |
+| `InitialBackoff` | `duration` | `5s` | Initial wait time before the first retry (backoff mode) |
+| `MaxBackoff` | `duration` | `60s` | Maximum wait time between retries (backoff mode) |
+| `BackoffMultiplier` | `float64` | `2.0` | Multiplier applied to the backoff duration on each retry |
+| `Delays` | `[]duration` | `[]` | Explicit list of wait times for each retry attempt (delays mode) |
+
+Example:
+
+```toml
+[L1NetworkConfig.RPC]
+URL = "http://localhost:8545"
+Mode = "basic"
+HashFromJSON = false
+BatchBlockHeaderRetrieval = true
+RetryMode = "backoff"
+MaxRetries = 5
+InitialBackoff = "5s"
+MaxBackoff = "60s"
+BackoffMultiplier = 2.0
+
+[Common.L2RPC]
+URL = "http://localhost:8123"
+Mode = "basic"
+HashFromJSON = true
+BatchBlockHeaderRetrieval = true
+RetryMode = "delays"
+MaxRetries = 6
+Delays = ["1s", "2s", "5s", "10s", "30s", "60s"]
+```

--- a/etherman/batch_requests.go
+++ b/etherman/batch_requests.go
@@ -3,9 +3,6 @@ package etherman
 import (
 	"context"
 	"fmt"
-	"maps"
-	"math/big"
-	"sort"
 	"sync"
 
 	aggkitcommon "github.com/agglayer/aggkit/common"
@@ -54,96 +51,12 @@ func (b *blockRawEth) ToBlockHeader() (*aggkittypes.BlockHeader, error) {
 // https://www.alchemy.com/docs/reference/batch-requests
 const batchRequestLimitHTTP = 1000
 
-// BlockHeadersResult contiene los resultados de la recuperación de block headers,
-// separando los exitosos de los fallidos
-type BlockHeadersResult struct {
-	// Headers contiene los block headers recuperados exitosamente, mapeados por block number
-	Headers map[uint64]*aggkittypes.BlockHeader
+// BlockHeadersResult is an alias for aggkittypes.BlockHeadersResult for backward compatibility.
+type BlockHeadersResult = aggkittypes.BlockHeadersResult
 
-	// Errors contiene los errores de recuperación, mapeados por block number
-	Errors map[uint64]error
-}
-
-// NewBlockHeadersResult crea un nuevo BlockHeadersResult
+// NewBlockHeadersResult creates a new BlockHeadersResult.
 func NewBlockHeadersResult() *BlockHeadersResult {
-	return &BlockHeadersResult{
-		Headers: make(map[uint64]*aggkittypes.BlockHeader),
-		Errors:  make(map[uint64]error),
-	}
-}
-
-// Success retorna true si todos los bloques se recuperaron exitosamente
-func (r *BlockHeadersResult) Success() bool {
-	return len(r.Errors) == 0
-}
-
-// PartialSuccess retorna true si al menos un bloque se recuperó exitosamente
-func (r *BlockHeadersResult) PartialSuccess() bool {
-	return len(r.Headers) > 0
-}
-
-// GetOrderedHeaders retorna los headers en el orden de blockNumbers solicitados,
-// solo para los bloques que se recuperaron exitosamente
-func (r *BlockHeadersResult) GetOrderedHeaders(blockNumbers []uint64) []*aggkittypes.BlockHeader {
-	result := make([]*aggkittypes.BlockHeader, 0, len(r.Headers))
-	for _, bn := range blockNumbers {
-		if header, ok := r.Headers[bn]; ok {
-			result = append(result, header)
-		}
-	}
-	return result
-}
-
-// AddHeader añade un header exitoso al resultado
-func (r *BlockHeadersResult) AddHeader(blockNumber uint64, header *aggkittypes.BlockHeader) {
-	r.Headers[blockNumber] = header
-}
-
-// AddError añade un error para un block number específico
-func (r *BlockHeadersResult) AddError(blockNumber uint64, err error) {
-	r.Errors[blockNumber] = err
-}
-
-// Merge combina otro BlockHeadersResult en este
-func (r *BlockHeadersResult) Merge(other *BlockHeadersResult) {
-	maps.Copy(r.Headers, other.Headers)
-	maps.Copy(r.Errors, other.Errors)
-}
-
-func (r *BlockHeadersResult) AreAllErrorsNotFound() bool {
-	for _, err := range r.Errors {
-		if !IsErrNotFound(err) {
-			return false
-		}
-	}
-	return true
-}
-
-// ListBlocksNumberNotFound returns the list of not found block numbers in the result ordered by block number
-func (r *BlockHeadersResult) ListBlocksNumberNotFound() []uint64 {
-	var notFoundBlocks []uint64
-	for bn, err := range r.Errors {
-		if IsErrNotFound(err) {
-			notFoundBlocks = append(notFoundBlocks, bn)
-		}
-	}
-	sort.Slice(notFoundBlocks, func(i, j int) bool {
-		return notFoundBlocks[i] < notFoundBlocks[j]
-	})
-	return notFoundBlocks
-}
-
-// ComposeError returns a single error summarizing the errors in the result, or nil if there are no errors
-func (r *BlockHeadersResult) ComposeError() error {
-	if len(r.Errors) == 0 {
-		return nil
-	}
-	errResult := fmt.Errorf("RetrieveBlockHeaders errors")
-	errBlockNumbers := r.ListBlocksNumberNotFound()
-	for _, bn := range errBlockNumbers {
-		errResult = fmt.Errorf("%w\nBlock %d: %w", errResult, bn, r.Errors[bn])
-	}
-	return errResult
+	return aggkittypes.NewBlockHeadersResult()
 }
 
 // RetrieveBlockHeaders retrieves block headers for the given block numbers using batch requests
@@ -190,12 +103,12 @@ func RetrieveBlockHeadersLegacy(ctx context.Context,
 		func(ctx context.Context, blocks []uint64) (*BlockHeadersResult, error) {
 			result := NewBlockHeadersResult()
 			for _, blockNumber := range blocks {
-				header, err := ethClient.HeaderByNumber(ctx, big.NewInt(int64(blockNumber)))
+				header, err := ethClient.CustomHeaderByNumber(ctx, aggkittypes.NewBlockNumber(blockNumber))
 				if err != nil {
 					result.AddError(blockNumber, fmt.Errorf("cannot get block header: %w", err))
 					continue
 				}
-				result.AddHeader(blockNumber, aggkittypes.NewBlockHeaderFromEthHeader(header))
+				result.AddHeader(blockNumber, header)
 			}
 			return result, nil
 		}, blockNumbers, 1, maxConcurrency)

--- a/etherman/batch_requests_test.go
+++ b/etherman/batch_requests_test.go
@@ -3,7 +3,6 @@ package etherman
 import (
 	"context"
 	"errors"
-	"math/big"
 	"os"
 	"testing"
 
@@ -11,7 +10,6 @@ import (
 	aggkittypes "github.com/agglayer/aggkit/types"
 	mockaggkittypes "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
@@ -92,11 +90,9 @@ func TestRetrieveBlockHeaders(t *testing.T) {
 	t.Run("uses legacy when rpcClient is nil", func(t *testing.T) {
 		mockEthClient := mockaggkittypes.NewBaseEthereumClienter(t)
 		for _, bn := range blockNumbers {
-			mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(int64(bn))).
-				Return(&types.Header{
-					Number: big.NewInt(int64(bn)),
-					Time:   123,
-				}, nil).Once()
+			mockEthClient.EXPECT().
+				CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(bn)).
+				Return(&aggkittypes.BlockHeader{Number: bn}, nil).Once()
 		}
 		result, err := RetrieveBlockHeaders(ctx, logger, mockEthClient, nil, blockNumbers, maxConcurrency)
 
@@ -116,7 +112,9 @@ func TestRetrieveBlockHeaders(t *testing.T) {
 
 	t.Run("collects errors from legacy method", func(t *testing.T) {
 		mockEthClient := mockaggkittypes.NewBaseEthereumClienter(t)
-		mockEthClient.EXPECT().HeaderByNumber(mock.Anything, mock.Anything).Return(nil, errors.New("legacy error")).Times(len(blockNumbers))
+		mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, mock.Anything).
+			Return(nil, errors.New("legacy error")).Times(len(blockNumbers))
 		result, err := RetrieveBlockHeaders(ctx, logger, mockEthClient, nil, blockNumbers, maxConcurrency)
 
 		require.NoError(t, err) // No catastrophic error
@@ -127,31 +125,59 @@ func TestRetrieveBlockHeaders(t *testing.T) {
 		}
 	})
 }
+
 func TestRetrieveBlockHeadersLegacy(t *testing.T) {
 	ctx := t.Context()
 	logger := log.WithFields("test", "test")
-	blockNumbers := []uint64{
-		100,
-		200,
-		400,
-		500,
-	}
+	blockNumbers := []uint64{100, 200, 400, 500}
 	maxConcurrency := 1
 
 	t.Run("successful retrieval", func(t *testing.T) {
 		mockEthClient := mockaggkittypes.NewBaseEthereumClienter(t)
 		for _, bn := range blockNumbers {
-			mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(int64(bn))).
-				Return(&types.Header{
-					Number: big.NewInt(int64(bn)),
-					Time:   123,
-				}, nil).Once()
+			mockEthClient.EXPECT().
+				CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(bn)).
+				Return(&aggkittypes.BlockHeader{Number: bn}, nil).Once()
 		}
 		result, err := RetrieveBlockHeadersLegacy(ctx, logger, mockEthClient, blockNumbers, maxConcurrency)
 
 		require.NoError(t, err)
 		require.True(t, result.Success())
 		assert.Equal(t, len(blockNumbers), len(result.Headers))
+		for _, bn := range blockNumbers {
+			require.Equal(t, bn, result.Headers[bn].Number)
+		}
+	})
+
+	t.Run("partial failure", func(t *testing.T) {
+		mockEthClient := mockaggkittypes.NewBaseEthereumClienter(t)
+		mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(blockNumbers[0])).
+			Return(&aggkittypes.BlockHeader{Number: blockNumbers[0]}, nil).Once()
+		for _, bn := range blockNumbers[1:] {
+			mockEthClient.EXPECT().
+				CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(bn)).
+				Return(nil, errors.New("rpc error")).Once()
+		}
+		result, err := RetrieveBlockHeadersLegacy(ctx, logger, mockEthClient, blockNumbers, maxConcurrency)
+
+		require.NoError(t, err)
+		require.False(t, result.Success())
+		require.True(t, result.PartialSuccess())
+		require.Len(t, result.Headers, 1)
+		require.Len(t, result.Errors, len(blockNumbers)-1)
+	})
+
+	t.Run("all fail", func(t *testing.T) {
+		mockEthClient := mockaggkittypes.NewBaseEthereumClienter(t)
+		mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, mock.Anything).
+			Return(nil, errors.New("not found")).Times(len(blockNumbers))
+		result, err := RetrieveBlockHeadersLegacy(ctx, logger, mockEthClient, blockNumbers, maxConcurrency)
+
+		require.NoError(t, err)
+		require.False(t, result.Success())
+		require.Len(t, result.Errors, len(blockNumbers))
 	})
 }
 

--- a/etherman/config/network.go
+++ b/etherman/config/network.go
@@ -103,6 +103,9 @@ type RPCClientConfig struct {
 	// If true, the block Hash is getted from JSON RPC
 	// if false, the block Hash is getted from go-ethereum RLP hashing of header
 	HashFromJSON bool `mapstructure:"HashFromJSON"`
+	// BatchBlockHeaderRetrieval enables using JSON-RPC batch requests when fetching block headers.
+	// Disable this if the node does not support batch requests. Default: true.
+	BatchBlockHeaderRetrieval bool `mapstructure:"BatchBlockHeaderRetrieval"`
 	//
 	// Params specific per client
 	// ExtraParams contains any additional parameters that may be needed for the RPC client
@@ -112,9 +115,10 @@ type RPCClientConfig struct {
 // NewDefaultRPCClientConfig returns a new RPCClientConfig with default values
 func NewDefaultRPCClientConfig() *RPCClientConfig {
 	return &RPCClientConfig{
-		Mode:         RPCModeDefault,
-		HashFromJSON: false,
-		ExtraParams:  make(map[string]any),
+		Mode:                      RPCModeDefault,
+		HashFromJSON:              false,
+		BatchBlockHeaderRetrieval: true,
+		ExtraParams:               make(map[string]any),
 		RetryPolicyGenericConfig: common.RetryPolicyGenericConfig{
 			Mode:              common.RetryConfigModeBackoff,
 			MaxRetries:        5,                                          //nolint: mnd

--- a/etherman/default_eth_client.go
+++ b/etherman/default_eth_client.go
@@ -25,8 +25,9 @@ type DefaultEthClient struct {
 
 	// If true, the block Hash is getted from JSON RPC
 	// if false, the block Hash is getted from go-ethereum RLP hashing of header
-	HashFromJSON bool
-	logger       aggkitcommon.Logger
+	HashFromJSON      bool
+	batchBlockHeaders bool
+	logger            aggkitcommon.Logger
 }
 
 // DialWithRetry attempts to connect to an Ethereum client with retries and exponential backoff.
@@ -74,12 +75,17 @@ func NewDefaultEthClientWithLogger(
 		logger.Warnf("rpcClient is nil, cannot use HashFromJSON=true, setting to false")
 		hashFromJSON = false
 	}
+	batchBlockHeaders := cfg.BatchBlockHeaderRetrieval
+	if rpcClient == nil && cfg.BatchBlockHeaderRetrieval {
+		batchBlockHeaders = false
+	}
 
 	return &DefaultEthClient{
-		EthereumClienter: client,
-		RPCClienter:      rpcClient,
-		HashFromJSON:     hashFromJSON,
-		logger:           logger,
+		EthereumClienter:  client,
+		RPCClienter:       rpcClient,
+		HashFromJSON:      hashFromJSON,
+		batchBlockHeaders: batchBlockHeaders,
+		logger:            logger,
 	}
 }
 
@@ -160,6 +166,18 @@ func (c *DefaultEthClient) rpcGetBlockByNumber(ctx context.Context, number *big.
 		return nil, fmt.Errorf("rpcGetBlockByNumber:not found:  %s", blockArg)
 	}
 	return rawEthHeader.ToBlockHeader()
+}
+
+// RetrieveBlockHeaders retrieves block headers for the given block numbers.
+// Uses batch RPC when BatchBlockHeaderRetrieval is enabled and an rpcClient is available,
+// otherwise falls back to individual requests.
+func (c *DefaultEthClient) RetrieveBlockHeaders(
+	ctx context.Context, blockNumbers []uint64, maxConcurrency int,
+) (*aggkittypes.BlockHeadersResult, error) {
+	if c.batchBlockHeaders {
+		return RetrieveBlockHeadersBatch(ctx, c.logger, c.RPCClienter, blockNumbers, maxConcurrency)
+	}
+	return RetrieveBlockHeadersLegacy(ctx, c.logger, c, blockNumbers, maxConcurrency)
 }
 
 func (c *DefaultEthClient) Call(result any, method string, args ...any) error {

--- a/etherman/default_eth_client_test.go
+++ b/etherman/default_eth_client_test.go
@@ -2,15 +2,18 @@ package etherman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
 	"testing"
 
 	ethermanconfig "github.com/agglayer/aggkit/etherman/config"
+	"github.com/agglayer/aggkit/log"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -228,5 +231,112 @@ func TestDefaultEthClient_CustomHeaderByNumber(t *testing.T) {
 
 	t.Run("SafeBlock with negative offset (HashFromJSON=false)", func(t *testing.T) {
 		testBlockWithOffsetHelperGeth(t, ctx, "SafeBlock/-3", big.NewInt(-4), 50, 47)
+	})
+}
+
+func TestDefaultEthClient_RetrieveBlockHeaders(t *testing.T) {
+	ctx := context.Background()
+	logger := log.WithFields("test", "test")
+	blockNumbers := []uint64{100, 200}
+	maxConcurrency := 2
+
+	t.Run("batch path delegates to RPCClienter", func(t *testing.T) {
+		mockEth := mocks.NewEthereumClienter(t)
+		mockRPC := mocks.NewRPCClienter(t)
+		cfg := &ethermanconfig.RPCClientConfig{BatchBlockHeaderRetrieval: true}
+		client := NewDefaultEthClientWithLogger(logger, mockEth, mockRPC, cfg)
+
+		mockRPC.EXPECT().BatchCallContext(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, b []rpc.BatchElem) {
+				for idx := range b {
+					block, ok := b[idx].Result.(*blockRawEth)
+					require.True(t, ok)
+					block.Number = fmt.Sprintf("0x%x", blockNumbers[idx])
+					block.Hash = fmt.Sprintf("0x%064x", idx+1)
+					block.Timestamp = "0x1"
+				}
+			}).
+			Return(nil).Once()
+
+		result, err := client.RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)
+		require.NoError(t, err)
+		require.True(t, result.Success())
+		require.Len(t, result.Headers, len(blockNumbers))
+	})
+
+	t.Run("batch path propagates RPC error", func(t *testing.T) {
+		mockEth := mocks.NewEthereumClienter(t)
+		mockRPC := mocks.NewRPCClienter(t)
+		cfg := &ethermanconfig.RPCClientConfig{BatchBlockHeaderRetrieval: true}
+		client := NewDefaultEthClientWithLogger(logger, mockEth, mockRPC, cfg)
+
+		mockRPC.EXPECT().BatchCallContext(mock.Anything, mock.Anything).
+			Return(errors.New("rpc unavailable")).Once()
+
+		_, err := client.RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rpc unavailable")
+	})
+
+	t.Run("legacy path with HashFromJSON=false uses HeaderByNumber", func(t *testing.T) {
+		mockEth := mocks.NewEthereumClienter(t)
+		mockRPC := mocks.NewRPCClienter(t)
+		cfg := &ethermanconfig.RPCClientConfig{BatchBlockHeaderRetrieval: false, HashFromJSON: false}
+		client := NewDefaultEthClientWithLogger(logger, mockEth, mockRPC, cfg)
+
+		for _, bn := range blockNumbers {
+			mockEth.EXPECT().
+				HeaderByNumber(mock.Anything, new(big.Int).SetUint64(bn)).
+				Return(&types.Header{Number: new(big.Int).SetUint64(bn)}, nil).Once()
+		}
+
+		result, err := client.RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)
+		require.NoError(t, err)
+		require.True(t, result.Success())
+		require.Len(t, result.Headers, len(blockNumbers))
+	})
+
+	t.Run("legacy path with HashFromJSON=true uses CallContext", func(t *testing.T) {
+		mockEth := mocks.NewEthereumClienter(t)
+		mockRPC := mocks.NewRPCClienter(t)
+		cfg := &ethermanconfig.RPCClientConfig{BatchBlockHeaderRetrieval: false, HashFromJSON: true}
+		client := NewDefaultEthClientWithLogger(logger, mockEth, mockRPC, cfg)
+
+		for _, bn := range blockNumbers {
+			bnHex := fmt.Sprintf("0x%x", bn)
+			mockRPC.EXPECT().
+				CallContext(mock.Anything, mock.Anything, "eth_getBlockByNumber", bnHex, false).
+				Run(func(_ context.Context, result interface{}, _ string, args ...interface{}) {
+					raw, ok := result.(**blockRawEth)
+					require.True(t, ok)
+					*raw = &blockRawEth{
+						Number:    bnHex,
+						Hash:      fmt.Sprintf("0x%064x", bn),
+						Timestamp: "0x1",
+					}
+				}).
+				Return(nil).Once()
+		}
+
+		result, err := client.RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)
+		require.NoError(t, err)
+		require.True(t, result.Success())
+		require.Len(t, result.Headers, len(blockNumbers))
+	})
+
+	t.Run("legacy path collects per-block errors without failing", func(t *testing.T) {
+		mockEth := mocks.NewEthereumClienter(t)
+		mockRPC := mocks.NewRPCClienter(t)
+		cfg := &ethermanconfig.RPCClientConfig{BatchBlockHeaderRetrieval: false, HashFromJSON: false}
+		client := NewDefaultEthClientWithLogger(logger, mockEth, mockRPC, cfg)
+
+		mockEth.EXPECT().
+			HeaderByNumber(mock.Anything, mock.Anything).
+			Return(nil, errors.New("not found")).Times(len(blockNumbers))
+
+		result, err := client.RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)
+		require.NoError(t, err)
+		require.False(t, result.Success())
+		require.Len(t, result.Errors, len(blockNumbers))
 	})
 }

--- a/etherman/errors.go
+++ b/etherman/errors.go
@@ -3,6 +3,8 @@ package etherman
 import (
 	"errors"
 	"strings"
+
+	aggkittypes "github.com/agglayer/aggkit/types"
 )
 
 var (
@@ -28,7 +30,7 @@ var (
 	// ErrMissingTrieNode means that a node is missing on the trie
 	ErrMissingTrieNode = errors.New("missing trie node")
 	// ErrNotFound is used when the object is not found
-	ErrNotFound = errors.New("not found")
+	ErrNotFound = aggkittypes.ErrNotFound
 	// ErrPrivateKeyNotFound used when the provided sender does not have a private key registered to be used
 	ErrPrivateKeyNotFound = errors.New("can't find sender private key to sign tx")
 
@@ -57,19 +59,7 @@ func TryParseError(err error) (error, bool) {
 	return parsedError, exists
 }
 
+// IsErrNotFound checks if the error is a "not found" error
 func IsErrNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, ErrNotFound) {
-		return true
-	}
-	if err.Error() == ErrNotFound.Error() {
-		return true
-	}
-	// If error contains "not found" (case sensitive) is an ErrNotFound
-	if strings.Contains(err.Error(), "not found") {
-		return true
-	}
-	return false
+	return aggkittypes.IsErrNotFound(err)
 }

--- a/multidownloader/evm_multidownloader.go
+++ b/multidownloader/evm_multidownloader.go
@@ -14,7 +14,6 @@ import (
 	jRPC "github.com/0xPolygon/cdk-rpc/rpc"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/db/compatibility"
-	"github.com/agglayer/aggkit/etherman"
 	ethermanblocknotifier "github.com/agglayer/aggkit/etherman/block_notifier"
 	ethermantypes "github.com/agglayer/aggkit/etherman/types"
 	"github.com/agglayer/aggkit/log"
@@ -625,8 +624,7 @@ func (dh *EVMMultidownloader) StepUnsafe(ctx context.Context) (bool, error) {
 	}
 	blocks := pendingBlockRange.ListBlockNumbers()
 	// TODO: Check that the blocks are all inside unsafe range
-	blockHeadersResult, err := etherman.RetrieveBlockHeaders(ctx, dh.log, dh.ethClient, dh.rpcClient,
-		blocks, dh.cfg.MaxParallelBlockHeaderRetrieval)
+	blockHeadersResult, err := dh.ethClient.RetrieveBlockHeaders(ctx, blocks, dh.cfg.MaxParallelBlockHeaderRetrieval)
 	if err != nil {
 		return false, fmt.Errorf("Unsafe/Step: failed to retrieve %s block headers: %w", pendingBlockRange.String(), err)
 	}
@@ -699,23 +697,25 @@ func (dh *EVMMultidownloader) StepSafe(ctx context.Context) (bool, error) {
 		logQueryData.BlockRange.String(), logQueryData.Addrs)
 	blocks := getBlockNumbers(logs)
 	dh.log.Debugf("Safe/Step: querying blockHeaders for %d blocks", len(blocks))
-	blockHeadersResult, err := etherman.RetrieveBlockHeaders(ctx, dh.log, dh.ethClient, dh.rpcClient,
-		blocks, dh.cfg.MaxParallelBlockHeaderRetrieval)
-	if err != nil {
-		return false, fmt.Errorf("Safe/Step: failed to retrieve %d block headers: %w", len(blocks), err)
-	}
-	// Check for partial failures
-	if !blockHeadersResult.Success() {
-		for blockNum, blockErr := range blockHeadersResult.Errors {
-			dh.log.Errorf("Safe/Step: failed to retrieve block %d: %v", blockNum, blockErr)
+	var blockHeaders []*aggkittypes.BlockHeader
+	if len(blocks) > 0 {
+		blockHeadersResult, err := dh.ethClient.RetrieveBlockHeaders(ctx, blocks, dh.cfg.MaxParallelBlockHeaderRetrieval)
+		if err != nil {
+			return false, fmt.Errorf("Safe/Step: failed to retrieve %d block headers: %w", len(blocks), err)
 		}
-		if !blockHeadersResult.PartialSuccess() {
-			return false, fmt.Errorf("Safe/Step: failed to retrieve any block headers")
+		// Check for partial failures
+		if !blockHeadersResult.Success() {
+			for blockNum, blockErr := range blockHeadersResult.Errors {
+				dh.log.Errorf("Safe/Step: failed to retrieve block %d: %v", blockNum, blockErr)
+			}
+			if !blockHeadersResult.PartialSuccess() {
+				return false, fmt.Errorf("Safe/Step: failed to retrieve any block headers")
+			}
+			dh.log.Warnf("Safe/Step: partial success retrieving block headers: %d/%d succeeded",
+				len(blockHeadersResult.Headers), len(blocks))
 		}
-		dh.log.Warnf("Safe/Step: partial success retrieving block headers: %d/%d succeeded",
-			len(blockHeadersResult.Headers), len(blocks))
+		blockHeaders = blockHeadersResult.GetOrderedHeaders(blocks)
 	}
-	blockHeaders := blockHeadersResult.GetOrderedHeaders(blocks)
 
 	// Calculate new state (not set in memory until commit is successful)
 	dh.mutex.Lock()
@@ -1048,8 +1048,8 @@ func (dh *EVMMultidownloader) detectReorgs(ctx context.Context,
 		return nil
 	}
 	blocksNumber := blocks.BlockNumbers()
-	currentBlockHeadersResult, err := etherman.RetrieveBlockHeaders(ctx, dh.log, dh.ethClient, dh.rpcClient,
-		blocksNumber, dh.cfg.MaxParallelBlockHeaderRetrieval)
+	currentBlockHeadersResult, err := dh.ethClient.RetrieveBlockHeaders(
+		ctx, blocksNumber, dh.cfg.MaxParallelBlockHeaderRetrieval)
 	if err != nil {
 		return fmt.Errorf("detectReorgs: cannot retrieve block headers: %w", err)
 	}

--- a/multidownloader/evm_multidownloader_test.go
+++ b/multidownloader/evm_multidownloader_test.go
@@ -364,6 +364,38 @@ func TestEVMMultidownloader_StepSafe(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestEVMMultidownloader_StepSafe_TotalHeaderFailure(t *testing.T) {
+	data := newEVMMultidownloaderTestData(t, true)
+	data.MockInitialize(t, 1)
+	err := data.mdr.RegisterSyncer(aggkittypes.SyncerConfig{
+		SyncerID:          "syncer1",
+		ContractAddresses: []common.Address{common.HexToAddress("0x1")},
+		FromBlock:         100,
+		ToBlock:           aggkittypes.FinalizedBlock,
+	})
+	require.NoError(t, err)
+	data.mockBlockNotifierManager.EXPECT().GetCurrentBlockNumber(mock.Anything, aggkittypes.FinalizedBlock).
+		Return(uint64(150), nil).Maybe()
+	err = data.mdr.Initialize(t.Context())
+	require.NoError(t, err)
+
+	// FilterLogs returns one log so blocks is not empty
+	testLog := ethtypes.Log{BlockNumber: 120, Address: common.HexToAddress("0x1")}
+	data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.Anything).
+		Return([]ethtypes.Log{testLog}, nil).Once()
+
+	// All headers fail — no partial success
+	rpcResult := aggkittypes.NewBlockHeadersResult()
+	rpcResult.AddError(120, fmt.Errorf("rpc error"))
+	data.mockEthClient.EXPECT().
+		RetrieveBlockHeaders(mock.Anything, []uint64{120}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).
+		Return(rpcResult, nil).Once()
+
+	_, err = data.mdr.StepSafe(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to retrieve any block headers")
+}
+
 func TestEVMMultidownloader_Start(t *testing.T) {
 	t.Run("initialization error is returned", func(t *testing.T) {
 		testData := newEVMMultidownloaderTestData(t, true)
@@ -625,8 +657,10 @@ func TestEVMMultidownloader_MoveUnsafeToSafeIfPossible(t *testing.T) {
 			Return(unsafeBlocks, nil).Once()
 
 		// Mock RPC block headers retrieval for reorg detection
-		data.mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(195)).Return(header195, nil).Once()
-		data.mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(196)).Return(header196, nil).Once()
+		rpcResult := aggkittypes.NewBlockHeadersResult()
+		rpcResult.AddHeader(195, aggkittypes.NewBlockHeaderFromEthHeader(header195))
+		rpcResult.AddHeader(196, aggkittypes.NewBlockHeaderFromEthHeader(header196))
+		data.mockEthClient.EXPECT().RetrieveBlockHeaders(mock.Anything, []uint64{195, 196}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).Return(rpcResult, nil).Once()
 
 		// Mock update to finalized
 		data.mockStorage.EXPECT().UpdateBlockToFinalized(mockTx, []uint64{195, 196}).Return(nil).Once()
@@ -750,7 +784,9 @@ func TestEVMMultidownloader_MoveUnsafeToSafeIfPossible(t *testing.T) {
 			ParentHash: common.HexToHash("0xDIFFERENT"),
 			Time:       9999999,
 		}
-		data.mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(195)).Return(headerDifferent, nil).Once()
+		rpcResultReorg := aggkittypes.NewBlockHeadersResult()
+		rpcResultReorg.AddHeader(195, aggkittypes.NewBlockHeaderFromEthHeader(headerDifferent))
+		data.mockEthClient.EXPECT().RetrieveBlockHeaders(mock.Anything, []uint64{195}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).Return(rpcResultReorg, nil).Once()
 
 		err := data.mdr.moveUnsafeToSafeIfPossible(ctx)
 		require.Error(t, err)
@@ -790,7 +826,9 @@ func TestEVMMultidownloader_MoveUnsafeToSafeIfPossible(t *testing.T) {
 			Return(unsafeBlocks, nil).Once()
 
 		// Mock RPC block headers (no reorg)
-		data.mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(195)).Return(header195, nil).Once()
+		rpcResult195 := aggkittypes.NewBlockHeadersResult()
+		rpcResult195.AddHeader(195, aggkittypes.NewBlockHeaderFromEthHeader(header195))
+		data.mockEthClient.EXPECT().RetrieveBlockHeaders(mock.Anything, []uint64{195}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).Return(rpcResult195, nil).Once()
 
 		// Mock update error
 		expectedErr := fmt.Errorf("update error")
@@ -834,7 +872,9 @@ func TestEVMMultidownloader_MoveUnsafeToSafeIfPossible(t *testing.T) {
 			Return(unsafeBlocks, nil).Once()
 
 		// Mock RPC block headers (no reorg)
-		data.mockEthClient.EXPECT().HeaderByNumber(mock.Anything, big.NewInt(195)).Return(header195, nil).Once()
+		rpcResult195Commit := aggkittypes.NewBlockHeadersResult()
+		rpcResult195Commit.AddHeader(195, aggkittypes.NewBlockHeaderFromEthHeader(header195))
+		data.mockEthClient.EXPECT().RetrieveBlockHeaders(mock.Anything, []uint64{195}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).Return(rpcResult195Commit, nil).Once()
 
 		// Mock update success
 		data.mockStorage.EXPECT().UpdateBlockToFinalized(mockTx, []uint64{195}).Return(nil).Once()
@@ -843,6 +883,39 @@ func TestEVMMultidownloader_MoveUnsafeToSafeIfPossible(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot commit tx")
 		require.Contains(t, err.Error(), expectedErr.Error())
+	})
+
+	t.Run("all blocks not found triggers MissingBlock reorg error", func(t *testing.T) {
+		data := newEVMMultidownloaderTestData(t, true)
+		data.FakeInitialized(t)
+		ctx := context.Background()
+
+		finalizedBlockNumber := uint64(200)
+		data.mockBlockNotifierManager.EXPECT().GetCurrentBlockNumber(mock.Anything, data.mdr.cfg.BlockFinality).
+			Return(finalizedBlockNumber, nil).Once()
+
+		mockTx := dbmocks.NewTxer(t)
+		mockTx.EXPECT().Rollback().Return(nil).Once()
+		data.mockStorage.EXPECT().NewTx(mock.Anything).Return(mockTx, nil).Once()
+
+		unsafeBlocks := aggkittypes.ListBlockHeaders{
+			&aggkittypes.BlockHeader{Number: 195, Hash: common.HexToHash("0x195")},
+		}
+		data.mockStorage.EXPECT().GetBlockHeadersNotFinalized(mockTx, &finalizedBlockNumber).
+			Return(unsafeBlocks, nil).Once()
+
+		rpcResult := aggkittypes.NewBlockHeadersResult()
+		rpcResult.AddError(195, aggkittypes.ErrNotFound)
+		data.mockEthClient.EXPECT().
+			RetrieveBlockHeaders(mock.Anything, []uint64{195}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).
+			Return(rpcResult, nil).Once()
+
+		err := data.mdr.moveUnsafeToSafeIfPossible(ctx)
+		require.Error(t, err)
+		reorgErr := mdrtypes.CastDetectedReorgError(err)
+		require.NotNil(t, reorgErr)
+		require.Equal(t, mdrtypes.ReorgDetectionReason_MissingBlock, reorgErr.ReorgDetectionReason)
+		require.Equal(t, uint64(195), reorgErr.OffendingBlockNumber)
 	})
 }
 

--- a/multidownloader/reorg_processor_port.go
+++ b/multidownloader/reorg_processor_port.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	dbtypes "github.com/agglayer/aggkit/db/types"
-	"github.com/agglayer/aggkit/etherman"
 	mdtypes "github.com/agglayer/aggkit/multidownloader/types"
 	aggkittypes "github.com/agglayer/aggkit/types"
 )
@@ -28,7 +27,7 @@ func (r *ReorgPort) GetBlockStorageAndRPC(ctx context.Context, tx dbtypes.Querie
 		return nil, fmt.Errorf("error getting block in storage: %w", err)
 	}
 	rpcBlock, err := r.ethClient.CustomHeaderByNumber(ctx, aggkittypes.NewBlockNumber(blockNumber))
-	if err != nil && !etherman.IsErrNotFound(err) {
+	if err != nil && !aggkittypes.IsErrNotFound(err) {
 		return nil, fmt.Errorf("error getting block in RPC: %w", err)
 	}
 	return &mdtypes.CompareBlockHeaders{

--- a/test/helpers/simulated.go
+++ b/test/helpers/simulated.go
@@ -83,6 +83,10 @@ func (t *TestClient) CustomHeaderByNumber(ctx context.Context, number *aggkittyp
 	return t.defaultEthClient.CustomHeaderByNumber(ctx, number)
 }
 
+func (t *TestClient) RetrieveBlockHeaders(ctx context.Context, blockNumbers []uint64, maxConcurrency int) (*aggkittypes.BlockHeadersResult, error) {
+	return t.defaultEthClient.RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)
+}
+
 // SimulatedBackendSetup defines the setup for a simulated backend.
 type SimulatedBackendSetup struct {
 	UserAuth            *bind.TransactOpts

--- a/tools/remove_ger/config.go
+++ b/tools/remove_ger/config.go
@@ -68,11 +68,12 @@ func LoadConfig(c *cli.Context) (*Config, error) {
 	}
 
 	// Prepend defaults so template variables ({{L1Config.URL}}, {{L2URL}}, etc.) resolve.
-	allFiles := []aggkitConfig.FileData{
-		{Name: "default_mandatory_vars", Content: aggkitConfig.DefaultMandatoryVars},
-		{Name: "default_vars", Content: aggkitConfig.DefaultVars},
-		{Name: "default_values", Content: aggkitConfig.DefaultValues},
-	}
+	allFiles := make([]aggkitConfig.FileData, 0, 3+len(userFiles)) //nolint:mnd
+	allFiles = append(allFiles,
+		aggkitConfig.FileData{Name: "default_mandatory_vars", Content: aggkitConfig.DefaultMandatoryVars},
+		aggkitConfig.FileData{Name: "default_vars", Content: aggkitConfig.DefaultVars},
+		aggkitConfig.FileData{Name: "default_values", Content: aggkitConfig.DefaultValues},
+	)
 	allFiles = append(allFiles, userFiles...)
 
 	rendered, err := aggkitConfig.NewConfigRender(allFiles, aggkitConfig.EnvVarPrefix).Render()

--- a/types/block_headers_result.go
+++ b/types/block_headers_result.go
@@ -1,0 +1,105 @@
+package types
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+)
+
+// BlockHeadersResult holds the results of block header retrieval,
+// separating successful headers from failed ones.
+type BlockHeadersResult struct {
+	// Headers contains successfully retrieved block headers, mapped by block number
+	Headers map[uint64]*BlockHeader
+	// Errors contains retrieval errors, mapped by block number
+	Errors map[uint64]error
+}
+
+// NewBlockHeadersResult creates a new BlockHeadersResult
+func NewBlockHeadersResult() *BlockHeadersResult {
+	return &BlockHeadersResult{
+		Headers: make(map[uint64]*BlockHeader),
+		Errors:  make(map[uint64]error),
+	}
+}
+
+// Success returns true if all blocks were retrieved successfully
+func (r *BlockHeadersResult) Success() bool {
+	return len(r.Errors) == 0
+}
+
+// PartialSuccess returns true if at least one block was retrieved successfully
+func (r *BlockHeadersResult) PartialSuccess() bool {
+	return len(r.Headers) > 0
+}
+
+// GetOrderedHeaders returns headers in the order of the requested blockNumbers,
+// only for blocks that were retrieved successfully
+func (r *BlockHeadersResult) GetOrderedHeaders(blockNumbers []uint64) []*BlockHeader {
+	result := make([]*BlockHeader, 0, len(r.Headers))
+	for _, bn := range blockNumbers {
+		if header, ok := r.Headers[bn]; ok {
+			result = append(result, header)
+		}
+	}
+	return result
+}
+
+// AddHeader adds a successful header to the result
+func (r *BlockHeadersResult) AddHeader(blockNumber uint64, header *BlockHeader) {
+	r.Headers[blockNumber] = header
+}
+
+// AddError adds an error for a specific block number
+func (r *BlockHeadersResult) AddError(blockNumber uint64, err error) {
+	r.Errors[blockNumber] = err
+}
+
+// Merge combines another BlockHeadersResult into this one
+func (r *BlockHeadersResult) Merge(other *BlockHeadersResult) {
+	maps.Copy(r.Headers, other.Headers)
+	maps.Copy(r.Errors, other.Errors)
+}
+
+// AreAllErrorsNotFound returns true if all errors are "not found" errors
+func (r *BlockHeadersResult) AreAllErrorsNotFound() bool {
+	for _, err := range r.Errors {
+		if !IsErrNotFound(err) {
+			return false
+		}
+	}
+	return true
+}
+
+// ListBlocksNumberNotFound returns the list of not-found block numbers ordered by block number
+func (r *BlockHeadersResult) ListBlocksNumberNotFound() []uint64 {
+	var notFoundBlocks []uint64
+	for bn, err := range r.Errors {
+		if IsErrNotFound(err) {
+			notFoundBlocks = append(notFoundBlocks, bn)
+		}
+	}
+	sort.Slice(notFoundBlocks, func(i, j int) bool {
+		return notFoundBlocks[i] < notFoundBlocks[j]
+	})
+	return notFoundBlocks
+}
+
+// ComposeError returns a single error summarizing all errors in the result, or nil if there are no errors
+func (r *BlockHeadersResult) ComposeError() error {
+	if len(r.Errors) == 0 {
+		return nil
+	}
+	errBlockNumbers := make([]uint64, 0, len(r.Errors))
+	for bn := range r.Errors {
+		errBlockNumbers = append(errBlockNumbers, bn)
+	}
+	sort.Slice(errBlockNumbers, func(i, j int) bool {
+		return errBlockNumbers[i] < errBlockNumbers[j]
+	})
+	errResult := fmt.Errorf("RetrieveBlockHeaders errors")
+	for _, bn := range errBlockNumbers {
+		errResult = fmt.Errorf("%w\nBlock %d: %w", errResult, bn, r.Errors[bn])
+	}
+	return errResult
+}

--- a/types/block_headers_result_test.go
+++ b/types/block_headers_result_test.go
@@ -1,0 +1,261 @@
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockHeadersResult_Success(t *testing.T) {
+	t.Run("empty result is success", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		require.True(t, r.Success())
+	})
+	t.Run("result with headers and no errors is success", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddHeader(1, &BlockHeader{Number: 1})
+		require.True(t, r.Success())
+	})
+	t.Run("result with any error is not success", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddHeader(1, &BlockHeader{Number: 1})
+		r.AddError(2, errors.New("timeout"))
+		require.False(t, r.Success())
+	})
+}
+
+func TestBlockHeadersResult_PartialSuccess(t *testing.T) {
+	t.Run("no headers is not partial success", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddError(1, errors.New("err"))
+		require.False(t, r.PartialSuccess())
+	})
+	t.Run("at least one header is partial success", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddHeader(1, &BlockHeader{Number: 1})
+		r.AddError(2, errors.New("err"))
+		require.True(t, r.PartialSuccess())
+	})
+}
+
+func TestBlockHeadersResult_GetOrderedHeaders(t *testing.T) {
+	r := NewBlockHeadersResult()
+	r.AddHeader(10, &BlockHeader{Number: 10})
+	r.AddHeader(20, &BlockHeader{Number: 20})
+	r.AddError(30, errors.New("err"))
+
+	ordered := r.GetOrderedHeaders([]uint64{30, 10, 20})
+	require.Len(t, ordered, 2)
+	assert.Equal(t, uint64(10), ordered[0].Number)
+	assert.Equal(t, uint64(20), ordered[1].Number)
+}
+
+func TestBlockHeadersResult_Merge(t *testing.T) {
+	a := NewBlockHeadersResult()
+	a.AddHeader(1, &BlockHeader{Number: 1})
+	a.AddError(2, errors.New("err-a"))
+
+	b := NewBlockHeadersResult()
+	b.AddHeader(3, &BlockHeader{Number: 3})
+	b.AddError(4, errors.New("err-b"))
+
+	a.Merge(b)
+	require.Len(t, a.Headers, 2)
+	require.Len(t, a.Errors, 2)
+	assert.NotNil(t, a.Headers[3])
+	assert.NotNil(t, a.Errors[4])
+}
+
+func TestBlockHeadersResult_ComposeError(t *testing.T) {
+	t.Run("nil when no errors", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddHeader(1, &BlockHeader{Number: 1})
+		require.NoError(t, r.ComposeError())
+	})
+
+	t.Run("includes not-found errors", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddError(100, ErrNotFound)
+		r.AddError(200, ErrNotFound)
+		err := r.ComposeError()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Block 100")
+		assert.Contains(t, err.Error(), "Block 200")
+	})
+
+	t.Run("includes non-not-found errors", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddError(50, errors.New("rpc timeout"))
+		r.AddError(100, ErrNotFound)
+		err := r.ComposeError()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Block 50")
+		assert.Contains(t, err.Error(), "rpc timeout")
+		assert.Contains(t, err.Error(), "Block 100")
+	})
+
+	t.Run("errors are ordered by block number", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddError(300, errors.New("err-300"))
+		r.AddError(100, errors.New("err-100"))
+		r.AddError(200, errors.New("err-200"))
+		err := r.ComposeError()
+		require.Error(t, err)
+		msg := err.Error()
+		pos100 := findPos(msg, "Block 100")
+		pos200 := findPos(msg, "Block 200")
+		pos300 := findPos(msg, "Block 300")
+		assert.Less(t, pos100, pos200)
+		assert.Less(t, pos200, pos300)
+	})
+
+	t.Run("wraps all errors for errors.Is", func(t *testing.T) {
+		r := NewBlockHeadersResult()
+		r.AddError(1, ErrNotFound)
+		err := r.ComposeError()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+	})
+}
+
+func TestBlockHeadersResult_AreAllErrorsNotFound(t *testing.T) {
+	tests := []struct {
+		name     string
+		errors   map[uint64]error
+		expected bool
+	}{
+		{
+			name:     "no errors returns true",
+			errors:   map[uint64]error{},
+			expected: true,
+		},
+		{
+			name: "all errors are ErrNotFound sentinel",
+			errors: map[uint64]error{
+				100: ErrNotFound,
+				200: ErrNotFound,
+			},
+			expected: true,
+		},
+		{
+			name: "all errors have exact 'not found' message",
+			errors: map[uint64]error{
+				100: errors.New("not found"),
+				200: errors.New("not found"),
+			},
+			expected: true,
+		},
+		{
+			name: "mixed: some ErrNotFound some other",
+			errors: map[uint64]error{
+				100: ErrNotFound,
+				200: errors.New("connection timeout"),
+			},
+			expected: false,
+		},
+		{
+			name: "all errors are unrelated",
+			errors: map[uint64]error{
+				100: errors.New("timeout"),
+				200: errors.New("rpc error"),
+			},
+			expected: false,
+		},
+		{
+			name: "wrapped ErrNotFound counts as not found",
+			errors: map[uint64]error{
+				100: errors.New("batch element error: not found"),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &BlockHeadersResult{
+				Headers: make(map[uint64]*BlockHeader),
+				Errors:  tt.errors,
+			}
+			assert.Equal(t, tt.expected, r.AreAllErrorsNotFound())
+		})
+	}
+}
+
+func TestBlockHeadersResult_ListBlocksNumberNotFound(t *testing.T) {
+	tests := []struct {
+		name     string
+		errors   map[uint64]error
+		expected []uint64
+	}{
+		{
+			name:     "no errors returns nil",
+			errors:   map[uint64]error{},
+			expected: nil,
+		},
+		{
+			name: "all ErrNotFound sentinels, sorted",
+			errors: map[uint64]error{
+				300: ErrNotFound,
+				100: ErrNotFound,
+				200: ErrNotFound,
+			},
+			expected: []uint64{100, 200, 300},
+		},
+		{
+			name: "exact 'not found' message, sorted",
+			errors: map[uint64]error{
+				300: errors.New("not found"),
+				100: errors.New("not found"),
+			},
+			expected: []uint64{100, 300},
+		},
+		{
+			name: "mixed: only not-found blocks returned",
+			errors: map[uint64]error{
+				100: ErrNotFound,
+				200: errors.New("connection timeout"),
+				300: ErrNotFound,
+				150: errors.New("other error"),
+				250: errors.New("not found"),
+			},
+			expected: []uint64{100, 250, 300},
+		},
+		{
+			name: "no not-found errors",
+			errors: map[uint64]error{
+				100: errors.New("timeout"),
+				200: errors.New("rpc error"),
+			},
+			expected: nil,
+		},
+		{
+			name: "substring 'not found' in message counts",
+			errors: map[uint64]error{
+				100: errors.New("block not found"),
+				200: errors.New("timeout"),
+			},
+			expected: []uint64{100},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &BlockHeadersResult{
+				Headers: make(map[uint64]*BlockHeader),
+				Errors:  tt.errors,
+			}
+			assert.Equal(t, tt.expected, r.ListBlocksNumberNotFound())
+		})
+	}
+}
+
+func findPos(s, substr string) int {
+	for i := range s {
+		if len(s[i:]) >= len(substr) && s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/types/errors.go
+++ b/types/errors.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrNotFound is used when the object is not found
+var ErrNotFound = errors.New("not found")
+
+// IsErrNotFound checks if the error is a "not found" error
+func IsErrNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrNotFound) {
+		return true
+	}
+	if err.Error() == ErrNotFound.Error() {
+		return true
+	}
+	// If error contains "not found" (case sensitive) is an ErrNotFound
+	if strings.Contains(err.Error(), "not found") {
+		return true
+	}
+	return false
+}

--- a/types/eth_client.go
+++ b/types/eth_client.go
@@ -49,6 +49,9 @@ type BaseEthereumClienter interface {
 type CustomEthereumClienter interface {
 	// Like HeaderByNumber but returns a custom BlockHeader type.
 	CustomHeaderByNumber(ctx context.Context, number *BlockNumberFinality) (*BlockHeader, error)
+	// RetrieveBlockHeaders retrieves block headers for the given block numbers.
+	// Uses batch RPC requests when available, falling back to individual requests otherwise.
+	RetrieveBlockHeaders(ctx context.Context, blockNumbers []uint64, maxConcurrency int) (*BlockHeadersResult, error)
 }
 
 // RPCClienter defines an interface for making generic RPC calls.

--- a/types/mocks/mock_base_ethereum_clienter.go
+++ b/types/mocks/mock_base_ethereum_clienter.go
@@ -1260,6 +1260,66 @@ func (_c *BaseEthereumClienter_TransactionReceipt_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// RetrieveBlockHeaders provides a mock function with given fields: ctx, blockNumbers, maxConcurrency
+func (_m *BaseEthereumClienter) RetrieveBlockHeaders(ctx context.Context, blockNumbers []uint64, maxConcurrency int) (*types.BlockHeadersResult, error) {
+	ret := _m.Called(ctx, blockNumbers, maxConcurrency)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RetrieveBlockHeaders")
+	}
+
+	var r0 *types.BlockHeadersResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, int) (*types.BlockHeadersResult, error)); ok {
+		return rf(ctx, blockNumbers, maxConcurrency)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, int) *types.BlockHeadersResult); ok {
+		r0 = rf(ctx, blockNumbers, maxConcurrency)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.BlockHeadersResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []uint64, int) error); ok {
+		r1 = rf(ctx, blockNumbers, maxConcurrency)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// BaseEthereumClienter_RetrieveBlockHeaders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RetrieveBlockHeaders'
+type BaseEthereumClienter_RetrieveBlockHeaders_Call struct {
+	*mock.Call
+}
+
+// RetrieveBlockHeaders is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blockNumbers []uint64
+//   - maxConcurrency int
+func (_e *BaseEthereumClienter_Expecter) RetrieveBlockHeaders(ctx interface{}, blockNumbers interface{}, maxConcurrency interface{}) *BaseEthereumClienter_RetrieveBlockHeaders_Call {
+	return &BaseEthereumClienter_RetrieveBlockHeaders_Call{Call: _e.mock.On("RetrieveBlockHeaders", ctx, blockNumbers, maxConcurrency)}
+}
+
+func (_c *BaseEthereumClienter_RetrieveBlockHeaders_Call) Run(run func(ctx context.Context, blockNumbers []uint64, maxConcurrency int)) *BaseEthereumClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]uint64), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *BaseEthereumClienter_RetrieveBlockHeaders_Call) Return(_a0 *types.BlockHeadersResult, _a1 error) *BaseEthereumClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *BaseEthereumClienter_RetrieveBlockHeaders_Call) RunAndReturn(run func(context.Context, []uint64, int) (*types.BlockHeadersResult, error)) *BaseEthereumClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewBaseEthereumClienter creates a new instance of BaseEthereumClienter. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewBaseEthereumClienter(t interface {

--- a/types/mocks/mock_custom_ethereum_clienter.go
+++ b/types/mocks/mock_custom_ethereum_clienter.go
@@ -81,6 +81,66 @@ func (_c *CustomEthereumClienter_CustomHeaderByNumber_Call) RunAndReturn(run fun
 	return _c
 }
 
+// RetrieveBlockHeaders provides a mock function with given fields: ctx, blockNumbers, maxConcurrency
+func (_m *CustomEthereumClienter) RetrieveBlockHeaders(ctx context.Context, blockNumbers []uint64, maxConcurrency int) (*types.BlockHeadersResult, error) {
+	ret := _m.Called(ctx, blockNumbers, maxConcurrency)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RetrieveBlockHeaders")
+	}
+
+	var r0 *types.BlockHeadersResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, int) (*types.BlockHeadersResult, error)); ok {
+		return rf(ctx, blockNumbers, maxConcurrency)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, int) *types.BlockHeadersResult); ok {
+		r0 = rf(ctx, blockNumbers, maxConcurrency)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.BlockHeadersResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []uint64, int) error); ok {
+		r1 = rf(ctx, blockNumbers, maxConcurrency)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CustomEthereumClienter_RetrieveBlockHeaders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RetrieveBlockHeaders'
+type CustomEthereumClienter_RetrieveBlockHeaders_Call struct {
+	*mock.Call
+}
+
+// RetrieveBlockHeaders is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blockNumbers []uint64
+//   - maxConcurrency int
+func (_e *CustomEthereumClienter_Expecter) RetrieveBlockHeaders(ctx interface{}, blockNumbers interface{}, maxConcurrency interface{}) *CustomEthereumClienter_RetrieveBlockHeaders_Call {
+	return &CustomEthereumClienter_RetrieveBlockHeaders_Call{Call: _e.mock.On("RetrieveBlockHeaders", ctx, blockNumbers, maxConcurrency)}
+}
+
+func (_c *CustomEthereumClienter_RetrieveBlockHeaders_Call) Run(run func(ctx context.Context, blockNumbers []uint64, maxConcurrency int)) *CustomEthereumClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]uint64), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *CustomEthereumClienter_RetrieveBlockHeaders_Call) Return(_a0 *types.BlockHeadersResult, _a1 error) *CustomEthereumClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *CustomEthereumClienter_RetrieveBlockHeaders_Call) RunAndReturn(run func(context.Context, []uint64, int) (*types.BlockHeadersResult, error)) *CustomEthereumClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewCustomEthereumClienter creates a new instance of CustomEthereumClienter. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewCustomEthereumClienter(t interface {

--- a/types/mocks/mock_eth_clienter.go
+++ b/types/mocks/mock_eth_clienter.go
@@ -1426,6 +1426,66 @@ func (_c *EthClienter_TransactionReceipt_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// RetrieveBlockHeaders provides a mock function with given fields: ctx, blockNumbers, maxConcurrency
+func (_m *EthClienter) RetrieveBlockHeaders(ctx context.Context, blockNumbers []uint64, maxConcurrency int) (*types.BlockHeadersResult, error) {
+	ret := _m.Called(ctx, blockNumbers, maxConcurrency)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RetrieveBlockHeaders")
+	}
+
+	var r0 *types.BlockHeadersResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, int) (*types.BlockHeadersResult, error)); ok {
+		return rf(ctx, blockNumbers, maxConcurrency)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []uint64, int) *types.BlockHeadersResult); ok {
+		r0 = rf(ctx, blockNumbers, maxConcurrency)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.BlockHeadersResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []uint64, int) error); ok {
+		r1 = rf(ctx, blockNumbers, maxConcurrency)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EthClienter_RetrieveBlockHeaders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RetrieveBlockHeaders'
+type EthClienter_RetrieveBlockHeaders_Call struct {
+	*mock.Call
+}
+
+// RetrieveBlockHeaders is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blockNumbers []uint64
+//   - maxConcurrency int
+func (_e *EthClienter_Expecter) RetrieveBlockHeaders(ctx interface{}, blockNumbers interface{}, maxConcurrency interface{}) *EthClienter_RetrieveBlockHeaders_Call {
+	return &EthClienter_RetrieveBlockHeaders_Call{Call: _e.mock.On("RetrieveBlockHeaders", ctx, blockNumbers, maxConcurrency)}
+}
+
+func (_c *EthClienter_RetrieveBlockHeaders_Call) Run(run func(ctx context.Context, blockNumbers []uint64, maxConcurrency int)) *EthClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]uint64), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *EthClienter_RetrieveBlockHeaders_Call) Return(_a0 *types.BlockHeadersResult, _a1 error) *EthClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *EthClienter_RetrieveBlockHeaders_Call) RunAndReturn(run func(context.Context, []uint64, int) (*types.BlockHeadersResult, error)) *EthClienter_RetrieveBlockHeaders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewEthClienter creates a new instance of EthClienter. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewEthClienter(t interface {


### PR DESCRIPTION
## 🔄 Changes Summary

Cherry-pick of #1601 (originally merged into `release/0.10`) into `develop`.

- Moves `BlockHeadersResult`, `ErrNotFound` and `IsErrNotFound` from `etherman` to the `types` package
- Adds `RetrieveBlockHeaders(ctx, blockNumbers, maxConcurrency)` to the `CustomEthereumClienter` interface, implemented by `DefaultEthClient`
- Adds `BatchBlockHeaderRetrieval bool` (default `true`) to `RPCClientConfig` — operators can disable batch RPC requests for nodes that do not support them
- Simplifies `multidownloader` call sites: the three `etherman.RetrieveBlockHeaders(ctx, log, ethClient, rpcClient, ...)` calls collapse to `dh.ethClient.RetrieveBlockHeaders(ctx, ...)`
- Documents `RPCClientConfig` in `docs/common_config.md`

## ⚠️ Breaking Changes
N/A

## 📋 Config Updates
- 🧾 New optional field in `[L1NetworkConfig.RPC]` and `[Common.L2RPC]`:
```toml
BatchBlockHeaderRetrieval = true  # default, disable for nodes without batch support
```

## ✅ Testing
- 🤖 **Automatic**: existing unit tests updated; `TestLoadDefaultConfig` asserts the new default
- Cherry-picked from: #1601

## 📝 Notes
- `etherman.BlockHeadersResult` and `etherman.NewBlockHeadersResult` are kept as type aliases for backward compatibility
- `etherman.ErrNotFound` and `etherman.IsErrNotFound` are kept as wrappers delegating to `types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)