### PR TITLE
fix: avoid spurious error log when block range is too large in l2gersync

### DIFF
--- a/l2gersync/l2_evm_ger_reader.go
+++ b/l2gersync/l2_evm_ger_reader.go
@@ -80,6 +80,7 @@ func (e *L2EVMGERReader) GetInjectedGERsForRange(ctx context.Context,
 				make(map[common.Hash]GlobalExitRootInfo),
 			)
 		}
+		log.Errorf("failed to create InsertGlobalExitRoot event iterator: %v", err)
 		return nil, err
 	}
 
@@ -97,7 +98,6 @@ func (e *L2EVMGERReader) fetchInjectedGERs(ctx context.Context,
 			End:     &toBlock,
 		}, nil, nil)
 	if err != nil {
-		log.Errorf("failed to create InsertGlobalExitRoot event iterator: %v", err)
 		return nil, err
 	}
 
@@ -176,6 +176,7 @@ func (e *L2EVMGERReader) GetRemovedGERsForRange(ctx context.Context,
 				[]*agglayertypes.RemovedGER{},
 			)
 		}
+		log.Errorf("failed to create RemoveGlobalExitRoot event iterator: %v", err)
 		return nil, err
 	}
 
@@ -192,7 +193,6 @@ func (e *L2EVMGERReader) fetchRemovedGERs(ctx context.Context,
 			End:     &toBlock,
 		}, nil, nil)
 	if err != nil {
-		log.Errorf("failed to create RemoveGlobalExitRoot event iterator: %v", err)
 		return nil, err
 	}
 

--- a/l2gersync/l2_evm_ger_reader.go
+++ b/l2gersync/l2_evm_ger_reader.go
@@ -180,11 +180,11 @@ func (e *L2EVMGERReader) GetRemovedGERsForRange(ctx context.Context,
 				[]*agglayertypes.RemovedGER{},
 			)
 			if err != nil {
-				log.Errorf("failed to create RemoveGlobalExitRoot event iterator: %v", err)
+				log.Errorf("failed to fetch removed GERs for block range [%d, %d]: %v", fromBlock, toBlock, err)
 			}
 			return result, err
 		}
-		log.Errorf("failed to create RemoveGlobalExitRoot event iterator: %v", err)
+		log.Errorf("failed to fetch removed GERs for block range [%d, %d]: %v", fromBlock, toBlock, err)
 		return nil, err
 	}
 

--- a/l2gersync/l2_evm_ger_reader.go
+++ b/l2gersync/l2_evm_ger_reader.go
@@ -80,11 +80,11 @@ func (e *L2EVMGERReader) GetInjectedGERsForRange(ctx context.Context,
 				make(map[common.Hash]GlobalExitRootInfo),
 			)
 			if err != nil {
-				log.Errorf("failed to create InsertGlobalExitRoot event iterator: %v", err)
+				log.Errorf("failed to fetch injected GERs: %v", err)
 			}
 			return result, err
 		}
-		log.Errorf("failed to create InsertGlobalExitRoot event iterator: %v", err)
+		log.Errorf("failed to fetch injected GERs: %v", err)
 		return nil, err
 	}
 

--- a/l2gersync/l2_evm_ger_reader.go
+++ b/l2gersync/l2_evm_ger_reader.go
@@ -69,7 +69,7 @@ func (e *L2EVMGERReader) GetInjectedGERsForRange(ctx context.Context,
 		maxRange, isMaxRangeErr := aggkitcommon.ParseMaxRangeFromError(err.Error())
 		if isMaxRangeErr {
 			log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
-			return aggkitcommon.ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange,
+			result, err := aggkitcommon.ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange,
 				e.fetchInjectedGERs,
 				func(all map[common.Hash]GlobalExitRootInfo,
 					chunk map[common.Hash]GlobalExitRootInfo,
@@ -79,6 +79,10 @@ func (e *L2EVMGERReader) GetInjectedGERsForRange(ctx context.Context,
 				},
 				make(map[common.Hash]GlobalExitRootInfo),
 			)
+			if err != nil {
+				log.Errorf("failed to create InsertGlobalExitRoot event iterator: %v", err)
+			}
+			return result, err
 		}
 		log.Errorf("failed to create InsertGlobalExitRoot event iterator: %v", err)
 		return nil, err
@@ -168,13 +172,17 @@ func (e *L2EVMGERReader) GetRemovedGERsForRange(ctx context.Context,
 		maxRange, isMaxRangeErr := aggkitcommon.ParseMaxRangeFromError(err.Error())
 		if isMaxRangeErr {
 			log.Debugf("block range too large, splitting into chunks of max %d blocks", maxRange)
-			return aggkitcommon.ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange,
+			result, err := aggkitcommon.ChunkedRangeQuery(ctx, fromBlock, toBlock, maxRange,
 				e.fetchRemovedGERs,
 				func(all, chunk []*agglayertypes.RemovedGER) []*agglayertypes.RemovedGER {
 					return append(all, chunk...)
 				},
 				[]*agglayertypes.RemovedGER{},
 			)
+			if err != nil {
+				log.Errorf("failed to create RemoveGlobalExitRoot event iterator: %v", err)
+			}
+			return result, err
 		}
 		log.Errorf("failed to create RemoveGlobalExitRoot event iterator: %v", err)
 		return nil, err

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsErrNotFound(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "exact ErrNotFound sentinel",
+			err:      ErrNotFound,
+			expected: true,
+		},
+		{
+			name:     "wrapped ErrNotFound via fmt.Errorf",
+			err:      fmt.Errorf("context: %w", ErrNotFound),
+			expected: true,
+		},
+		{
+			name:     "errors.New with exact 'not found' message",
+			err:      errors.New("not found"),
+			expected: true,
+		},
+		{
+			name:     "error containing 'not found' substring",
+			err:      errors.New("block not found"),
+			expected: true,
+		},
+		{
+			name:     "wrapped error containing 'not found' substring",
+			err:      fmt.Errorf("rpc error: %w", errors.New("block not found")),
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      errors.New("connection timeout"),
+			expected: false,
+		},
+		{
+			name:     "error with 'Not Found' different case",
+			err:      errors.New("Not Found"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsErrNotFound(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## 🔄 Changes Summary
- Move `log.Errorf` from internal fetch functions (`fetchInjectedGERs`, `fetchRemovedGERs`) to their callers (`GetInjectedGERsForRange`, `GetRemovedGERsForRange`), so the error is only logged when it is a real failure — not when it is a recoverable max-block-range condition that is transparently handled by splitting into chunks.

## ⚠️ Breaking Changes
- None

## ✅ Testing
- 🤖 **Automatic**: existing unit tests pass

## 🐞 Issues
- Closes #1604

## 📝 Notes
- Root cause: `fetchRemovedGERs`/`fetchInjectedGERs` logged `Errorf` unconditionally on any filter error, but their callers detect `isMaxRangeErr` and retry transparently with `ChunkedRangeQuery`. The log fired before the caller had a chance to handle the error gracefully, producing a confusing `ERROR` in the logs that was not actually an error.