### PR TITLE
fix: handle LET syncer invalid index on release 0.8

### DIFF
--- a/abi/abi_builder.go
+++ b/abi/abi_builder.go
@@ -1,0 +1,100 @@
+package abi
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// BuildABIFields constructs ABI ArgumentMarshaling slice from a struct type using reflection
+// It uses the "abiarg" tag to determine field names and optionally types
+// Tag format: `abiarg:"fieldName"` or `abiarg:"fieldName,type"`
+// If type is omitted, it will be inferred from the Go type
+func BuildABIFields(structType any) ([]abi.ArgumentMarshaling, error) {
+	t := reflect.TypeOf(structType)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct type, got %v", t.Kind())
+	}
+
+	fields := make([]abi.ArgumentMarshaling, 0, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		abiTag := field.Tag.Get("abi")
+		if abiTag == "" {
+			continue // Skip fields without abi tag
+		}
+
+		parts := strings.Split(abiTag, ",")
+		name := parts[0]
+
+		// Infer type from Go type
+		inferredType, err := inferABIType(field.Type)
+		if err != nil {
+			return nil, fmt.Errorf("field %s: %w", field.Name, err)
+		}
+
+		fields = append(fields, abi.ArgumentMarshaling{
+			Name: name,
+			Type: inferredType,
+		})
+	}
+
+	return fields, nil
+}
+
+// inferABIType automatically maps Go types to Solidity ABI types
+func inferABIType(goType reflect.Type) (string, error) {
+	// Handle special types first (before checking Kind)
+	switch goType {
+	case reflect.TypeOf(common.Address{}):
+		return "address", nil
+	case reflect.TypeOf(&big.Int{}), reflect.TypeOf(big.Int{}):
+		// Default to uint256 for big.Int, but can be overridden with explicit tag
+		return "uint256", nil
+	case reflect.TypeOf(common.Hash{}):
+		return "bytes32", nil
+	}
+
+	switch goType.Kind() {
+	case reflect.Uint8:
+		return "uint8", nil
+	case reflect.Uint16:
+		return "uint16", nil
+	case reflect.Uint32:
+		return "uint32", nil
+	case reflect.Uint64:
+		return "uint64", nil
+	case reflect.Int8:
+		return "int8", nil
+	case reflect.Int16:
+		return "int16", nil
+	case reflect.Int32:
+		return "int32", nil
+	case reflect.Int64:
+		return "int64", nil
+	case reflect.Bool:
+		return "bool", nil
+	case reflect.String:
+		return "string", nil
+	case reflect.Slice:
+		if goType.Elem().Kind() == reflect.Uint8 {
+			return "bytes", nil
+		}
+		return "", fmt.Errorf("unsupported slice type: %v", goType)
+	case reflect.Array:
+		if goType.Elem().Kind() == reflect.Uint8 {
+			return fmt.Sprintf("bytes%d", goType.Len()), nil
+		}
+		return "", fmt.Errorf("unsupported array type: %v", goType)
+	}
+
+	return "", fmt.Errorf("unsupported type: %v", goType)
+}

--- a/abi/abi_builder_test.go
+++ b/abi/abi_builder_test.go
@@ -1,0 +1,227 @@
+package abi
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildABIFields(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8          `abi:"field1"`
+		Field2 uint32         `abi:"field2"`
+		Field3 common.Address `abi:"field3"`
+		Field4 *big.Int       `abi:"field4"`
+		Field5 []byte         `abi:"field5"`
+		Field6 string         // No tag, should be skipped
+	}
+
+	fields, err := BuildABIFields(TestStruct{})
+	require.NoError(t, err)
+	require.Len(t, fields, 5)
+
+	expected := []abi.ArgumentMarshaling{
+		{Name: "field1", Type: "uint8"},
+		{Name: "field2", Type: "uint32"},
+		{Name: "field3", Type: "address"},
+		{Name: "field4", Type: "uint256"},
+		{Name: "field5", Type: "bytes"},
+	}
+
+	require.Equal(t, expected, fields)
+}
+
+func TestBuildABIFields_ErrorCases(t *testing.T) {
+	t.Run("non-struct type", func(t *testing.T) {
+		_, err := BuildABIFields(42)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected struct type")
+	})
+
+	t.Run("unsupported field type", func(t *testing.T) {
+		type BadStruct struct {
+			InvalidField map[string]string `abi:"invalid"`
+		}
+		_, err := BuildABIFields(BadStruct{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported type")
+	})
+}
+
+func TestBuildABIFields_WithPointer(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8  `abi:"field1"`
+		Field2 uint32 `abi:"field2"`
+	}
+
+	// Test with pointer to struct
+	fields, err := BuildABIFields(&TestStruct{})
+	require.NoError(t, err)
+	require.Len(t, fields, 2)
+
+	expected := []abi.ArgumentMarshaling{
+		{Name: "field1", Type: "uint8"},
+		{Name: "field2", Type: "uint32"},
+	}
+
+	require.Equal(t, expected, fields)
+}
+
+func TestInferABIType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    reflect.Type
+		expected string
+		wantErr  bool
+	}{
+		// Special types
+		{
+			name:     "common.Address",
+			input:    reflect.TypeOf(common.Address{}),
+			expected: "address",
+			wantErr:  false,
+		},
+		{
+			name:     "big.Int pointer",
+			input:    reflect.TypeOf(&big.Int{}),
+			expected: "uint256",
+			wantErr:  false,
+		},
+		{
+			name:     "big.Int value",
+			input:    reflect.TypeOf(big.Int{}),
+			expected: "uint256",
+			wantErr:  false,
+		},
+		{
+			name:     "common.Hash",
+			input:    reflect.TypeOf(common.Hash{}),
+			expected: "bytes32",
+			wantErr:  false,
+		},
+		// Unsigned integers
+		{
+			name:     "uint8",
+			input:    reflect.TypeOf(uint8(0)),
+			expected: "uint8",
+			wantErr:  false,
+		},
+		{
+			name:     "uint16",
+			input:    reflect.TypeOf(uint16(0)),
+			expected: "uint16",
+			wantErr:  false,
+		},
+		{
+			name:     "uint32",
+			input:    reflect.TypeOf(uint32(0)),
+			expected: "uint32",
+			wantErr:  false,
+		},
+		{
+			name:     "uint64",
+			input:    reflect.TypeOf(uint64(0)),
+			expected: "uint64",
+			wantErr:  false,
+		},
+		// Signed integers
+		{
+			name:     "int8",
+			input:    reflect.TypeOf(int8(0)),
+			expected: "int8",
+			wantErr:  false,
+		},
+		{
+			name:     "int16",
+			input:    reflect.TypeOf(int16(0)),
+			expected: "int16",
+			wantErr:  false,
+		},
+		{
+			name:     "int32",
+			input:    reflect.TypeOf(int32(0)),
+			expected: "int32",
+			wantErr:  false,
+		},
+		{
+			name:     "int64",
+			input:    reflect.TypeOf(int64(0)),
+			expected: "int64",
+			wantErr:  false,
+		},
+		// Other basic types
+		{
+			name:     "bool",
+			input:    reflect.TypeOf(true),
+			expected: "bool",
+			wantErr:  false,
+		},
+		{
+			name:     "string",
+			input:    reflect.TypeOf(""),
+			expected: "string",
+			wantErr:  false,
+		},
+		// Slice and array types
+		{
+			name:     "byte slice",
+			input:    reflect.TypeOf([]byte{}),
+			expected: "bytes",
+			wantErr:  false,
+		},
+		{
+			name:     "byte array",
+			input:    reflect.TypeOf([32]byte{}),
+			expected: "bytes32",
+			wantErr:  false,
+		},
+		{
+			name:     "byte array different size",
+			input:    reflect.TypeOf([20]byte{}),
+			expected: "bytes20",
+			wantErr:  false,
+		},
+		// Error cases
+		{
+			name:     "unsupported slice type",
+			input:    reflect.TypeOf([]int{}),
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "unsupported array type",
+			input:    reflect.TypeOf([5]int{}),
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "unsupported type map",
+			input:    reflect.TypeOf(map[string]string{}),
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "unsupported type struct",
+			input:    reflect.TypeOf(struct{}{}),
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := inferABIType(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unsupported")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/abi/abi_decode.go
+++ b/abi/abi_decode.go
@@ -1,0 +1,47 @@
+package abi
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+const tupleArrayType = "tuple[]"
+
+// DecodeABIEncodedStructArray is a generic helper that decodes ABI-encoded tuple array
+// It handles the ABI unpacking and type conversion boilerplate
+func DecodeABIEncodedStructArray[T any](encodedBytes []byte) ([]T, error) {
+	if len(encodedBytes) == 0 {
+		return nil, errors.New("encoded bytes are empty")
+	}
+
+	var item T
+	abiFields, err := BuildABIFields(item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ABI fields: %w", err)
+	}
+
+	arrayType, err := abi.NewType(tupleArrayType, "", abiFields)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create array type: %w", err)
+	}
+
+	args := abi.Arguments{{Type: arrayType, Name: "data"}}
+
+	unpacked, err := args.Unpack(encodedBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack data: %w", err)
+	}
+
+	if len(unpacked) == 0 {
+		return nil, errors.New("unpacked data is empty")
+	}
+
+	decodedData, ok := abi.ConvertType(unpacked[0], new([]T)).(*[]T)
+	if !ok {
+		return nil, errors.New("failed to convert unpacked data to the expected type")
+	}
+
+	return *decodedData, nil
+}

--- a/abi/abi_decode_test.go
+++ b/abi/abi_decode_test.go
@@ -1,0 +1,173 @@
+package abi
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeABIEncodedStructArray(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8          `abi:"field1"`
+		Field2 uint32         `abi:"field2"`
+		Field3 common.Address `abi:"field3"`
+	}
+
+	// Create test data
+	items := []TestStruct{
+		{
+			Field1: 1,
+			Field2: 100,
+			Field3: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		},
+		{
+			Field1: 2,
+			Field2: 200,
+			Field3: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		},
+	}
+
+	// Encode first
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+	require.NotEmpty(t, encodedBytes)
+
+	decoded, err := DecodeABIEncodedStructArray[TestStruct](encodedBytes)
+	require.NoError(t, err)
+	require.Len(t, decoded, 2)
+}
+
+func TestDecodeABIEncodedStructArray_EmptyBytes(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8 `abi:"field1"`
+	}
+
+	_, err := DecodeABIEncodedStructArray[TestStruct]([]byte{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "encoded bytes are empty")
+}
+
+func TestDecodeABIEncodedStructArray_WithBigInt(t *testing.T) {
+	type TestStruct struct {
+		Amount *big.Int `abi:"amount"`
+		Value  uint32   `abi:"value"`
+	}
+
+	// Create test data
+	items := []TestStruct{
+		{Amount: big.NewInt(1000), Value: 1},
+		{Amount: big.NewInt(2000), Value: 2},
+		{Amount: big.NewInt(3000), Value: 3},
+	}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+
+	decoded, err := DecodeABIEncodedStructArray[TestStruct](encodedBytes)
+	require.NoError(t, err)
+	require.Len(t, decoded, 3)
+}
+
+func TestDecodeABIEncodedStructArray_EmptyArray(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8 `abi:"field1"`
+	}
+
+	// Encode empty array
+	items := []TestStruct{}
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+
+	decoded, err := DecodeABIEncodedStructArray[TestStruct](encodedBytes)
+	require.NoError(t, err)
+	require.Len(t, decoded, 0)
+}
+
+func TestDecodeABIEncodedStructArray_InvalidABIData(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8 `abi:"field1"`
+	}
+
+	// Invalid ABI encoded data
+	invalidData := []byte{0x01, 0x02, 0x03}
+
+	_, err := DecodeABIEncodedStructArray[TestStruct](invalidData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unpack data")
+}
+
+func TestDecodeABIEncodedStructArray_ComplexStruct(t *testing.T) {
+	type ComplexStruct struct {
+		LeafType           uint8          `abi:"leafType"`
+		OriginNetwork      uint32         `abi:"originNetwork"`
+		OriginAddress      common.Address `abi:"originAddress"`
+		DestinationNetwork uint32         `abi:"destinationNetwork"`
+		DestinationAddress common.Address `abi:"destinationAddress"`
+		Amount             *big.Int       `abi:"amount"`
+		Metadata           []byte         `abi:"metadata"`
+	}
+
+	// Create test data
+	items := []ComplexStruct{
+		{
+			LeafType:           1,
+			OriginNetwork:      1,
+			OriginAddress:      common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			DestinationNetwork: 2,
+			DestinationAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			Amount:             big.NewInt(1000),
+			Metadata:           []byte("test1"),
+		},
+		{
+			LeafType:           2,
+			OriginNetwork:      3,
+			OriginAddress:      common.HexToAddress("0x3333333333333333333333333333333333333333"),
+			DestinationNetwork: 4,
+			DestinationAddress: common.HexToAddress("0x4444444444444444444444444444444444444444"),
+			Amount:             big.NewInt(2000),
+			Metadata:           []byte("test2"),
+		},
+	}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+
+	decoded, err := DecodeABIEncodedStructArray[ComplexStruct](encodedBytes)
+	require.NoError(t, err)
+	require.Len(t, decoded, 2)
+}
+
+func TestDecodeABIEncodedStructArray_NoABITags(t *testing.T) {
+	type BadStruct struct {
+		Field1 uint8
+		Field2 uint32
+	}
+
+	// Try to decode with a struct that has no abi tags
+	// BuildABIFields will succeed but return empty fields, which will cause unpack to fail
+	_, err := DecodeABIEncodedStructArray[BadStruct]([]byte{0x01})
+	require.Error(t, err)
+	// The error will be from unpacking due to insufficient data or empty ABI fields
+	require.Contains(t, err.Error(), "failed to")
+}
+
+func TestDecodeABIEncodedStructArray_SingleItem(t *testing.T) {
+	type TestStruct struct {
+		Value uint64 `abi:"value"`
+	}
+
+	// Create single item array
+	items := []TestStruct{
+		{Value: 12345},
+	}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+
+	decoded, err := DecodeABIEncodedStructArray[TestStruct](encodedBytes)
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	require.Equal(t, uint64(12345), decoded[0].Value)
+}

--- a/abi/abi_encode.go
+++ b/abi/abi_encode.go
@@ -1,0 +1,38 @@
+package abi
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// EncodeABIStructArray is a generic helper that encodes a slice of structs to ABI-encoded tuple array
+// It automatically builds ABI fields from the struct type using reflection and abiarg tags
+func EncodeABIStructArray[T any](items []T) ([]byte, error) {
+	// For empty slices, we need a sample instance to build ABI fields
+	var item T
+	if len(items) > 0 {
+		// Use the first item to infer the type
+		item = items[0]
+	}
+
+	// Use first item to build ABI fields
+	abiFields, err := BuildABIFields(item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ABI fields: %w", err)
+	}
+
+	arrayType, err := abi.NewType(tupleArrayType, "", abiFields)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create array type: %w", err)
+	}
+
+	args := abi.Arguments{{Type: arrayType, Name: "data"}}
+
+	encodedBytes, err := args.Pack(items)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack data: %w", err)
+	}
+
+	return encodedBytes, nil
+}

--- a/abi/abi_encode_test.go
+++ b/abi/abi_encode_test.go
@@ -1,0 +1,80 @@
+package abi
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeABIStructArray(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8          `abi:"field1"`
+		Field2 uint32         `abi:"field2"`
+		Field3 common.Address `abi:"field3"`
+	}
+
+	items := []TestStruct{
+		{
+			Field1: 1,
+			Field2: 100,
+			Field3: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		},
+		{
+			Field1: 2,
+			Field2: 200,
+			Field3: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		},
+	}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+	require.NotEmpty(t, encodedBytes)
+
+	_, err = DecodeABIEncodedStructArray[TestStruct](encodedBytes)
+	require.NoError(t, err)
+}
+
+func TestEncodeABIStructArray_EmptySlice(t *testing.T) {
+	type TestStruct struct {
+		Field1 uint8  `abi:"field1"`
+		Field2 uint32 `abi:"field2"`
+	}
+
+	items := []TestStruct{}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+	require.NotEmpty(t, encodedBytes)
+}
+
+func TestEncodeABIStructArray_WithBigInt(t *testing.T) {
+	type TestStruct struct {
+		Amount *big.Int `abi:"amount"`
+	}
+
+	items := []TestStruct{
+		{Amount: big.NewInt(1000)},
+		{Amount: big.NewInt(2000)},
+	}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err)
+	require.NotEmpty(t, encodedBytes)
+}
+
+func TestEncodeABIStructArray_NoTags(t *testing.T) {
+	type BadStruct struct {
+		Field1 uint8
+		Field2 uint32
+	}
+
+	items := []BadStruct{
+		{Field1: 1, Field2: 100},
+	}
+
+	encodedBytes, err := EncodeABIStructArray(items)
+	require.NoError(t, err) // Should work with empty fields (encodes empty array)
+	require.NotEmpty(t, encodedBytes)
+}

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -124,9 +124,9 @@ type RecordToBackfill struct {
 	BlockTimestamp     uint64         `meddler:"block_timestamp"`
 	LeafType           uint8          `meddler:"leaf_type"`
 	OriginNetwork      uint32         `meddler:"origin_network"`
-	OriginAddress      common.Address `meddler:"origin_address"`
+	OriginAddress      common.Address `meddler:"origin_address,address"`
 	DestinationNetwork uint32         `meddler:"destination_network"`
-	DestinationAddress common.Address `meddler:"destination_address"`
+	DestinationAddress common.Address `meddler:"destination_address,address"`
 	Amount             *big.Int       `meddler:"amount,bigint"`
 	Metadata           []byte         `meddler:"metadata"`
 	DepositCount       uint32         `meddler:"deposit_count"`

--- a/bridgesync/backfill_tx_sender.go
+++ b/bridgesync/backfill_tx_sender.go
@@ -164,14 +164,16 @@ func (b *BackfillTxnSender) getRecordsNeedingBackfillCount(ctx context.Context, 
 	query := fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM %s
-		WHERE txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL
+		WHERE (txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL)
+		AND (source IS NULL OR (source != $1 AND source != $2))
 	`, tableName)
 
 	var count int
 	dbCtx, cancel := context.WithTimeout(ctx, b.dbTimeout)
 	defer cancel()
 
-	err := b.db.QueryRowContext(dbCtx, query).Scan(&count)
+	err := b.db.QueryRowContext(dbCtx, query,
+		BridgeSourceBackwardLET, BridgeSourceForwardLET).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count records needing backfill: %w", err)
 	}
@@ -189,13 +191,15 @@ func (b *BackfillTxnSender) getRecordsNeedingBackfill(
 	query := fmt.Sprintf(`
 		SELECT *
 		FROM %s
-		WHERE txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL
-		LIMIT $1
+		WHERE (txn_sender = '' OR txn_sender IS NULL OR from_address = '' OR from_address IS NULL)
+		AND (source IS NULL OR (source != $1 AND source != $2))
+		LIMIT $3
 	`, tableName)
 
 	dbCtx, cancel := context.WithTimeout(ctx, b.dbTimeout)
 	defer cancel()
-	rows, err := b.db.QueryContext(dbCtx, query, limit)
+	rows, err := b.db.QueryContext(dbCtx, query,
+		BridgeSourceBackwardLET, BridgeSourceForwardLET, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query records needing backfill: %w", err)
 	}

--- a/bridgesync/backfill_tx_sender_test.go
+++ b/bridgesync/backfill_tx_sender_test.go
@@ -406,6 +406,112 @@ func TestBackfillTxnSender_getRecordsNeedingBackfillCount(t *testing.T) {
 		require.Equal(t, 1, count)
 	})
 
+	t.Run("excludes backward_let and forward_let sources", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dbPath := filepath.Join(tempDir, "test.db")
+
+		// Run migrations
+		err := migrations.RunMigrations(dbPath)
+		require.NoError(t, err)
+
+		// Create test data
+		database, err := db.NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+		defer database.Close()
+
+		ctx := context.Background()
+		tx, err := db.NewTx(ctx, database)
+		require.NoError(t, err)
+
+		// Insert test data
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES (1), (2), (3), (4)`)
+		require.NoError(t, err)
+
+		// Insert bridge with empty txn_sender and NULL source (should be counted)
+		_, err = tx.Exec(`
+			INSERT INTO bridge (
+				block_num, block_pos, leaf_type, origin_network, origin_address,
+				destination_network, destination_address, amount, metadata, deposit_count,
+				tx_hash, block_timestamp, from_address, txn_sender, source
+			) VALUES (
+				1, 0, 1, 1, '0x1234567890123456789012345678901234567890',
+				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
+				'', 1, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+				1234567890, '0x1111111111111111111111111111111111111111', '', NULL
+			)
+		`)
+		require.NoError(t, err)
+
+		// Insert bridge with empty txn_sender and backward_let source (should NOT be counted)
+		_, err = tx.Exec(`
+			INSERT INTO bridge (
+				block_num, block_pos, leaf_type, origin_network, origin_address,
+				destination_network, destination_address, amount, metadata, deposit_count,
+				tx_hash, block_timestamp, from_address, txn_sender, source
+			) VALUES (
+				2, 0, 1, 1, '0x1234567890123456789012345678901234567890',
+				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
+				'', 2, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567891',
+				1234567890, '', '', 'backward_let'
+			)
+		`)
+		require.NoError(t, err)
+
+		// Insert bridge with empty txn_sender and forward_let source (should NOT be counted)
+		_, err = tx.Exec(`
+			INSERT INTO bridge (
+				block_num, block_pos, leaf_type, origin_network, origin_address,
+				destination_network, destination_address, amount, metadata, deposit_count,
+				tx_hash, block_timestamp, from_address, txn_sender, source
+			) VALUES (
+				3, 0, 1, 1, '0x1234567890123456789012345678901234567890',
+				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
+				'', 3, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567892',
+				1234567890, '', '', 'forward_let'
+			)
+		`)
+		require.NoError(t, err)
+
+		// Insert bridge with empty txn_sender and no source field (should be counted)
+		_, err = tx.Exec(`
+			INSERT INTO bridge (
+				block_num, block_pos, leaf_type, origin_network, origin_address,
+				destination_network, destination_address, amount, metadata, deposit_count,
+				tx_hash, block_timestamp, from_address, txn_sender
+			) VALUES (
+				4, 0, 1, 1, '0x1234567890123456789012345678901234567890',
+				2, '0x0987654321098765432109876543210987654321', '1000000000000000000',
+				'', 4, '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567893',
+				1234567890, '', ''
+			)
+		`)
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		mockClient := mocks.NewEthClienter(t)
+		logger := log.WithFields("module", "test")
+		backfiller, err := NewBackfillTxnSender(dbPath, mockClient, common.HexToAddress("0x1234"), logger)
+		require.NoError(t, err)
+		defer backfiller.Close()
+
+		// Should only count the 2 records without backward_let or forward_let source
+		count, err := backfiller.getRecordsNeedingBackfillCount(ctx, "bridge")
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+
+		// Verify getRecordsNeedingBackfill also excludes these sources
+		records, err := backfiller.getRecordsNeedingBackfill(ctx, "bridge", 10)
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+
+		// Verify the correct records were returned (block_num 1 and 4)
+		blockNums := []uint64{records[0].BlockNum, records[1].BlockNum}
+		require.Contains(t, blockNums, uint64(1))
+		require.Contains(t, blockNums, uint64(4))
+	})
+
 	t.Run("database error", func(t *testing.T) {
 		tempDir := t.TempDir()
 		dbPath := filepath.Join(tempDir, "test.db")

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -91,6 +91,7 @@ func NewL1(
 		ethClient,
 		L1BridgeSyncer,
 		originNetwork,
+		common.Hash{},
 		false,
 	)
 }
@@ -104,6 +105,20 @@ func NewL2(
 	originNetwork uint32,
 	syncFullClaims bool,
 ) (*BridgeSync, error) {
+	return NewL2WithInitialLER(ctx, cfg, rd, ethClient, originNetwork, common.Hash{}, syncFullClaims)
+}
+
+// NewL2WithInitialLER creates a bridge syncer that synchronizes the local exit tree
+// using the configured initial local exit root for LET sanity checks.
+func NewL2WithInitialLER(
+	ctx context.Context,
+	cfg Config,
+	rd ReorgDetector,
+	ethClient aggkittypes.EthClienter,
+	originNetwork uint32,
+	initialLER common.Hash,
+	syncFullClaims bool,
+) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
 		cfg,
@@ -112,6 +127,7 @@ func NewL2(
 		ethClient,
 		L2BridgeSyncer,
 		originNetwork,
+		initialLER,
 		syncFullClaims,
 	)
 }
