### PR TITLE
fix(exit-certificate): F-01 implement ERC-20 balance storage patching for SC-locked exits

### DIFF
--- a/tools/exit_certificate/CLAUDE.md
+++ b/tools/exit_certificate/CLAUDE.md
@@ -62,7 +62,7 @@ All checks run regardless of individual failures. A combined error lists every f
 
 ### Step 0 — Generate LBT
 
-- **Trigger:** runs unless `lbtFile` is set and the file exists.
+- **Trigger:** always runs as part of the full pipeline.
 - **Does:** scans L2 bridge `NewWrappedToken` events, fetches `totalSupply` per token at `targetBlock`, computes unlocked native balance.
 - **Output:** `step-0-lbt.json` (`[]LBTEntry`)
 
@@ -108,7 +108,7 @@ Creates the `*agglayertypes.Certificate` with `BridgeExit` entries:
 
 - **Requires:** `agglayerAdminURL` in options (skipped otherwise).
 - Calls `admin_getTokenBalance` on the agglayer admin RPC and performs a **three-way comparison** per token: `LBT (Step 0) == agglayer == certificate sum`. Each token is logged with ✅ or ❌.
-- **LBT data:** loaded from `step-0-lbt.json` (or `lbtFile`). If unavailable, falls back to two-way comparison (certificate vs agglayer).
+- **LBT data:** loaded from `step-0-lbt.json`. If unavailable, falls back to two-way comparison (certificate vs agglayer).
 - **On mismatch:** aborts the pipeline with an error by default.
 - **`continueIfBalanceMismatch=true`:** suppresses the error and produces `step-f-capped-certificate.json`, where each mismatched token's bridge exits are proportionally scaled down to `min(agglayer, lbt)`. The pipeline (and `runSingleG`) automatically uses this capped certificate for subsequent steps.
 - `buildCapMap` / `capBridgeExits` are the internal helpers for computing and applying the caps. Proportional scaling preserves the exact capped total by adding any integer-division remainder to the last exit of each group.
@@ -232,7 +232,7 @@ Defaults applied by `LoadConfig`:
 - `options.blockRange` = 5000, `concurrencyLimit` = 20, `rpcBatchSize` = 200
 - `options.abortOnGenesisBalance` = `true` — abort if any address has a non-zero ETH balance at block 0 (genesis preload guard). Set `false` only for Kurtosis/test environments.
 - `options.continueIfBalanceMismatch` = `false` — when `true`, Step F does not abort on token balance mismatches and instead produces a capped certificate.
