### PR TITLE
fix: cherry-pick: include .git in Docker build context for version embedding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-# Version control
-.git/
+# Version control — exclude credential files that actions/checkout writes
+# but keep the rest of .git so git describe / git rev-parse work correctly.
+.git/config
 .gitignore
 
 # Sensitive / secret files

--- a/.github/workflows/build-aggkit-image.yml
+++ b/.github/workflows/build-aggkit-image.yml
@@ -30,8 +30,19 @@ jobs:
       - name: Build Aggkit Docker Image
         run: make build-docker
 
+      - name: Verify version in image
+        env:
+          IMAGE_NAME: ${{ inputs.docker-image-name }}
+        run: |
+          out=$(docker run --rm "${IMAGE_NAME}:local" version) || { echo "ERROR: docker run failed"; exit 1; }
+          ver=$(echo "$out" | awk '/^Version:/{print $2}')
+          [ -n "$ver" ] || { echo "ERROR: Docker image has no version embedded"; exit 1; }
+          echo "Version check passed: $ver"
+
       - name: Save Aggkit Image to Archive
-        run: docker save --output /tmp/${{ inputs.docker-image-name }}.tar ${{ inputs.docker-image-name }}
+        env:
+          IMAGE_NAME: ${{ inputs.docker-image-name }}
+        run: docker save --output "/tmp/${IMAGE_NAME}.tar" "${IMAGE_NAME}"
 
       - name: Upload Aggkit Archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -92,6 +92,13 @@ jobs:
             INCLUDE_SHELL=${{ matrix.variant.include_shell }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true
 
+      - name: Verify version in image
+        run: |
+          out=$(docker run --rm "${{ env.REGISTRY_IMAGE }}@${{ steps.build.outputs.digest }}" version) || { echo "ERROR: docker run failed"; exit 1; }
+          ver=$(echo "$out" | awk '/^Version:/{print $2}')
+          [ -n "$ver" ] || { echo "ERROR: Docker image has no version embedded"; exit 1; }
+          echo "Version check passed: $ver"
+
       - name: Export digest
         run: |
           mkdir -p /tmp/digests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,15 @@ jobs:
             INCLUDE_SHELL=${{ matrix.variant.include_shell }}
           outputs: type=image,name=${{ (matrix.variant.suffix == '') && steps.image_builder_prod.outputs.IMAGE || steps.image_builder_dev.outputs.IMAGE }},push-by-digest=true,push=true
 
+      - name: Verify version in image
+        run: |
+          IMAGE_NAME="${{ (matrix.variant.suffix == '') && steps.image_builder_prod.outputs.IMAGE || steps.image_builder_dev.outputs.IMAGE }}"
+          DIGEST="${{ steps.build.outputs.digest }}"
+          out=$(docker run --rm "${IMAGE_NAME}@${DIGEST}" version) || { echo "ERROR: docker run failed"; exit 1; }
+          ver=$(echo "$out" | awk '/^Version:/{print $2}')
+          [ -n "$ver" ] || { echo "ERROR: Docker image has no version embedded"; exit 1; }
+          echo "Version check passed: $ver"
+
       - name: Export digest
         run: |
           mkdir -p /tmp/digests


### PR DESCRIPTION
## 🔄 Changes Summary
- Cherry-pick of #1621 from `release/0.10` into `develop`
- Remove `.git/` from `.dockerignore` so that `git describe` and `git rev-parse` run correctly inside the builder stage, embedding the correct `Version`, `GitRev` and `GitBranch` values in the binary
- Update CI workflows (`build-aggkit-image.yml`, `build-push-docker-image.yml`, `release.yml`) to include `.git` in the Docker build context

## ⚠️ Breaking Changes
- None

## 📋 Config Updates
- None

## ✅ Testing
- 🖱️ **Manual**: `make build-docker && docker run aggkit:local version` shows correct `Version`, `Git revision` and `Git branch` fields

## 🐞 Issues
- Related to #1618

## 🔗 Related PRs
- Cherry-pick of #1621 (originally merged into `release/0.10`)

## 📝 Notes
- `.git/` was excluded from the Docker context for security and context-size reasons. Since the builder stage only uses git metadata to set ldflags and the `.git` directory is not copied into the final runtime image, the security concern does not apply.
- `Dockerfile`, `Makefile`, and `version.mk` were not included because `develop` already has the correct state for those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)