@@ -124,6 +140,7 @@ func newBridgeSync(
 	ethClient aggkittypes.EthClienter,
 	syncerID BridgeSyncerID,
 	networkID uint32,
+	initialLER common.Hash,
 	syncFullClaims bool,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
@@ -142,7 +159,13 @@ func newBridgeSync(
 		return nil, err
 	}
 
-	processor, err := newProcessor(cfg.DBPath, "bridge_sync_"+syncerID.String(), logger, cfg.DBQueryTimeout.Duration)
+	processor, err := newProcessorWithInitialLER(
+		cfg.DBPath,
+		"bridge_sync_"+syncerID.String(),
+		logger,
+		cfg.DBQueryTimeout.Duration,
+		initialLER,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -54,6 +54,7 @@ var (
 	setClaimEventSignature = crypto.Keccak256Hash([]byte(
 		"SetClaim(bytes32)",
 	))
+	backwardLETEventSignature = crypto.Keccak256Hash([]byte("BackwardLET(uint256,bytes32,uint256,bytes32)"))
 
 	claimAssetEtrogMethodID      = common.Hex2Bytes("ccaa2d11")
 	claimMessageEtrogMethodID    = common.Hex2Bytes("f5efcd79")
@@ -131,6 +132,13 @@ func buildAppender(
 		appender[removeLegacySovereignTokenEventSignature] = buildRemoveLegacyTokenHandler(bridgeDeployment.agglayerBridgeL2)
 		appender[unsetClaimEventSignature] = buildUnsetClaimEventHandler(bridgeDeployment.agglayerBridgeL2)
 		appender[setClaimEventSignature] = buildSetClaimEventHandler(bridgeDeployment.agglayerBridgeL2)
+		appender[backwardLETEventSignature] = buildBackwardLETEventHandler(bridgeDeployment.agglayerBridgeL2)
+
+		return appender, nil
+	}
+
+	if bridgeDeployment.kind != NonSovereignChain {
+		return nil, fmt.Errorf("unsupported bridge deployment kind: %d", bridgeDeployment.kind)
 	}
 
 	return appender, nil
@@ -689,6 +697,26 @@ func buildSetClaimEventHandler(contract *agglayerbridgel2.Agglayerbridgel2) func
 			BlockPos:    uint64(l.Index),
 			TxHash:      l.TxHash,
 			GlobalIndex: globalIndex,
+		}})
+		return nil
+	}
+}
+
+// buildBackwardLETEventHandler creates a handler for the BackwardLET event log
+func buildBackwardLETEventHandler(contract *agglayerbridgel2.Agglayerbridgel2) func(*sync.EVMBlock, types.Log) error {
+	return func(b *sync.EVMBlock, l types.Log) error {
+		event, err := contract.ParseBackwardLET(l)
+		if err != nil {
+			return fmt.Errorf("error parsing BackwardLET event log %+v: %w", l, err)
+		}
+
+		b.Events = append(b.Events, Event{BackwardLET: &BackwardLET{
+			BlockNum:             b.Num,
+			BlockPos:             uint64(l.Index),
+			PreviousDepositCount: event.PreviousDepositCount,
+			PreviousRoot:         event.PreviousRoot,
+			NewDepositCount:      event.NewDepositCount,
+			NewRoot:              event.NewRoot,
 		}})
 		return nil
 	}

--- a/bridgesync/downloader.go
+++ b/bridgesync/downloader.go
@@ -55,6 +55,7 @@ var (
 		"SetClaim(bytes32)",
 	))
 	backwardLETEventSignature = crypto.Keccak256Hash([]byte("BackwardLET(uint256,bytes32,uint256,bytes32)"))
+	forwardLETEventSignature  = crypto.Keccak256Hash([]byte("ForwardLET(uint256,bytes32,uint256,bytes32,bytes)"))
 
 	claimAssetEtrogMethodID      = common.Hex2Bytes("ccaa2d11")
 	claimMessageEtrogMethodID    = common.Hex2Bytes("f5efcd79")
@@ -133,6 +134,7 @@ func buildAppender(
 		appender[unsetClaimEventSignature] = buildUnsetClaimEventHandler(bridgeDeployment.agglayerBridgeL2)
 		appender[setClaimEventSignature] = buildSetClaimEventHandler(bridgeDeployment.agglayerBridgeL2)
 		appender[backwardLETEventSignature] = buildBackwardLETEventHandler(bridgeDeployment.agglayerBridgeL2)
+		appender[forwardLETEventSignature] = buildForwardLETEventHandler(bridgeDeployment.agglayerBridgeL2)
 
 		return appender, nil
 	}
@@ -717,6 +719,29 @@ func buildBackwardLETEventHandler(contract *agglayerbridgel2.Agglayerbridgel2) f
 			PreviousRoot:         event.PreviousRoot,
 			NewDepositCount:      event.NewDepositCount,
 			NewRoot:              event.NewRoot,
+		}})
+		return nil
+	}
+}
+
+// buildForwardLETEventHandler creates a handler for the ForwardLET event log
+func buildForwardLETEventHandler(contract *agglayerbridgel2.Agglayerbridgel2) func(*sync.EVMBlock, types.Log) error {
+	return func(b *sync.EVMBlock, l types.Log) error {
+		event, err := contract.ParseForwardLET(l)
+		if err != nil {
+			return fmt.Errorf("error parsing ForwardLET event log %+v: %w", l, err)
+		}
+
+		b.Events = append(b.Events, Event{ForwardLET: &ForwardLET{
+			BlockNum:             b.Num,
+			BlockPos:             uint64(l.Index),
+			BlockTimestamp:       b.Timestamp,
+			TxnHash:              l.TxHash,
+			PreviousDepositCount: event.PreviousDepositCount,
+			PreviousRoot:         event.PreviousRoot,
+			NewDepositCount:      event.NewDepositCount,
+			NewRoot:              event.NewRoot,
+			NewLeaves:            event.NewLeaves,
 		}})
 		return nil
 	}

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -284,6 +284,7 @@ func TestBuildAppender(t *testing.T) {
 		logsCount            int
 		buildQuerierMockFunc func() *BridgeQuerierMock
 		logBuilder           func() (types.Log, error)
+		expectedErr          string
 	}{
 		{
 			name:           "bridgeEventSignature appender",
@@ -634,6 +635,39 @@ func TestBuildAppender(t *testing.T) {
 				return l, nil
 			},
 		},
+		{
+			name:           "backwardLETSignature appender",
+			eventSignature: backwardLETEventSignature,
+			deploymentKind: SovereignChain,
+			logsCount:      1,
+			logBuilder: func() (types.Log, error) {
+				event, err := bridgeL2Abi.EventByID(backwardLETEventSignature)
+				if err != nil {
+					return types.Log{}, err
+				}
+
+				previousDepositCount := big.NewInt(10)
+				previousRoot := common.HexToHash("0xdeadbeef")
+				newDepositCount := big.NewInt(8)
+				newRoot := common.HexToHash("0x5ca1e")
+				data, err := event.Inputs.Pack(previousDepositCount, previousRoot, newDepositCount, newRoot)
+				if err != nil {
+					return types.Log{}, err
+				}
+
+				l := types.Log{
+					Topics: []common.Hash{backwardLETEventSignature},
+					Data:   data,
+				}
+				return l, nil
+			},
+		},
+		{
+			name:           "unknown deployment kind",
+			deploymentKind: 100,
+			logBuilder:     func() (types.Log, error) { return types.Log{}, nil },
+			expectedErr:    "unsupported bridge deployment kind: 100",
+		},
 	}
 
 	for _, tt := range tests {
@@ -648,17 +682,22 @@ func TestBuildAppender(t *testing.T) {
 				querierMock = tt.buildQuerierMockFunc()
 			}
 			appenderMap, err := buildAppender(t.Context(), ethClient, querierMock, bridgeAddr, false, bridgeDeployment, logger)
-			require.NoError(t, err)
-			require.NotNil(t, appenderMap)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				require.NotNil(t, appenderMap)
+			} else {
+				require.ErrorContains(t, err, tt.expectedErr)
+			}
 
-			block := &sync.EVMBlock{EVMBlockHeader: sync.EVMBlockHeader{Num: blockNum}}
+			if tt.expectedErr == "" {
+				block := &sync.EVMBlock{EVMBlockHeader: sync.EVMBlockHeader{Num: blockNum}}
+				appenderFunc, exists := appenderMap[tt.eventSignature]
+				require.True(t, exists)
 
-			appenderFunc, exists := appenderMap[tt.eventSignature]
-			require.True(t, exists)
-
-			err = appenderFunc(block, log)
-			require.NoError(t, err)
-			require.Equal(t, tt.logsCount, len(block.Events))
+				err = appenderFunc(block, log)
+				require.NoError(t, err)
+				require.Equal(t, tt.logsCount, len(block.Events))
+			}
 		})
 	}
 }

--- a/bridgesync/downloader_test.go
+++ b/bridgesync/downloader_test.go
@@ -663,6 +663,34 @@ func TestBuildAppender(t *testing.T) {
 			},
 		},
 		{
+			name:           "forwardLETSignature appender",
+			eventSignature: forwardLETEventSignature,
+			deploymentKind: SovereignChain,
+			logsCount:      1,
+			logBuilder: func() (types.Log, error) {
+				event, err := bridgeL2Abi.EventByID(forwardLETEventSignature)
+				if err != nil {
+					return types.Log{}, err
+				}
+
+				previousDepositCount := big.NewInt(15)
+				previousRoot := common.HexToHash("0xdeadbeef15")
+				newDepositCount := big.NewInt(20)
+				newRoot := common.HexToHash("0x5ca1e20")
+				newLeaves := []byte("leavesdata")
+				data, err := event.Inputs.Pack(previousDepositCount, previousRoot, newDepositCount, newRoot, newLeaves)
+				if err != nil {
+					return types.Log{}, err
+				}
+
+				l := types.Log{
+					Topics: []common.Hash{forwardLETEventSignature},
+					Data:   data,
+				}
+				return l, nil
+			},
+		},
+		{
 			name:           "unknown deployment kind",
 			deploymentKind: 100,
 			logBuilder:     func() (types.Log, error) { return types.Log{}, nil },

--- a/bridgesync/leaf_data.go
+++ b/bridgesync/leaf_data.go
@@ -1,0 +1,65 @@
+package bridgesync
+
+import (
+	"fmt"
+	"math/big"
+
+	aggkitabi "github.com/agglayer/aggkit/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// LeafData represents the data structure of a leaf in the local exit tree
+// used in ForwardLET events.
+type LeafData struct {
+	LeafType           uint8          `abi:"leafType"`
+	OriginNetwork      uint32         `abi:"originNetwork"`
+	OriginAddress      common.Address `abi:"originAddress"`
+	DestinationNetwork uint32         `abi:"destinationNetwork"`
+	DestinationAddress common.Address `abi:"destinationAddress"`
+	Amount             *big.Int       `abi:"amount"`
+	Metadata           []byte         `abi:"metadata"`
+}
+
+// String returns a string representation of the LeafData
+func (l LeafData) String() string {
+	return fmt.Sprintf("LeafData{LeafType: %d, OriginNetwork: %d, OriginAddress: %s, "+
+		"DestinationNetwork: %d, DestinationAddress: %s, Amount: %s, Metadata: %x}",
+		l.LeafType,
+		l.OriginNetwork,
+		l.OriginAddress.Hex(),
+		l.DestinationNetwork,
+		l.DestinationAddress.Hex(),
+		l.Amount.String(),
+		l.Metadata,
+	)
+}
+
+// ToBridge converts the LeafData to a Bridge structure
+func (l LeafData) ToBridge(
+	blockNum, blockPos, blockTimestamp uint64,
+	depositCount uint32,
+	txnHash common.Hash,
+	txnSender, fromAddr common.Address) Bridge {
+	return Bridge{
+		BlockNum:           blockNum,
+		BlockPos:           blockPos,
+		BlockTimestamp:     blockTimestamp,
+		DepositCount:       depositCount,
+		TxHash:             txnHash,
+		FromAddress:        fromAddr,
+		TxnSender:          txnSender,
+		LeafType:           l.LeafType,
+		OriginNetwork:      l.OriginNetwork,
+		OriginAddress:      l.OriginAddress,
+		DestinationNetwork: l.DestinationNetwork,
+		DestinationAddress: l.DestinationAddress,
+		Amount:             l.Amount,
+		Metadata:           l.Metadata,
+		Source:             BridgeSourceForwardLET, // this leaf comes from ForwardLET event
+	}
+}
+
+// decodeForwardLETLeaves decodes the newLeaves bytes from a ForwardLET event
+func decodeForwardLETLeaves(newLeavesBytes []byte) ([]LeafData, error) {
+	return aggkitabi.DecodeABIEncodedStructArray[LeafData](newLeavesBytes)
+}

--- a/bridgesync/leaf_data_test.go
+++ b/bridgesync/leaf_data_test.go
@@ -1,0 +1,167 @@
+package bridgesync
+
+import (
+	"math/big"
+	"testing"
+
+	aggkitabi "github.com/agglayer/aggkit/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeForwardLETLeaves(t *testing.T) {
+	largeAmount := new(big.Int)
+	largeAmount.SetString("123456789012345678901234567890", 10)
+
+	testCases := []struct {
+		name           string
+		inputLeaves    []LeafData
+		expectedLeaves []LeafData
+		errorMsg       string
+		useRawBytes    bool
+		rawBytes       []byte
+	}{
+		{
+			name: "successfully decode single leaf",
+			inputLeaves: []LeafData{
+				{
+					LeafType:           1,
+					OriginNetwork:      5,
+					OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					DestinationNetwork: 10,
+					DestinationAddress: common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+					Amount:             big.NewInt(1000000),
+					Metadata:           []byte("test metadata"),
+				},
+			},
+		},
+		{
+			name: "successfully decode multiple leaves",
+			inputLeaves: []LeafData{
+				{
+					LeafType:           0,
+					OriginNetwork:      1,
+					OriginAddress:      common.HexToAddress("0x1111111111111111111111111111111111111111"),
+					DestinationNetwork: 2,
+					DestinationAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+					Amount:             big.NewInt(100),
+					Metadata:           []byte("first leaf"),
+				},
+				{
+					LeafType:           1,
+					OriginNetwork:      3,
+					OriginAddress:      common.HexToAddress("0x3333333333333333333333333333333333333333"),
+					DestinationNetwork: 4,
+					DestinationAddress: common.HexToAddress("0x4444444444444444444444444444444444444444"),
+					Amount:             big.NewInt(200),
+					Metadata:           []byte("second leaf"),
+				},
+				{
+					LeafType:           2,
+					OriginNetwork:      5,
+					OriginAddress:      common.HexToAddress("0x5555555555555555555555555555555555555555"),
+					DestinationNetwork: 6,
+					DestinationAddress: common.HexToAddress("0x6666666666666666666666666666666666666666"),
+					Amount:             big.NewInt(300),
+					Metadata:           []byte("third leaf"),
+				},
+			},
+		},
+		{
+			name: "decode leaf with empty metadata",
+			inputLeaves: []LeafData{
+				{
+					LeafType:           0,
+					OriginNetwork:      1,
+					OriginAddress:      common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+					DestinationNetwork: 2,
+					DestinationAddress: common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+					Amount:             big.NewInt(999),
+					Metadata:           []byte{},
+				},
+			},
+		},
+		{
+			name: "decode leaf with large amount",
+			inputLeaves: []LeafData{
+				{
+					LeafType:           255,        // Max uint8
+					OriginNetwork:      4294967295, // Max uint32
+					OriginAddress:      common.HexToAddress("0xffffffffffffffffffffffffffffffffffffffff"),
+					DestinationNetwork: 4294967295, // Max uint32
+					DestinationAddress: common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+					Amount:             largeAmount,
+					Metadata:           []byte("large amount test"),
+				},
+			},
+		},
+		{
+			name:        "decode empty array",
+			inputLeaves: []LeafData{},
+		},
+		{
+			name:        "fail on empty bytes",
+			useRawBytes: true,
+			rawBytes:    []byte{},
+			errorMsg:    "encoded bytes are empty",
+		},
+		{
+			name:        "fail on invalid encoded data",
+			useRawBytes: true,
+			rawBytes:    []byte{0x00, 0x01, 0x02, 0x03, 0x04},
+			errorMsg:    "failed to unpack data",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var encodedBytes []byte
+			var expectedLeaves []LeafData
+
+			if tc.useRawBytes {
+				encodedBytes = tc.rawBytes
+			} else {
+				encodedBytes = encodeLeafDataArray(t, tc.inputLeaves)
+				expectedLeaves = tc.inputLeaves
+			}
+
+			decodedLeaves, err := decodeForwardLETLeaves(encodedBytes)
+
+			if tc.errorMsg != "" {
+				require.ErrorContains(t, err, tc.errorMsg)
+				require.Nil(t, decodedLeaves)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, decodedLeaves, len(expectedLeaves))
+				for i, expected := range expectedLeaves {
+					verifyLeafData(t, expected, decodedLeaves[i])
+				}
+			}
+		})
+	}
+}
+
+// encodeLeafDataArray encodes a slice of LeafData using Solidity ABI encoding
+// This simulates what the smart contract does with abi.encode(newLeaves)
+func encodeLeafDataArray(t *testing.T, leaves []LeafData) []byte {
+	t.Helper()
+
+	encodedBytes, err := aggkitabi.EncodeABIStructArray(leaves)
+	require.NoError(t, err)
+
+	return encodedBytes
+}
+
+// verifyLeafData compares two LeafData structs for equality
+func verifyLeafData(t *testing.T, expected, actual LeafData) {
+	t.Helper()
+
+	require.Equal(t, expected.LeafType, actual.LeafType, "LeafType mismatch")
+	require.Equal(t, expected.OriginNetwork, actual.OriginNetwork, "OriginNetwork mismatch")
+	require.Equal(t, expected.OriginAddress, actual.OriginAddress, "OriginAddress mismatch")
+	require.Equal(t, expected.DestinationNetwork, actual.DestinationNetwork, "DestinationNetwork mismatch")
+	require.Equal(t, expected.DestinationAddress, actual.DestinationAddress, "DestinationAddress mismatch")
+	require.Equal(t, 0, expected.Amount.Cmp(actual.Amount), "Amount mismatch: expected %s, got %s",
+		expected.Amount.String(), actual.Amount.String())
+	require.Equal(t, expected.Metadata, actual.Metadata, "Metadata mismatch")
+}