-- Relative paths in `lbtFile`, `options.outputDir`, and `signerConfig.Path` resolve from the directory containing the config file.
+- Relative paths in `options.outputDir` and `signerConfig.Path` resolve from the directory containing the config file.
 
 `signerConfig` uses `signertypes.SignerConfig` (same type as aggsender's `AggsenderPrivateKey`). The JSON format is flat — `Method`, `Path`, `Password` are top-level keys (matching the TOML inline table style). Parsed by `parseSignerConfig` which splits `Method` out and puts the rest into `Config map[string]any`.
 
@@ -249,7 +249,7 @@ Defaults applied by `LoadConfig`:
 - **Output dir:** All intermediate files land in `options.outputDir` (default `./output` relative to the config file). The dir is created automatically.
 - **`parameters.json` and `output/` are git-ignored** — never commit them.
 - **File chain:** Step D → `step-d-exit-certificate.json`; Step E → `step-e-exit-certificate.json` (adds unclaimed deposits); Step I → `exit-certificate-final.json` (sets `NewLocalExitRoot` from G and `PrevLocalExitRoot` from H). Always submit `exit-certificate-final.json` (or the signed variant).
-- **LBT resolution:** `resolveOrGenerateLBT` → if `lbtFile` is set and exists, use it and skip Step 0; if set but missing, fall back to Step 0 with a warning; if not set, always run Step 0.
+- **LBT resolution:** `resolveOrGenerateLBT` always runs Step 0 and saves `step-0-lbt.json`.
 - **Step F reads from `step-d-exit-certificate.json`** for the balance check (not the final certificate), so the comparison reflects pure L2 exits before Step E additions. When capping is triggered, the caps are also applied to the final (Step E) certificate's `BridgeExits` in `runAll`, and saved as `step-f-capped-certificate.json`.
 - **File chain with capping:** when `continueIfBalanceMismatch=true` produces a capped cert, the effective chain becomes: Step D → Step E → **Step F (capped)** → Step G → … Always check whether `step-f-capped-certificate.json` exists when investigating balance issues.
 - **`--verbose` flag:** the logger defaults to `info` level; pass `--verbose` to enable `debug` output.

--- a/tools/exit_certificate/README.md
+++ b/tools/exit_certificate/README.md
@@ -58,7 +58,6 @@ cp parameters.json.example parameters.json
 | `l2NetworkId` | No | L2 network ID. Defaults to `1`. |
 | `targetBlock` | Yes | Target block number or `"latest"`. All state is captured at this block. |
 | `exitAddress` | No | Address that receives SC-locked value exits. Defaults to zero address. |
-| `lbtFile` | No | Path to a pre-generated LBT JSON file. If omitted, the tool generates it automatically via Step 0. Can also be generated externally with the [`getLBT`](https://github.com/agglayer/agglayer-contracts/tree/v12.2.3/tools/getLBT) tool from `agglayer-contracts`. |
 | `destinationNetwork` | No | Destination network for bridge exits. Defaults to `0` (L1). |
 | `sovereignRollupAddr` | Yes* | Address of the `aggchainbase` contract on L1. Required by Step CHECK (network type and threshold verification). |
 | `l1GlobalExitRootAddress` | Yes* | Address of `PolygonZkEVMGlobalExitRootV2` on L1. Required by Step I to fetch `L1InfoTreeLeafCount`. |
@@ -191,7 +190,7 @@ Runs all steps sequentially: CHECK → 0 → A → B → C → D → E → F →
 | Step | Name | What it does |
 | :--: | ---- | ------------ |
 | CHECK | Verify prerequisites | Checks Anvil, L1 RPC, network type (PP only), threshold = 1, no custom gas token. |
-| 0 | Generate LBT | Scans `NewWrappedToken` events and fetches `totalSupply` per wrapped token at `targetBlock`. Skipped if `lbtFile` is set. |
+| 0 | Generate LBT | Scans `NewWrappedToken` events and fetches `totalSupply` per wrapped token at `targetBlock`. |
 | A | Collect addresses | Traces every L2 transaction via `debug_traceTransaction` and collects all addresses that touched state. |
 | B | EOA balances | Classifies addresses as EOA vs contract; fetches ETH balance and every wrapped-token balance for each EOA at `targetBlock`. |
 | C | SC-locked value | Computes value locked in contracts: `SC_locked = LBT_totalSupply − EOA_accumulated` per token. |
@@ -255,7 +254,7 @@ All checks run regardless of individual failures; a combined error lists every f
 
 Scans the L2 bridge contract for `NewWrappedToken` events and fetches the `totalSupply` of each wrapped token at `targetBlock`. Also computes the unlocked native token balance and checks for WETH.
 
-This step replaces the need for the external [`getLBT`](https://github.com/agglayer/agglayer-contracts/tree/v12.2.3/tools/getLBT) tool and the `lbtFile` config parameter. If `lbtFile` is already set and the file exists, this step is skipped and the pre-generated file is used instead.
+This step replaces the need for the external [`getLBT`](https://github.com/agglayer/agglayer-contracts/tree/v12.2.3/tools/getLBT) tool.
 
 **Output:** `step-0-lbt.json`
 
@@ -270,7 +269,7 @@ Scans all blocks from `l2StartBlock` to `targetBlock` and collects every address
 
 ### Step B — EOA balance checking
 
-Classifies addresses as EOA vs contract, then queries ETH balance and every wrapped-token balance at `targetBlock` for all EOAs. The wrapped token list comes from the LBT data (Step 0 or `lbtFile`).
+Classifies addresses as EOA vs contract, then queries ETH balance and every wrapped-token balance at `targetBlock` for all EOAs. The wrapped token list comes from the LBT data (Step 0).
 
 **Phases:**
 
@@ -282,7 +281,7 @@ Classifies addresses as EOA vs contract, then queries ETH balance and every wrap
 
 ### Step C — SC-locked value extraction
 
-Computes value locked in smart contracts using: `SC_locked = LBT_totalSupply - accumulated_EOA_balances`. Uses the LBT data (Step 0 or `lbtFile`) for total supply per token.
+Computes value locked in smart contracts using: `SC_locked = LBT_totalSupply - accumulated_EOA_balances`. Uses the LBT data (Step 0) for total supply per token.
 
 **Output:** `step-c-sc-locked-values.json`
 
@@ -335,7 +334,7 @@ All three values must be equal. Each token is logged with ✅ or ❌:
 
 When running Step G individually it also prefers `step-f-capped-certificate.json` over `step-e-exit-certificate.json` if the capped file exists (logged with ⚠️).
 
-LBT data comes from `step-0-lbt.json` (or `lbtFile`). If not available, the comparison falls back to two-way (certificate vs agglayer only).
+LBT data comes from `step-0-lbt.json`. If not available, the comparison falls back to two-way (certificate vs agglayer only).
 
 Skipped automatically when `agglayerAdminURL` is not set in options.
 

--- a/tools/exit_certificate/cmd/main.go
+++ b/tools/exit_certificate/cmd/main.go
@@ -19,7 +19,7 @@ func main() {
 Pipeline steps (run in order by default):
 
   0  Generate the Locked Balance Table (LBT) by scanning the L2 bridge contract
-     for wrapped token mappings. Skipped when lbtFile is set in the config.
+     for wrapped token mappings.
 
   A  Collect all unique sender/receiver addresses from bridge events up to the
      target block.

--- a/tools/exit_certificate/config.go
+++ b/tools/exit_certificate/config.go
@@ -61,7 +61,6 @@ type Config struct {
 	L2NetworkID         uint32         `json:"l2NetworkId"`
 	TargetBlock         string         `json:"targetBlock"`
 	ExitAddress         common.Address `json:"exitAddress"`
-	LBTFile             string         `json:"lbtFile"`
 	DestinationNetwork  uint32         `json:"destinationNetwork"`
 	SovereignRollupAddr common.Address `json:"sovereignRollupAddr"`
 	// L1GlobalExitRootAddress is the address of the PolygonZkEVMGlobalExitRootV2 contract on L1.
@@ -134,7 +133,6 @@ func LoadConfig(configPath string) (*Config, error) {
 		cfg.L2NetworkID = 1
 	}
 
-	cfg.LBTFile = resolvePath(configDir, raw.LBTFile)
 	cfg.Options = mergeOptions(raw.Options, configDir)
 	if len(raw.SignerConfig) > 0 {
 		signerCfg, err := parseSignerConfig(raw.SignerConfig, configDir)
@@ -274,7 +272,6 @@ type rawConfig struct {
 	L2NetworkID             uint32          `json:"l2NetworkId"`
 	TargetBlock             string          `json:"targetBlock"`
 	ExitAddress             string          `json:"exitAddress"`
-	LBTFile                 string          `json:"lbtFile"`
 	DestinationNetwork      uint32          `json:"destinationNetwork"`
 	SovereignRollupAddr     string          `json:"sovereignRollupAddr"`
 	L1GlobalExitRootAddress string          `json:"l1GlobalExitRootAddress"`

--- a/tools/exit_certificate/config_test.go
+++ b/tools/exit_certificate/config_test.go
@@ -130,24 +130,6 @@ func TestLoadConfig_DefaultOptions(t *testing.T) {
 	require.Equal(t, uint64(0), cfg.Options.L1StartBlock)
 }
 
-func TestLoadConfig_RelativeLBTFile(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "parameters.json")
-	data := `{
-		"l2RpcUrl": "http://localhost:8545",
-		"l2BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
-		"targetBlock": "100",
-		"lbtFile": "../some/lbt.json"
-	}`
-	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
-
-	cfg, err := LoadConfig(path)
-	require.NoError(t, err)
-	require.Equal(t, filepath.Join(dir, "../some/lbt.json"), cfg.LBTFile)
-}
-
 func TestLoadConfig_RelativeOutputDir(t *testing.T) {
 	t.Parallel()
 

--- a/tools/exit_certificate/integration_test.go
+++ b/tools/exit_certificate/integration_test.go
@@ -31,7 +31,6 @@ func TestLoadParametersJSON(t *testing.T) {
 	require.Greater(t, cfg.Options.BlockRange, 0)
 	require.Greater(t, cfg.Options.ConcurrencyLimit, 0)
 	require.Greater(t, cfg.Options.RPCBatchSize, 0)
-	require.NotEmpty(t, cfg.LBTFile)
 }
 
 // TestStepD_WithProductionLikeData tests Step D with data structures matching

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -293,7 +293,7 @@ func runAllStepC(dir string, lbtEntries []LBTEntry, stepBResult *StepBResult) (*
 		log.Warn("STEP C skipped: no LBT data available")
 		return &StepCResult{}, nil
 	}
-	stepCResult, err := RunStepCWithEntries(lbtEntries, stepBResult)
+	stepCResult, err := RunStepC(lbtEntries, stepBResult)
 	if err != nil {
 		return nil, fmt.Errorf("step C: %w", err)
 	}
@@ -410,11 +410,6 @@ func logPipelineConfig(cfg *Config) {
 	log.Infof("L2 Network ID:    %d", cfg.L2NetworkID)
 	log.Infof("Exit Address:     %s", cfg.ExitAddress.Hex())
 	log.Infof("Dest Network:     %d", cfg.DestinationNetwork)
-	if cfg.LBTFile != "" {
-		log.Infof("LBT File:         %s (pre-generated, skipping step 0)", cfg.LBTFile)
-	} else {
-		log.Info("LBT File:         (not configured — will generate via step 0)")
-	}
 	log.Infof("Output Dir:       %s", cfg.Options.OutputDir)
 	log.Infof("Concurrency:      %d", cfg.Options.ConcurrencyLimit)
 	log.Infof("Block Range:      %d", cfg.Options.BlockRange)
@@ -450,7 +445,7 @@ func runSingleStep(ctx context.Context, step string, cfg *Config) error {
 	case "b":
 		return runSingleB(ctx, cfg, dir)
 	case "c":
-		return runSingleC(cfg, dir)
+		return runSingleC(dir)
 	case "d":
 		return runSingleD(cfg, dir)
 	case "e":
@@ -507,7 +502,7 @@ func runSingleB(ctx context.Context, cfg *Config, dir string) error {
 	if err := loadJSON(dir, "step-a-addresses.json", &addresses); err != nil {
 		return fmt.Errorf("load step A output: %w", err)
 	}
-	wrappedTokens, err := loadWrappedTokensFromLBT(cfg, dir)
+	wrappedTokens, err := loadWrappedTokensFromLBT(dir)
 	if err != nil {
 		return err
 	}
@@ -526,12 +521,16 @@ func runSingleB(ctx context.Context, cfg *Config, dir string) error {
 	return nil
 }
 
-func runSingleC(cfg *Config, dir string) error {
+func runSingleC(dir string) error {
 	var accumulated []AccumulatedBalance
 	if err := loadJSON(dir, "step-b-accumulated.json", &accumulated); err != nil {
 		return fmt.Errorf("load step B output: %w", err)
 	}
-	result, err := RunStepC(cfg, &StepBResult{Accumulated: accumulated})
+	var lbtEntries []LBTEntry
+	if err := loadJSON(dir, "step-0-lbt.json", &lbtEntries); err != nil {
+		return fmt.Errorf("load LBT data (step 0): %w", err)
+	}
+	result, err := RunStepC(lbtEntries, &StepBResult{Accumulated: accumulated})
 	if err != nil {
 		return err
 	}
@@ -617,9 +616,6 @@ func runSingleF(ctx context.Context, cfg *Config, dir string) error {
 	// Try to load LBT entries for three-way comparison; nil disables LBT check.
 	var lbtEntries []LBTEntry
 	lbtPath := filepath.Join(dir, "step-0-lbt.json")
-	if cfg.LBTFile != "" {
-		lbtPath = cfg.LBTFile
-	}
 	if entries, err := LoadLBTEntries(lbtPath); err == nil {
 		lbtEntries = entries
 	} else {
@@ -656,9 +652,6 @@ func runSingleG(ctx context.Context, cfg *Config, dir string) error {
 	}
 
 	lbtPath := filepath.Join(dir, "step-0-lbt.json")
-	if cfg.LBTFile != "" {
-		lbtPath = cfg.LBTFile
-	}
 	var lbtEntries []LBTEntry
 	if entries, err := LoadLBTEntries(lbtPath); err == nil {
 		lbtEntries = entries
@@ -720,41 +713,21 @@ func runSingleI(ctx context.Context, cfg *Config, dir string) error {
 
 // --- LBT resolution ---
 
-// resolveOrGenerateLBT loads from lbtFile if present, otherwise runs Step 0.
+// resolveOrGenerateLBT always runs Step 0 and saves step-0-lbt.json.
 func resolveOrGenerateLBT(ctx context.Context, cfg *Config, dir string) ([]LBTEntry, []WrappedToken, error) {
-	if cfg.LBTFile != "" {
-		if _, err := os.Stat(cfg.LBTFile); err == nil {
-			entries, err := LoadLBTEntries(cfg.LBTFile)
-			if err != nil {
-				return nil, nil, fmt.Errorf("load LBT file: %w", err)
-			}
-			tokens := LBTEntriesToWrappedTokens(entries)
-			log.Infof("Loaded %d LBT entries (%d wrapped tokens) from %s", len(entries), len(tokens), cfg.LBTFile)
-			return entries, tokens, nil
-		}
-		log.Warnf("LBT file not found at %s — generating via step 0", cfg.LBTFile)
-	}
-
 	entries, err := RunStep0(ctx, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 	saveJSON(dir, "step-0-lbt.json", entries)
-	cfg.LBTFile = filepath.Join(dir, "step-0-lbt.json")
-
 	return entries, LBTEntriesToWrappedTokens(entries), nil
 }
 
-// loadWrappedTokensFromLBT loads tokens from lbtFile or the step-0 output.
-func loadWrappedTokensFromLBT(cfg *Config, dir string) ([]WrappedToken, error) {
-	if cfg.LBTFile != "" {
-		if tokens, err := LoadLBTWrappedTokens(cfg.LBTFile); err == nil && len(tokens) > 0 {
-			return tokens, nil
-		}
-	}
+// loadWrappedTokensFromLBT loads tokens from the step-0 output.
+func loadWrappedTokensFromLBT(dir string) ([]WrappedToken, error) {
 	tokens, err := LoadLBTWrappedTokens(filepath.Join(dir, "step-0-lbt.json"))
 	if err != nil {
-		return nil, fmt.Errorf("no LBT data available: configure lbtFile or run step 0 first")
+		return nil, fmt.Errorf("no LBT data available: run step 0 first")
 	}
 	return tokens, nil
 }

--- a/tools/exit_certificate/scripts/bridge_l1_to_l2.sh
+++ b/tools/exit_certificate/scripts/bridge_l1_to_l2.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# Bridges ETH (or an ERC-20) from L1 to L2 by calling bridgeAsset on the L1 bridge
+# contract in a running Kurtosis enclave. Requires: kurtosis, cast (Foundry).
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+log_warn()  { echo -e "${ORANGE}[WARN]${NC} $*" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [OPTIONS] [NETWORK_INDEX]
+
+Bridges ETH from L1 to L2 by calling bridgeAsset on the L1 bridge contract.
+
+Arguments:
+  NETWORK_INDEX   L2 network index to target (default: 1)
+
+Options:
+  -e, --enclave   ENCLAVE      Kurtosis enclave name (default: \$KURTOSIS_ENCLAVE or "op")
+  -a, --amount    AMOUNT_WEI   Amount to bridge in wei (default: 1234567890)
+  -d, --dest      ADDRESS      Destination address on L2 (default: sender address)
+  -t, --token     ADDRESS      ERC-20 token address to bridge (default: 0x0 = native ETH)
+  -k, --key       PRIVATE_KEY  Sender private key (default: \$PRIVATE_KEY or Foundry test key)
+  -w, --wait                   Wait for the deposit to be claimed on L2 (polls isClaimed)
+  -h, --help                   Show this help
+
+Environment variables (override defaults):
+  KURTOSIS_ENCLAVE                  Enclave name
+  PRIVATE_KEY                       Sender private key
+  BRIDGE_AMOUNT                     Amount in wei
+  DEST_ADDRESS                      Destination address on L2
+  TOKEN_ADDRESS                     ERC-20 token address (0x0 for ETH)
+  L1_SERVICE                        Kurtosis L1 execution service (default: el-1-geth-lighthouse)
+  L2_SERVICE_PREFIX                 Kurtosis L2 execution service prefix (default: op-el-1-op-geth-op-node)
+  KURTOSIS_ARTIFACT_AGGKIT_CONFIG   Aggkit config artifact name (default: aggkit-config)
+
+Examples:
+  $0                              # Bridge 0.01 ETH to network 1
+  $0 2                            # Bridge to network 2
+  $0 --amount 1000000000000000000 # Bridge 1 ETH
+  $0 --dest 0xABCD... --wait      # Bridge to specific address and wait for claim
+  PRIVATE_KEY=0x... $0 1
+EOF
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+KURTOSIS_ENCLAVE="${KURTOSIS_ENCLAVE:-aggkit}"
+KURTOSIS_ARTIFACT_AGGKIT_CONFIG="${KURTOSIS_ARTIFACT_AGGKIT_CONFIG:-aggkit-config}"
+L1_SERVICE="${L1_SERVICE:-el-1-geth-lighthouse}"
+L2_SERVICE_PREFIX="${L2_SERVICE_PREFIX:-op-el-1-op-geth-op-node}"
+
+# Kurtosis L1 faucet (1,000,000,000 ETH on L1 in local enclaves).
+# Override with PRIVATE_KEY env var or --key flag for other environments.
+PRIVATE_KEY="${PRIVATE_KEY:-0x04b9f63ecf84210c5366c66d68fa1f5da1fa4f634fad6dfc86178e4d79ff9e59}"
+
+BRIDGE_AMOUNT="${BRIDGE_AMOUNT:-1234567890}"
+
+# address(0) = native ETH
+TOKEN_ADDRESS="${TOKEN_ADDRESS:-0x0000000000000000000000000000000000000000}"
+
+DEST_ADDRESS="${DEST_ADDRESS:-}"
+NETWORK_INDEX=1
+WAIT_FOR_CLAIM=false
+
+# ---------------------------------------------------------------------------
+# Parse flags and positional args
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage ;;
+        -e|--enclave)
+            [[ $# -lt 2 ]] && { log_error "--enclave requires a value"; usage; }
+            KURTOSIS_ENCLAVE="$2"; shift 2 ;;
+        -a|--amount)
+            [[ $# -lt 2 ]] && { log_error "--amount requires a value"; usage; }
+            BRIDGE_AMOUNT="$2"; shift 2 ;;
+        -d|--dest)
+            [[ $# -lt 2 ]] && { log_error "--dest requires a value"; usage; }
+            DEST_ADDRESS="$2"; shift 2 ;;
+        -t|--token)
+            [[ $# -lt 2 ]] && { log_error "--token requires a value"; usage; }
+            TOKEN_ADDRESS="$2"; shift 2 ;;
+        -k|--key)
+            [[ $# -lt 2 ]] && { log_error "--key requires a value"; usage; }
+            PRIVATE_KEY="$2"; shift 2 ;;
+        -w|--wait)
+            WAIT_FOR_CLAIM=true; shift ;;
+        [0-9]*)
+            NETWORK_INDEX="$1"; shift ;;
+        *)
+            log_error "Unknown argument: $1"; usage ;;
+    esac
+done
+
+NETWORK_SUFFIX=$(printf '%03d' "$NETWORK_INDEX")
+L2_SERVICE="${L2_SERVICE_PREFIX}-${NETWORK_SUFFIX}"
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+check_deps() {
+    local missing=()
+    command -v kurtosis &>/dev/null || missing+=("kurtosis")
+    command -v cast     &>/dev/null || missing+=("cast (foundry)")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        log_error "Install Foundry: https://getfoundry.sh"
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Kurtosis helpers
+# ---------------------------------------------------------------------------
+
+port_to_localhost_url() {
+    local raw_url="$1"
+    local port
+    port=$(echo "$raw_url" | sed -E 's|^[a-zA-Z]+://||' | cut -f2 -d':')
+    echo "http://localhost:${port}"
+}
+
+get_l1_rpc_url() {
+    local raw
+    if ! raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$L1_SERVICE" rpc 2>/dev/null); then
+        log_error "Failed to get L1 RPC port from service '$L1_SERVICE' in enclave '$KURTOSIS_ENCLAVE'"
+        log_error "Ensure the enclave is running: kurtosis enclave inspect $KURTOSIS_ENCLAVE"
+        exit 1
+    fi
+    port_to_localhost_url "$raw"
+}
+
+get_l2_rpc_url() {
+    local raw
+    if ! raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$L2_SERVICE" rpc 2>/dev/null); then
+        log_error "Failed to get L2 RPC port from service '$L2_SERVICE' in enclave '$KURTOSIS_ENCLAVE'"
+        log_error "To use a different prefix, set L2_SERVICE_PREFIX"
+        exit 1
+    fi
+    port_to_localhost_url "$raw"
+}
+
+get_bridge_address() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp_dir'" RETURN
+
+    local artifact_name="${KURTOSIS_ARTIFACT_AGGKIT_CONFIG}-${NETWORK_SUFFIX}"
+    if ! kurtosis files download "$KURTOSIS_ENCLAVE" "$artifact_name" "$tmp_dir" &>/dev/null; then
+        log_warn "Artifact '$artifact_name' not found, trying '$KURTOSIS_ARTIFACT_AGGKIT_CONFIG'..."
+        artifact_name="$KURTOSIS_ARTIFACT_AGGKIT_CONFIG"
+        if ! kurtosis files download "$KURTOSIS_ENCLAVE" "$artifact_name" "$tmp_dir" &>/dev/null; then
+            log_error "Could not download artifact '$artifact_name' from enclave '$KURTOSIS_ENCLAVE'"
+            exit 1
+        fi
+    fi
+
+    local config_file="$tmp_dir/config.toml"
+    if [[ ! -f "$config_file" ]]; then
+        log_error "config.toml not found in downloaded artifact '$artifact_name'"
+        exit 1
+    fi
+
+    local addr
+    addr=$(grep 'BridgeAddr' "$config_file" | head -1 | tr -d '[:space:]' | cut -f2 -d'=' | tr -d '"')
+    if [[ -z "$addr" ]]; then
+        log_error "BridgeAddr not found in $config_file"
+        exit 1
+    fi
+    echo "$addr"
+}
+
+# ---------------------------------------------------------------------------
+# bridgeAsset ABI
+#
+# function bridgeAsset(
+#   uint32  destinationNetwork,
+#   address destinationAddress,
+#   uint256 amount,
+#   address token,
+#   bool    forceUpdate,
+#   bytes   calldata permitData
+# ) external payable
+# ---------------------------------------------------------------------------
+
+# wait_for_claim polls isClaimed(depositCount, sourceBridgeNetwork=0) on the L2 bridge.
+# depositCount is extracted from the DepositCount field of the BridgeEvent emitted in the tx.
+wait_for_claim() {
+    local l2_rpc="$1"
+    local l2_bridge="$2"
+    local deposit_count="$3"
+    local timeout_secs="${4:-300}"
+    local poll_secs=5
+
+    # isClaimed(uint32 leafIndex, uint32 sourceBridgeNetwork) — selector: 0xcc461632
+    local leaf_idx_hex
+    local src_net_hex
+    leaf_idx_hex=$(printf '%064x' "$deposit_count")
+    src_net_hex=$(printf '%064x' 0)
+    local calldata="0xcc461632${leaf_idx_hex}${src_net_hex}"
+
+    log_info "Waiting for claim on L2 (depositCount=$deposit_count, timeout=${timeout_secs}s)..."
+
+    local elapsed=0
+    while [[ $elapsed -lt $timeout_secs ]]; do
+        local result
+        result=$(cast call --rpc-url "$l2_rpc" "$l2_bridge" "$calldata" 2>/dev/null || true)
+        # isClaimed returns a non-zero uint256 when claimed
+        local val
+        val=$(cast --to-dec "${result:-0x0}" 2>/dev/null || echo "0")
+        if [[ "$val" != "0" ]]; then
+            log_info "Deposit claimed on L2! (depositCount=$deposit_count)"
+            return 0
+        fi
+        sleep "$poll_secs"
+        elapsed=$((elapsed + poll_secs))
+        log_info "  Still waiting... ${elapsed}s / ${timeout_secs}s"
+    done
+
+    log_warn "Timed out waiting for claim after ${timeout_secs}s"
+    return 1
+}
+
+# extract_deposit_count parses the DepositCount from a BridgeEvent log in a tx receipt.
+# BridgeEvent topic: keccak256("BridgeEvent(uint8,uint32,address,uint32,address,uint256,bytes,uint32)")
+extract_deposit_count() {
+    local tx_hash="$1"
+    local l1_rpc="$2"
+
+    local bridge_event_topic="0x501781209a1f8899323b96b4ef08b168df93e0a90c673d1e4cce39366cb62f9b"
+
+    local receipt
+    receipt=$(cast receipt --rpc-url "$l1_rpc" "$tx_hash" --json 2>/dev/null || true)
+    if [[ -z "$receipt" ]]; then
+        log_warn "Could not fetch receipt for $tx_hash — skipping claim wait"
+        echo ""
+        return
+    fi
+
+    # Find the BridgeEvent log and decode depositCount from the ABI-encoded data.
+    # Layout (32-byte words): leafType | originNetwork | originAddress | destNetwork |
+    #                          destAddress | amount | metadataOffset | depositCount | ...
+    local data
+    data=$(echo "$receipt" | python3 -c "
+import sys, json
+receipt = json.load(sys.stdin)
+topic = '$bridge_event_topic'
+for log in receipt.get('logs', []):
+    if log.get('topics', [None])[0] == topic:
+        print(log.get('data', ''))
+        break
+" 2>/dev/null || true)
+
+    if [[ -z "$data" ]]; then
+        log_warn "BridgeEvent log not found in tx $tx_hash"
+        echo ""
+        return
+    fi
+
+    # depositCount is the 8th 32-byte word (offset 7*32=224 bytes, 0x prefix stripped)
+    local hex_data="${data#0x}"
+    local deposit_count_hex="${hex_data:448:64}"  # word 7 (0-indexed): 7*64=448 chars
+    local deposit_count
+    deposit_count=$(python3 -c "print(int('$deposit_count_hex', 16))" 2>/dev/null || echo "")
+    echo "$deposit_count"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+check_deps
+
+log_info "Enclave:          $KURTOSIS_ENCLAVE"
+log_info "Network index:    $NETWORK_INDEX (suffix: $NETWORK_SUFFIX)"
+log_info "L1 service:       $L1_SERVICE"
+log_info "L2 service:       $L2_SERVICE"
+log_info "Amount:           $BRIDGE_AMOUNT wei"
+log_info "Token:            $TOKEN_ADDRESS"
+
+log_info "Getting L1 RPC URL..."
+L1_RPC_URL=$(get_l1_rpc_url)
+log_info "L1 RPC URL: $L1_RPC_URL"
+
+log_info "Getting bridge address from aggkit config artifact..."
+BRIDGE_ADDR=$(get_bridge_address)
+log_info "Bridge address: $BRIDGE_ADDR"
+
+# Derive sender address from private key
+SENDER_ADDR=$(cast wallet address --private-key "$PRIVATE_KEY")
+log_info "Sender address: $SENDER_ADDR"
+
+# Use sender as destination if not specified
+if [[ -z "$DEST_ADDRESS" ]]; then
+    DEST_ADDRESS="$SENDER_ADDR"
+fi
+log_info "Destination:      $DEST_ADDRESS (network $NETWORK_INDEX)"
+
+# Check sender balance
+SENDER_BALANCE=$(cast balance --rpc-url "$L1_RPC_URL" "$SENDER_ADDR")
+SENDER_BALANCE_ETH=$(cast --from-wei "$SENDER_BALANCE" ether)
+log_info "Sender L1 balance: $SENDER_BALANCE_ETH ETH ($SENDER_BALANCE wei)"
+
+IS_ETH_BRIDGE="false"
+if [[ "$TOKEN_ADDRESS" == "0x0000000000000000000000000000000000000000" ]]; then
+    IS_ETH_BRIDGE="true"
+fi
+
+# bash integer arithmetic overflows for wei values > 2^63; use python3 for the comparison.
+if [[ "$IS_ETH_BRIDGE" == "true" ]] && python3 -c "import sys; sys.exit(0 if int('$SENDER_BALANCE') < int('$BRIDGE_AMOUNT') else 1)"; then
+    BRIDGE_AMOUNT_ETH=$(cast --from-wei "$BRIDGE_AMOUNT" ether)
+    log_error "Insufficient balance: sender has $SENDER_BALANCE_ETH ETH, needs $BRIDGE_AMOUNT_ETH ETH"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# For ERC-20: approve the bridge contract first
+# ---------------------------------------------------------------------------
+
+if [[ "$IS_ETH_BRIDGE" != "true" ]]; then
+    log_info "ERC-20 bridge: approving bridge contract to spend $BRIDGE_AMOUNT of $TOKEN_ADDRESS..."
+    APPROVE_TX=$(cast send \
+        --rpc-url "$L1_RPC_URL" \
+        --private-key "$PRIVATE_KEY" \
+        "$TOKEN_ADDRESS" \
+        "approve(address,uint256)" \
+        "$BRIDGE_ADDR" \
+        "$BRIDGE_AMOUNT")
+    log_info "Approve tx: $APPROVE_TX"
+fi
+
+# ---------------------------------------------------------------------------
+# Call bridgeAsset
+#
+#   bridgeAsset(
+#     uint32  destinationNetwork,   → NETWORK_INDEX
+#     address destinationAddress,   → DEST_ADDRESS
+#     uint256 amount,               → BRIDGE_AMOUNT
+#     address token,                → TOKEN_ADDRESS (0x0 for ETH)
+#     bool    forceUpdate,          → true  (forces local exit root update)
+#     bytes   permitData            → 0x    (empty)
+#   )
+#   msg.value = BRIDGE_AMOUNT for ETH; 0 for ERC-20
+# ---------------------------------------------------------------------------
+
+log_info "Calling bridgeAsset on L1 bridge..."
+
+if [[ "$IS_ETH_BRIDGE" == "true" ]]; then
+    TX_HASH=$(cast send \
+        --rpc-url "$L1_RPC_URL" \
+        --private-key "$PRIVATE_KEY" \
+        --value "$BRIDGE_AMOUNT" \
+        --json \
+        "$BRIDGE_ADDR" \
+        "bridgeAsset(uint32,address,uint256,address,bool,bytes)" \
+        "$NETWORK_INDEX" \
+        "$DEST_ADDRESS" \
+        "$BRIDGE_AMOUNT" \
+        "0x0000000000000000000000000000000000000000" \
+        true \
+        "0x" | python3 -c "import sys,json; print(json.load(sys.stdin)['transactionHash'])")
+else
+    TX_HASH=$(cast send \
+        --rpc-url "$L1_RPC_URL" \
+        --private-key "$PRIVATE_KEY" \
+        --json \
+        "$BRIDGE_ADDR" \
+        "bridgeAsset(uint32,address,uint256,address,bool,bytes)" \
+        "$NETWORK_INDEX" \
+        "$DEST_ADDRESS" \
+        "$BRIDGE_AMOUNT" \
+        "$TOKEN_ADDRESS" \
+        true \
+        "0x" | python3 -c "import sys,json; print(json.load(sys.stdin)['transactionHash'])")
+fi
+
+log_info "Bridge tx hash: $TX_HASH"
+
+log_info "Waiting for receipt..."
+TX_STATUS=$(cast receipt --rpc-url "$L1_RPC_URL" "$TX_HASH" status 2>/dev/null || true)
+TX_BLOCK=$(cast receipt --rpc-url "$L1_RPC_URL" "$TX_HASH" blockNumber 2>/dev/null || true)
+if [[ -z "$TX_STATUS" ]]; then
+    log_warn "Could not fetch receipt for $TX_HASH"
+elif [[ "$TX_STATUS" == *"success"* ]]; then
+    log_info "Receipt: status=success blockNumber=$TX_BLOCK"
+else
+    log_error "Receipt: status=REVERTED blockNumber=$TX_BLOCK"
+    log_error "Replaying transaction to get revert reason..."
+    cast run --rpc-url "$L1_RPC_URL" "$TX_HASH" 2>&1 | grep -E "revert|Revert|error|Error|←" | head -20 >&2
+    exit 1
+fi
+
+log_info "Bridge from L1 to L2 network $NETWORK_INDEX submitted successfully."
+log_info "  Sender:       $SENDER_ADDR"
+log_info "  Destination:  $DEST_ADDRESS"
+log_info "  Amount:       $BRIDGE_AMOUNT wei"
+log_info "  Token:        $TOKEN_ADDRESS"
+log_info "  Bridge:       $BRIDGE_ADDR"
+
+# ---------------------------------------------------------------------------
+# Optionally wait for the deposit to be auto-claimed on L2
+# ---------------------------------------------------------------------------
+
+if [[ "$WAIT_FOR_CLAIM" == "true" ]]; then
+    log_info "Getting L2 RPC URL..."
+    L2_RPC_URL=$(get_l2_rpc_url)
+    log_info "L2 RPC URL: $L2_RPC_URL"
+
+    DEPOSIT_COUNT=$(extract_deposit_count "$TX_HASH" "$L1_RPC_URL")
+    if [[ -n "$DEPOSIT_COUNT" ]]; then
+        wait_for_claim "$L2_RPC_URL" "$BRIDGE_ADDR" "$DEPOSIT_COUNT" 300
+    else
+        log_warn "Could not determine depositCount — skipping claim check"
+    fi
+fi

--- a/tools/exit_certificate/scripts/configuration_based_on_kurtosis.sh
+++ b/tools/exit_certificate/scripts/configuration_based_on_kurtosis.sh
@@ -56,7 +56,27 @@ L2_SERVICE_PREFIX="${L2_SERVICE_PREFIX:-op-el-1-op-geth-op-node}"
 L1_SERVICE="${L1_SERVICE:-el-1-geth-lighthouse}"
 AGGLAYER_SERVICE="${AGGLAYER_SERVICE:-agglayer}"
 ZKEVM_BRIDGE_SERVICE_PREFIX="${ZKEVM_BRIDGE_SERVICE_PREFIX:-zkevm-bridge-service}"
-EXIT_ADDRESS="${EXIT_ADDRESS:-0x0000000000000000000000000000000000000000}"
+_EXIT_ADDRESS_DEFAULT="0xe25f5B65E4976025f670e52b790a9746F27A3DB6"
+_EXIT_PRIVKEY_DEFAULT="0xe78f81aa81c6cf9e996084770b2aae4ee1d9e7cddb8724f4dfe60a8bd1c309fe"
+_EXIT_KEYSTORE_DEFAULT='{"crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"ed35c21427a13a62ca21f86751eb2138"},"ciphertext":"8bbd3830f060f97242508910cbfe38684647fbd915da1ba69298ba7a4fce751d","kdf":"scrypt","kdfparams":{"dklen":32,"n":8192,"p":1,"r":8,"salt":"fb2518fcadcccc9c72cac2dee9c379b3d6f744e7ceabd54f0a830acdbd51589f"},"mac":"371d6de1c647951463b43faab5f7a7f01da59cab491b518ca9c46a023b3875a0"},"id":"0983519f-aef8-448b-8a4b-7f2e0e924845","version":3}'
+_EXIT_KEYSTORE_PASSWORD="test"
+EXIT_ADDRESS="${EXIT_ADDRESS:-$_EXIT_ADDRESS_DEFAULT}"
+if [[ "$EXIT_ADDRESS" == "$_EXIT_ADDRESS_DEFAULT" ]]; then
+    _key_dir="$PROJECT_ROOT/tmp"
+    mkdir -p "$_key_dir"
+    _privkey_file="$_key_dir/exit_address_privatekey.txt"
+    _keystore_file="$_key_dir/exit_address.keystore"
+    if [[ ! -f "$_privkey_file" ]]; then
+        printf '%s\n' "$_EXIT_PRIVKEY_DEFAULT" > "$_privkey_file"
+        chmod 600 "$_privkey_file"
+        log_info "Exit address private key saved to: $_privkey_file"
+    fi
+    if [[ ! -f "$_keystore_file" ]]; then
+        printf '%s\n' "$_EXIT_KEYSTORE_DEFAULT" > "$_keystore_file"
+        chmod 600 "$_keystore_file"
+        log_info "Exit address keystore saved to: $_keystore_file (password: $_EXIT_KEYSTORE_PASSWORD)"
+    fi
+fi
 OUTPUT_FILE="${OUTPUT_FILE:-tmp/exit_certificate-kurtosis.json}"
 NETWORK_INDEX=1
 

--- a/tools/exit_certificate/scripts/reproduce_sc_locked.sh
+++ b/tools/exit_certificate/scripts/reproduce_sc_locked.sh
@@ -1,0 +1,607 @@
+#!/usr/bin/env bash
+# reproduce_sc_locked.sh — reproduce the SC-locked ERC-20 exit error in Step G
+#
+# Issue: ensureERC20Balance() returns an error for SC-locked ERC-20 exits instead of
+# patching the Anvil storage slot. This script sets up the scenario and runs the tool.
+#
+# Steps:
+#   1. Deploy a test ERC-20 on L1 (TestToken with 1000 TTK)
+#   2. Bridge some TTK from L1 to L2, wait for claim (wrapped wTTK minted to recipient)
+#   3. Deploy a dummy contract on L2 (SC holder — any address with code)
+#   4. Transfer half the wTTK from the EOA to the SC holder
+#   5. Generate the exit-certificate config and run the full pipeline
+#   6. Step G will fail with: "ERC-20 balance insufficient token: ... account: exitAddress"
+#
+# Requirements: kurtosis, cast, forge (Foundry), go, anvil
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+log_warn()    { echo -e "${ORANGE}[WARN]${NC} $*" >&2; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_section() { echo -e "\n${BLUE}══ $* ══${NC}" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$TOOL_DIR/../../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+KURTOSIS_ENCLAVE="${KURTOSIS_ENCLAVE:-aggkit}"
+L1_SERVICE="${L1_SERVICE:-el-1-geth-lighthouse}"
+L2_SERVICE="${L2_SERVICE:-op-el-1-op-geth-op-node-001}"
+AGGLAYER_SERVICE="${AGGLAYER_SERVICE:-agglayer}"
+NETWORK_INDEX="${NETWORK_INDEX:-1}"
+
+# Kurtosis L1 faucet key (1_000_000_000 ETH on L1 in local enclaves)
+PRIVATE_KEY="${PRIVATE_KEY:-0x04b9f63ecf84210c5366c66d68fa1f5da1fa4f634fad6dfc86178e4d79ff9e59}"
+
+# exitAddress: receives SC-locked value in the certificate — must NOT hold wTTK
+EXIT_ADDRESS="${EXIT_ADDRESS:-0x000000000000000000000000000000000000dEaD}"
+
+TOKEN_TOTAL_SUPPLY="1000000000000000000000"  # 1000 TTK (18 decimals)
+BRIDGE_AMOUNT="600000000000000000000"        # 600 TTK bridged to L2
+SC_LOCK_AMOUNT="400000000000000000000"       # 400 TTK transferred to SC (SC-locked)
+
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/sc-locked-reproduce}"
+
+CLAIM_TIMEOUT="${CLAIM_TIMEOUT:-300}"  # seconds to wait for L2 auto-claim
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+check_deps() {
+    local missing=()
+    command -v kurtosis &>/dev/null || missing+=("kurtosis")
+    command -v cast     &>/dev/null || missing+=("cast")
+    command -v forge    &>/dev/null || missing+=("forge")
+    command -v anvil    &>/dev/null || missing+=("anvil")
+    command -v go       &>/dev/null || missing+=("go")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        log_error "Install Foundry: https://getfoundry.sh"
+        exit 1
+    fi
+}
+
+port_to_localhost_url() {
+    local raw_url="$1"
+    local port
+    port=$(echo "$raw_url" | sed -E 's|^[a-zA-Z]+://||' | cut -f2 -d':')
+    echo "http://localhost:${port}"
+}
+
+get_rpc_url() {
+    local service="$1" port_name="$2"
+    local raw
+    raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$service" "$port_name" 2>/dev/null) \
+        || { log_error "Cannot get port '$port_name' from '$service'"; exit 1; }
+    port_to_localhost_url "$raw"
+}
+
+wait_for_claim() {
+    local l2_rpc="$1" l2_bridge="$2" deposit_count="$3"
+    local timeout_secs="${CLAIM_TIMEOUT}" poll_secs=5 elapsed=0
+
+    local leaf_idx_hex src_net_hex
+    leaf_idx_hex=$(printf '%064x' "$deposit_count")
+    src_net_hex=$(printf '%064x' 0)
+    local calldata="0xcc461632${leaf_idx_hex}${src_net_hex}"
+
+    log_info "Waiting for auto-claim on L2 (depositCount=$deposit_count)..."
+    while [[ $elapsed -lt $timeout_secs ]]; do
+        local result val
+        result=$(cast call --rpc-url "$l2_rpc" "$l2_bridge" "$calldata" 2>/dev/null || echo "0x")
+        val=$(cast to-dec "${result:-0x0}" 2>/dev/null || echo "0")
+        if [[ "$val" != "0" ]]; then
+            log_info "Deposit claimed on L2 after ${elapsed}s"
+            return 0
+        fi
+        sleep "$poll_secs"
+        elapsed=$((elapsed + poll_secs))
+        log_info "  Waiting for claim... ${elapsed}s / ${timeout_secs}s"
+    done
+    log_error "Timed out waiting for claim after ${timeout_secs}s"
+    exit 1
+}
+
+extract_deposit_count() {
+    local tx_hash="$1" l1_rpc="$2"
+    local bridge_event_topic="0x501781209a1f8899323b96b4ef08b168df93e0a90c673d1e4cce39366cb62f9b"
+    local receipt data
+    receipt=$(cast receipt --rpc-url "$l1_rpc" "$tx_hash" --json 2>/dev/null || echo "{}")
+    data=$(echo "$receipt" | python3 -c "
+import sys, json
+receipt = json.load(sys.stdin)
+topic = '$bridge_event_topic'
+for log in receipt.get('logs', []):
+    if log.get('topics', [None])[0] == topic:
+        print(log.get('data', ''))
+        break
+" 2>/dev/null || true)
+    [[ -z "$data" ]] && { log_warn "BridgeEvent log not found"; echo ""; return; }
+    # depositCount is the 8th 32-byte word (7*64=448 hex chars offset)
+    local hex_data="${data#0x}"
+    local deposit_count_hex="${hex_data:448:64}"
+    python3 -c "print(int('$deposit_count_hex', 16))" 2>/dev/null || echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Deploy test ERC-20 on L1
+# ---------------------------------------------------------------------------
+
+deploy_test_erc20() {
+    local l1_rpc="$1"
+    log_section "Step 1: Deploy test ERC-20 on L1"
+
+    # Write minimal ERC-20 Solidity source
+    local sol_dir="$OUTPUT_DIR/contracts"
+    mkdir -p "$sol_dir"
+    cat > "$sol_dir/TestToken.sol" <<'EOF'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract TestToken {
+    string  public name     = "TestToken";
+    string  public symbol   = "TTK";
+    uint8   public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    event Transfer(address indexed from, address indexed to,              uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    constructor(uint256 _supply) {
+        totalSupply          = _supply;
+        balanceOf[msg.sender] = _supply;
+        emit Transfer(address(0), msg.sender, _supply);
+    }
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to]          += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from]              -= amount;
+        balanceOf[to]                += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}
+EOF
+
+    log_info "Deploying TestToken on L1 (supply: $TOKEN_TOTAL_SUPPLY)..."
+    local out
+    out=$(forge create \
+        --rpc-url "$l1_rpc" \
+        --private-key "$PRIVATE_KEY" \
+        --broadcast \
+        "$sol_dir/TestToken.sol:TestToken" \
+        --constructor-args "$TOKEN_TOTAL_SUPPLY" \
+        2>&1)
+    echo "$out" >&2
+
+    local l1_token_addr
+    l1_token_addr=$(echo "$out" | grep "Deployed to:" | awk '{print $3}')
+    if [[ -z "$l1_token_addr" ]]; then
+        log_error "Failed to extract deployed address from forge output"
+        exit 1
+    fi
+    log_info "TestToken deployed at: $l1_token_addr"
+    echo "$l1_token_addr"
+}
+
+# ---------------------------------------------------------------------------
+# Step 2: Bridge TTK from L1 to L2
+# ---------------------------------------------------------------------------
+
+bridge_erc20_to_l2() {
+    local l1_rpc="$1" l2_rpc="$2" l1_bridge="$3" l1_token="$4" recipient="$5"
+    log_section "Step 2: Bridge $BRIDGE_AMOUNT TTK from L1 to L2"
+
+    log_info "Approving L1 bridge to spend $BRIDGE_AMOUNT TTK..."
+    cast send \
+        --rpc-url "$l1_rpc" \
+        --private-key "$PRIVATE_KEY" \
+        "$l1_token" \
+        "approve(address,uint256)" \
+        "$l1_bridge" \
+        "$BRIDGE_AMOUNT" >/dev/null
+    log_info "Approval done."
+
+    log_info "Calling bridgeAsset on L1 bridge..."
+    local tx_json
+    tx_json=$(cast send \
+        --rpc-url "$l1_rpc" \
+        --private-key "$PRIVATE_KEY" \
+        --json \
+        "$l1_bridge" \
+        "bridgeAsset(uint32,address,uint256,address,bool,bytes)" \
+        "$NETWORK_INDEX" \
+        "$recipient" \
+        "$BRIDGE_AMOUNT" \
+        "$l1_token" \
+        true \
+        "0x")
+    local tx_hash
+    tx_hash=$(echo "$tx_json" | python3 -c "import sys,json; print(json.load(sys.stdin)['transactionHash'])")
+    log_info "Bridge tx: $tx_hash"
+
+    local deposit_count
+    deposit_count=$(extract_deposit_count "$tx_hash" "$l1_rpc")
+    if [[ -z "$deposit_count" ]]; then
+        log_error "Could not extract depositCount from bridge tx — cannot wait for claim"
+        exit 1
+    fi
+    log_info "depositCount: $deposit_count"
+
+    wait_for_claim "$l2_rpc" "$l1_bridge" "$deposit_count"
+    echo "$deposit_count"
+}
+
+# ---------------------------------------------------------------------------
+# Step 3: Find wrapped token address on L2
+# ---------------------------------------------------------------------------
+
+find_wrapped_token_on_l2() {
+    local l2_rpc="$1" l2_bridge="$2" l1_network_id="$3" l1_token="$4"
+    log_section "Step 3: Find wrapped token address on L2"
+
+    # getTokenWrappedAddress(uint32 originNetwork, address originTokenAddress) returns (address)
+    local calldata
+    calldata=$(cast calldata "getTokenWrappedAddress(uint32,address)" "$l1_network_id" "$l1_token")
+    local result
+    result=$(cast call --rpc-url "$l2_rpc" "$l2_bridge" "$calldata")
+    local wrapped
+    wrapped=$(cast parse-bytes32-address "$result" 2>/dev/null || echo "")
+    if [[ -z "$wrapped" ]] || [[ "$wrapped" == "0x0000000000000000000000000000000000000000" ]]; then
+        # fallback: decode as address
+        wrapped=$(cast abi-decode "f()(address)" "$result" 2>/dev/null | head -1 || echo "")
+    fi
+    if [[ -z "$wrapped" ]] || [[ "$wrapped" == "0x0000000000000000000000000000000000000000" ]]; then
+        log_error "Wrapped token not found on L2 for L1 token $l1_token (network $l1_network_id)"
+        exit 1
+    fi
+    log_info "Wrapped token on L2: $wrapped"
+    echo "$wrapped"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4: Deploy dummy SC holder on L2 and transfer tokens
+# ---------------------------------------------------------------------------
+
+create_sc_locked_tokens() {
+    local l2_rpc="$1" l2_bridge="$2" wrapped_token="$3" sender="$4"
+    log_section "Step 4: Create SC-locked tokens on L2"
+
+    # Fund sender on L2 first (bridge ETH for gas)
+    log_info "Checking L2 ETH balance for gas..."
+    local l2_bal
+    l2_bal=$(cast balance --rpc-url "$l2_rpc" "$sender")
+    if python3 -c "import sys; sys.exit(0 if int('$l2_bal') < 10**15 else 1)" 2>/dev/null; then
+        log_info "L2 balance low ($l2_bal), bridging ETH for gas..."
+        local gas_amount="100000000000000000"  # 0.1 ETH
+        cast send \
+            --rpc-url "$(get_rpc_url "$L1_SERVICE" rpc)" \
+            --private-key "$PRIVATE_KEY" \
+            --value "$gas_amount" \
+            "$l2_bridge" \
+            "bridgeAsset(uint32,address,uint256,address,bool,bytes)" \
+            "$NETWORK_INDEX" \
+            "$sender" \
+            "$gas_amount" \
+            "0x0000000000000000000000000000000000000000" \
+            true \
+            "0x" >/dev/null
+        log_info "ETH bridge submitted. Waiting for L2 balance..."
+        local elapsed=0
+        while [[ $elapsed -lt 120 ]]; do
+            l2_bal=$(cast balance --rpc-url "$l2_rpc" "$sender")
+            python3 -c "import sys; sys.exit(1 if int('$l2_bal') < 10**15 else 0)" 2>/dev/null && break
+            sleep 5; elapsed=$((elapsed + 5))
+        done
+        log_info "L2 ETH balance: $(cast from-wei "$l2_bal" ether) ETH"
+    else
+        log_info "L2 ETH balance: $(cast from-wei "$l2_bal" ether) ETH (sufficient)"
+    fi
+
+    # Deploy a Solidity holder contract (must have runtime bytecode so eth_getCode != 0x)
+    log_info "Deploying SC holder on L2 (Solidity contract with runtime code)..."
+    local sol_dir="$OUTPUT_DIR/contracts"
+    mkdir -p "$sol_dir"
+    cat > "$sol_dir/TokenHolder.sol" <<'EOF'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+// A non-EOA address that holds ERC-20 tokens.
+// Empty Solidity contracts still have non-empty runtime bytecode (compiler metadata hash).
+contract TokenHolder {}
+EOF
+    local holder_out
+    holder_out=$(forge create \
+        --rpc-url "$l2_rpc" \
+        --private-key "$PRIVATE_KEY" \
+        --broadcast \
+        "$sol_dir/TokenHolder.sol:TokenHolder" 2>&1)
+    echo "$holder_out" >&2
+    local holder_addr
+    holder_addr=$(echo "$holder_out" | grep "Deployed to:" | awk '{print $3}')
+    if [[ -z "$holder_addr" ]]; then
+        log_error "Failed to deploy holder contract"
+        exit 1
+    fi
+    # Verify it has code (essential — otherwise Step B classifies it as EOA)
+    local holder_code
+    holder_code=$(cast code --rpc-url "$l2_rpc" "$holder_addr" 2>/dev/null || echo "0x")
+    if [[ "$holder_code" == "0x" ]]; then
+        log_error "Holder contract at $holder_addr has no code — Step B will treat it as EOA"
+        exit 1
+    fi
+    log_info "SC holder deployed at: $holder_addr (code length: ${#holder_code} bytes hex)"
+
+    # Check wTTK balance on L2 (use raw hex → decimal to avoid cast annotation like "[2e20]")
+    balanceof_hex() { cast call --rpc-url "$l2_rpc" "$wrapped_token" "balanceOf(address)" "$1" 2>/dev/null; }
+    local sender_bal_hex
+    sender_bal_hex=$(balanceof_hex "$sender")
+    local sender_wttk
+    sender_wttk=$(cast to-dec "$sender_bal_hex")
+    log_info "wTTK balance of sender: $sender_wttk"
+
+    # Determine actual transfer amount: min(SC_LOCK_AMOUNT, sender_balance)
+    local transfer_amount
+    transfer_amount=$(python3 -c "print(min(int('$SC_LOCK_AMOUNT'), int('$sender_wttk')))")
+    log_info "Transferring $transfer_amount wTTK to SC holder $holder_addr..."
+    cast send \
+        --rpc-url "$l2_rpc" \
+        --private-key "$PRIVATE_KEY" \
+        "$wrapped_token" \
+        "transfer(address,uint256)" \
+        "$holder_addr" \
+        "$transfer_amount" >/dev/null
+    log_info "Transfer done."
+
+    local eoa_bal sc_bal
+    eoa_bal=$(cast to-dec "$(balanceof_hex "$sender")")
+    sc_bal=$(cast to-dec "$(balanceof_hex "$holder_addr")")
+    log_info "wTTK balance — EOA: $eoa_bal  |  SC holder: $sc_bal"
+    log_info "SC-locked amount: $sc_bal (will trigger ensureERC20Balance error in Step G)"
+
+    echo "$holder_addr"
+}
+
+# ---------------------------------------------------------------------------
+# Step 5: Build the exit-certificate tool
+# ---------------------------------------------------------------------------
+
+build_tool() {
+    log_section "Step 5: Build exit-certificate tool"
+    pushd "$TOOL_DIR" >/dev/null
+    go build -o "$OUTPUT_DIR/exit-certificate" ./cmd
+    popd >/dev/null
+    log_info "Binary: $OUTPUT_DIR/exit-certificate"
+}
+
+# ---------------------------------------------------------------------------
+# Step 6: Generate config and run pipeline
+# ---------------------------------------------------------------------------
+
+run_pipeline() {
+    local l1_rpc="$1" l2_rpc="$2" l2_bridge="$3" l1_network_id="$4" target_block="$5" l1_token="$6"
+    log_section "Step 6: Run exit-certificate pipeline"
+
+    local agglayer_grpc sovereign_rollup l1_ger_addr
+    agglayer_grpc=$(get_rpc_url_grpc "$AGGLAYER_SERVICE")
+
+    local config_tmp
+    config_tmp=$(mktemp -d)
+    trap "rm -rf '$config_tmp'" RETURN
+    kurtosis files download "$KURTOSIS_ENCLAVE" "aggkit-bridge-config-001" "$config_tmp" &>/dev/null || true
+    sovereign_rollup=$(grep -E '^\s*SovereignRollupAddr\s*=' "$config_tmp/config.toml" 2>/dev/null \
+        | head -1 | tr -d '[:space:]' | cut -f2 -d'=' | tr -d '"' || echo "")
+    l1_ger_addr=$(grep -E '^\s*polygonZkEVMGlobalExitRootAddress\s*=' "$config_tmp/config.toml" 2>/dev/null \
+        | head -1 | tr -d '[:space:]' | cut -f2 -d'=' | tr -d '"' || echo "")
+
+    local config_file="$OUTPUT_DIR/parameters.json"
+    cat > "$config_file" <<EOF
+{
+    "l2RpcUrl":       "$l2_rpc",
+    "l1RpcUrl":       "$l1_rpc",
+    "l2BridgeAddress":"$l2_bridge",
+    "l1BridgeAddress":"$l2_bridge",
+    "l2NetworkId":    $NETWORK_INDEX,
+    "targetBlock":    "$target_block",
+    "exitAddress":    "$EXIT_ADDRESS",
+    "destinationNetwork": 0,
+    "sovereignRollupAddr":    "${sovereign_rollup:-0x0000000000000000000000000000000000000000}",
+    "l1GlobalExitRootAddress":"${l1_ger_addr:-0x0000000000000000000000000000000000000000}",
+    "options": {
+        "blockRange":           5000,
+        "concurrencyLimit":     20,
+        "rpcBatchSize":         200,
+        "rpcDelayMs":           0,
+        "outputDir":            "$OUTPUT_DIR/output",
+        "l1StartBlock":         0,
+        "agglayerClient":       { "GRPC": { "URL": "$agglayer_grpc" } },
+        "abortOnGenesisBalance": false
+    }
+}
+EOF
+    log_info "Config written to: $config_file"
+
+    # Phase 1: run steps 0→E to build intermediate files (LBT, addresses, balances, certificate)
+    # Stop before Step G since genesis ETH in other addresses causes LocalBalanceTreeUnderflow.
+    log_info "Phase 1: running steps 0 → E to build intermediate files..."
+    rm -rf "$OUTPUT_DIR/output"
+    set +e
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step 0    --verbose 2>&1 | tee -a "$OUTPUT_DIR/tool-output.log"
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step a    --verbose 2>&1 | tee -a "$OUTPUT_DIR/tool-output.log"
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step b    --verbose 2>&1 | tee -a "$OUTPUT_DIR/tool-output.log"
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step c    --verbose 2>&1 | tee -a "$OUTPUT_DIR/tool-output.log"
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step d    --verbose 2>&1 | tee -a "$OUTPUT_DIR/tool-output.log"
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step e    --verbose 2>&1 | tee -a "$OUTPUT_DIR/tool-output.log"
+    set -e
+
+    # Show SC-locked values found
+    if [[ -f "$OUTPUT_DIR/output/step-c-sc-locked-values.json" ]]; then
+        log_info "SC-locked values (step C output):"
+        python3 -c "
+import json
+data = json.load(open('$OUTPUT_DIR/output/step-c-sc-locked-values.json'))
+for e in data:
+    bal = e.get('scLockedBalance', e.get('sc_locked_balance', '0'))
+    addr = e.get('wrappedTokenAddress', e.get('wrapped_token_address', '?'))
+    print(f'  token={addr}  sc_locked={bal}')
+" 2>/dev/null || true
+    fi
+
+    # Phase 2: patch step-e-exit-certificate.json to contain ONLY the SC-locked ERC-20 exit,
+    # then run step G. This isolates the bug (ensureERC20Balance) from unrelated ETH underflow
+    # errors caused by genesis balances.
+    log_info "Phase 2: patching certificate to keep only SC-locked ERC-20 exits..."
+    local cert_file="$OUTPUT_DIR/output/step-e-exit-certificate.json"
+    python3 - "$cert_file" "$l1_token" "$EXIT_ADDRESS" <<'PYEOF'
+import json, sys, re
+
+cert_path = sys.argv[1]
+l1_token   = sys.argv[2].lower()
+exit_addr  = sys.argv[3].lower()
+
+with open(cert_path) as f:
+    cert = json.load(f)
+
+orig = cert.get('bridge_exits', [])
+# Keep only exits where: token matches our L1 TestToken AND destination is exitAddress (SC-locked)
+sc_exits = [
+    e for e in orig
+    if (e.get('token_info', {}).get('origin_token_address', '').lower() == l1_token
+        and e.get('dest_address', '').lower() == exit_addr)
+]
+print(f"  Original exits: {len(orig)}, SC-locked TestToken exits: {len(sc_exits)}", file=sys.stderr)
+if not sc_exits:
+    print("  WARNING: no SC-locked exits found for TestToken — check if step C found SC-locked value > 0", file=sys.stderr)
+    sys.exit(1)
+
+cert['bridge_exits'] = sc_exits
+with open(cert_path, 'w') as f:
+    json.dump(cert, f, indent=2)
+print(f"  Patched certificate has {len(sc_exits)} SC-locked exit(s).", file=sys.stderr)
+PYEOF
+
+    # Phase 3: run step G against the patched certificate — expect the ensureERC20Balance error
+    log_info "Phase 3: running step G — expect ensureERC20Balance error..."
+    log_info ""
+    set +e
+    "$OUTPUT_DIR/exit-certificate" --config "$config_file" --step g --verbose 2>&1 | tee "$OUTPUT_DIR/step-g-output.log"
+    local exit_code=$?
+    set -e
+
+    echo ""
+    if [[ $exit_code -ne 0 ]]; then
+        log_warn "Step G failed (exit $exit_code) — this is the bug described in F-01"
+        log_info ""
+        grep -E "ERC-20 balance insufficient|ensure ERC-20 balance|patching via storage" \
+            "$OUTPUT_DIR/step-g-output.log" | head -10 || true
+        log_info ""
+        log_info "Root cause (step_g.go:ensureERC20Balance):"
+        log_info "  The function sees exitAddress has 0 wTTK balance and returns an error."
+        log_info "  It should instead call hardhat_setStorageAt to patch the ERC-20 storage slot."
+    else
+        log_info "Step G completed successfully (bug may have been fixed)"
+    fi
+}
+
+get_rpc_url_grpc() {
+    local service="$1"
+    local raw port
+    raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$service" aglr-grpc 2>/dev/null) \
+        || { log_error "Cannot get gRPC port from '$service'"; exit 1; }
+    port=$(echo "$raw" | sed -E 's|^[a-zA-Z]+://||' | cut -f2 -d':')
+    echo "http://localhost:${port}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+check_deps
+
+log_info "Enclave:      $KURTOSIS_ENCLAVE"
+log_info "Network:      $NETWORK_INDEX"
+log_info "EXIT_ADDRESS: $EXIT_ADDRESS  (receives SC-locked value, must have no wTTK)"
+log_info "Output dir:   $OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+L1_RPC=$(get_rpc_url "$L1_SERVICE" rpc)
+L2_RPC=$(get_rpc_url "$L2_SERVICE" rpc)
+log_info "L1 RPC: $L1_RPC"
+log_info "L2 RPC: $L2_RPC"
+
+# Determine L1 network ID (needed to look up wrapped token on L2)
+L1_NETWORK_ID=$(cast chain-id --rpc-url "$L1_RPC")
+log_info "L1 chainId (used as originNetwork): $L1_NETWORK_ID"
+
+SENDER=$(cast wallet address --private-key "$PRIVATE_KEY")
+log_info "Sender: $SENDER"
+
+# Get bridge address
+BRIDGE_TMP=$(mktemp -d)
+kurtosis files download "$KURTOSIS_ENCLAVE" "aggkit-bridge-config-001" "$BRIDGE_TMP" &>/dev/null
+L2_BRIDGE=$(grep 'BridgeAddr' "$BRIDGE_TMP/config.toml" | head -1 | tr -d '[:space:]' \
+    | cut -f2 -d'=' | tr -d '"')
+rm -rf "$BRIDGE_TMP"
+log_info "L2 Bridge: $L2_BRIDGE"
+
+# Step 1: Deploy test ERC-20 on L1
+L1_TOKEN=$(deploy_test_erc20 "$L1_RPC")
+log_info "L1 TestToken: $L1_TOKEN"
+
+# Step 2: Bridge TTK to L2 (sends to SENDER address on L2)
+bridge_erc20_to_l2 "$L1_RPC" "$L2_RPC" "$L2_BRIDGE" "$L1_TOKEN" "$SENDER"
+
+# Step 3: Find wrapped token on L2
+# Note: the bridge uses the L2 networkId as originNetwork for wrapped tokens, not L1 chainId.
+# For cross-chain wrapped tokens, originNetwork is the network that originally issued the token.
+# In AgglayerBridge, for an L1-originated token bridged to L2, the wrapped token is looked up
+# by (originNetwork=0, originTokenAddress=L1_TOKEN) where 0 is the L1 network in the bridge topology.
+# But the bridge topology uses networkId(). Let's try network 0 first (typical L1 network in bridge).
+WRAPPED_TOKEN=""
+for origin_net in 0 1 "$L1_NETWORK_ID"; do
+    candidate=$(cast call --rpc-url "$L2_RPC" "$L2_BRIDGE" \
+        "getTokenWrappedAddress(uint32,address)(address)" \
+        "$origin_net" "$L1_TOKEN" 2>/dev/null || echo "0x0000000000000000000000000000000000000000")
+    if [[ "$candidate" != "0x0000000000000000000000000000000000000000" ]]; then
+        log_info "Found wrapped token at originNetwork=$origin_net: $candidate"
+        WRAPPED_TOKEN="$candidate"
+        break
+    fi
+done
+if [[ -z "$WRAPPED_TOKEN" ]]; then
+    log_error "Could not find wrapped token on L2 for L1 token $L1_TOKEN"
+    log_error "It may still be pending. Try increasing CLAIM_TIMEOUT."
+    exit 1
+fi
+
+# Step 4: Create SC-locked tokens
+create_sc_locked_tokens "$L2_RPC" "$L2_BRIDGE" "$WRAPPED_TOKEN" "$SENDER"
+
+# Capture current L2 block as target
+TARGET_BLOCK=$(cast block-number --rpc-url "$L2_RPC")
+log_info "Target block (current L2 tip): $TARGET_BLOCK"
+
+# Step 5: Build the tool
+build_tool
+
+# Step 6: Run and observe the error
+run_pipeline "$L1_RPC" "$L2_RPC" "$L2_BRIDGE" "$L1_NETWORK_ID" "$TARGET_BLOCK" "$L1_TOKEN"

--- a/tools/exit_certificate/step_c.go
+++ b/tools/exit_certificate/step_c.go
@@ -7,23 +7,13 @@ import (
 	"github.com/agglayer/aggkit/log"
 )
 
-// RunStepC loads LBT entries from the configured file and computes SC-locked values.
-func RunStepC(cfg *Config, stepB *StepBResult) (*StepCResult, error) {
-	lbtEntries, err := LoadLBTEntries(cfg.LBTFile)
-	if err != nil {
-		return nil, err
-	}
-	log.Infof("Loading LBT data from: %s", cfg.LBTFile)
-	return RunStepCWithEntries(lbtEntries, stepB)
-}
-
-// RunStepCWithEntries computes the value locked in smart contracts for each token.
+// RunStepC computes the value locked in smart contracts for each token.
 //
 // Formula: SC_locked = LBT_totalSupply − accumulated_EOA_balances
 //
 // The LBT gives total supply per token. The accumulated EOA balances (Step B)
 // tell us how much is held by EOAs. The difference is held by smart contracts.
-func RunStepCWithEntries(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
+func RunStepC(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP C — SC-locked value extraction")
 	log.Info("═══════════════════════════════════════════")

--- a/tools/exit_certificate/step_c_test.go
+++ b/tools/exit_certificate/step_c_test.go
@@ -1,10 +1,7 @@
 package exit_certificate
 
 import (
-	"encoding/json"
 	"math/big"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,9 +10,6 @@ import (
 
 func TestRunStepC_Basic(t *testing.T) {
 	t.Parallel()
-
-	dir := t.TempDir()
-	lbtPath := filepath.Join(dir, "lbt.json")
 
 	tokenAddr := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 	originAddr := common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
@@ -29,11 +23,6 @@ func TestRunStepC_Basic(t *testing.T) {
 		},
 	}
 
-	data, err := json.Marshal(lbtEntries)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(lbtPath, data, 0o600))
-
-	cfg := &Config{LBTFile: lbtPath}
 	stepB := &StepBResult{
 		Accumulated: []AccumulatedBalance{
 			{
@@ -45,7 +34,7 @@ func TestRunStepC_Basic(t *testing.T) {
 		},
 	}
 
-	result, err := RunStepC(cfg, stepB)
+	result, err := RunStepC(lbtEntries, stepB)
 	require.NoError(t, err)
 	require.Len(t, result.SCLockedValues, 1)
 
@@ -56,9 +45,6 @@ func TestRunStepC_Basic(t *testing.T) {
 
 func TestRunStepC_EOAExceedsLBT(t *testing.T) {
 	t.Parallel()
-
-	dir := t.TempDir()
-	lbtPath := filepath.Join(dir, "lbt.json")
 
 	tokenAddr := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 	originAddr := common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
@@ -72,11 +58,6 @@ func TestRunStepC_EOAExceedsLBT(t *testing.T) {
 		},
 	}
 
-	data, err := json.Marshal(lbtEntries)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(lbtPath, data, 0o600))
-
-	cfg := &Config{LBTFile: lbtPath}
 	stepB := &StepBResult{
 		Accumulated: []AccumulatedBalance{
 			{
@@ -88,7 +69,7 @@ func TestRunStepC_EOAExceedsLBT(t *testing.T) {
 		},
 	}
 
-	result, err := RunStepC(cfg, stepB)
+	result, err := RunStepC(lbtEntries, stepB)
 	require.NoError(t, err)
 	require.Len(t, result.SCLockedValues, 1)
 
@@ -96,32 +77,16 @@ func TestRunStepC_EOAExceedsLBT(t *testing.T) {
 	require.Equal(t, "0", result.SCLockedValues[0].SCLockedBalance)
 }
 
-func TestRunStepC_NoLBTFile(t *testing.T) {
+func TestRunStepC_EmptyLBT(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{LBTFile: ""}
-	stepB := &StepBResult{Accumulated: nil}
-
-	result, err := RunStepC(cfg, stepB)
+	result, err := RunStepC([]LBTEntry{}, &StepBResult{Accumulated: nil})
 	require.NoError(t, err)
 	require.Empty(t, result.SCLockedValues)
 }
 
-func TestRunStepC_MissingLBTFile(t *testing.T) {
-	t.Parallel()
-
-	cfg := &Config{LBTFile: "/nonexistent/lbt.json"}
-	stepB := &StepBResult{Accumulated: nil}
-
-	_, err := RunStepC(cfg, stepB)
-	require.Error(t, err)
-}
-
 func TestRunStepC_MultipleTokens(t *testing.T) {
 	t.Parallel()
-
-	dir := t.TempDir()
-	lbtPath := filepath.Join(dir, "lbt.json")
 
 	token1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	token2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -133,11 +98,6 @@ func TestRunStepC_MultipleTokens(t *testing.T) {
 		{WrappedTokenAddress: token2, OriginNetwork: 1, OriginTokenAddress: origin2, Balance: "2000000"},
 	}
 
-	data, err := json.Marshal(lbtEntries)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(lbtPath, data, 0o600))
-
-	cfg := &Config{LBTFile: lbtPath}
 	stepB := &StepBResult{
 		Accumulated: []AccumulatedBalance{
 			{WrappedTokenAddress: token1, OriginNetwork: 0, OriginTokenAddress: origin1, TotalBalance: "300000"},
@@ -145,7 +105,7 @@ func TestRunStepC_MultipleTokens(t *testing.T) {
 		},
 	}
 
-	result, err := RunStepC(cfg, stepB)
+	result, err := RunStepC(lbtEntries, stepB)
 	require.NoError(t, err)
 	require.Len(t, result.SCLockedValues, 2)
 
@@ -161,23 +121,14 @@ func TestRunStepC_MultipleTokens(t *testing.T) {
 func TestRunStepC_TokenNotInLBT(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	lbtPath := filepath.Join(dir, "lbt.json")
-
 	token1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	origin1 := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	extraToken := common.HexToAddress("0x9999999999999999999999999999999999999999")
 
 	lbtEntries := []LBTEntry{
 		{WrappedTokenAddress: token1, OriginNetwork: 0, OriginTokenAddress: origin1, Balance: "1000000"},
 	}
 
-	data, err := json.Marshal(lbtEntries)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(lbtPath, data, 0o600))
-
-	extraToken := common.HexToAddress("0x9999999999999999999999999999999999999999")
-
-	cfg := &Config{LBTFile: lbtPath}
 	stepB := &StepBResult{
 		Accumulated: []AccumulatedBalance{
 			{WrappedTokenAddress: token1, OriginNetwork: 0, OriginTokenAddress: origin1, TotalBalance: "300000"},
@@ -185,7 +136,7 @@ func TestRunStepC_TokenNotInLBT(t *testing.T) {
 		},
 	}
 
-	result, err := RunStepC(cfg, stepB)
+	result, err := RunStepC(lbtEntries, stepB)
 	require.NoError(t, err)
 	// Only token1 is in LBT, so only 1 SC-locked entry
 	require.Len(t, result.SCLockedValues, 1)

--- a/tools/exit_certificate/step_g.go
+++ b/tools/exit_certificate/step_g.go
@@ -29,6 +29,8 @@ const (
 
 	// largeETHBalance is MaxUint256 in hex, enough for any bridgeAsset call regardless of exit amounts.
 	largeETHBalance = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+	abiFuncSelectorSize = 4 // bytes in an ABI function selector
 )
 
 var (
@@ -473,9 +475,10 @@ func callGetTokenWrappedAddress(
 	return addr, nil
 }
 
-// erc20NamespacedStorageLocation is the ERC-20 storage namespace for OZ v5 upgradeable tokens:
-// keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC20")) - 1)) & ~bytes32(0xff)
-var erc20NamespacedStorageLocation = common.HexToHash("0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00")
+// erc20NamespacedStorageLocation is the ERC-20 storage namespace for OZ v5 upgradeable tokens.
+var erc20NamespacedStorageLocation = common.HexToHash(
+	"0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00",
+)
 
 // ensureERC20Balance checks the ERC-20 balance of account on tokenAddr.
 // If insufficient it patches _balances[account] via hardhat_setStorageAt.
@@ -486,8 +489,9 @@ func ensureERC20Balance(
 	ctx context.Context, rpcURL string, tokenAddr, account common.Address, required *big.Int,
 ) error {
 	balanceOf := func() (*big.Int, error) {
-		callData := append(crypto.Keccak256([]byte("balanceOf(address)"))[:4],
-			common.LeftPadBytes(account.Bytes(), abiWordBytes)...)
+		callData := make([]byte, abiFuncSelectorSize+abiWordBytes)
+		copy(callData, crypto.Keccak256([]byte("balanceOf(address)"))[:abiFuncSelectorSize])
+		copy(callData[abiFuncSelectorSize:], common.LeftPadBytes(account.Bytes(), abiWordBytes))
 		raw, err := singleRPC(ctx, rpcURL, "eth_call", []any{
 			map[string]any{"to": tokenAddr.Hex(), "data": "0x" + hex.EncodeToString(callData)},
 			"latest",
@@ -533,8 +537,8 @@ func ensureERC20Balance(
 
 	// Try OZ v4 (slot 0) first, then OZ v5 upgradeable (namespaced storage).
 	candidates := []string{
-		erc20BalanceSlot(common.Hash{}),                     // OZ v4: _balances at slot 0
-		erc20BalanceSlot(erc20NamespacedStorageLocation),    // OZ v5 upgradeable
+		erc20BalanceSlot(common.Hash{}),                  // OZ v4: _balances at slot 0
+		erc20BalanceSlot(erc20NamespacedStorageLocation), // OZ v5 upgradeable
 	}
 
 	for _, slotHex := range candidates {

--- a/tools/exit_certificate/step_g.go
+++ b/tools/exit_certificate/step_g.go
@@ -473,45 +473,90 @@ func callGetTokenWrappedAddress(
 	return addr, nil
 }
 
+// erc20NamespacedStorageLocation is the ERC-20 storage namespace for OZ v5 upgradeable tokens:
+// keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC20")) - 1)) & ~bytes32(0xff)
+var erc20NamespacedStorageLocation = common.HexToHash("0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00")
+
 // ensureERC20Balance checks the ERC-20 balance of account on tokenAddr.
-// If the balance is below required, it sets the OZ slot-0 storage entry via
-// hardhat_setStorageAt so that the subsequent bridgeAsset call does not revert.
+// If insufficient it patches _balances[account] via hardhat_setStorageAt.
+// Tries two storage layouts in order, verifying balanceOf after each patch:
+//  1. OZ v4 non-upgradeable: _balances at mapping slot 0
+//  2. OZ v5 upgradeable: _balances inside the namespaced ERC20Storage struct
 func ensureERC20Balance(
 	ctx context.Context, rpcURL string, tokenAddr, account common.Address, required *big.Int,
 ) error {
-	selector := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
-	selector = append(selector, common.LeftPadBytes(account.Bytes(), abiWordBytes)...)
-	callData := selector
+	balanceOf := func() (*big.Int, error) {
+		callData := append(crypto.Keccak256([]byte("balanceOf(address)"))[:4],
+			common.LeftPadBytes(account.Bytes(), abiWordBytes)...)
+		raw, err := singleRPC(ctx, rpcURL, "eth_call", []any{
+			map[string]any{"to": tokenAddr.Hex(), "data": "0x" + hex.EncodeToString(callData)},
+			"latest",
+		}, defaultRetries)
+		if err != nil {
+			return nil, fmt.Errorf("balanceOf(%s): %w", account.Hex(), err)
+		}
+		var hexBal string
+		if err := json.Unmarshal(raw, &hexBal); err != nil {
+			return nil, fmt.Errorf("parse balanceOf result: %w", err)
+		}
+		bal, ok := new(big.Int).SetString(strings.TrimPrefix(hexBal, "0x"), hexBase)
+		if !ok {
+			return nil, fmt.Errorf("invalid balanceOf hex: %s", hexBal)
+		}
+		return bal, nil
+	}
 
-	raw, err := singleRPC(ctx, rpcURL, "eth_call", []any{
-		map[string]any{
-			"to":   tokenAddr.Hex(),
-			"data": "0x" + hex.EncodeToString(callData),
-		},
-		"latest",
-	}, defaultRetries)
+	bal, err := balanceOf()
 	if err != nil {
-		return fmt.Errorf("balanceOf(%s): %w", account.Hex(), err)
+		return err
 	}
-
-	var hexBal string
-	if err := json.Unmarshal(raw, &hexBal); err != nil {
-		return fmt.Errorf("parse balanceOf result: %w", err)
-	}
-	bal, ok := new(big.Int).SetString(strings.TrimPrefix(hexBal, "0x"), hexBase)
-	if !ok {
-		return fmt.Errorf("invalid balanceOf hex: %s", hexBal)
-	}
-
 	if bal.Cmp(required) >= 0 {
 		log.Debugf("ERC-20 %s balance of %s is sufficient (%s >= %s)", tokenAddr.Hex(), account.Hex(), bal, required)
 		return nil
 	}
 
-	log.Infof("❌ ERC-20 %s balance of %s insufficient (%s < %s) — patching via storage",
+	log.Infof("ERC-20 %s balance of %s insufficient (%s < %s) — patching via storage slot",
 		tokenAddr.Hex(), account.Hex(), bal, required)
-	return fmt.Errorf("ERC-20 balance insufficient token: %s account: %s balance: %s required: %s",
-		tokenAddr.Hex(), account.Hex(), bal, required)
+
+	valueHex := "0x" + hex.EncodeToString(common.LeftPadBytes(required.Bytes(), abiWordBytes))
+
+	// erc20BalanceSlot returns keccak256(abi.encode(account, mapSlot)),
+	// which is the Solidity storage slot for _balances[account] when _balances
+	// is a mapping located at mapSlot.
+	erc20BalanceSlot := func(mapSlot common.Hash) string {
+		preimage := append(
+			common.LeftPadBytes(account.Bytes(), abiWordBytes),
+			mapSlot.Bytes()...,
+		)
+		return "0x" + hex.EncodeToString(crypto.Keccak256(preimage))
+	}
+
+	// Try OZ v4 (slot 0) first, then OZ v5 upgradeable (namespaced storage).
+	candidates := []string{
+		erc20BalanceSlot(common.Hash{}),                     // OZ v4: _balances at slot 0
+		erc20BalanceSlot(erc20NamespacedStorageLocation),    // OZ v5 upgradeable
+	}
+
+	for _, slotHex := range candidates {
+		if _, err := singleRPC(ctx, rpcURL, "hardhat_setStorageAt",
+			[]any{tokenAddr.Hex(), slotHex, valueHex}, defaultRetries); err != nil {
+			return fmt.Errorf("set ERC-20 balance storage slot: %w", err)
+		}
+		newBal, err := balanceOf()
+		if err != nil {
+			return err
+		}
+		if newBal.Cmp(required) >= 0 {
+			log.Infof("✅ ERC-20 %s balance of %s patched to %s (slot %s)",
+				tokenAddr.Hex(), account.Hex(), required, slotHex)
+			return nil
+		}
+		log.Debugf("slot %s did not update balanceOf — trying next layout", slotHex)
+	}
+
+	return fmt.Errorf("could not patch ERC-20 balance for token %s account %s: "+
+		"no storage layout matched (tried OZ v4 slot-0 and OZ v5 upgradeable)",
+		tokenAddr.Hex(), account.Hex())
 }
 
 // encodeERC20ApproveCallRaw ABI-encodes an ERC-20 approve(spender, amount) call.


### PR DESCRIPTION
## 🔄 Changes Summary

### Fix F-01: `ensureERC20Balance` storage patching for SC-locked ERC-20 exits
- Implements `ensureERC20Balance` in Step G, which was a stub that always returned an error without actually patching Anvil storage.
- The function now patches `_balances[account]` via `hardhat_setStorageAt` using a two-layout detection strategy, verifying `balanceOf` after each attempt:
  1. **OZ v4 non-upgradeable**: `_balances` mapping at storage slot 0
  2. **OZ v5 upgradeable**: `_balances` inside the namespaced `ERC20Storage` struct at `ERC20StorageLocation = 0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00`
- Adds a package-level `erc20NamespacedStorageLocation` constant documenting the OZ v5 storage namespace derivation.

### Refactor: remove `lbtFile` config option
- `lbtFile` was an escape hatch to skip Step 0 by providing a pre-generated LBT. Step 0 now always runs, so the field is removed.
- Merges `RunStepCWithEntries` back into `RunStepC` (simpler API, no config dependency).
- Updates `resolveOrGenerateLBT`, `loadWrappedTokensFromLBT`, `runSingleC`, `runSingleB`, `runSingleF`, `runSingleG` accordingly.

### Kurtosis script improvements
- Adds two helper scripts for the Kurtosis test environment.
- Embeds a pre-generated exit address keypair (`0xe25f5B65E4976025f670e52b790a9746F27A3DB6`) in `configuration_based_on_kurtosis.sh` so the exit address is stable across runs without requiring Foundry at script runtime. The private key and an encrypted keystore (password: `test`) are written to `tmp/` on first execution.

## ⚠️ Breaking Changes
- `lbtFile` config field removed. Any existing config files using it will have the field silently ignored (unknown JSON fields are not errors, but Step 0 will now always run).

## 📋 Config Updates
- `lbtFile` removed from `Config` and `rawConfig`. Step 0 is no longer skippable via config.

## ✅ Testing
- 🤖 **Automatic**: Existing unit tests pass (`ok github.com/agglayer/aggkit/tools/exit_certificate`)
- 🖱️ **Manual**:
  1. Run `tools/exit_certificate/scripts/reproduce_sc_locked.sh` against a live Kurtosis `aggkit` enclave
  2. The script deploys a `TokenHolder` smart contract on L2, transfers wrapped ERC-20 tokens to it, then drives the exit-certificate tool from steps 0→G
  3. Before fix: Step G failed with `ERC20InsufficientBalance` (`0xe450d38c`) when replaying the SC-locked `BridgeExit`
  4. After fix: Step G completes and emits a valid `NewLocalExitRoot`

## 🐞 Issues
- Fixes: #1624 

## 🔗 Related PRs
- N/A

## 📝 Notes
- `TokenWrapped` (wTTK) deployed by `AgglayerBridge` uses OZ v5 upgradeable storage, so the slot-0 attempt is a no-op. The second candidate (namespaced storage) is the one that matches and patches the balance correctly.
- The two-layout approach is safe: a failed slot write leaves the token balance unchanged and the loop moves to the next candidate. If neither layout works the function returns a descriptive error.