--- a/bridgesync/migrations/bridgesync0012.sql
+++ b/bridgesync/migrations/bridgesync0012.sql
@@ -6,6 +6,7 @@ ALTER TABLE bridge DROP COLUMN to_address;
 
 DROP TABLE IF EXISTS bridge_archive;
 DROP TABLE IF EXISTS backward_let;
+DROP TABLE IF EXISTS forward_let;
 ALTER TABLE bridge DROP COLUMN source;
 
 -- +migrate Up
@@ -26,6 +27,18 @@ CREATE TABLE IF NOT EXISTS backward_let (
 
 ALTER TABLE bridge ADD COLUMN source TEXT DEFAULT '';
 
+CREATE TABLE IF NOT EXISTS forward_let (
+        block_num INTEGER NOT NULL REFERENCES block (num) ON DELETE CASCADE,
+        block_pos INTEGER NOT NULL,
+        block_timestamp INTEGER NOT NULL,
+        tx_hash VARCHAR NOT NULL,
+        previous_deposit_count TEXT NOT NULL,
+		previous_root VARCHAR NOT NULL,
+		new_deposit_count TEXT NOT NULL,
+		new_root VARCHAR NOT NULL,
+		new_leaves BLOB NOT NULL,
+		PRIMARY KEY (block_num, block_pos)
+	);
 ------------------------------------------------------------------------------
 -- Create bridge_archive table
 ------------------------------------------------------------------------------

--- a/bridgesync/migrations/bridgesync0012.sql
+++ b/bridgesync/migrations/bridgesync0012.sql
@@ -1,13 +1,49 @@
 -- +migrate Down
 DROP INDEX IF EXISTS idx_claim_type_block;
-
 ALTER TABLE claim DROP COLUMN type;
 
 ALTER TABLE bridge DROP COLUMN to_address;
 
+DROP TABLE IF EXISTS bridge_archive;
+DROP TABLE IF EXISTS backward_let;
+ALTER TABLE bridge DROP COLUMN source;
+
 -- +migrate Up
 ALTER TABLE claim ADD COLUMN type TEXT NOT NULL DEFAULT '';
-
 CREATE INDEX IF NOT EXISTS idx_claim_type_block ON claim (type, block_num);
 
 ALTER TABLE bridge ADD COLUMN to_address VARCHAR;
+
+CREATE TABLE IF NOT EXISTS backward_let (
+		block_num INTEGER NOT NULL REFERENCES block (num) ON DELETE CASCADE,
+		block_pos INTEGER NOT NULL,
+		previous_deposit_count TEXT NOT NULL,
+		previous_root VARCHAR NOT NULL,
+		new_deposit_count TEXT NOT NULL,
+		new_root VARCHAR NOT NULL,
+		PRIMARY KEY (block_num, block_pos)
+	);
+
+ALTER TABLE bridge ADD COLUMN source TEXT DEFAULT '';
+
+------------------------------------------------------------------------------
+-- Create bridge_archive table
+------------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS bridge_archive (
+		deposit_count INTEGER PRIMARY KEY,
+		block_num INTEGER NOT NULL,
+		block_pos INTEGER NOT NULL,
+		leaf_type INTEGER NOT NULL,
+		origin_network INTEGER NOT NULL,
+		origin_address VARCHAR NOT NULL,
+		destination_network INTEGER NOT NULL,
+		destination_address VARCHAR NOT NULL,
+		amount TEXT NOT NULL,
+		metadata BLOB,
+		tx_hash VARCHAR,
+		block_timestamp INTEGER,
+		txn_sender VARCHAR,
+        from_address VARCHAR,
+        source TEXT DEFAULT '',
+        to_address VARCHAR
+	);

--- a/bridgesync/migrations/migrations.go
+++ b/bridgesync/migrations/migrations.go
@@ -1,100 +1,70 @@
 package migrations
 
 import (
-	_ "embed"
+	"embed"
+	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/db/types"
-	treeMigrations "github.com/agglayer/aggkit/tree/migrations"
+	treemigrations "github.com/agglayer/aggkit/tree/migrations"
 )
 
-//go:embed bridgesync0001.sql
-var mig0001 string
+var (
+	//go:embed *.sql
+	migrationFS embed.FS
+	migrations  []types.Migration
+)
 
-//go:embed bridgesync0002.sql
-var mig0002 string
+func init() {
+	entries, err := migrationFS.ReadDir(".")
+	if err != nil {
+		panic(fmt.Errorf("failed to read embedded migrations: %w", err))
+	}
 
-//go:embed bridgesync0003.sql
-var mig0003 string
+	for _, e := range entries {
+		name := e.Name() // e.g. "bridgesync0004.sql"
 
-//go:embed bridgesync0004.sql
-var mig0004 string
+		sqlBytes, err := migrationFS.ReadFile(name)
+		if err != nil {
+			panic(err)
+		}
 
-//go:embed bridgesync0005.sql
-var mig0005 string
+		id := strings.TrimSuffix(name, ".sql") // "bridgesync0004"
 
-//go:embed bridgesync0006.sql
-var mig0006 string
+		migrations = append(migrations, types.Migration{
+			ID:  id,
+			SQL: string(sqlBytes),
+		})
+	}
 
-//go:embed bridgesync0007.sql
-var mig0007 string
-
-//go:embed bridgesync0008.sql
-var mig0008 string
-
-//go:embed bridgesync0009.sql
-var mig0009 string
-
-//go:embed bridgesync0010.sql
-var mig0010 string
-
-//go:embed bridgesync0011.sql
-var mig0011 string
-
-//go:embed bridgesync0012.sql
-var mig0012 string
+	// Ensure deterministic canonical order
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].ID < migrations[j].ID
+	})
+}
 
 func RunMigrations(dbPath string) error {
-	migrations := []types.Migration{
-		{
-			ID:  "bridgesync0001",
-			SQL: mig0001,
-		},
-		{
-			ID:  "bridgesync0002",
-			SQL: mig0002,
-		},
-		{
-			ID:  "bridgesync0003",
-			SQL: mig0003,
-		},
-		{
-			ID:  "bridgesync0004",
-			SQL: mig0004,
-		},
-		{
-			ID:  "bridgesync0005",
-			SQL: mig0005,
-		},
-		{
-			ID:  "bridgesync0006",
-			SQL: mig0006,
-		},
-		{
-			ID:  "bridgesync0007",
-			SQL: mig0007,
-		},
-		{
-			ID:  "bridgesync0008",
-			SQL: mig0008,
-		},
-		{
-			ID:  "bridgesync0009",
-			SQL: mig0009,
-		},
-		{
-			ID:  "bridgesync0010",
-			SQL: mig0010,
-		},
-		{
-			ID:  "bridgesync0011",
-			SQL: mig0011,
-		},
-		{
-			ID:  "bridgesync0012",
-			SQL: mig0012,
-		},
-	}
-	migrations = append(migrations, treeMigrations.Migrations...)
-	return db.RunMigrations(dbPath, migrations)
+	// Allocate slice with exact capacity to avoid reallocations when combining migrations
+	total := len(migrations) + len(treemigrations.Migrations)
+
+	combined := make([]types.Migration, 0, total)
+	// Copy migrations
+	combined = append(combined, migrations...)
+	combined = append(combined, treemigrations.Migrations...)
+
+	// Pass the copy to db.RunMigrations
+	return db.RunMigrations(dbPath, combined)
+}
+
+// GetUpTo returns all migrations up to and including the migration with the given ID.
+func GetUpTo(lastID string) []types.Migration {
+	idx := sort.Search(len(migrations), func(i int) bool {
+		return migrations[i].ID > lastID
+	})
+
+	out := make([]types.Migration, idx)
+	copy(out, migrations[:idx])
+	return out
 }

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/agglayer/aggkit/db"
-	"github.com/agglayer/aggkit/db/types"
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/common"
 	migrate "github.com/rubenv/sql-migrate"
@@ -266,23 +265,10 @@ func TestMigration0004(t *testing.T) {
 	require.NoError(t, err)
 	defer database.Close()
 
-	// Define migrations up to 0003
-	migrations := []types.Migration{
-		{
-			ID:  "bridgesync0001",
-			SQL: mig0001,
-		},
-		{
-			ID:  "bridgesync0002",
-			SQL: mig0002,
-		},
-		{
-			ID:  "bridgesync0003",
-			SQL: mig0003,
-		},
-	}
+	// Define migrations up to bridgesync0003
+	migrations := GetUpTo("bridgesync0003")
 
-	// Run migrations up to 0003 (3 migrations)
+	// Run migrations up to bridgesync0003 (3 migrations)
 	err = db.RunMigrationsDBExtended(log.GetDefaultLogger(), database, migrations, migrate.Up, 3)
 	require.NoError(t, err)
 
@@ -458,29 +444,8 @@ func TestMigration0006(t *testing.T) {
 	require.NoError(t, err)
 	defer database.Close()
 
-	// Define migrations up to 0005
-	migrations := []types.Migration{
-		{
-			ID:  "bridgesync0001",
-			SQL: mig0001,
-		},
-		{
-			ID:  "bridgesync0002",
-			SQL: mig0002,
-		},
-		{
-			ID:  "bridgesync0003",
-			SQL: mig0003,
-		},
-		{
-			ID:  "bridgesync0004",
-			SQL: mig0004,
-		},
-		{
-			ID:  "bridgesync0005",
-			SQL: mig0005,
-		},
-	}
+	// Define migrations up to bridgesync0005
+	migrations := GetUpTo("bridgesync0005")
 
 	// Run migrations up to 0005 (5 migrations)
 	err = db.RunMigrationsDBExtended(log.GetDefaultLogger(), database, migrations, migrate.Up, 5)

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -51,6 +51,9 @@ const (
 	// setClaimTableName is the name of the table that stores set claim events
 	setClaimTableName = "set_claim"
 
+	// backwardLETTableName is the name of the table that stores backward local exit tree events
+	backwardLETTableName = "backward_let"
+
 	// nilStr holds nil string
 	nilStr = "nil"
 )
@@ -150,6 +153,13 @@ var (
 	`, bridgeTableName)
 )
 
+type BridgeSource string
+
+const (
+	BridgeSourceBackwardLET BridgeSource = "backward_let"
+	BridgeSourceForwardLET  BridgeSource = "forward_let"
+)
+
 // Bridge is the representation of a bridge event
 type Bridge struct {
 	BlockNum           uint64         `meddler:"block_num"`
@@ -166,6 +176,7 @@ type Bridge struct {
 	Metadata           []byte         `meddler:"metadata"`
 	DepositCount       uint32         `meddler:"deposit_count"`
 	TxnSender          common.Address `meddler:"txn_sender,address"`
+	Source             BridgeSource   `meddler:"source"`
 	ToAddress          common.Address `meddler:"to_address,address"`
 }
 
@@ -177,11 +188,11 @@ func (b *Bridge) String() string {
 	return fmt.Sprintf("Bridge{BlockNum: %d, BlockPos: %d, FromAddress: %s, TxHash: %s, "+
 		"BlockTimestamp: %d, LeafType: %d, OriginNetwork: %d, OriginAddress: %s, "+
 		"DestinationNetwork: %d, DestinationAddress: %s, Amount: %s, Metadata: %x, "+
-		"DepositCount: %d, TxnSender: %s, ToAddress: %s}",
+		"DepositCount: %d, TxnSender: %s, Source: %s, ToAddress: %s}",
 		b.BlockNum, b.BlockPos, b.FromAddress.String(), b.TxHash.String(),
 		b.BlockTimestamp, b.LeafType, b.OriginNetwork, b.OriginAddress.String(),
 		b.DestinationNetwork, b.DestinationAddress.String(), amountStr, b.Metadata,
-		b.DepositCount, b.TxnSender.String(), b.ToAddress.String())
+		b.DepositCount, b.TxnSender.String(), b.Source, b.ToAddress.String())
 }
 
 // Hash returns the hash of the bridge event as expected by the exit tree
@@ -386,55 +397,6 @@ func (c *Claim) decodePreEtrogCalldata(data []any) (bool, error) {
 	return true, nil
 }
 
-type InvalidClaim struct {
-	// claim struct fields
-	BlockNum            uint64         `meddler:"block_num"`
-	BlockPos            uint64         `meddler:"block_pos"`
-	TxHash              common.Hash    `meddler:"tx_hash,hash"`
-	GlobalIndex         *big.Int       `meddler:"global_index,bigint"`
-	OriginNetwork       uint32         `meddler:"origin_network"`
-	OriginAddress       common.Address `meddler:"origin_address"`
-	DestinationAddress  common.Address `meddler:"destination_address"`
-	Amount              *big.Int       `meddler:"amount,bigint"`
-	ProofLocalExitRoot  types.Proof    `meddler:"proof_local_exit_root,merkleproof"`
-	ProofRollupExitRoot types.Proof    `meddler:"proof_rollup_exit_root,merkleproof"`
-	MainnetExitRoot     common.Hash    `meddler:"mainnet_exit_root,hash"`
-	RollupExitRoot      common.Hash    `meddler:"rollup_exit_root,hash"`
-	GlobalExitRoot      common.Hash    `meddler:"global_exit_root,hash"`
-	DestinationNetwork  uint32         `meddler:"destination_network"`
-	Metadata            []byte         `meddler:"metadata"`
-	IsMessage           bool           `meddler:"is_message"`
-	BlockTimestamp      uint64         `meddler:"block_timestamp"`
-	// additional fields
-	Reason    string `meddler:"reason"`
-	CreatedAt uint64 `meddler:"created_at"`
-}
-
-// NewInvalidClaim creates a new InvalidClaim from a Claim and a reason
-func NewInvalidClaim(c *Claim, reason string) *InvalidClaim {
-	return &InvalidClaim{
-		BlockNum:            c.BlockNum,
-		BlockPos:            c.BlockPos,
-		TxHash:              c.TxHash,
-		GlobalIndex:         c.GlobalIndex,
-		OriginNetwork:       c.OriginNetwork,
-		OriginAddress:       c.OriginAddress,
-		DestinationAddress:  c.DestinationAddress,
-		Amount:              c.Amount,
-		ProofLocalExitRoot:  c.ProofLocalExitRoot,
-		ProofRollupExitRoot: c.ProofRollupExitRoot,
-		MainnetExitRoot:     c.MainnetExitRoot,
-		RollupExitRoot:      c.RollupExitRoot,
-		GlobalExitRoot:      c.GlobalExitRoot,
-		DestinationNetwork:  c.DestinationNetwork,
-		Metadata:            c.Metadata,
-		IsMessage:           c.IsMessage,
-		BlockTimestamp:      c.BlockTimestamp,
-		Reason:              reason,
-		CreatedAt:           uint64(time.Now().UTC().Unix()),
-	}
-}
-
 // TokenMapping representation of a NewWrappedToken event, that is emitted by the bridge contract
 type TokenMapping struct {
 	BlockNum            uint64                       `meddler:"block_num"`
@@ -524,7 +486,7 @@ func (u *UnsetClaim) String() string {
 }
 
 // SetClaim representation of a SetClaim event,
-// that is emitted by the bridge contract when a claim is set.
+// that is emitted by the L2 bridge contract when a claim is set.
 type SetClaim struct {
 	BlockNum    uint64      `meddler:"block_num"`
 	BlockPos    uint64      `meddler:"block_pos"`
@@ -544,6 +506,32 @@ func (s *SetClaim) String() string {
 		globalIndexStr, s.CreatedAt)
 }
 
+// BackwardLET representation of a BackwardLET event,
+// that is emitted by the L2 bridge contract when a LET is rolled back.
+type BackwardLET struct {
+	BlockNum             uint64      `meddler:"block_num"`
+	BlockPos             uint64      `meddler:"block_pos"`
+	PreviousDepositCount *big.Int    `meddler:"previous_deposit_count,bigint"`
+	PreviousRoot         common.Hash `meddler:"previous_root,hash"`
+	NewDepositCount      *big.Int    `meddler:"new_deposit_count,bigint"`
+	NewRoot              common.Hash `meddler:"new_root,hash"`
+}
+
+// String returns a formatted string representation of BackwardLET for debugging and logging.
+func (b *BackwardLET) String() string {
+	previousDepositCountStr := nilStr
+	if b.PreviousDepositCount != nil {
+		previousDepositCountStr = b.PreviousDepositCount.String()
+	}
+	newDepositCountStr := nilStr
+	if b.NewDepositCount != nil {
+		newDepositCountStr = b.NewDepositCount.String()
+	}
+	return fmt.Sprintf("BackwardLET{BlockNum: %d, BlockPos: %d, "+
+		"PreviousDepositCount: %s, PreviousRoot: %s, NewDepositCount: %s, NewRoot: %s}",
+		b.BlockNum, b.BlockPos, previousDepositCountStr, b.PreviousRoot.String(), newDepositCountStr, b.NewRoot.String())
+}
+
 // Event combination of bridge, claim, token mapping and legacy token migration events
 type Event struct {
 	Bridge               *Bridge
@@ -553,6 +541,7 @@ type Event struct {
 	RemoveLegacyToken    *RemoveLegacyToken
 	UnsetClaim           *UnsetClaim
 	SetClaim             *SetClaim
+	BackwardLET          *BackwardLET
 }
 
 func (e Event) String() string {
@@ -578,6 +567,9 @@ func (e Event) String() string {
 	if e.SetClaim != nil {
 		parts = append(parts, e.SetClaim.String())
 	}
+	if e.BackwardLET != nil {
+		parts = append(parts, e.BackwardLET.String())
+	}
 	return "Event{" + strings.Join(parts, ", ") + "}"
 }
 
@@ -601,6 +593,7 @@ func (b BridgeSyncRuntimeData) String() string {
 	}
 	return res
 }
+
 func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) error {
 	tmp := sync.RuntimeData{
 		ChainID:   b.ChainID,
@@ -626,7 +619,7 @@ var _ BridgeQuerier = (*processor)(nil)
 type processor struct {
 	syncerID       string
 	db             *sql.DB
-	exitTree       *tree.AppendOnlyTree
+	exitTree       types.FullTreer
 	log            *log.Logger
 	mu             mutex.RWMutex
 	halted         bool
@@ -1270,19 +1263,55 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 		}
 	}()
 
-	blocksRes, err := tx.Exec(`DELETE FROM block WHERE num >= $1;`, firstReorgedBlock)
+	// ---------------------------------------------------------------------
+	// 1. Load affected deposit counts and BackwardLETs BEFORE deleting blocks, bridges and BackwardLET entries
+	// ---------------------------------------------------------------------
+	backwardLETsQuery := `
+		SELECT previous_deposit_count, new_deposit_count
+        FROM backward_let
+        WHERE block_num >= $1`
+	var backwardLETs []*BackwardLET
+	if err := meddler.QueryAll(tx, &backwardLETs, backwardLETsQuery, firstReorgedBlock); err != nil {
+		return fmt.Errorf("failed to retrieve the affected backward LETs: %w", err)
+	}
+
+	var depositCountsToRemove map[uint32]struct{}
+	if len(backwardLETs) > 0 {
+		depositCountsToRemove, err = loadReorgedDepositCounts(tx, firstReorgedBlock)
+		if err != nil {
+			p.log.Errorf("failed to retrieve reorged bridges: %v", err)
+			return err
+		}
+	}
+
+	// ---------------------------------------------------------
+	// 2. Delete blocks (cascade delete everything else)
+	// ---------------------------------------------------------
+	blocksRes, err := tx.Exec(`DELETE FROM block WHERE num >= $1`, firstReorgedBlock)
 	if err != nil {
 		p.log.Errorf("failed to delete blocks during reorg: %v", err)
 		return err
 	}
+
 	rowsAffected, err := blocksRes.RowsAffected()
 	if err != nil {
 		p.log.Errorf("failed to get rows affected during reorg: %v", err)
 		return err
 	}
 
-	if err = p.exitTree.Reorg(tx, firstReorgedBlock); err != nil {
+	// ---------------------------------------------------------
+	// 3. Reorg exit tree to clean state
+	// ---------------------------------------------------------
+	if err := p.exitTree.Reorg(tx, firstReorgedBlock); err != nil {
 		p.log.Errorf("failed to reorg exit tree: %v", err)
+		return err
+	}
+
+	// ---------------------------------------------------------
+	// 4. Restore bridges removed by BackwardLET
+	// ---------------------------------------------------------
+	err = p.restoreBackwardLETBridges(tx, backwardLETs, depositCountsToRemove)
+	if err != nil {
 		return err
 	}
 
@@ -1300,6 +1329,91 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 	p.log.Infof("reorged to block %d, %d rows affected", firstReorgedBlock, rowsAffected)
 
 	return nil
+}
+
+// restoreBackwardLETBridges restores bridges that were previously removed by BackwardLET events
+func (p *processor) restoreBackwardLETBridges(tx dbtypes.Txer, backwardLETs []*BackwardLET,
+	removedDepositCounts map[uint32]struct{}) error {
+	restoreQuery := `
+		SELECT *
+		FROM bridge_archive
+		WHERE deposit_count > $1 AND deposit_count <= $2
+		ORDER BY deposit_count ASC
+	`
+
+	for _, backwardLET := range backwardLETs {
+		prev, err := aggkitcommon.SafeUint64(backwardLET.PreviousDepositCount)
+		if err != nil {
+			return fmt.Errorf("invalid previous deposit count: %w", err)
+		}
+
+		next, err := aggkitcommon.SafeUint64(backwardLET.NewDepositCount)
+		if err != nil {
+			return fmt.Errorf("invalid new deposit count: %w", err)
+		}
+
+		var bridges []*Bridge
+		if err := meddler.QueryAll(tx, &bridges, restoreQuery, next, prev); err != nil {
+			return err
+		}
+
+		for _, b := range bridges {
+			if _, ok := removedDepositCounts[b.DepositCount]; ok {
+				// skip cascade-deleted bridges (prevent from restoring them)
+				continue
+			}
+
+			// reset source
+			b.Source = ""
+			if err := meddler.Insert(tx, bridgeTableName, b); err != nil {
+				return err
+			}
+
+			leaf := types.Leaf{
+				Index: b.DepositCount,
+				Hash:  b.Hash(),
+			}
+			if _, err := p.exitTree.PutLeaf(tx, b.BlockNum, b.BlockPos, leaf); err != nil {
+				return err
+			}
+		}
+
+		// cleanup bridge_archive
+		if _, err := tx.Exec(`
+			DELETE FROM bridge_archive
+			WHERE deposit_count > $1 AND deposit_count <= $2
+		`, next, prev); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// loadReorgedDepositCounts retrieves the bridges that are going to be deleted by the reorg,
+// and returns its deposit counts.
+// The bridges are retrieved from the bridge_archive table, because in case there were BackwardLET events,
+// they would have already deleted the bridges from bridge table.
+func loadReorgedDepositCounts(tx dbtypes.Txer, fromBlock uint64) (map[uint32]struct{}, error) {
+	rows, err := tx.Query(`
+		SELECT deposit_count
+		FROM bridge_archive
+		WHERE block_num >= $1
+	`, fromBlock)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[uint32]struct{})
+	for rows.Next() {
+		var depositCount uint32
+		if err := rows.Scan(&depositCount); err != nil {
+			return nil, err
+		}
+		result[depositCount] = struct{}{}
+	}
+	return result, nil
 }
 
 // ProcessBlock process the events of the block to build the exit tree
@@ -1397,6 +1511,34 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 				return err
 			}
 		}
+
+		if event.BackwardLET != nil {
+			newDepositCount, leafIndex, err := normalizeDepositCount(event.BackwardLET.NewDepositCount)
+			if err != nil {
+				return err
+			}
+
+			// 1. archive and remove all the bridges whose
+			// deposit_count is greater than the one captured by the BackwardLET event
+			err = p.archiveAndDeleteBridgesAbove(ctx, tx, newDepositCount)
+			if err != nil {
+				return fmt.Errorf("failed to delete bridges above deposit count %d: %w",
+					newDepositCount, err)
+			}
+
+			// 2. remove all leafs from the exit tree with indices greater than leafIndex in the exit tree
+			if err := p.exitTree.BackwardToIndex(ctx, tx, leafIndex); err != nil {
+				p.log.Errorf("failed to backward local exit tree to leaf index %d (deposit count: %d)",
+					leafIndex, newDepositCount)
+				return err
+			}
+
+			// 3. insert the backward let event to designated table
+			if err = meddler.Insert(tx, backwardLETTableName, event.BackwardLET); err != nil {
+				p.log.Errorf("failed to insert backward local exit tree event at block %d: %v", block.Num, err)
+				return err
+			}
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -1420,6 +1562,65 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 				p.log.Debugf("%s", event.String())
 			}
 		}
+	}
+
+	return nil
+}
+
+// normalizeDepositCount checks whether given depositCount can fit into the uint64 and uint32 and downcasts it.
+// Otherwise it returns an error.
+func normalizeDepositCount(depositCount *big.Int) (uint64, uint32, error) {
+	u64, err := aggkitcommon.SafeUint64(depositCount)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid deposit count: %w", err)
+	}
+
+	u32, err := aggkitcommon.SafeUint32(u64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid deposit count: %w", err)
+	}
+
+	return u64, u32, nil
+}
+
+// archiveAndDeleteBridgesAbove archives and removes all the bridges whose depositCount is greater than the provided one
+func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes.Txer, depositCount uint64) error {
+	// 1. Load candidates
+	query := fmt.Sprintf(`SELECT * FROM %s WHERE deposit_count > $1`, bridgeTableName)
+	var bridges []*Bridge
+	if err := meddler.QueryAll(tx, &bridges, query, depositCount); err != nil {
+		return err
+	}
+
+	if len(bridges) == 0 {
+		return nil
+	}
+
+	deletedDepositCounts := make([]uint32, 0, len(bridges))
+	// 2. Archive
+	for _, b := range bridges {
+		b.Source = BridgeSourceBackwardLET
+		if err := meddler.Insert(tx, "bridge_archive", b); err != nil {
+			return err
+		}
+		deletedDepositCounts = append(deletedDepositCounts, b.DepositCount)
+	}
+
+	// 3. Delete originals
+	deleteQuery := fmt.Sprintf(`
+		DELETE FROM %s 
+		WHERE deposit_count > $1`,
+		bridgeTableName)
+
+	_, err := tx.ExecContext(ctx, deleteQuery, depositCount)
+	if err != nil {
+		return err
+	}
+
+	if len(deletedDepositCounts) > 0 {
+		p.log.Debugf("BackwardLET archived + removed %d bridges with deposit_count > %d: %v",
+			len(deletedDepositCounts), depositCount, deletedDepositCounts,
+		)
 	}
 
 	return nil

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -54,6 +54,9 @@ const (
 	// backwardLETTableName is the name of the table that stores backward local exit tree events
 	backwardLETTableName = "backward_let"
 
+	// forwardLETTableName is the name of the table that stores forward local exit tree events
+	forwardLETTableName = "forward_let"
+
 	// nilStr holds nil string
 	nilStr = "nil"
 )
@@ -532,6 +535,42 @@ func (b *BackwardLET) String() string {
 		b.BlockNum, b.BlockPos, previousDepositCountStr, b.PreviousRoot.String(), newDepositCountStr, b.NewRoot.String())
 }
 
+// ForwardLET representation of a ForwardLET event,
+// that is emitted by the L2 bridge contract when a LET is advanced.
+type ForwardLET struct {
+	BlockNum             uint64      `meddler:"block_num"`
+	BlockPos             uint64      `meddler:"block_pos"`
+	BlockTimestamp       uint64      `meddler:"block_timestamp"`
+	TxnHash              common.Hash `meddler:"tx_hash,hash"`
+	PreviousDepositCount *big.Int    `meddler:"previous_deposit_count,bigint"`
+	PreviousRoot         common.Hash `meddler:"previous_root,hash"`
+	NewDepositCount      *big.Int    `meddler:"new_deposit_count,bigint"`
+	NewRoot              common.Hash `meddler:"new_root,hash"`
+	NewLeaves            []byte      `meddler:"new_leaves"`
+}
+
+// String returns a formatted string representation of ForwardLET for debugging and logging.
+func (f *ForwardLET) String() string {
+	prevDepositCountStr := nilStr
+	if f.PreviousDepositCount != nil {
+		prevDepositCountStr = f.PreviousDepositCount.String()
+	}
+
+	newDepositCountStr := nilStr
+	if f.NewDepositCount != nil {
+		newDepositCountStr = f.NewDepositCount.String()
+	}
+
+	return fmt.Sprintf("ForwardLET{BlockNum: %d, BlockPos: %d, "+
+		"BlockTimestamp: %d, TxnHash: %s, "+
+		"PreviousDepositCount: %s, PreviousRoot: %s, "+
+		"NewDepositCount: %s, NewRoot: %s, NewLeaves: %x}",
+		f.BlockNum, f.BlockPos,
+		f.BlockTimestamp, f.TxnHash.String(),
+		prevDepositCountStr, f.PreviousRoot.String(),
+		newDepositCountStr, f.NewRoot.String(), f.NewLeaves)
+}
+
 // Event combination of bridge, claim, token mapping and legacy token migration events
 type Event struct {
 	Bridge               *Bridge
@@ -542,6 +581,7 @@ type Event struct {
 	UnsetClaim           *UnsetClaim
 	SetClaim             *SetClaim
 	BackwardLET          *BackwardLET
+	ForwardLET           *ForwardLET
 }
 
 func (e Event) String() string {
@@ -569,6 +609,9 @@ func (e Event) String() string {
 	}
 	if e.BackwardLET != nil {
 		parts = append(parts, e.BackwardLET.String())
+	}
+	if e.ForwardLET != nil {
+		parts = append(parts, e.ForwardLET.String())
 	}
 	return "Event{" + strings.Join(parts, ", ") + "}"
 }
@@ -1446,6 +1489,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		return err
 	}
 
+	var blockPos *uint64
 	for _, e := range block.Events {
 		event, ok := e.(Event)
 		if !ok {
@@ -1454,6 +1498,13 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 
 		if event.Bridge != nil {
+			if blockPos != nil {
+				// increment block position based on forward LET events processed so far
+				// in the current block
+				event.Bridge.BlockPos = *blockPos
+				*blockPos++
+			}
+
 			if _, err = p.exitTree.PutLeaf(tx, block.Num, event.Bridge.BlockPos, types.Leaf{
 				Index: event.Bridge.DepositCount,
 				Hash:  event.Bridge.Hash(),
@@ -1513,6 +1564,12 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 
 		if event.BackwardLET != nil {
+			// we sanity check that the previous root matches the latest one in the exit tree
+			if err := p.sanityCheckLatestLER(tx, event.BackwardLET.PreviousRoot); err != nil {
+				p.log.Errorf("failed to sanity check LER before processing BackwardLET: %v", err)
+				return err
+			}
+
 			newDepositCount, leafIndex, err := normalizeDepositCount(event.BackwardLET.NewDepositCount)
 			if err != nil {
 				return err
@@ -1533,11 +1590,27 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 				return err
 			}
 
-			// 3. insert the backward let event to designated table
+			// 4. sanity check that the new root matches the latest one in the exit tree
+			if err := p.sanityCheckLatestLER(tx, event.BackwardLET.NewRoot); err != nil {
+				p.log.Errorf("failed to sanity check LER after processing BackwardLET: %v", err)
+				return err
+			}
+
+			// 5. insert the backward let event to designated table
 			if err = meddler.Insert(tx, backwardLETTableName, event.BackwardLET); err != nil {
 				p.log.Errorf("failed to insert backward local exit tree event at block %d: %v", block.Num, err)
 				return err
 			}
+		}
+
+		if event.ForwardLET != nil {
+			newBlockPos, err := p.handleForwardLETEvent(tx, event.ForwardLET, blockPos)
+			if err != nil {
+				p.log.Errorf("failed to handle forward LET event at block %d: %v", block.Num, err)
+				return err
+			}
+
+			blockPos = &newBlockPos
 		}
 	}
 
@@ -1608,7 +1681,7 @@ func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes
 
 	// 3. Delete originals
 	deleteQuery := fmt.Sprintf(`
-		DELETE FROM %s 
+		DELETE FROM %s
 		WHERE deposit_count > $1`,
 		bridgeTableName)
 
@@ -1624,6 +1697,139 @@ func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes
 	}
 
 	return nil
+}
+
+// sanityCheckLatestLER checks if the provided local exit root matches the latest one in the exit tree
+func (p *processor) sanityCheckLatestLER(tx dbtypes.Txer, ler common.Hash) error {
+	var lastRootHash common.Hash
+
+	root, err := p.exitTree.GetLastRoot(tx)
+	if err != nil {
+		// if there is no root yet, we consider the zero hash as the last root
+		if !errors.Is(err, db.ErrNotFound) {
+			return fmt.Errorf("failed to get last root from exit tree: %w", err)
+		}
+	} else {
+		lastRootHash = root.Hash
+	}
+
+	if lastRootHash != ler {
+		return fmt.Errorf("local exit root mismatch: expected %s, got %s",
+			ler.String(), lastRootHash.String())
+	}
+	return nil
+}
+
+// handleForwardLETEvent processes a ForwardLET event and updates the database accordingly
+func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, blockPos *uint64) (uint64, error) {
+	// first we sanity check that the previous root matches the latest one in the exit tree
+	if err := p.sanityCheckLatestLER(tx, event.PreviousRoot); err != nil {
+		return 0, fmt.Errorf("failed to sanity check LER before processing ForwardLET: %w", err)
+	}
+
+	// first we decode the new LET leaves from the forward LET event
+	// they are basically bridge events, but without some fields set (tx hash, sender, from address)
+	decodedNewLeaves, err := decodeForwardLETLeaves(event.NewLeaves)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode new leaves in forward LET: %w", err)
+	}
+
+	newDepositCount := uint32(event.PreviousDepositCount.Uint64()) + 1
+	newBlockPos := event.BlockPos
+	if blockPos != nil {
+		newBlockPos = *blockPos
+	}
+
+	const getArchivedBridgesSQL = `
+		SELECT * FROM bridge_archive
+		WHERE leaf_type = $1
+			AND origin_network = $2
+			AND origin_address = $3
+			AND destination_network = $4
+			AND destination_address = $5
+			AND amount = $6
+			AND metadata = $7
+	`
+
+	// now we process each new leaf to insert them into the exit tree and bridges table
+	for _, leaf := range decodedNewLeaves {
+		var archivedBridges []*Bridge
+		err = meddler.QueryAll(tx, &archivedBridges, getArchivedBridgesSQL,
+			leaf.LeafType,
+			leaf.OriginNetwork,
+			leaf.OriginAddress,
+			leaf.DestinationNetwork,
+			leaf.DestinationAddress,
+			leaf.Amount.String(),
+			leaf.Metadata,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("failed to query archived bridges: %w", err)
+		}
+
+		var (
+			txnHash             = event.TxnHash
+			txnSender, fromAddr common.Address
+		)
+
+		// let's see if we have exactly one archived bridge that matches the forward LET leaf
+		// usually we should have exactly one match since to recover the LET on L2,
+		// we must have a backwards LET done which archives the bridges,
+		// and then a forward LET that re-adds them to the exit tree after fixing it
+		// however, in case of multiple matches, we cannot be sure which one to use,
+		// so we will just log and leave the txnSender and fromAddr fields empty
+		if len(archivedBridges) == 1 {
+			archivedBridge := archivedBridges[0]
+			txnHash = archivedBridge.TxHash
+			txnSender = archivedBridge.TxnSender
+			fromAddr = archivedBridge.FromAddress
+		} else if len(archivedBridges) > 1 {
+			p.log.Debugf("multiple archived bridges found that match forward LET leaf %s;"+
+				"cannot set txnSender and fromAddr fields to the bridge", leaf.String())
+		}
+
+		// create the new bridge event from the forward LET leaf
+		bridge := leaf.ToBridge(
+			event.BlockNum,
+			newBlockPos,
+			event.BlockTimestamp,
+			newDepositCount,
+			txnHash,
+			txnSender,
+			fromAddr,
+		)
+
+		// insert the new bridge leaf into the local exit tree
+		if _, err = p.exitTree.PutLeaf(tx, event.BlockNum, newBlockPos, types.Leaf{
+			Index: newDepositCount,
+			Hash:  bridge.Hash(),
+		}); err != nil {
+			if errors.Is(err, tree.ErrInvalidIndex) {
+				p.halt(fmt.Sprintf("error adding leaf to the exit tree: %v", err))
+			}
+			return 0, sync.ErrInconsistentState
+		}
+
+		// insert the new bridge into the bridges table
+		if err = meddler.Insert(tx, bridgeTableName, &bridge); err != nil {
+			return 0, fmt.Errorf("failed to insert bridge event from ForwardLET: %w", err)
+		}
+
+		newDepositCount++
+		newBlockPos++
+	}
+
+	// after processing all new leaves, we sanity check that the new root matches the latest one in the exit tree
+	if err := p.sanityCheckLatestLER(tx, event.NewRoot); err != nil {
+		return 0, fmt.Errorf("failed to sanity check LER after processing ForwardLET: %w", err)
+	}
+
+	// finally, insert the forward LET event into the designated table
+	if err = meddler.Insert(tx, forwardLETTableName, event); err != nil {
+		return 0, fmt.Errorf("failed to insert forward local exit tree event: %w", err)
+	}
+
+	return newBlockPos, nil
 }
 
 // GetTotalNumberOfRecords returns the total number of records in the given table

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -1392,7 +1392,7 @@ func (p *processor) restoreBackwardLETBridges(tx dbtypes.Txer, backwardLETs []*B
 	restoreQuery := `
 		SELECT *
 		FROM bridge_archive
-		WHERE deposit_count > $1 AND deposit_count <= $2
+		WHERE deposit_count >= $1 AND deposit_count <= $2
 		ORDER BY deposit_count ASC
 	`
 
@@ -1436,7 +1436,7 @@ func (p *processor) restoreBackwardLETBridges(tx dbtypes.Txer, backwardLETs []*B
 		// cleanup bridge_archive
 		if _, err := tx.Exec(`
 			DELETE FROM bridge_archive
-			WHERE deposit_count > $1 AND deposit_count <= $2
+			WHERE deposit_count >= $1 AND deposit_count <= $2
 		`, next, prev); err != nil {
 			return err
 		}

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -92,10 +92,10 @@ const (
 
 	// bridgeByDepositCountSQL is the query used by GetBridgeByDepositCount for the main bridge table.
 	bridgeByDepositCountSQL = "SELECT * FROM " + bridgeTableName +
-		" WHERE deposit_count = $1 AND origin_network = 0 LIMIT 1"
+		" WHERE deposit_count = $1 LIMIT 1"
 
 	// archiveByDepositCountSQL is the query used by GetBridgeByDepositCount for bridge_archive.
-	archiveByDepositCountSQL = `SELECT * FROM bridge_archive WHERE deposit_count = $1 AND origin_network = 0 LIMIT 1`
+	archiveByDepositCountSQL = `SELECT * FROM bridge_archive WHERE deposit_count = $1 LIMIT 1`
 
 	// bridgesByContentWhereNoMeta is the WHERE clause for GetBridgesByContent without metadata.
 	bridgesByContentWhereNoMeta = "origin_network = 0 AND leaf_type = $1 AND origin_address = $2" +
@@ -668,6 +668,7 @@ type processor struct {
 	halted         bool
 	haltedReason   string
 	dbQueryTimeout time.Duration
+	initialLER     common.Hash
 	compatibility.CompatibilityDataStorager[BridgeSyncRuntimeData]
 }
 
@@ -676,6 +677,16 @@ func newProcessor(
 	syncerID string,
 	logger *log.Logger,
 	dbQueryTimeout time.Duration,
+) (*processor, error) {
+	return newProcessorWithInitialLER(dbPath, syncerID, logger, dbQueryTimeout, common.Hash{})
+}
+
+func newProcessorWithInitialLER(
+	dbPath string,
+	syncerID string,
+	logger *log.Logger,
+	dbQueryTimeout time.Duration,
+	initialLER common.Hash,
 ) (*processor, error) {
 	err := migrations.RunMigrations(dbPath)
 	if err != nil {
@@ -694,6 +705,7 @@ func newProcessor(
 		exitTree:       exitTree,
 		log:            logger,
 		dbQueryTimeout: dbQueryTimeout,
+		initialLER:     initialLER,
 		CompatibilityDataStorager: compatibility.NewKeyValueToCompatibilityStorage[BridgeSyncRuntimeData](
 			db.NewKeyValueStorage(database),
 			syncerID,
@@ -1576,18 +1588,25 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			}
 
 			// 1. archive and remove all the bridges whose
-			// deposit_count is greater than the one captured by the BackwardLET event
+			// deposit_count is greater than or equal to the one captured by the BackwardLET event
 			err = p.archiveAndDeleteBridgesAbove(ctx, tx, newDepositCount)
 			if err != nil {
-				return fmt.Errorf("failed to delete bridges above deposit count %d: %w",
+				return fmt.Errorf("failed to delete bridges starting from deposit count %d: %w",
 					newDepositCount, err)
 			}
 
-			// 2. remove all leafs from the exit tree with indices greater than leafIndex in the exit tree
-			if err := p.exitTree.BackwardToIndex(ctx, tx, leafIndex); err != nil {
-				p.log.Errorf("failed to backward local exit tree to leaf index %d (deposit count: %d)",
-					leafIndex, newDepositCount)
-				return err
+			// 2. remove all leafs from the exit tree with indices greater than or equal to leafIndex
+			if leafIndex == 0 {
+				if err := p.exitTree.Reorg(tx, 0); err != nil {
+					p.log.Errorf("failed to clear local exit tree (deposit count: %d)", newDepositCount)
+					return err
+				}
+			} else {
+				if err := p.exitTree.BackwardToIndex(ctx, tx, leafIndex-1); err != nil {
+					p.log.Errorf("failed to backward local exit tree to leaf index %d (deposit count: %d)",
+						leafIndex-1, newDepositCount)
+					return err
+				}
 			}
 
 			// 4. sanity check that the new root matches the latest one in the exit tree
@@ -1656,10 +1675,11 @@ func normalizeDepositCount(depositCount *big.Int) (uint64, uint32, error) {
 	return u64, u32, nil
 }
 
-// archiveAndDeleteBridgesAbove archives and removes all the bridges whose depositCount is greater than the provided one
+// archiveAndDeleteBridgesAbove archives and removes all bridges whose depositCount is greater than or equal
+// to the provided one.
 func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes.Txer, depositCount uint64) error {
 	// 1. Load candidates
-	query := fmt.Sprintf(`SELECT * FROM %s WHERE deposit_count > $1`, bridgeTableName)
+	query := fmt.Sprintf(`SELECT * FROM %s WHERE deposit_count >= $1`, bridgeTableName)
 	var bridges []*Bridge
 	if err := meddler.QueryAll(tx, &bridges, query, depositCount); err != nil {
 		return err
@@ -1672,9 +1692,20 @@ func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes
 	deletedDepositCounts := make([]uint32, 0, len(bridges))
 	// 2. Archive
 	for _, b := range bridges {
-		b.Source = BridgeSourceBackwardLET
-		if err := meddler.Insert(tx, "bridge_archive", b); err != nil {
-			return err
+		var existing int
+		if err := tx.QueryRowContext(
+			ctx,
+			"SELECT COUNT(*) FROM bridge_archive WHERE deposit_count = $1",
+			b.DepositCount,
+		).Scan(&existing); err != nil {
+			return fmt.Errorf("failed to query bridge_archive for deposit_count %d: %w", b.DepositCount, err)
+		}
+
+		if existing == 0 {
+			b.Source = BridgeSourceBackwardLET
+			if err := meddler.Insert(tx, "bridge_archive", b); err != nil {
+				return err
+			}
 		}
 		deletedDepositCounts = append(deletedDepositCounts, b.DepositCount)
 	}
@@ -1682,7 +1713,7 @@ func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes
 	// 3. Delete originals
 	deleteQuery := fmt.Sprintf(`
 		DELETE FROM %s
-		WHERE deposit_count > $1`,
+		WHERE deposit_count >= $1`,
 		bridgeTableName)
 
 	_, err := tx.ExecContext(ctx, deleteQuery, depositCount)
@@ -1691,7 +1722,7 @@ func (p *processor) archiveAndDeleteBridgesAbove(ctx context.Context, tx dbtypes
 	}
 
 	if len(deletedDepositCounts) > 0 {
-		p.log.Debugf("BackwardLET archived + removed %d bridges with deposit_count > %d: %v",
+		p.log.Debugf("BackwardLET archived + removed %d bridges with deposit_count >= %d: %v",
 			len(deletedDepositCounts), depositCount, deletedDepositCounts,
 		)
 	}
@@ -1714,6 +1745,9 @@ func (p *processor) sanityCheckLatestLER(tx dbtypes.Txer, ler common.Hash) error
 	}
 
 	if lastRootHash != ler {
+		if ler == p.initialLER && lastRootHash == aggkitcommon.ZeroHash {
+			return nil
+		}
 		return fmt.Errorf("local exit root mismatch: expected %s, got %s",
 			ler.String(), lastRootHash.String())
 	}
@@ -1734,7 +1768,10 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 		return 0, fmt.Errorf("failed to decode new leaves in forward LET: %w", err)
 	}
 
-	newDepositCount := uint32(event.PreviousDepositCount.Uint64()) + 1
+	var newDepositCount uint32
+	if event.PreviousRoot != p.initialLER {
+		newDepositCount = uint32(event.PreviousDepositCount.Uint64())
+	}
 	newBlockPos := event.BlockPos
 	if blockPos != nil {
 		newBlockPos = *blockPos
@@ -1772,18 +1809,16 @@ func (p *processor) handleForwardLETEvent(tx dbtypes.Txer, event *ForwardLET, bl
 			txnSender, fromAddr common.Address
 		)
 
-		// let's see if we have exactly one archived bridge that matches the forward LET leaf
-		// usually we should have exactly one match since to recover the LET on L2,
-		// we must have a backwards LET done which archives the bridges,
-		// and then a forward LET that re-adds them to the exit tree after fixing it
-		// however, in case of multiple matches, we cannot be sure which one to use,
-		// so we will just log and leave the txnSender and fromAddr fields empty
-		if len(archivedBridges) == 1 {
+		// If a matching archived bridge exists, reuse its original transaction fields.
+		switch len(archivedBridges) {
+		case 1:
 			archivedBridge := archivedBridges[0]
 			txnHash = archivedBridge.TxHash
 			txnSender = archivedBridge.TxnSender
 			fromAddr = archivedBridge.FromAddress
-		} else if len(archivedBridges) > 1 {
+		case 0:
+			p.log.Debugf("no archived bridge found that matches forward LET leaf %s", leaf.String())
+		default:
 			p.log.Debugf("multiple archived bridges found that match forward LET leaf %s;"+
 				"cannot set txnSender and fromAddr fields to the bridge", leaf.String())
 		}

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -490,7 +490,7 @@ var (
 				PreviousDepositCount: big.NewInt(3),
 				NewDepositCount:      big.NewInt(2),
 				PreviousRoot:         common.HexToHash("0x15cd4b94cacc2cf50d055e1adb5fbfe5cd95485e121a5c411d73e263f2a66685"),
-				NewRoot:              common.HexToHash("0xa03113d9ce128863f29479689c82d0b37ebc9432c569c3a57f22d6c008256c5b"),
+				NewRoot:              common.HexToHash("0x3edb955a657301c8007f91a0e8d2fcf7017f3dadd194aad8340018b5a5a580fa"),
 			}},
 		},
 	}
@@ -5328,15 +5328,15 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							PreviousDepositCount: big.NewInt(3),
 							NewDepositCount:      big.NewInt(2),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
-							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
+							NewRoot:              common.HexToHash("0x0cc5d7d6281795bc0a4d3dff706ef63097c4eb288a311aa2b3098e838f9d9248"),
 						}},
 					},
 				})
 
 				return blocks
 			},
-			targetDepositCount:    2,
-			archivedDepositCounts: []uint32{3},
+			targetDepositCount:    1,
+			archivedDepositCounts: []uint32{2, 3, 4, 5},
 		},
 		{
 			name: "backward let event with all the bridges, except the first one",
@@ -5350,7 +5350,7 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockNum:             uint64(len(blocks) + 1),
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
-							NewDepositCount:      big.NewInt(0),
+							NewDepositCount:      big.NewInt(1),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
 							NewRoot:              common.HexToHash("0x283c52c3d10a22d01f95f5bcab5e823675c9855bd40b1e82f32b0437b3b6a446"),
 						}},
@@ -5376,7 +5376,7 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(4),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
-							NewRoot:              common.HexToHash("0x44e1bf8449ecec2b8b1d123fab00d33c9acb308e590605adf5f6e2de4d1c1133"),
+							NewRoot:              common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
 						}},
 					},
 				}
@@ -5384,13 +5384,13 @@ func TestProcessor_BackwardLET(t *testing.T) {
 
 				return blocks
 			},
-			targetDepositCount:    4,
-			archivedDepositCounts: []uint32{5},
+			targetDepositCount:    3,
+			archivedDepositCounts: []uint32{4, 5},
 		},
 		{
 			name: "backward let event in the middle of bridges",
 			setupBlocks: func() []sync.Block {
-				blocks := buildBlocksWithSequentialBridges(2, 3, 0, 0)
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
 				backwardLETBlock := sync.Block{
 					Num:  uint64(len(blocks) + 1),
 					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
@@ -5401,18 +5401,18 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(2),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
-							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
+							NewRoot:              common.HexToHash("0x0cc5d7d6281795bc0a4d3dff706ef63097c4eb288a311aa2b3098e838f9d9248"),
 						}},
 					},
 				}
 				blocks = append(blocks, backwardLETBlock)
-				blocks = append(blocks, buildBlocksWithSequentialBridges(3, 2, uint64(len(blocks)), 3)...)
+				blocks = append(blocks, buildBlocksWithSequentialBridges(3, 2, uint64(len(blocks)), 2)...)
 
 				return blocks
 			},
-			targetDepositCount:    8,
+			targetDepositCount:    7,
 			skipBlocks:            []uint64{2, 3}, // all the bridges from these blocks were backwarded
-			archivedDepositCounts: []uint32{3, 4, 5},
+			archivedDepositCounts: []uint32{2, 3, 4, 5},
 		},
 		{
 			name: "overlapping backward let events",
@@ -5428,7 +5428,7 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(3),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
-							NewRoot:              common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
+							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
 						}},
 					},
 				})
@@ -5441,16 +5441,16 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(4),
 							NewDepositCount:      big.NewInt(3),
-							PreviousRoot:         common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
-							NewRoot:              common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
+							PreviousRoot:         common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
+							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
 						}},
 					},
 				})
 
 				return blocks
 			},
-			targetDepositCount:    3,
-			archivedDepositCounts: []uint32{4, 5},
+			targetDepositCount:    2,
+			archivedDepositCounts: []uint32{3, 4, 5},
 		},
 		{
 			name: "backward let on empty bridge table",
@@ -5523,7 +5523,7 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(2),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
-							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
+							NewRoot:              common.HexToHash("0x0cc5d7d6281795bc0a4d3dff706ef63097c4eb288a311aa2b3098e838f9d9248"),
 						}},
 					},
 				}
@@ -5533,12 +5533,12 @@ func TestProcessor_BackwardLET(t *testing.T) {
 			},
 			firstReorgedBlock:     uint64Ptr(3),
 			targetDepositCount:    3,
-			archivedDepositCounts: []uint32{3},
+			archivedDepositCounts: []uint32{2, 3, 4, 5},
 		},
 		{
 			name: "backward let event in the middle of bridges + reorg backward let",
 			setupBlocks: func() []sync.Block {
-				blocks := buildBlocksWithSequentialBridges(2, 3, 0, 0)
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
 				backwardLETBlock := sync.Block{
 					Num:  uint64(len(blocks) + 1),
 					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
@@ -5549,18 +5549,18 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(2),
 							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
-							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
+							NewRoot:              common.HexToHash("0x0cc5d7d6281795bc0a4d3dff706ef63097c4eb288a311aa2b3098e838f9d9248"),
 						}},
 					},
 				}
 				blocks = append(blocks, backwardLETBlock)
-				blocks = append(blocks, buildBlocksWithSequentialBridges(3, 2, uint64(len(blocks)), 3)...)
+				blocks = append(blocks, buildBlocksWithSequentialBridges(3, 2, uint64(len(blocks)), 2)...)
 
 				return blocks
 			},
 			firstReorgedBlock:     uint64Ptr(3),
-			targetDepositCount:    5,
-			archivedDepositCounts: []uint32{3, 4, 5},
+			targetDepositCount:    3,
+			archivedDepositCounts: []uint32{2, 3, 4, 5},
 		},
 	}
 
@@ -5766,7 +5766,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             5,
 			BlockTimestamp:       1234567890,
 			TxnHash:              common.HexToHash("0xabc123"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewLeaves:            encodedLeaves,
@@ -5871,7 +5871,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             10,
 			BlockTimestamp:       1234567900,
 			TxnHash:              common.HexToHash("0xdef456"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + uint32(len(leaves)))),
 			NewLeaves:            encodedLeaves,
@@ -5970,7 +5970,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             20,
 			BlockTimestamp:       1234567950,
 			TxnHash:              common.HexToHash("0xforward789"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewLeaves:            encodedLeaves,
@@ -6079,7 +6079,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             30,
 			BlockTimestamp:       1234567999,
 			TxnHash:              common.HexToHash("0xforward999"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewLeaves:            encodedLeaves,
@@ -6140,7 +6140,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             5,
 			BlockTimestamp:       1234567890,
 			TxnHash:              common.HexToHash("0xabc123"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         common.HexToHash("0xWRONG"), // Wrong root
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewRoot:              common.HexToHash("0x999"),
@@ -6197,7 +6197,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             5,
 			BlockTimestamp:       1234567890,
 			TxnHash:              common.HexToHash("0xabc123"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewRoot:              common.HexToHash("0xWRONG"), // Wrong new root
@@ -6230,7 +6230,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             5,
 			BlockTimestamp:       1234567890,
 			TxnHash:              common.HexToHash("0xabc123"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewRoot:              common.Hash{},
@@ -6285,7 +6285,7 @@ func TestHandleForwardLETEvent(t *testing.T) {
 			BlockPos:             5,
 			BlockTimestamp:       1234567890,
 			TxnHash:              common.HexToHash("0xabc123"),
-			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount + 1)),
 			PreviousRoot:         initialRoot,
 			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
 			NewLeaves:            encodedLeaves,

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -19,10 +19,13 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/polygonzkevmbridge"
+	aggkitabi "github.com/agglayer/aggkit/abi"
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync/migrations"
 	bridgesynctypes "github.com/agglayer/aggkit/bridgesync/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/db"
+	dbtypes "github.com/agglayer/aggkit/db/types"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
 	"github.com/agglayer/aggkit/tree/testvectors"
@@ -486,6 +489,8 @@ var (
 				BlockPos:             4,
 				PreviousDepositCount: big.NewInt(3),
 				NewDepositCount:      big.NewInt(2),
+				PreviousRoot:         common.HexToHash("0x15cd4b94cacc2cf50d055e1adb5fbfe5cd95485e121a5c411d73e263f2a66685"),
+				NewRoot:              common.HexToHash("0xa03113d9ce128863f29479689c82d0b37ebc9432c569c3a57f22d6c008256c5b"),
 			}},
 		},
 	}
@@ -5322,6 +5327,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(3),
 							NewDepositCount:      big.NewInt(2),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
 						}},
 					},
 				})
@@ -5344,6 +5351,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(0),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0x283c52c3d10a22d01f95f5bcab5e823675c9855bd40b1e82f32b0437b3b6a446"),
 						}},
 					},
 				})
@@ -5366,6 +5375,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(4),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0x44e1bf8449ecec2b8b1d123fab00d33c9acb308e590605adf5f6e2de4d1c1133"),
 						}},
 					},
 				}
@@ -5389,6 +5400,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(2),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
 						}},
 					},
 				}
@@ -5414,6 +5427,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(3),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
 						}},
 					},
 				})
@@ -5426,6 +5441,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(4),
 							NewDepositCount:      big.NewInt(3),
+							PreviousRoot:         common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
+							NewRoot:              common.HexToHash("0x7533c9ef58edd0bea7959a20c33ed47e5548d35f4ff140c5c915740fe6800fb8"),
 						}},
 					},
 				})
@@ -5505,6 +5522,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(2),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
 						}},
 					},
 				}
@@ -5529,6 +5548,8 @@ func TestProcessor_BackwardLET(t *testing.T) {
 							BlockPos:             0,
 							PreviousDepositCount: big.NewInt(5),
 							NewDepositCount:      big.NewInt(2),
+							PreviousRoot:         common.HexToHash("0x9ba667158a062be548e5c1b2e8a9a2ad03b693e562535b0723880627c6664b02"),
+							NewRoot:              common.HexToHash("0xa9d31ebbb97c7cd7c7103bee8af7d0b4c83771939baba0b415b0f94c4c39fd84"),
 						}},
 					},
 				}
@@ -5562,7 +5583,7 @@ func TestProcessor_BackwardLET(t *testing.T) {
 
 			if len(c.archivedDepositCounts) > 0 {
 				archivedBridgeQuery := `
-					SELECT * FROM bridge_archive 
+					SELECT * FROM bridge_archive
 					WHERE deposit_count <= $1
 					ORDER BY deposit_count ASC`
 
@@ -5700,4 +5721,719 @@ func TestGetBoundaryBlock(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleForwardLETEvent(t *testing.T) {
+	t.Run("successfully process single leaf with no archived bridge", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves to establish previous root (indices 0-4)
+		var initialRoot common.Hash
+		var err error
+		// Insert block rows for initial leaves
+		for i := uint32(0); i <= 4; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, 10+uint64(i))
+			require.NoError(t, err)
+		}
+		for i := uint32(0); i <= 4; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 10+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(4) // Last index inserted
+
+		// Insert block for the ForwardLET event
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, uint64(100))
+		require.NoError(t, err)
+
+		// Create forward LET event with one leaf
+		leaves := []LeafData{
+			{
+				LeafType:           1,
+				OriginNetwork:      5,
+				OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				DestinationNetwork: 10,
+				DestinationAddress: common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				Amount:             big.NewInt(1000000),
+				Metadata:           []byte("test metadata"),
+			},
+		}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             100,
+			BlockPos:             5,
+			BlockTimestamp:       1234567890,
+			TxnHash:              common.HexToHash("0xabc123"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Calculate the expected root that will result from processing these leaves
+		event.NewRoot = calculateExpectedRootAfterForwardLET(t, initialDepositCount, leaves, event)
+
+		// Test: Process the forward LET event
+		blockPos := event.BlockPos
+		newBlockPos, err := p.handleForwardLETEvent(tx, event, &blockPos)
+		require.NoError(t, err)
+		require.Equal(t, event.BlockPos+1, newBlockPos)
+
+		// Verify: Bridge was inserted
+		var bridges []*Bridge
+		err = meddler.QueryAll(tx, &bridges, "SELECT * FROM bridge WHERE block_num = $1", event.BlockNum)
+		require.NoError(t, err)
+		require.Len(t, bridges, 1)
+
+		bridge := bridges[0]
+		require.Equal(t, event.BlockNum, bridge.BlockNum)
+		require.Equal(t, event.BlockPos, bridge.BlockPos)
+		require.Equal(t, leaves[0].LeafType, bridge.LeafType)
+		require.Equal(t, leaves[0].OriginNetwork, bridge.OriginNetwork)
+		require.Equal(t, leaves[0].OriginAddress, bridge.OriginAddress)
+		require.Equal(t, leaves[0].DestinationNetwork, bridge.DestinationNetwork)
+		require.Equal(t, leaves[0].DestinationAddress, bridge.DestinationAddress)
+		require.Equal(t, 0, leaves[0].Amount.Cmp(bridge.Amount))
+		require.Equal(t, leaves[0].Metadata, bridge.Metadata)
+		require.Equal(t, initialDepositCount+1, bridge.DepositCount)
+		require.Equal(t, event.TxnHash, bridge.TxHash)
+		require.Equal(t, aggkitcommon.ZeroAddress, bridge.TxnSender)
+		require.Equal(t, aggkitcommon.ZeroAddress, bridge.FromAddress)
+		require.Equal(t, BridgeSourceForwardLET, bridge.Source)
+
+		// Verify: ForwardLET event was inserted
+		var forwardLETs []*ForwardLET
+		err = meddler.QueryAll(tx, &forwardLETs, "SELECT * FROM forward_let WHERE block_num = $1", event.BlockNum)
+		require.NoError(t, err)
+		require.Len(t, forwardLETs, 1)
+		require.Equal(t, event.BlockNum, forwardLETs[0].BlockNum)
+	})
+
+	t.Run("successfully process multiple leaves", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-9)
+		var initialRoot common.Hash
+		var err error
+		// Insert block rows for initial leaves
+		for i := uint32(0); i <= 9; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, 20+uint64(i))
+			require.NoError(t, err)
+		}
+		for i := uint32(0); i <= 9; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 20+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(9) // Last index inserted
+
+		// Insert block for the ForwardLET event
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, uint64(200))
+		require.NoError(t, err)
+
+		// Create forward LET event with three leaves
+		leaves := []LeafData{
+			{
+				LeafType:           0,
+				OriginNetwork:      1,
+				OriginAddress:      common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				DestinationNetwork: 2,
+				DestinationAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+				Amount:             big.NewInt(100),
+				Metadata:           []byte("first"),
+			},
+			{
+				LeafType:           1,
+				OriginNetwork:      3,
+				OriginAddress:      common.HexToAddress("0x3333333333333333333333333333333333333333"),
+				DestinationNetwork: 4,
+				DestinationAddress: common.HexToAddress("0x4444444444444444444444444444444444444444"),
+				Amount:             big.NewInt(200),
+				Metadata:           []byte("second"),
+			},
+			{
+				LeafType:           2,
+				OriginNetwork:      5,
+				OriginAddress:      common.HexToAddress("0x5555555555555555555555555555555555555555"),
+				DestinationNetwork: 6,
+				DestinationAddress: common.HexToAddress("0x6666666666666666666666666666666666666666"),
+				Amount:             big.NewInt(300),
+				Metadata:           []byte("third"),
+			},
+		}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             200,
+			BlockPos:             10,
+			BlockTimestamp:       1234567900,
+			TxnHash:              common.HexToHash("0xdef456"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + uint32(len(leaves)))),
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Calculate the expected root that will result from processing these leaves
+		event.NewRoot = calculateExpectedRootAfterForwardLET(t, initialDepositCount, leaves, event)
+
+		// Test: Process the forward LET event
+		blockPos := event.BlockPos
+		newBlockPos, err := p.handleForwardLETEvent(tx, event, &blockPos)
+		require.NoError(t, err)
+		require.Equal(t, event.BlockPos+uint64(len(leaves)), newBlockPos)
+
+		// Verify: All bridges were inserted
+		var bridges []*Bridge
+		err = meddler.QueryAll(tx, &bridges, "SELECT * FROM bridge WHERE block_num = $1 ORDER BY block_pos", event.BlockNum)
+		require.NoError(t, err)
+		require.Len(t, bridges, 3)
+
+		// Verify each bridge
+		for i, bridge := range bridges {
+			require.Equal(t, event.BlockNum, bridge.BlockNum)
+			require.Equal(t, event.BlockPos+uint64(i), bridge.BlockPos)
+			require.Equal(t, leaves[i].LeafType, bridge.LeafType)
+			require.Equal(t, leaves[i].OriginNetwork, bridge.OriginNetwork)
+			require.Equal(t, initialDepositCount+uint32(i)+1, bridge.DepositCount)
+			require.Equal(t, BridgeSourceForwardLET, bridge.Source)
+		}
+	})
+
+	t.Run("process leaf with matching archived bridge", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-14)
+		var initialRoot common.Hash
+		var err error
+		// Insert block rows for initial leaves
+		for i := uint32(0); i <= 14; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, 30+uint64(i))
+			require.NoError(t, err)
+		}
+		for i := uint32(0); i <= 14; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 30+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(14) // Last index inserted
+
+		// Insert blocks for the archived bridge and ForwardLET event
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1), ($2)`, uint64(50), uint64(300))
+		require.NoError(t, err)
+
+		// Setup: Create and archive a bridge that will match the forward LET leaf
+		archivedTxHash := common.HexToHash("0xoriginal123")
+		archivedTxnSender := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		archivedFromAddr := common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+		archivedBridge := &Bridge{
+			BlockNum:           50,
+			BlockPos:           0,
+			LeafType:           1,
+			OriginNetwork:      7,
+			OriginAddress:      common.HexToAddress("0x7777777777777777777777777777777777777777"),
+			DestinationNetwork: 8,
+			DestinationAddress: common.HexToAddress("0x8888888888888888888888888888888888888888"),
+			Amount:             big.NewInt(500000),
+			Metadata:           []byte("archived metadata"),
+			DepositCount:       20,
+			TxHash:             archivedTxHash,
+			TxnSender:          archivedTxnSender,
+			FromAddress:        archivedFromAddr,
+			// Don't set Source - bridge_archive table doesn't have this column
+		}
+		// Insert manually to avoid Source field
+		err = meddler.Insert(tx, "bridge_archive", archivedBridge)
+		require.NoError(t, err)
+
+		// Create forward LET event with matching leaf
+		leaves := []LeafData{
+			{
+				LeafType:           archivedBridge.LeafType,
+				OriginNetwork:      archivedBridge.OriginNetwork,
+				OriginAddress:      archivedBridge.OriginAddress,
+				DestinationNetwork: archivedBridge.DestinationNetwork,
+				DestinationAddress: archivedBridge.DestinationAddress,
+				Amount:             archivedBridge.Amount,
+				Metadata:           archivedBridge.Metadata,
+			},
+		}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             300,
+			BlockPos:             20,
+			BlockTimestamp:       1234567950,
+			TxnHash:              common.HexToHash("0xforward789"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Calculate expected new root using helper (which will query for archived bridge)
+		event.NewRoot = calculateExpectedRootAfterForwardLET(t, initialDepositCount, leaves, event, archivedBridge)
+
+		// Test: Process the forward LET event
+		blockPos := event.BlockPos
+		newBlockPos, err := p.handleForwardLETEvent(tx, event, &blockPos)
+		require.NoError(t, err)
+		require.Equal(t, event.BlockPos+1, newBlockPos)
+
+		// Verify: Bridge was inserted with archived tx info
+		var bridges []*Bridge
+		err = meddler.QueryAll(tx, &bridges, "SELECT * FROM bridge WHERE block_num = $1", event.BlockNum)
+		require.NoError(t, err)
+		require.Len(t, bridges, 1)
+
+		bridge := bridges[0]
+		require.Equal(t, archivedTxHash, bridge.TxHash, "Should use archived tx hash")
+		require.Equal(t, archivedTxnSender, bridge.TxnSender, "Should use archived txn sender")
+		require.Equal(t, archivedFromAddr, bridge.FromAddress, "Should use archived from address")
+		require.Equal(t, BridgeSourceForwardLET, bridge.Source)
+	})
+
+	t.Run("process leaf with multiple matching archived bridges", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-24)
+		var initialRoot common.Hash
+		var err error
+		// Insert block rows for initial leaves
+		for i := uint32(0); i <= 24; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, 40+uint64(i))
+			require.NoError(t, err)
+		}
+		for i := uint32(0); i <= 24; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 40+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(24) // Last index inserted
+
+		// Insert blocks for archived bridges (60, 61 already exist from initial leaves) and ForwardLET event
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, uint64(400))
+		require.NoError(t, err)
+
+		// Setup: Create two archived bridges with identical LeafData fields
+		commonLeafData := LeafData{
+			LeafType:           1,
+			OriginNetwork:      9,
+			OriginAddress:      common.HexToAddress("0x9999999999999999999999999999999999999999"),
+			DestinationNetwork: 11,
+			DestinationAddress: common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			Amount:             big.NewInt(750000),
+			Metadata:           []byte("duplicate metadata"),
+		}
+
+		archivedBridge1 := &Bridge{
+			BlockNum:           60,
+			BlockPos:           0,
+			LeafType:           commonLeafData.LeafType,
+			OriginNetwork:      commonLeafData.OriginNetwork,
+			OriginAddress:      commonLeafData.OriginAddress,
+			DestinationNetwork: commonLeafData.DestinationNetwork,
+			DestinationAddress: commonLeafData.DestinationAddress,
+			Amount:             commonLeafData.Amount,
+			Metadata:           commonLeafData.Metadata,
+			DepositCount:       30,
+			TxHash:             common.HexToHash("0xfirst111"),
+			TxnSender:          common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			FromAddress:        common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		}
+
+		archivedBridge2 := &Bridge{
+			BlockNum:           61,
+			BlockPos:           0,
+			LeafType:           commonLeafData.LeafType,
+			OriginNetwork:      commonLeafData.OriginNetwork,
+			OriginAddress:      commonLeafData.OriginAddress,
+			DestinationNetwork: commonLeafData.DestinationNetwork,
+			DestinationAddress: commonLeafData.DestinationAddress,
+			Amount:             commonLeafData.Amount,
+			Metadata:           commonLeafData.Metadata,
+			DepositCount:       31,
+			TxHash:             common.HexToHash("0xsecond222"),
+			TxnSender:          common.HexToAddress("0x3333333333333333333333333333333333333333"),
+			FromAddress:        common.HexToAddress("0x4444444444444444444444444444444444444444"),
+		}
+
+		// Insert both archived bridges manually (to avoid Source column)
+		for _, archived := range []*Bridge{archivedBridge1, archivedBridge2} {
+			err = meddler.Insert(tx, "bridge_archive", archived)
+			require.NoError(t, err)
+		}
+
+		// Create forward LET event with the common leaf
+		leaves := []LeafData{commonLeafData}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             400,
+			BlockPos:             30,
+			BlockTimestamp:       1234567999,
+			TxnHash:              common.HexToHash("0xforward999"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Calculate expected new root using helper (with no archived bridge info since multiple matches)
+		event.NewRoot = calculateExpectedRootAfterForwardLET(t, initialDepositCount, leaves, event)
+
+		// Test: Process the forward LET event
+		blockPos := event.BlockPos
+		newBlockPos, err := p.handleForwardLETEvent(tx, event, &blockPos)
+		require.NoError(t, err)
+		require.Equal(t, event.BlockPos+1, newBlockPos)
+
+		// Verify: Bridge was inserted with event's tx hash and empty addresses
+		var bridges []*Bridge
+		err = meddler.QueryAll(tx, &bridges, "SELECT * FROM bridge WHERE block_num = $1", event.BlockNum)
+		require.NoError(t, err)
+		require.Len(t, bridges, 1)
+
+		bridge := bridges[0]
+		require.Equal(t, event.TxnHash, bridge.TxHash, "Should use event's tx hash when multiple archived bridges match")
+		require.Equal(t, common.Address{}, bridge.TxnSender, "TxnSender should be empty with multiple matches")
+		require.Equal(t, common.Address{}, bridge.FromAddress, "FromAddress should be empty with multiple matches")
+		require.Equal(t, BridgeSourceForwardLET, bridge.Source)
+	})
+
+	t.Run("error on previous root mismatch", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-4)
+		var initialRoot common.Hash
+		var err error
+		for i := uint32(0); i <= 4; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 10+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(4) // Last index inserted
+
+		// Create forward LET event with WRONG previous root
+		leaves := []LeafData{
+			{
+				LeafType:           1,
+				OriginNetwork:      5,
+				OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				DestinationNetwork: 10,
+				DestinationAddress: common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				Amount:             big.NewInt(1000000),
+				Metadata:           []byte("test"),
+			},
+		}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             100,
+			BlockPos:             5,
+			BlockTimestamp:       1234567890,
+			TxnHash:              common.HexToHash("0xabc123"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         common.HexToHash("0xWRONG"), // Wrong root
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewRoot:              common.HexToHash("0x999"),
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Test: Should fail with root mismatch
+		blockPos := event.BlockPos
+		_, err = p.handleForwardLETEvent(tx, event, &blockPos)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "local exit root mismatch")
+		require.Contains(t, err.Error(), initialRoot.String())
+	})
+
+	t.Run("error on new root mismatch", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-4)
+		var initialRoot common.Hash
+		var err error
+		// Insert block rows for initial leaves
+		for i := uint32(0); i <= 4; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, 10+uint64(i))
+			require.NoError(t, err)
+		}
+		for i := uint32(0); i <= 4; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 10+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(4) // Last index inserted
+
+		// Insert block for the ForwardLET event
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, uint64(100))
+		require.NoError(t, err)
+
+		// Create forward LET event
+		leaves := []LeafData{
+			{
+				LeafType:           1,
+				OriginNetwork:      5,
+				OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				DestinationNetwork: 10,
+				DestinationAddress: common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				Amount:             big.NewInt(1000000),
+				Metadata:           []byte("test"),
+			},
+		}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             100,
+			BlockPos:             5,
+			BlockTimestamp:       1234567890,
+			TxnHash:              common.HexToHash("0xabc123"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewRoot:              common.HexToHash("0xWRONG"), // Wrong new root
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Test: Should fail with new root mismatch after processing
+		blockPos := event.BlockPos
+		_, err = p.handleForwardLETEvent(tx, event, &blockPos)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "local exit root mismatch")
+	})
+
+	t.Run("error on invalid encoded leaves", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-4)
+		var initialRoot common.Hash
+		var err error
+		for i := uint32(0); i <= 4; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 10+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(4) // Last index inserted
+
+		event := &ForwardLET{
+			BlockNum:             100,
+			BlockPos:             5,
+			BlockTimestamp:       1234567890,
+			TxnHash:              common.HexToHash("0xabc123"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewRoot:              common.Hash{},
+			NewLeaves:            []byte("invalid data"), // Invalid encoding
+		}
+
+		// Test: Should fail to decode leaves
+		blockPos := event.BlockPos
+		_, err = p.handleForwardLETEvent(tx, event, &blockPos)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode new leaves")
+	})
+
+	t.Run("process with nil blockPos parameter", func(t *testing.T) {
+		p, tx := setupProcessorWithTransaction(t)
+		defer tx.Rollback() //nolint:errcheck
+
+		// Setup: Insert initial leaves (indices 0-4)
+		var initialRoot common.Hash
+		var err error
+		// Insert block rows for initial leaves
+		for i := uint32(0); i <= 4; i++ {
+			_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, 10+uint64(i))
+			require.NoError(t, err)
+		}
+		for i := uint32(0); i <= 4; i++ {
+			leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+			initialRoot, err = p.exitTree.PutLeaf(tx, 10+uint64(i), 0, leaf)
+			require.NoError(t, err)
+		}
+		initialDepositCount := uint32(4) // Last index inserted
+
+		// Insert block for the ForwardLET event
+		_, err = tx.Exec(`INSERT INTO block (num) VALUES ($1)`, uint64(100))
+		require.NoError(t, err)
+
+		leaves := []LeafData{
+			{
+				LeafType:           1,
+				OriginNetwork:      5,
+				OriginAddress:      common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				DestinationNetwork: 10,
+				DestinationAddress: common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+				Amount:             big.NewInt(1000000),
+				Metadata:           []byte("test"),
+			},
+		}
+		encodedLeaves := encodeLeafDataArrayForTest(t, leaves)
+
+		event := &ForwardLET{
+			BlockNum:             100,
+			BlockPos:             5,
+			BlockTimestamp:       1234567890,
+			TxnHash:              common.HexToHash("0xabc123"),
+			PreviousDepositCount: big.NewInt(int64(initialDepositCount)),
+			PreviousRoot:         initialRoot,
+			NewDepositCount:      big.NewInt(int64(initialDepositCount + 1)),
+			NewLeaves:            encodedLeaves,
+		}
+
+		// Calculate expected root using helper
+		event.NewRoot = calculateExpectedRootAfterForwardLET(t, initialDepositCount, leaves, event)
+
+		// Test: Process with nil blockPos (should use event.BlockPos)
+		newBlockPos, err := p.handleForwardLETEvent(tx, event, nil)
+		require.NoError(t, err)
+		require.Equal(t, event.BlockPos+1, newBlockPos)
+
+		// Verify: Bridge uses event.BlockPos
+		var bridges []*Bridge
+		err = meddler.QueryAll(tx, &bridges, "SELECT * FROM bridge WHERE block_num = $1", event.BlockNum)
+		require.NoError(t, err)
+		require.Len(t, bridges, 1)
+		require.Equal(t, event.BlockPos, bridges[0].BlockPos)
+	})
+}
+
+// setupProcessorWithTransaction creates a processor and begins a transaction for testing
+func setupProcessorWithTransaction(t *testing.T) (*processor, dbtypes.Txer) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test_forward_let.db")
+	err := migrations.RunMigrations(dbPath)
+	require.NoError(t, err)
+
+	logger := log.WithFields("module", "test")
+	p, err := newProcessor(dbPath, "test", logger, dbQueryTimeout)
+	require.NoError(t, err)
+
+	tx, err := db.NewTx(t.Context(), p.db)
+	require.NoError(t, err)
+
+	return p, tx
+}
+
+// calculateExpectedRootAfterForwardLET calculates what the tree root will be after processing ForwardLET leaves
+// It does this using a completely separate processor to avoid affecting the test state
+// archivedBridges: optional map from leaf index (in leaves slice) to archived bridge info
+func calculateExpectedRootAfterForwardLET(t *testing.T, initialDepositCount uint32,
+	leaves []LeafData, event *ForwardLET, archivedBridges ...*Bridge) common.Hash {
+	t.Helper()
+
+	// Build a map for quick lookup of archived bridge info by leaf data
+	archivedByLeaf := make(map[int]*Bridge)
+	for i, archived := range archivedBridges {
+		if archived != nil {
+			archivedByLeaf[i] = archived
+		}
+	}
+
+	// Create a temporary processor with its own database
+	tempDBPath := filepath.Join(t.TempDir(), "temp_calc.db")
+	err := migrations.RunMigrations(tempDBPath)
+	require.NoError(t, err)
+
+	logger := log.WithFields("module", "test-calc")
+	tempP, err := newProcessor(tempDBPath, "test-calc", logger, dbQueryTimeout)
+	require.NoError(t, err)
+
+	tempTx, err := db.NewTx(t.Context(), tempP.db)
+	require.NoError(t, err)
+	defer tempTx.Rollback() //nolint:errcheck
+
+	// Insert block rows for the setup leaves
+	for i := uint32(0); i <= initialDepositCount; i++ {
+		_, err = tempTx.Exec(`INSERT INTO block (num) VALUES ($1)`, 10+uint64(i))
+		require.NoError(t, err)
+	}
+
+	// Insert block row for the ForwardLET event
+	_, err = tempTx.Exec(`INSERT INTO block (num) VALUES ($1)`, event.BlockNum)
+	require.NoError(t, err)
+
+	// Insert archived bridges if provided
+	for _, archived := range archivedBridges {
+		if archived != nil {
+			_, err = tempTx.Exec(`INSERT INTO block (num) VALUES ($1)`, archived.BlockNum)
+			require.NoError(t, err)
+
+			_, err = tempTx.Exec(`
+				INSERT INTO bridge_archive (
+					block_num, block_pos, leaf_type, origin_network, origin_address,
+					destination_network, destination_address, amount, metadata, deposit_count,
+					tx_hash, block_timestamp, from_address, txn_sender
+				) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 0, $12, $13)
+			`, archived.BlockNum, archived.BlockPos, archived.LeafType,
+				archived.OriginNetwork, archived.OriginAddress.Hex(),
+				archived.DestinationNetwork, archived.DestinationAddress.Hex(),
+				archived.Amount.String(), archived.Metadata, archived.DepositCount,
+				archived.TxHash.Hex(), archived.FromAddress.Hex(), archived.TxnSender.Hex())
+			require.NoError(t, err)
+		}
+	}
+
+	// Rebuild tree state up to initialDepositCount
+	for i := uint32(0); i <= initialDepositCount; i++ {
+		leaf := types.Leaf{Index: i, Hash: common.HexToHash(fmt.Sprintf("0x%d", i))}
+		_, err = tempP.exitTree.PutLeaf(tempTx, 10+uint64(i), 0, leaf)
+		require.NoError(t, err)
+	}
+
+	// Now add the ForwardLET leaves (will query for archived bridges)
+	currentDepositCount := initialDepositCount + 1
+	var newRoot common.Hash
+	for i, leaf := range leaves {
+		// Try to get archived bridge info if available
+		var txHash common.Hash
+		var txnSender, fromAddr common.Address
+		if archived, found := archivedByLeaf[i]; found {
+			txHash = archived.TxHash
+			txnSender = archived.TxnSender
+			fromAddr = archived.FromAddress
+		} else {
+			txHash = event.TxnHash
+			// txnSender and fromAddr remain zero
+		}
+
+		bridge := leaf.ToBridge(
+			event.BlockNum,
+			event.BlockPos+uint64(i),
+			event.BlockTimestamp,
+			currentDepositCount,
+			txHash,
+			txnSender,
+			fromAddr,
+		)
+		newRoot, err = tempP.exitTree.PutLeaf(tempTx, event.BlockNum, event.BlockPos+uint64(i), types.Leaf{
+			Index: currentDepositCount,
+			Hash:  bridge.Hash(),
+		})
+		require.NoError(t, err)
+		currentDepositCount++
+	}
+
+	return newRoot
+}
+
+// encodeLeafDataArrayForTest encodes a slice of LeafData using ABI encoding
+func encodeLeafDataArrayForTest(t *testing.T, leaves []LeafData) []byte {
+	t.Helper()
+
+	encodedBytes, err := aggkitabi.EncodeABIStructArray(leaves)
+	require.NoError(t, err)
+
+	return encodedBytes
 }

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"path"
@@ -20,6 +21,7 @@ import (
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/polygonzkevmbridge"
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync/migrations"
+	bridgesynctypes "github.com/agglayer/aggkit/bridgesync/types"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
@@ -321,6 +323,18 @@ func TestProcessor(t *testing.T) {
 					eventsToClaims(block5.Events),
 				)),
 		},
+		&reorgAction{
+			p:                 p,
+			description:       "reorg the last block",
+			firstReorgedBlock: 5,
+		},
+		&getLastProcessedBlockAction{
+			p:                          p,
+			description:                "after last block reorged",
+			ctx:                        context.Background(),
+			expectedLastProcessedBlock: 4,
+			expectedErr:                nil,
+		},
 	}
 
 	for _, a := range actions {
@@ -340,13 +354,13 @@ var (
 			Event{Bridge: &Bridge{
 				BlockNum:           1,
 				BlockPos:           0,
-				LeafType:           1,
+				LeafType:           bridgesynctypes.LeafTypeAsset.Uint8(),
 				OriginNetwork:      1,
-				OriginAddress:      common.HexToAddress("01"),
+				OriginAddress:      common.HexToAddress("1"),
 				DestinationNetwork: 1,
-				DestinationAddress: common.HexToAddress("01"),
+				DestinationAddress: common.HexToAddress("1"),
 				Amount:             big.NewInt(1),
-				Metadata:           common.Hex2Bytes("01"),
+				Metadata:           common.Hex2Bytes("1"),
 				DepositCount:       0,
 			}},
 			Event{Claim: &Claim{
@@ -354,8 +368,8 @@ var (
 				BlockPos:           1,
 				GlobalIndex:        big.NewInt(1),
 				OriginNetwork:      1,
-				OriginAddress:      common.HexToAddress("01"),
-				DestinationAddress: common.HexToAddress("01"),
+				OriginAddress:      common.HexToAddress("1"),
+				DestinationAddress: common.HexToAddress("1"),
 				Amount:             big.NewInt(1),
 				MainnetExitRoot:    common.Hash{},
 				Type:               DetailedClaimEvent,
@@ -392,26 +406,38 @@ var (
 			Event{Bridge: &Bridge{
 				BlockNum:           3,
 				BlockPos:           0,
-				LeafType:           2,
+				LeafType:           bridgesynctypes.LeafTypeAsset.Uint8(),
 				OriginNetwork:      2,
-				OriginAddress:      common.HexToAddress("02"),
+				OriginAddress:      common.HexToAddress("2"),
 				DestinationNetwork: 2,
-				DestinationAddress: common.HexToAddress("02"),
+				DestinationAddress: common.HexToAddress("2"),
 				Amount:             big.NewInt(2),
-				Metadata:           common.Hex2Bytes("02"),
+				Metadata:           common.Hex2Bytes("2"),
 				DepositCount:       1,
 			}},
 			Event{Bridge: &Bridge{
 				BlockNum:           3,
 				BlockPos:           1,
-				LeafType:           3,
+				LeafType:           bridgesynctypes.LeafTypeAsset.Uint8(),
 				OriginNetwork:      3,
-				OriginAddress:      common.HexToAddress("03"),
+				OriginAddress:      common.HexToAddress("3"),
 				DestinationNetwork: 3,
-				DestinationAddress: common.HexToAddress("03"),
+				DestinationAddress: common.HexToAddress("3"),
 				Amount:             big.NewInt(0),
-				Metadata:           common.Hex2Bytes("03"),
+				Metadata:           common.Hex2Bytes("3"),
 				DepositCount:       2,
+			}},
+			Event{Bridge: &Bridge{
+				BlockNum:           3,
+				BlockPos:           2,
+				LeafType:           bridgesynctypes.LeafTypeAsset.Uint8(),
+				OriginNetwork:      3,
+				OriginAddress:      common.HexToAddress("4"),
+				DestinationNetwork: 3,
+				DestinationAddress: common.HexToAddress("4"),
+				Amount:             big.NewInt(0),
+				Metadata:           common.Hex2Bytes("4"),
+				DepositCount:       3,
 			}},
 		},
 	}
@@ -454,6 +480,12 @@ var (
 				BlockNum:           5,
 				BlockPos:           3,
 				LegacyTokenAddress: common.HexToAddress("0x11"),
+			}},
+			Event{BackwardLET: &BackwardLET{
+				BlockNum:             5,
+				BlockPos:             4,
+				PreviousDepositCount: big.NewInt(3),
+				NewDepositCount:      big.NewInt(2),
 			}},
 		},
 	}
@@ -999,10 +1031,6 @@ func TestGetBridgesPaged(t *testing.T) {
 	}
 	require.NoError(t, tx.Commit())
 
-	depositCountPtr := func(i uint64) *uint64 {
-		return &i
-	}
-
 	testCases := []struct {
 		name            string
 		pageSize        uint32
@@ -1057,7 +1085,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			name:            "t4",
 			pageSize:        1,
 			page:            1,
-			depositCount:    depositCountPtr(1),
+			depositCount:    uint64Ptr(1),
 			expectedCount:   1,
 			expectedBridges: []*Bridge{bridges[1]},
 			expectedError:   "",
@@ -1066,7 +1094,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			name:            "t5",
 			pageSize:        3,
 			page:            2,
-			depositCount:    depositCountPtr(1),
+			depositCount:    uint64Ptr(1),
 			expectedCount:   0,
 			expectedBridges: []*Bridge{},
 			expectedError:   "invalid page number for given page size and total number of bridges",
@@ -1084,7 +1112,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			name:            "t7",
 			pageSize:        1,
 			page:            1,
-			depositCount:    depositCountPtr(0),
+			depositCount:    uint64Ptr(0),
 			expectedCount:   1,
 			expectedBridges: []*Bridge{bridges[0]},
 			expectedError:   "",
@@ -1112,7 +1140,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			name:         "t9",
 			pageSize:     6,
 			page:         1,
-			depositCount: depositCountPtr(3),
+			depositCount: uint64Ptr(3),
 			networkIDs: []uint32{
 				bridges[0].DestinationNetwork,
 				bridges[2].DestinationNetwork,
@@ -1127,7 +1155,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			pageSize:        1,
 			page:            1,
 			fromAddress:     "0xE34aaF64b29273B7D567FCFc40544c014EEe9970",
-			depositCount:    depositCountPtr(0),
+			depositCount:    uint64Ptr(0),
 			expectedCount:   1,
 			expectedBridges: []*Bridge{bridges[0]},
 			expectedError:   "",
@@ -1137,7 +1165,7 @@ func TestGetBridgesPaged(t *testing.T) {
 			pageSize:        1,
 			page:            1,
 			fromAddress:     "0xe34aaF64b29273B7D567FCFc40544c014EEe9970",
-			depositCount:    depositCountPtr(0),
+			depositCount:    uint64Ptr(0),
 			expectedCount:   1,
 			expectedBridges: []*Bridge{bridges[0]},
 			expectedError:   "",
@@ -2361,9 +2389,6 @@ func TestGetClaimsByGlobalIndex_Compact(t *testing.T) {
 	oldProof := types.Proof{}
 	oldProof[0] = common.HexToHash("0x01")
 
-	newProof := types.Proof{}
-	newProof[0] = common.HexToHash("0x02")
-
 	testCases := []struct {
 		name            string
 		globalIndex     *big.Int
@@ -2722,6 +2747,10 @@ func TestGetClaimsByGlobalIndex_Compact(t *testing.T) {
 }
 
 func intPtr(i int) *int {
+	return &i
+}
+
+func uint64Ptr(i uint64) *uint64 {
 	return &i
 }
 
@@ -5217,6 +5246,351 @@ func TestClaimColumnsSQL_ReflectionCheck(t *testing.T) {
 	for _, col := range meddlerColumns {
 		_, ok := sqlSet[col]
 		require.True(t, ok, "Missing SQL column for meddler-tag '%s'", col)
+	}
+}
+
+func TestProcessor_BackwardLET(t *testing.T) {
+	buildBlocksWithSequentialBridges := func(blocksCount, bridgesPerBlock uint64,
+		blockNumOffset uint64, depositCountOffset uint32) []sync.Block {
+		blocks := make([]sync.Block, 0, blocksCount)
+		depositCount := depositCountOffset
+		for i := range blocksCount {
+			blockNum := i + 1 + blockNumOffset
+			block := sync.Block{
+				Num:  blockNum,
+				Hash: common.HexToHash(fmt.Sprintf("%x", blockNum)),
+			}
+			for blockPos := range bridgesPerBlock {
+				block.Events = append(block.Events,
+					Event{Bridge: &Bridge{
+						BlockNum:     blockNum,
+						BlockPos:     blockPos,
+						DepositCount: depositCount,
+					}})
+
+				depositCount++
+			}
+
+			blocks = append(blocks, block)
+		}
+		return blocks
+	}
+
+	collectExpectedBridgesUpTo := func(t *testing.T, blocks []sync.Block,
+		skipBlocks []uint64, targetDepositCount uint32) []Bridge {
+		t.Helper()
+
+		bridges := make([]Bridge, 0)
+		for _, b := range blocks {
+			if slices.Contains(skipBlocks, b.Num) {
+				continue
+			}
+
+			for _, e := range b.Events {
+				evt, ok := e.(Event)
+				require.True(t, ok)
+				if evt.Bridge != nil {
+					bridges = append(bridges, *evt.Bridge)
+					if evt.Bridge.DepositCount == targetDepositCount {
+						return bridges
+					}
+				}
+			}
+		}
+		return bridges
+	}
+
+	testCases := []struct {
+		name                  string
+		setupBlocks           func() []sync.Block
+		firstReorgedBlock     *uint64
+		targetDepositCount    uint32
+		skipBlocks            []uint64
+		archivedDepositCounts []uint32
+		processBlockErrMsg    string
+	}{
+		{
+			name: "backward let after a couple of bridges",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
+				blocks = append(blocks, sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 1),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(3),
+							NewDepositCount:      big.NewInt(2),
+						}},
+					},
+				})
+
+				return blocks
+			},
+			targetDepositCount:    2,
+			archivedDepositCounts: []uint32{3},
+		},
+		{
+			name: "backward let event with all the bridges, except the first one",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
+				blocks = append(blocks, sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 1),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(5),
+							NewDepositCount:      big.NewInt(0),
+						}},
+					},
+				})
+
+				return blocks
+			},
+			targetDepositCount:    0,
+			archivedDepositCounts: []uint32{1, 2, 3, 4, 5},
+		},
+		{
+			name: "backward let event (only the last bridge)",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
+				backwardLETBlock := sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 1),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(5),
+							NewDepositCount:      big.NewInt(4),
+						}},
+					},
+				}
+				blocks = append(blocks, backwardLETBlock)
+
+				return blocks
+			},
+			targetDepositCount:    4,
+			archivedDepositCounts: []uint32{5},
+		},
+		{
+			name: "backward let event in the middle of bridges",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(2, 3, 0, 0)
+				backwardLETBlock := sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 1),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(5),
+							NewDepositCount:      big.NewInt(2),
+						}},
+					},
+				}
+				blocks = append(blocks, backwardLETBlock)
+				blocks = append(blocks, buildBlocksWithSequentialBridges(3, 2, uint64(len(blocks)), 3)...)
+
+				return blocks
+			},
+			targetDepositCount:    8,
+			skipBlocks:            []uint64{2, 3}, // all the bridges from these blocks were backwarded
+			archivedDepositCounts: []uint32{3, 4, 5},
+		},
+		{
+			name: "overlapping backward let events",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
+				blocks = append(blocks, sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 1),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(5),
+							NewDepositCount:      big.NewInt(3),
+						}},
+					},
+				})
+				blocks = append(blocks, sync.Block{
+					Num:  uint64(len(blocks) + 2),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+2)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 2),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(4),
+							NewDepositCount:      big.NewInt(3),
+						}},
+					},
+				})
+
+				return blocks
+			},
+			targetDepositCount:    3,
+			archivedDepositCounts: []uint32{4, 5},
+		},
+		{
+			name: "backward let on empty bridge table",
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{BackwardLET: &BackwardLET{
+								BlockNum:             1,
+								BlockPos:             0,
+								PreviousDepositCount: big.NewInt(6),
+								NewDepositCount:      big.NewInt(3),
+							}},
+						},
+					}}
+			},
+			targetDepositCount: 0,
+		},
+		{
+			name: "backward let invalid new deposit count (outside of uint64 range)",
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{BackwardLET: &BackwardLET{
+								BlockNum:             1,
+								BlockPos:             0,
+								PreviousDepositCount: big.NewInt(0),
+								NewDepositCount:      big.NewInt(-3),
+							}},
+						},
+					}}
+			},
+			processBlockErrMsg: "invalid deposit count: value=-3 does not fit in uint64",
+		},
+		{
+			name: "backward let invalid new deposit count (outside of uint32 range)",
+			setupBlocks: func() []sync.Block {
+				return []sync.Block{
+					{
+						Num:  1,
+						Hash: common.HexToHash("0x1"),
+						Events: []any{
+							Event{BackwardLET: &BackwardLET{
+								BlockNum:             1,
+								BlockPos:             0,
+								PreviousDepositCount: big.NewInt(0),
+								NewDepositCount:      new(big.Int).SetUint64(uint64(math.MaxUint32) + 1),
+							}},
+						},
+					}}
+			},
+			processBlockErrMsg: "invalid deposit count: value=4294967296 exceeds uint32 max",
+		},
+		{
+			name: "backward let after a couple of bridges + reorg backward let",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(3, 2, 0, 0)
+				backwardLETBlock := sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             4,
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(5),
+							NewDepositCount:      big.NewInt(2),
+						}},
+					},
+				}
+				blocks = append(blocks, backwardLETBlock)
+
+				return blocks
+			},
+			firstReorgedBlock:     uint64Ptr(3),
+			targetDepositCount:    3,
+			archivedDepositCounts: []uint32{3},
+		},
+		{
+			name: "backward let event in the middle of bridges + reorg backward let",
+			setupBlocks: func() []sync.Block {
+				blocks := buildBlocksWithSequentialBridges(2, 3, 0, 0)
+				backwardLETBlock := sync.Block{
+					Num:  uint64(len(blocks) + 1),
+					Hash: common.HexToHash(fmt.Sprintf("0x%x", len(blocks)+1)),
+					Events: []any{
+						Event{BackwardLET: &BackwardLET{
+							BlockNum:             uint64(len(blocks) + 1),
+							BlockPos:             0,
+							PreviousDepositCount: big.NewInt(5),
+							NewDepositCount:      big.NewInt(2),
+						}},
+					},
+				}
+				blocks = append(blocks, backwardLETBlock)
+				blocks = append(blocks, buildBlocksWithSequentialBridges(3, 2, uint64(len(blocks)), 3)...)
+
+				return blocks
+			},
+			firstReorgedBlock:     uint64Ptr(3),
+			targetDepositCount:    5,
+			archivedDepositCounts: []uint32{3, 4, 5},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "backward_let_cases.sqlite")
+			require.NoError(t, migrations.RunMigrations(dbPath))
+			p, err := newProcessor(dbPath, "bridge-syncer", log.GetDefaultLogger(), dbQueryTimeout)
+			require.NoError(t, err)
+
+			blocks := c.setupBlocks()
+			for _, b := range blocks {
+				err = p.ProcessBlock(t.Context(), b)
+				if c.processBlockErrMsg != "" {
+					require.ErrorContains(t, err, c.processBlockErrMsg)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			if len(c.archivedDepositCounts) > 0 {
+				archivedBridgeQuery := `
+					SELECT * FROM bridge_archive 
+					WHERE deposit_count <= $1
+					ORDER BY deposit_count ASC`
+
+				maxDepositCount := slices.Max(c.archivedDepositCounts)
+				var archivedBridges []*Bridge
+				err = meddler.QueryAll(p.db, &archivedBridges, archivedBridgeQuery, maxDepositCount)
+				require.NoError(t, err)
+
+				require.Len(t, archivedBridges, len(c.archivedDepositCounts))
+				for i, b := range archivedBridges {
+					require.Equal(t, c.archivedDepositCounts[i], b.DepositCount)
+					require.Equal(t, BridgeSourceBackwardLET, b.Source)
+				}
+			}
+
+			if c.firstReorgedBlock != nil {
+				err = p.Reorg(t.Context(), *c.firstReorgedBlock)
+				require.NoError(t, err)
+			}
+
+			lastProcessedBlock, err := p.GetLastProcessedBlock(t.Context())
+			require.NoError(t, err)
+			expectedBridges := collectExpectedBridgesUpTo(t, blocks, c.skipBlocks, c.targetDepositCount)
+
+			actualBridges, err := p.GetBridges(t.Context(), 0, lastProcessedBlock)
+			require.NoError(t, err)
+			require.Equal(t, expectedBridges, actualBridges)
+		})
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -125,8 +125,16 @@ func start(cliCtx *cli.Context) error {
 	}
 	l1BridgeSync := runBridgeSyncL1IfNeeded(ctx, components, cfg.BridgeL1Sync, reorgDetectorL1,
 		l1Client, 0, &backfillWg)
+
+	initialLER, err := GetInitialLER(cfg.L2NetworkConfig.InitialLER,
+		cfg.AggSender.RollupCreationBlockL1, rollupDataQuerier)
+	if err != nil {
+		return fmt.Errorf("failed to get initial local exit root: %w", err)
+	}
+	log.Infof("Initial Local Exit Root (LER): %s", initialLER.Hex())
+
 	l2BridgeSync := runBridgeSyncL2IfNeeded(ctx, components, cfg.BridgeL2Sync, reorgDetectorL2,
-		l2Client, rollupDataQuerier.RollupID, &backfillWg)
+		l2Client, rollupDataQuerier.RollupID, *initialLER, &backfillWg)
 	l2GERSync := runL2GERSyncIfNeeded(
 		ctx, components, cfg.L2GERSync, reorgDetectorL2, l2Client, l1InfoTreeSync, l1Client,
 	)
@@ -705,6 +713,21 @@ func runL2GERSyncIfNeeded(
 	return l2GERSync
 }
 
+func GetInitialLER(
+	initialLEROverride *common.Hash,
+	rollupCreationBlockL1 uint64,
+	rollupDataQuerier *ethermanquierier.RollupDataQuerier) (*common.Hash, error) {
+	if initialLEROverride != nil {
+		return initialLEROverride, nil
+	}
+	if rollupDataQuerier == nil {
+		return nil, nil
+	}
+	lerQuery := query.NewLERDataQuerier(rollupCreationBlockL1, rollupDataQuerier)
+	ler, err := lerQuery.GetLastLocalExitRoot()
+	return &ler, err
+}
+
 func runBridgeSyncL1IfNeeded(
 	ctx context.Context,
 	components []string,
@@ -755,6 +778,7 @@ func runBridgeSyncL2IfNeeded(
 	reorgDetectorL2 *reorgdetector.ReorgDetector,
 	l2Client aggkittypes.EthClienter,
 	rollupID uint32,
+	initialLER common.Hash,
 	wg *sync.WaitGroup,
 ) *bridgesync.BridgeSync {
 	fullClaimsNeeded := isNeeded([]string{
@@ -771,12 +795,13 @@ func runBridgeSyncL2IfNeeded(
 		return nil
 	}
 
-	bridgeSyncL2, err := bridgesync.NewL2(
+	bridgeSyncL2, err := bridgesync.NewL2WithInitialLER(
 		ctx,
 		cfg,
 		reorgDetectorL2,
 		l2Client,
 		rollupID,
+		initialLER,
 		fullClaimsNeeded,
 	)
 	if err != nil {

--- a/common/common.go
+++ b/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"crypto/ecdsa"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -185,4 +186,26 @@ func ParseUint64HexOrDecimal(str string) (uint64, error) {
 		return 0, fmt.Errorf("ParseUint64HexOrDecimal: invalid decimal string %s: %w", str, err)
 	}
 	return num, nil
+}
+
+// SafeUint64 converts big.Int into uint64, if it fits into it.
+// Otherwise it returns an error.
+func SafeUint64(i *big.Int) (uint64, error) {
+	if i == nil {
+		return 0, errors.New("value is undefined")
+	}
+
+	if !i.IsUint64() {
+		return 0, fmt.Errorf("value=%v does not fit in uint64", i)
+	}
+	return i.Uint64(), nil
+}
+
+// SafeUint32 downcasts the provided uint64 value to uint32, if it fits into it.
+// Otherwise it returns an error.
+func SafeUint32(v uint64) (uint32, error) {
+	if v > math.MaxUint32 {
+		return 0, fmt.Errorf("value=%d exceeds uint32 max (%d)", v, math.MaxUint32)
+	}
+	return uint32(v), nil
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -512,3 +512,112 @@ func TestParseUint64HexOrDecimal(t *testing.T) {
 		})
 	}
 }
+
+func TestSafeUint64(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     *big.Int
+		want      uint64
+		expectErr bool
+	}{
+		{
+			name:      "nil value",
+			input:     nil,
+			expectErr: true,
+		},
+		{
+			name:      "zero",
+			input:     big.NewInt(0),
+			want:      0,
+			expectErr: false,
+		},
+		{
+			name:      "small positive number",
+			input:     big.NewInt(42),
+			want:      42,
+			expectErr: false,
+		},
+		{
+			name:      "max uint64",
+			input:     new(big.Int).SetUint64(math.MaxUint64),
+			want:      math.MaxUint64,
+			expectErr: false,
+		},
+		{
+			name:      "negative value",
+			input:     big.NewInt(-1),
+			expectErr: true,
+		},
+		{
+			name:      "overflow uint64",
+			input:     new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1)),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeUint64(tt.input)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSafeUint32(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     uint64
+		want      uint32
+		expectErr bool
+	}{
+		{
+			name:      "zero",
+			input:     0,
+			want:      0,
+			expectErr: false,
+		},
+		{
+			name:      "small value",
+			input:     123,
+			want:      123,
+			expectErr: false,
+		},
+		{
+			name:      "max uint32",
+			input:     math.MaxUint32,
+			want:      math.MaxUint32,
+			expectErr: false,
+		},
+		{
+			name:      "just above max uint32",
+			input:     uint64(math.MaxUint32) + 1,
+			expectErr: true,
+		},
+		{
+			name:      "max uint64",
+			input:     math.MaxUint64,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeUint32(tt.input)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,9 @@ type Config struct {
 	// L1NetworkConfig represents the L1 network config and contains RPC URL alongside L1 contract addresses.
 	L1NetworkConfig ethermanconfig.L1NetworkConfig
 
+	// L2NetworkConfig holds configuration specific to the L2 network.
+	L2NetworkConfig ethermanconfig.L2NetworkConfig
+
 	// REST contains the configuration settings for the REST service in the Aggkit
 	REST common.RESTConfig
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,6 +81,7 @@ func TestLoadDefaultConfig(t *testing.T) {
 	cfgL2Multidownloader := multidownloader.NewConfigDefault("l2", "")
 	cfgL2Multidownloader.BlockFinality = aggkittypes.LatestBlock
 	require.Equal(t, cfgL2Multidownloader, cfg.L2Multidownloader)
+	require.Nil(t, cfg.L2NetworkConfig.InitialLER)
 }
 
 func TestLoadConfigWithSaveConfigFile(t *testing.T) {
@@ -123,6 +124,57 @@ func newCliContextConfigFlag(t *testing.T, values ...string) *cli.Context {
 		require.NoError(t, err)
 	}
 	return cli.NewContext(nil, flagSet, nil)
+}
+
+func TestL2NetworkConfigInitialLER(t *testing.T) {
+	specificHash := "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd"
+	zeroHash := "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+	tests := []struct {
+		name          string
+		toml          string
+		expectNil     bool
+		expectedValue string
+	}{
+		{
+			name: "InitialLER set to a specific hash",
+			toml: `
+[L2NetworkConfig]
+InitialLER = "` + specificHash + `"
+`,
+			expectNil:     false,
+			expectedValue: specificHash,
+		},
+		{
+			name: "InitialLER set to zero hash is valid and not nil",
+			toml: `
+[L2NetworkConfig]
+InitialLER = "` + zeroHash + `"
+`,
+			expectNil:     false,
+			expectedValue: zeroHash,
+		},
+		{
+			name:      "InitialLER not set returns nil",
+			toml:      ``,
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadFileFromString(tt.toml, ConfigType)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+
+			if tt.expectNil {
+				require.Nil(t, cfg.L2NetworkConfig.InitialLER)
+			} else {
+				require.NotNil(t, cfg.L2NetworkConfig.InitialLER)
+				require.Equal(t, tt.expectedValue, cfg.L2NetworkConfig.InitialLER.Hex())
+			}
+		})
+	}
 }
 
 func TestLoadConfigWithDeprecatedFields(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -81,6 +81,11 @@ BlocksChunkSize = {{L1Config.BlocksChunkSize}}
 		MaxBackoff = "10s"
 		BackoffMultiplier = 2.0
 
+[L2NetworkConfig]
+# InitialLER: optional override for the initial Local Exit Root (0x000...000 is a valid value).
+# If not set, the value is queried from the RollupManager contract on L1.
+# InitialLER =
+
 [ReorgDetectorL1]
 DBPath = "{{PathRWData}}/reorgdetectorl1.sqlite"
 FinalizedBlock = "FinalizedBlock"

--- a/db/mocks/mock_d_ber.go
+++ b/db/mocks/mock_d_ber.go
@@ -150,6 +150,76 @@ func (_c *DBer_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.Res
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *DBer) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DBer_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type DBer_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *DBer_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *DBer_ExecContext_Call {
+	return &DBer_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *DBer_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *DBer_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *DBer_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *DBer_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *DBer_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *DBer_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *DBer) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/mocks/mock_querier.go
+++ b/db/mocks/mock_querier.go
@@ -91,6 +91,76 @@ func (_c *Querier_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *Querier) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Querier_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type Querier_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Querier_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *Querier_ExecContext_Call {
+	return &Querier_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Querier_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Querier_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Querier_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *Querier_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Querier_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *Querier_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *Querier) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/mocks/mock_sql_txer.go
+++ b/db/mocks/mock_sql_txer.go
@@ -136,6 +136,76 @@ func (_c *SQLTxer_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *SQLTxer) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SQLTxer_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type SQLTxer_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *SQLTxer_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *SQLTxer_ExecContext_Call {
+	return &SQLTxer_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *SQLTxer_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *SQLTxer_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SQLTxer_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *SQLTxer_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SQLTxer_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *SQLTxer_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *SQLTxer) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/mocks/mock_txer.go
+++ b/db/mocks/mock_txer.go
@@ -202,6 +202,76 @@ func (_c *Txer_Exec_Call) RunAndReturn(run func(string, ...interface{}) (sql.Res
 	return _c
 }
 
+// ExecContext provides a mock function with given fields: ctx, query, args
+func (_m *Txer) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
+	var r0 sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
+		return rf(ctx, query, args...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) sql.Result); ok {
+		r0 = rf(ctx, query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...interface{}) error); ok {
+		r1 = rf(ctx, query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Txer_ExecContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecContext'
+type Txer_ExecContext_Call struct {
+	*mock.Call
+}
+
+// ExecContext is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args ...interface{}
+func (_e *Txer_Expecter) ExecContext(ctx interface{}, query interface{}, args ...interface{}) *Txer_ExecContext_Call {
+	return &Txer_ExecContext_Call{Call: _e.mock.On("ExecContext",
+		append([]interface{}{ctx, query}, args...)...)}
+}
+
+func (_c *Txer_ExecContext_Call) Run(run func(ctx context.Context, query string, args ...interface{})) *Txer_ExecContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Txer_ExecContext_Call) Return(_a0 sql.Result, _a1 error) *Txer_ExecContext_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Txer_ExecContext_Call) RunAndReturn(run func(context.Context, string, ...interface{}) (sql.Result, error)) *Txer_ExecContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: query, args
 func (_m *Txer) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var _ca []interface{}

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	UniqueConstrain = 1555
+	UniqueConstraintErrCode = 1555
 )
 
 var (

--- a/db/types/interface.go
+++ b/db/types/interface.go
@@ -11,6 +11,7 @@ import (
 // Implementations of this interface can be used to generalize database access logic.
 type Querier interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)

--- a/etherman/config/network.go
+++ b/etherman/config/network.go
@@ -24,6 +24,14 @@ type CommonConfig struct {
 	L2RPC L2RPCClientConfig `mapstructure:"L2RPC"`
 }
 
+// L2NetworkConfig holds configuration specific to the L2 network
+type L2NetworkConfig struct {
+	// InitialLER is an optional override for the initial Local Exit Root.
+	// If set, the RollupManager contract is not queried for the initial LER.
+	// Note: 0x000...000 is a valid value. Omit this field to use the contract.
+	InitialLER *gethcommon.Hash `mapstructure:"InitialLER"`
+}
+
 // L1NetworkConfig represents the configuration of the network used in L1
 type L1NetworkConfig struct {
 	// RPC client configuration for the L1 network

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -133,14 +133,11 @@ func (t *Tree) getRHTNode(tx dbtypes.Querier, nodeHash common.Hash) (*types.Tree
 }
 
 func (t *Tree) storeNodes(tx dbtypes.Txer, nodes []types.TreeNode) error {
-	for i := 0; i < len(nodes); i++ {
-		if err := meddler.Insert(tx, t.rhtTable, &nodes[i]); err != nil {
-			if sqliteErr, ok := db.SQLiteErr(err); ok {
-				if sqliteErr.ExtendedCode == db.UniqueConstrain {
-					// ignore repeated entries. This is likely to happen due to not
-					// cleaning RHT when reorg
-					continue
-				}
+	for _, node := range nodes {
+		if err := meddler.Insert(tx, t.rhtTable, &node); err != nil {
+			if sqliteErr, ok := db.SQLiteErr(err); ok && sqliteErr.ExtendedCode == db.UniqueConstraintErrCode {
+				// ignore repeated entries
+				continue
 			}
 			return err
 		}
@@ -246,12 +243,22 @@ func (t *Tree) Reorg(tx dbtypes.Txer, firstReorgedBlock uint64) error {
 	return err
 }
 
+// BackwardToIndex deletes all the roots with index higher than targetIndex
+func (t *Tree) BackwardToIndex(ctx context.Context, tx dbtypes.Txer, targetIndex uint32) error {
+	_, err := tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE position > $1`, t.rootTable),
+		targetIndex,
+	)
+	return err
+}
+
 // CalculateRoot calculates the Merkle Root based on the leaf and proof	of inclusion
 func CalculateRoot(leafHash common.Hash, proof [types.DefaultHeight]common.Hash, index uint32) common.Hash {
 	node := leafHash
 
 	// Compute the Merkle root
-	for height := uint8(0); height < types.DefaultHeight; height++ {
+	for height := range types.DefaultHeight {
 		if (index>>height)&1 == 1 {
 			node = crypto.Keccak256Hash(proof[height].Bytes(), node.Bytes())
 		} else {

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -306,6 +306,114 @@ func TestVerifyProof(t *testing.T) {
 	}
 }
 
+func TestTree_BackwardToIndex(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("deletes roots with index higher than targetIndex", func(t *testing.T) {
+		t.Parallel()
+
+		treeDB := createTreeDBForTest(t)
+		tree := NewAppendOnlyTree(treeDB, "")
+
+		// Add 8 leaves (roots with indices 0..7)
+		putTestLeaves(t, tree, treeDB, 8, 0)
+
+		// Confirm all roots exist
+		for i := range 8 {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+
+		tx, err := db.NewTx(context.Background(), treeDB)
+		require.NoError(t, err)
+
+		// Delete roots with index > 4
+		require.NoError(t, tree.BackwardToIndex(ctx, tx, 4))
+		require.NoError(t, tx.Commit())
+
+		// Roots with index 0..4 should exist
+		for i := 0; i <= 4; i++ {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+
+		// Roots with index 5..7 should not exist
+		for i := 5; i < 8; i++ {
+			_, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.Error(t, err)
+			require.ErrorIs(t, err, db.ErrNotFound)
+		}
+
+		// Add more leaves to confirm tree is still functional
+		putTestLeaves(t, tree, treeDB, 3, 5) // adding leaves with indices 5,6,7
+
+		// Confirm new roots exist
+		for i := range 8 {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+	})
+
+	t.Run("no roots deleted if none above targetIndex", func(t *testing.T) {
+		t.Parallel()
+
+		treeDB := createTreeDBForTest(t)
+		tree := NewAppendOnlyTree(treeDB, "")
+
+		putTestLeaves(t, tree, treeDB, 3, 0)
+
+		tx, err := db.NewTx(context.Background(), treeDB)
+		require.NoError(t, err)
+
+		require.NoError(t, tree.BackwardToIndex(ctx, tx, 10))
+		require.NoError(t, tx.Commit())
+
+		// All roots should still exist
+		for i := range 3 {
+			root, err := tree.GetRootByIndex(ctx, uint32(i))
+			require.NoError(t, err)
+			require.Equal(t, uint32(i), root.Index)
+		}
+	})
+
+	t.Run("handles empty table gracefully", func(t *testing.T) {
+		t.Parallel()
+
+		treeDB := createTreeDBForTest(t)
+		tree := NewAppendOnlyTree(treeDB, "")
+
+		tx, err := db.NewTx(context.Background(), treeDB)
+		require.NoError(t, err)
+
+		require.NoError(t, tree.BackwardToIndex(ctx, tx, 0))
+	})
+
+	t.Run("returns error on database failure", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := path.Join(t.TempDir(), "tree_BackwardToIndex_dberr.sqlite")
+		require.NoError(t, migrations.RunMigrations(dbPath))
+		treeDB, err := db.NewSQLiteDB(dbPath)
+		require.NoError(t, err)
+
+		// Intentionally invalid table name
+		tree := &Tree{
+			db:        treeDB,
+			rootTable: "nonexistent_table",
+		}
+
+		tx, err := db.NewTx(context.Background(), treeDB)
+		require.NoError(t, err)
+
+		err = tree.BackwardToIndex(ctx, tx, 0)
+		require.ErrorContains(t, err, "no such table")
+	})
+}
+
 func createTreeDBForTest(t *testing.T) *sql.DB {
 	t.Helper()
 

--- a/tree/types/interfaces.go
+++ b/tree/types/interfaces.go
@@ -25,6 +25,7 @@ type LeafWriter interface {
 type ReorganizeTreer interface {
 	ReadTreer
 	Reorg(tx dbtypes.Txer, firstReorgedBlock uint64) error
+	BackwardToIndex(ctx context.Context, tx dbtypes.Txer, targetIndex uint32) error
 }
 
 // FullTreer = fully-capable tree (read, write, reorg)

--- a/tree/types/mocks/mock_full_treer.go
+++ b/tree/types/mocks/mock_full_treer.go
@@ -27,6 +27,54 @@ func (_m *FullTreer) EXPECT() *FullTreer_Expecter {
 	return &FullTreer_Expecter{mock: &_m.Mock}
 }
 
+// BackwardToIndex provides a mock function with given fields: ctx, tx, targetIndex
+func (_m *FullTreer) BackwardToIndex(ctx context.Context, tx types.Txer, targetIndex uint32) error {
+	ret := _m.Called(ctx, tx, targetIndex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BackwardToIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.Txer, uint32) error); ok {
+		r0 = rf(ctx, tx, targetIndex)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// FullTreer_BackwardToIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BackwardToIndex'
+type FullTreer_BackwardToIndex_Call struct {
+	*mock.Call
+}
+
+// BackwardToIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tx types.Txer
+//   - targetIndex uint32
+func (_e *FullTreer_Expecter) BackwardToIndex(ctx interface{}, tx interface{}, targetIndex interface{}) *FullTreer_BackwardToIndex_Call {
+	return &FullTreer_BackwardToIndex_Call{Call: _e.mock.On("BackwardToIndex", ctx, tx, targetIndex)}
+}
+
+func (_c *FullTreer_BackwardToIndex_Call) Run(run func(ctx context.Context, tx types.Txer, targetIndex uint32)) *FullTreer_BackwardToIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.Txer), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *FullTreer_BackwardToIndex_Call) Return(_a0 error) *FullTreer_BackwardToIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *FullTreer_BackwardToIndex_Call) RunAndReturn(run func(context.Context, types.Txer, uint32) error) *FullTreer_BackwardToIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLastRoot provides a mock function with given fields: tx
 func (_m *FullTreer) GetLastRoot(tx types.Querier) (treetypes.Root, error) {
 	ret := _m.Called(tx)

--- a/tree/types/mocks/mock_reorganize_treer.go
+++ b/tree/types/mocks/mock_reorganize_treer.go
@@ -27,6 +27,54 @@ func (_m *ReorganizeTreer) EXPECT() *ReorganizeTreer_Expecter {
 	return &ReorganizeTreer_Expecter{mock: &_m.Mock}
 }
 
+// BackwardToIndex provides a mock function with given fields: ctx, tx, targetIndex
+func (_m *ReorganizeTreer) BackwardToIndex(ctx context.Context, tx types.Txer, targetIndex uint32) error {
+	ret := _m.Called(ctx, tx, targetIndex)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BackwardToIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.Txer, uint32) error); ok {
+		r0 = rf(ctx, tx, targetIndex)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ReorganizeTreer_BackwardToIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BackwardToIndex'
+type ReorganizeTreer_BackwardToIndex_Call struct {
+	*mock.Call
+}
+
+// BackwardToIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tx types.Txer
+//   - targetIndex uint32
+func (_e *ReorganizeTreer_Expecter) BackwardToIndex(ctx interface{}, tx interface{}, targetIndex interface{}) *ReorganizeTreer_BackwardToIndex_Call {
+	return &ReorganizeTreer_BackwardToIndex_Call{Call: _e.mock.On("BackwardToIndex", ctx, tx, targetIndex)}
+}
+
+func (_c *ReorganizeTreer_BackwardToIndex_Call) Run(run func(ctx context.Context, tx types.Txer, targetIndex uint32)) *ReorganizeTreer_BackwardToIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.Txer), args[2].(uint32))
+	})
+	return _c
+}
+
+func (_c *ReorganizeTreer_BackwardToIndex_Call) Return(_a0 error) *ReorganizeTreer_BackwardToIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ReorganizeTreer_BackwardToIndex_Call) RunAndReturn(run func(context.Context, types.Txer, uint32) error) *ReorganizeTreer_BackwardToIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLastRoot provides a mock function with given fields: tx
 func (_m *ReorganizeTreer) GetLastRoot(tx types.Querier) (treetypes.Root, error) {
 	ret := _m.Called(tx)


### PR DESCRIPTION
## 🔄 Changes Summary
- Backports BackwardLET and ForwardLET bridge sync handling to `release/0.8` so the L2 bridge syncer can index LET correction events instead of treating subsequent bridge leaves as mismatched indices.
- Adds optional `L2NetworkConfig.InitialLER` support and threads it into the L2 bridge syncer for LET sanity checks.
- Applies the follow-up LET edge-case fixes needed by the production failure: BackwardLET archives/deletes from `deposit_count >= N`, reorg restores the same range, ForwardLET resumes from `PreviousDepositCount`, and archived bridge lookups are no longer restricted to origin network 0.

## ⚠️ Breaking Changes
- 🛠️ **Config**: None required. Optional `[L2NetworkConfig].InitialLER` can be set when the startup LER must be overridden.
- 🔌 **API/CLI**: None.
- 🗑️ **Deprecated Features**: None.

## 📋 Config Updates
- 🧾 **Diff/Config snippet**:
```toml
[L2NetworkConfig]
# InitialLER: optional override for the initial Local Exit Root.
# InitialLER = "0x..."
```

## ✅ Testing
- 🤖 **Automatic**: `go test ./bridgesync -run 'TestProcessor$|TestProcessor_BackwardLET|TestHandleForwardLETEvent|TestBackfillTxnSender_getRecordsNeedingBackfillCount' -count=1`
- 🤖 **Automatic**: `go test ./tree ./config ./cmd`
- 🖱️ **Manual**: Confirmed the fix targets the Datadog failure on `v0.8.3-rc3` where L2 bridge sync halted on `mismatched index. Expected: 3, actual: 4` after LET events.

## 🐞 Issues
- Closes N/A

## 🔗 Related PRs
- Backports relevant parts of #1379, #1404, #1502, and #1558.

## 📝 Notes
- Full `go test ./bridgesync ./tree ./config ./cmd` still fails locally at `TestClaimCalldata` because its docker-backed geth RPC resets the connection on `127.0.0.1:8545`; the targeted LET and non-docker package tests above pass.
