### PR TITLE
feat(exit-certificate): F05 - use same targetBlock between multiples runs

### DIFF
--- a/tools/exit_certificate/CLAUDE.md
+++ b/tools/exit_certificate/CLAUDE.md
@@ -63,8 +63,8 @@ All checks run regardless of individual failures. A combined error lists every f
 ### Step 0 — Generate LBT
 
 - **Trigger:** always runs as part of the full pipeline.
-- **Does:** scans L2 bridge `NewWrappedToken` events, fetches `totalSupply` per token at `targetBlock`, computes unlocked native balance.
-- **Output:** `step-0-lbt.json` (`[]LBTEntry`)
+- **Does:** first resolves `targetBlock` (finality keyword, optional offset, or concrete number) to a `uint64` via an RPC call when needed; then scans L2 bridge `NewWrappedToken` events, fetches `totalSupply` per token at the resolved block, computes unlocked native balance.
+- **Output:** `step-0-l2_target_block.json` (resolved block number as `uint64`), `step-0-lbt.json` (`[]LBTEntry`)
 
 ### Step A — Collect addresses
 
@@ -217,6 +217,8 @@ use the canonical `bridgesynctypes.EmptyLER` value (no Anvil needed).
 ## Config fields (`config.go`)
 
 Required: `l2RpcUrl`, `l2BridgeAddress`, `targetBlock`.
+
+`targetBlock` accepts: a finality keyword (`LatestBlock`, `FinalizedBlock`, `SafeBlock`, `PendingBlock`), an optional negative offset appended with `/` (e.g. `LatestBlock/-10`), a decimal block number (`"21000000"`), or a hex block number (`"0x1406f40"`). An empty string defaults to `LatestBlock`. The keyword is resolved to a concrete `uint64` at the start of Step 0 and written to `step-0-l2_target_block.json`; all subsequent steps (A, B, G) read that fixed number. The old lowercase aliases (`latest`, `finalized`, `safe`, `pending`) are **not** accepted — use the PascalCase keywords.
 
 Notable optional fields:
 

--- a/tools/exit_certificate/README.md
+++ b/tools/exit_certificate/README.md
@@ -56,7 +56,7 @@ cp parameters.json.example parameters.json
 | `l2BridgeAddress` | Yes | L2 bridge contract address. |
 | `l1BridgeAddress` | No | L1 bridge contract address. Defaults to `l2BridgeAddress`. |
 | `l2NetworkId` | No | L2 network ID. Defaults to `1`. |
-| `targetBlock` | Yes | Target block number or `"latest"`. All state is captured at this block. |
+| `targetBlock` | Yes | Target block for state capture. Accepts a decimal number (`"21000000"`), hex (`"0x1406f40"`), or a finality keyword: `"LatestBlock"`, `"FinalizedBlock"`, `"SafeBlock"`, `"PendingBlock"`. An optional negative offset can be appended (e.g. `"LatestBlock/-10"` = ten blocks before latest). Omitting the field or setting it to `""` defaults to `"LatestBlock"`. The keyword is resolved to a concrete block number at the start of Step 0 and saved to `step-0-l2_target_block.json`. All subsequent steps use that fixed number. |
 | `exitAddress` | No | Address that receives SC-locked value exits. Defaults to zero address. |
 | `destinationNetwork` | No | Destination network for bridge exits. Defaults to `0` (L1). |
 | `sovereignRollupAddr` | Yes* | Address of the `aggchainbase` contract on L1. Required by Step CHECK (network type and threshold verification). |
@@ -190,7 +190,7 @@ Runs all steps sequentially: CHECK → 0 → A → B → C → D → E → F →
 | Step | Name | What it does |
 | :--: | ---- | ------------ |
 | CHECK | Verify prerequisites | Checks Anvil, L1 RPC, network type (PP only), threshold = 1, no custom gas token. |
-| 0 | Generate LBT | Scans `NewWrappedToken` events and fetches `totalSupply` per wrapped token at `targetBlock`. |
+| 0 | Generate LBT | Resolves `targetBlock` to a concrete block number, then scans `NewWrappedToken` events and fetches `totalSupply` per wrapped token at that block. |
 | A | Collect addresses | Traces every L2 transaction via `debug_traceTransaction` and collects all addresses that touched state. |
 | B | EOA balances | Classifies addresses as EOA vs contract; fetches ETH balance and every wrapped-token balance for each EOA at `targetBlock`. |
 | C | SC-locked value | Computes value locked in contracts: `SC_locked = LBT_totalSupply − EOA_accumulated` per token. |
@@ -252,11 +252,29 @@ All checks run regardless of individual failures; a combined error lists every f
 
 ### Step 0 — Generate LBT (Local Balance Tree)
 
-Scans the L2 bridge contract for `NewWrappedToken` events and fetches the `totalSupply` of each wrapped token at `targetBlock`. Also computes the unlocked native token balance and checks for WETH.
+#### Target block resolution
+
+The `targetBlock` config field accepts a finality keyword, an optional offset, or a concrete block number. Step 0 resolves it to a `uint64` before doing any work:
+
+| `targetBlock` value | How it is resolved |
+| ------------------- | ------------------ |
+| `""` or omitted | Equivalent to `"LatestBlock"` |
+| `"LatestBlock"` | `eth_getBlockByNumber("latest")` on the L2 RPC |
+| `"FinalizedBlock"` | `eth_getBlockByNumber("finalized")` on the L2 RPC |
+| `"SafeBlock"` | `eth_getBlockByNumber("safe")` on the L2 RPC |
+| `"PendingBlock"` | `eth_getBlockByNumber("pending")` on the L2 RPC |
+| `"LatestBlock/-10"` | Latest block number minus 10 |
+| `"21000000"` / `"0x1406f40"` | Used directly, no RPC call needed |
+
+The resolved number is written to `step-0-l2_target_block.json` and used as a fixed reference by all subsequent steps (A, B, G). When running individual steps the file must exist (produced by a prior Step 0 run).
+
+#### LBT generation
+
+After resolution, Step 0 scans the L2 bridge contract for `NewWrappedToken` events and fetches the `totalSupply` of each wrapped token at the resolved block. It also applies any `SetSovereignTokenAddress` overrides (remapped wrapped addresses), computes the unlocked native token balance, and checks for a WETH entry if the chain has a custom gas token.
 
 This step replaces the need for the external [`getLBT`](https://github.com/agglayer/agglayer-contracts/tree/v12.2.3/tools/getLBT) tool.
 
-**Output:** `step-0-lbt.json`
+**Output:** `step-0-l2_target_block.json` (resolved block number), `step-0-lbt.json` (LBT entries)
 
 ### Step A — Collect addresses
 

--- a/tools/exit_certificate/README.md
+++ b/tools/exit_certificate/README.md
@@ -56,7 +56,7 @@ cp parameters.json.example parameters.json
 | `l2BridgeAddress` | Yes | L2 bridge contract address. |
 | `l1BridgeAddress` | No | L1 bridge contract address. Defaults to `l2BridgeAddress`. |
 | `l2NetworkId` | No | L2 network ID. Defaults to `1`. |
-| `targetBlock` | Yes | Target block for state capture. Accepts a decimal number (`"21000000"`), hex (`"0x1406f40"`), or a finality keyword: `"LatestBlock"`, `"FinalizedBlock"`, `"SafeBlock"`, `"PendingBlock"`. An optional negative offset can be appended (e.g. `"LatestBlock/-10"` = ten blocks before latest). Omitting the field or setting it to `""` defaults to `"LatestBlock"`. The keyword is resolved to a concrete block number at the start of Step 0 and saved to `step-0-l2_target_block.json`. All subsequent steps use that fixed number. |
+| `targetBlock` | No | Target block for state capture. Accepts a decimal number (`"21000000"`), hex (`"0x1406f40"`), or a finality keyword: `"LatestBlock"`, `"FinalizedBlock"`, `"SafeBlock"`, `"PendingBlock"`. An optional negative offset can be appended (e.g. `"LatestBlock/-10"` = ten blocks before latest). Omitting the field or setting it to `""` defaults to `"LatestBlock"`. The keyword is resolved to a concrete block number at the start of Step 0 and saved to `step-0-l2_target_block.json`. All subsequent steps use that fixed number. |
 | `exitAddress` | No | Address that receives SC-locked value exits. Defaults to zero address. |
 | `destinationNetwork` | No | Destination network for bridge exits. Defaults to `0` (L1). |
 | `sovereignRollupAddr` | Yes* | Address of the `aggchainbase` contract on L1. Required by Step CHECK (network type and threshold verification). |

--- a/tools/exit_certificate/config-examples/zkevm-cardona.json
+++ b/tools/exit_certificate/config-examples/zkevm-cardona.json
@@ -4,7 +4,7 @@
     "l1BridgeAddress": "0x528e26b25a34a4A5d0dbDa1d57D318153d2ED582",
     "l2BridgeAddress": "0x528e26b25a34a4A5d0dbDa1d57D318153d2ED582",
     "l2NetworkId": 1,
-    "targetBlock": "latest",
+    "targetBlock": "LatestBlock",
     "exitAddress": "0x0000000000000000000000000000000000001234",
     "sovereignRollupAddr": "0xA13Ddb14437A8F34897131367ad3ca78416d6bCa",
     "destinationNetwork": 0,

--- a/tools/exit_certificate/config-examples/zkevm-mainnet.json
+++ b/tools/exit_certificate/config-examples/zkevm-mainnet.json
@@ -4,7 +4,7 @@
     "l1BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
     "l2BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
     "l2NetworkId": 20,
-    "targetBlock": "latest",
+    "targetBlock": "LatestBlock",
     "exitAddress": "0x0000000000000000000000000000000000001234",
     "destinationNetwork": 0,
     "signerConfig": {

--- a/tools/exit_certificate/config.go
+++ b/tools/exit_certificate/config.go
@@ -109,6 +109,11 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	configDir := filepath.Dir(configPath)
 
+	targetBlock, err := parseTargetBlock(raw.TargetBlock)
+	if err != nil {
+		return nil, fmt.Errorf("invalid targetBlock %q: %w", raw.TargetBlock, err)
+	}
+
 	cfg := &Config{
 		L2RPCURL:                raw.L2RPCURL,
 		L1RPCURL:                raw.L1RPCURL,
@@ -116,7 +121,7 @@ func LoadConfig(configPath string) (*Config, error) {
 		L2NetworkID:             raw.L2NetworkID,
 		ExitAddress:             common.HexToAddress(raw.ExitAddress),
 		DestinationNetwork:      raw.DestinationNetwork,
-		TargetBlock:             parseTargetBlock(raw.TargetBlock),
+		TargetBlock:             targetBlock,
 		SovereignRollupAddr:     common.HexToAddress(raw.SovereignRollupAddr),
 		L1GlobalExitRootAddress: common.HexToAddress(raw.L1GlobalExitRootAddress),
 	}
@@ -144,16 +149,16 @@ func LoadConfig(configPath string) (*Config, error) {
 }
 
 // parseTargetBlock converts the raw JSON string to a BlockNumberFinality.
-// An empty or "latest" value resolves to LatestBlock.
-func parseTargetBlock(s string) aggkittypes.BlockNumberFinality {
+// An empty value resolves to LatestBlock; any other invalid value returns an error.
+func parseTargetBlock(s string) (aggkittypes.BlockNumberFinality, error) {
 	if s == "" {
-		return aggkittypes.LatestBlock
+		return aggkittypes.LatestBlock, nil
 	}
 	tb, err := aggkittypes.NewBlockNumberFinality(s)
 	if err != nil {
-		return aggkittypes.LatestBlock
+		return aggkittypes.LatestBlock, err
 	}
-	return *tb
+	return *tb, nil
 }
 
 // parseSignerConfig converts the flat JSON signer config into a SignerConfig.

--- a/tools/exit_certificate/config.go
+++ b/tools/exit_certificate/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
+	aggkittypes "github.com/agglayer/aggkit/types"
 	signertypes "github.com/agglayer/go_signer/signer/types"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -54,23 +55,20 @@ type Options struct {
 
 // Config holds all parameters required by the exit certificate tool.
 type Config struct {
-	L2RPCURL            string         `json:"l2RpcUrl"`
-	L1RPCURL            string         `json:"l1RpcUrl"`
-	L2BridgeAddress     common.Address `json:"l2BridgeAddress"`
-	L1BridgeAddress     common.Address `json:"l1BridgeAddress"`
-	L2NetworkID         uint32         `json:"l2NetworkId"`
-	TargetBlock         string         `json:"targetBlock"`
-	ExitAddress         common.Address `json:"exitAddress"`
-	DestinationNetwork  uint32         `json:"destinationNetwork"`
-	SovereignRollupAddr common.Address `json:"sovereignRollupAddr"`
+	L2RPCURL            string                          `json:"l2RpcUrl"`
+	L1RPCURL            string                          `json:"l1RpcUrl"`
+	L2BridgeAddress     common.Address                  `json:"l2BridgeAddress"`
+	L1BridgeAddress     common.Address                  `json:"l1BridgeAddress"`
+	L2NetworkID         uint32                          `json:"l2NetworkId"`
+	TargetBlock         aggkittypes.BlockNumberFinality `json:"targetBlock"`
+	ExitAddress         common.Address                  `json:"exitAddress"`
+	DestinationNetwork  uint32                          `json:"destinationNetwork"`
+	SovereignRollupAddr common.Address                  `json:"sovereignRollupAddr"`
 	// L1GlobalExitRootAddress is the address of the PolygonZkEVMGlobalExitRootV2 contract on L1.
 	// Required for Step I to fetch the L1InfoTreeLeafCount from UpdateL1InfoTreeV2 events.
 	L1GlobalExitRootAddress common.Address           `json:"l1GlobalExitRootAddress"`
 	Options                 Options                  `json:"options"`
 	SignerConfig            signertypes.SignerConfig `json:"-"`
-
-	// ResolvedTargetBlock is populated at runtime after resolving "latest".
-	ResolvedTargetBlock uint64 `json:"-"`
 }
 
 const (
@@ -118,7 +116,7 @@ func LoadConfig(configPath string) (*Config, error) {
 		L2NetworkID:             raw.L2NetworkID,
 		ExitAddress:             common.HexToAddress(raw.ExitAddress),
 		DestinationNetwork:      raw.DestinationNetwork,
-		TargetBlock:             raw.TargetBlock,
+		TargetBlock:             parseTargetBlock(raw.TargetBlock),
 		SovereignRollupAddr:     common.HexToAddress(raw.SovereignRollupAddr),
 		L1GlobalExitRootAddress: common.HexToAddress(raw.L1GlobalExitRootAddress),
 	}
@@ -143,6 +141,19 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// parseTargetBlock converts the raw JSON string to a BlockNumberFinality.
+// An empty or "latest" value resolves to LatestBlock.
+func parseTargetBlock(s string) aggkittypes.BlockNumberFinality {
+	if s == "" {
+		return aggkittypes.LatestBlock
+	}
+	tb, err := aggkittypes.NewBlockNumberFinality(s)
+	if err != nil {
+		return aggkittypes.LatestBlock
+	}
+	return *tb
 }
 
 // parseSignerConfig converts the flat JSON signer config into a SignerConfig.

--- a/tools/exit_certificate/config_test.go
+++ b/tools/exit_certificate/config_test.go
@@ -313,6 +313,89 @@ func TestMergeOptions_BridgeService(t *testing.T) {
 	require.Equal(t, "zkevm", cfg.Options.BridgeServiceType)
 }
 
+func TestParseTargetBlock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		wantErr      bool
+		wantBlock    string
+		wantSpecific uint64
+	}{
+		{
+			name:      "empty defaults to latest",
+			input:     "",
+			wantBlock: "LatestBlock",
+		},
+		{
+			name:      "LatestBlock tag",
+			input:     "LatestBlock",
+			wantBlock: "LatestBlock",
+		},
+		{
+			name:      "FinalizedBlock tag",
+			input:     "FinalizedBlock",
+			wantBlock: "FinalizedBlock",
+		},
+		{
+			name:         "numeric block",
+			input:        "12345",
+			wantSpecific: 12345,
+		},
+		{
+			name:    "typo FinalizedBock returns error",
+			input:   "FinalizedBock",
+			wantErr: true,
+		},
+		{
+			name:    "hex garbage returns error",
+			input:   "0xZZ",
+			wantErr: true,
+		},
+		{
+			name:    "random string returns error",
+			input:   "notablock",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parseTargetBlock(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantBlock != "" {
+				require.Equal(t, tc.wantBlock, result.Block.String())
+			}
+			if tc.wantSpecific != 0 {
+				require.Equal(t, tc.wantSpecific, result.Specific)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_InvalidTargetBlock(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cfg.json")
+	data := `{
+		"l2RpcUrl": "http://localhost:8545",
+		"l2BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
+		"targetBlock": "FinalizedBock"
+	}`
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid targetBlock")
+	require.Contains(t, err.Error(), "FinalizedBock")
+}
+
 func TestLoadLBTEntries_ValidFile(t *testing.T) {
 	t.Parallel()
 

--- a/tools/exit_certificate/config_test.go
+++ b/tools/exit_certificate/config_test.go
@@ -68,7 +68,7 @@ func TestLoadConfig_MinimalValid(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "http://localhost:8545", cfg.L2RPCURL)
 	require.Equal(t, common.HexToAddress("0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"), cfg.L2BridgeAddress)
-	require.Equal(t, "100", cfg.TargetBlock)
+	require.Equal(t, *aggkittypes.NewBlockNumber(100), cfg.TargetBlock)
 	require.Equal(t, uint32(1), cfg.L2NetworkID)
 	require.Equal(t, cfg.L2BridgeAddress, cfg.L1BridgeAddress)
 }

--- a/tools/exit_certificate/config_test.go
+++ b/tools/exit_certificate/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -82,7 +83,7 @@ func TestLoadConfig_FullConfig(t *testing.T) {
 		"l2BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
 		"l1BridgeAddress": "0x1111111111111111111111111111111111111111",
 		"l2NetworkId": 5,
-		"targetBlock": "latest",
+		"targetBlock": "LatestBlock",
 		"exitAddress": "0x0000000000000000000000000000000000000001",
 		"destinationNetwork": 0,
 		"options": {
@@ -100,7 +101,7 @@ func TestLoadConfig_FullConfig(t *testing.T) {
 	require.Equal(t, "http://l2:8545", cfg.L2RPCURL)
 	require.Equal(t, "http://l1:8545", cfg.L1RPCURL)
 	require.Equal(t, uint32(5), cfg.L2NetworkID)
-	require.Equal(t, "latest", cfg.TargetBlock)
+	require.Equal(t, aggkittypes.LatestBlock, cfg.TargetBlock)
 	require.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000001"), cfg.ExitAddress)
 	require.Equal(t, common.HexToAddress("0x1111111111111111111111111111111111111111"), cfg.L1BridgeAddress)
 	require.Equal(t, 10000, cfg.Options.BlockRange)

--- a/tools/exit_certificate/parameters.json.example
+++ b/tools/exit_certificate/parameters.json.example
@@ -4,7 +4,7 @@
     "l2BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
     "l1BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
     "l2NetworkId": 1,
-    "targetBlock": "latest",
+    "targetBlock": "LatestBlock",
     "exitAddress": "0x0000000000000000000000000000000000000001",
     "destinationNetwork": 0,
     "options": {

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -38,10 +37,6 @@ func Run(c *cli.Context) error {
 	cfg, err := LoadConfig(c.String("config"))
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
-	}
-
-	if err := resolveBlockA(ctx, cfg); err != nil {
-		return err
 	}
 
 	step := c.String("step")
@@ -134,25 +129,6 @@ func expandStepRange(token string) ([]string, error) {
 	return orderedSteps[fromIdx : toIdx+1], nil
 }
 
-// resolveBlockA resolves "latest" to a concrete block number, or parses the numeric value.
-func resolveBlockA(ctx context.Context, cfg *Config) error {
-	if cfg.TargetBlock == "latest" || cfg.TargetBlock == "" {
-		blockNum, err := resolveLatestBlock(ctx, cfg.L2RPCURL)
-		if err != nil {
-			return fmt.Errorf("resolve latest block: %w", err)
-		}
-		cfg.ResolvedTargetBlock = blockNum
-		log.Infof("Resolved targetBlock=\"latest\" → %d", cfg.ResolvedTargetBlock)
-		return nil
-	}
-	blockNum, err := parseBlockNumber(cfg.TargetBlock)
-	if err != nil {
-		return fmt.Errorf("invalid targetBlock %q: %w", cfg.TargetBlock, err)
-	}
-	cfg.ResolvedTargetBlock = blockNum
-	return nil
-}
-
 func resolveLatestBlock(ctx context.Context, rpcURL string) (uint64, error) {
 	result, err := singleRPC(ctx, rpcURL, "eth_blockNumber", nil, defaultRetries)
 	if err != nil {
@@ -163,18 +139,6 @@ func resolveLatestBlock(ctx context.Context, rpcURL string) (uint64, error) {
 		return 0, fmt.Errorf("parse block number: %w", err)
 	}
 	return hexToUint64(hex), nil
-}
-
-// parseBlockNumber parses a block number string (decimal or 0x-hex).
-func parseBlockNumber(s string) (uint64, error) {
-	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
-		return hexToUint64(s), nil
-	}
-	n, err := strconv.ParseUint(s, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("not a valid block number (expected decimal or 0x-hex): %w", err)
-	}
-	return n, nil
 }
 
 // --- Full pipeline ---
@@ -195,17 +159,17 @@ func runAll(ctx context.Context, cfg *Config) error {
 	}
 	saveJSON(dir, "step-check-result.json", checkResult)
 
-	lbtEntries, wrappedTokens, err := resolveOrGenerateLBT(ctx, cfg, dir)
+	lbtEntries, wrappedTokens, targetBlock, err := resolveOrGenerateLBT(ctx, cfg, dir)
 	if err != nil {
 		return fmt.Errorf("step 0 (LBT): %w", err)
 	}
 
-	stepAResult, err := runAllStepA(ctx, cfg, dir, wrappedTokens)
+	stepAResult, err := runAllStepA(ctx, cfg, dir, targetBlock, wrappedTokens)
 	if err != nil {
 		return err
 	}
 
-	stepBResult, err := runAllStepB(ctx, cfg, dir, stepAResult)
+	stepBResult, err := runAllStepB(ctx, cfg, dir, targetBlock, stepAResult)
 	if err != nil {
 		return err
 	}
@@ -230,7 +194,7 @@ func runAll(ctx context.Context, cfg *Config) error {
 		return err
 	}
 
-	gResult, err := runAllStepG(ctx, cfg, dir, finalCertificate, lbtEntries)
+	gResult, err := runAllStepG(ctx, cfg, dir, targetBlock, finalCertificate, lbtEntries)
 	if err != nil {
 		return err
 	}
@@ -263,8 +227,10 @@ func runAll(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
-func runAllStepA(ctx context.Context, cfg *Config, dir string, wrappedTokens []WrappedToken) (*StepAResult, error) {
-	stepAResult, err := RunStepA(ctx, cfg)
+func runAllStepA(
+	ctx context.Context, cfg *Config, dir string, targetBlock uint64, wrappedTokens []WrappedToken,
+) (*StepAResult, error) {
+	stepAResult, err := RunStepA(ctx, cfg, targetBlock)
 	if err != nil {
 		return nil, fmt.Errorf("step A: %w", err)
 	}
@@ -277,8 +243,10 @@ func runAllStepA(ctx context.Context, cfg *Config, dir string, wrappedTokens []W
 	return stepAResult, nil
 }
 
-func runAllStepB(ctx context.Context, cfg *Config, dir string, stepAResult *StepAResult) (*StepBResult, error) {
-	stepBResult, err := RunStepB(ctx, cfg, stepAResult)
+func runAllStepB(
+	ctx context.Context, cfg *Config, dir string, targetBlock uint64, stepAResult *StepAResult,
+) (*StepBResult, error) {
+	stepBResult, err := RunStepB(ctx, cfg, targetBlock, stepAResult)
 	if err != nil {
 		return nil, fmt.Errorf("step B: %w", err)
 	}
@@ -328,9 +296,10 @@ func runAllStepF(
 }
 
 func runAllStepG(
-	ctx context.Context, cfg *Config, dir string, certificate *agglayertypes.Certificate, lbtEntries []LBTEntry,
+	ctx context.Context, cfg *Config, dir string, targetBlock uint64,
+	certificate *agglayertypes.Certificate, lbtEntries []LBTEntry,
 ) (*StepGResult, error) {
-	result, err := RunStepG(ctx, cfg, certificate, lbtEntries)
+	result, err := RunStepG(ctx, cfg, targetBlock, certificate, lbtEntries)
 	if err != nil {
 		return nil, fmt.Errorf("step G: %w", err)
 	}
@@ -406,7 +375,7 @@ func logPipelineConfig(cfg *Config) {
 		log.Info("L1 RPC:           (not configured — step E will be skipped)")
 	}
 	log.Infof("L2 Bridge:        %s", cfg.L2BridgeAddress.Hex())
-	log.Infof("Target Block:     %d", cfg.ResolvedTargetBlock)
+	log.Infof("Target Block:     %s", cfg.TargetBlock)
 	log.Infof("L2 Network ID:    %d", cfg.L2NetworkID)
 	log.Infof("Exit Address:     %s", cfg.ExitAddress.Hex())
 	log.Infof("Dest Network:     %d", cfg.DestinationNetwork)
@@ -479,16 +448,21 @@ func runSingleCheck(ctx context.Context, cfg *Config, dir string) error {
 }
 
 func runSingle0(ctx context.Context, cfg *Config, dir string) error {
-	entries, err := RunStep0(ctx, cfg)
+	result, err := RunStep0(ctx, cfg)
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, "step-0-lbt.json", entries)
+	saveJSON(dir, "step-0-l2_target_block.json", result.TargetBlock)
+	saveJSON(dir, "step-0-lbt.json", result.Entries)
 	return nil
 }
 
 func runSingleA(ctx context.Context, cfg *Config, dir string) error {
-	result, err := RunStepA(ctx, cfg)
+	targetBlock, err := loadTargetBlock(dir)
+	if err != nil {
+		return err
+	}
+	result, err := RunStepA(ctx, cfg, targetBlock)
 	if err != nil {
 		return err
 	}
@@ -508,7 +482,11 @@ func runSingleB(ctx context.Context, cfg *Config, dir string) error {
 	}
 	log.Infof("Using %d wrapped tokens for balance scanning", len(wrappedTokens))
 
-	result, err := RunStepB(ctx, cfg, &StepAResult{
+	targetBlock, err := loadTargetBlock(dir)
+	if err != nil {
+		return err
+	}
+	result, err := RunStepB(ctx, cfg, targetBlock, &StepAResult{
 		Addresses:     addresses,
 		WrappedTokens: wrappedTokens,
 	})
@@ -660,7 +638,11 @@ func runSingleG(ctx context.Context, cfg *Config, dir string) error {
 		log.Warnf("STEP G: LBT not available, falling back to getTokenWrappedAddress: %v", err)
 	}
 
-	result, err := RunStepG(ctx, cfg, cert.toAgglayerCertificate(), lbtEntries)
+	targetBlock, err := loadTargetBlock(dir)
+	if err != nil {
+		return err
+	}
+	result, err := RunStepG(ctx, cfg, targetBlock, cert.toAgglayerCertificate(), lbtEntries)
 	if err != nil {
 		return err
 	}
@@ -714,13 +696,23 @@ func runSingleI(ctx context.Context, cfg *Config, dir string) error {
 // --- LBT resolution ---
 
 // resolveOrGenerateLBT always runs Step 0 and saves step-0-lbt.json.
-func resolveOrGenerateLBT(ctx context.Context, cfg *Config, dir string) ([]LBTEntry, []WrappedToken, error) {
-	entries, err := RunStep0(ctx, cfg)
+func resolveOrGenerateLBT(ctx context.Context, cfg *Config, dir string) ([]LBTEntry, []WrappedToken, uint64, error) {
+	result, err := RunStep0(ctx, cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	saveJSON(dir, "step-0-lbt.json", entries)
-	return entries, LBTEntriesToWrappedTokens(entries), nil
+	saveJSON(dir, "step-0-l2_target_block.json", result.TargetBlock)
+	saveJSON(dir, "step-0-lbt.json", result.Entries)
+	return result.Entries, LBTEntriesToWrappedTokens(result.Entries), result.TargetBlock, nil
+}
+
+// loadTargetBlock reads the resolved L2 target block number saved by Step 0.
+func loadTargetBlock(dir string) (uint64, error) {
+	var n uint64
+	if err := loadJSON(dir, "step-0-l2_target_block.json", &n); err != nil {
+		return 0, fmt.Errorf("load target block (run step 0 first): %w", err)
+	}
+	return n, nil
 }
 
 // loadWrappedTokensFromLBT loads tokens from the step-0 output.

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -375,7 +375,7 @@ func logPipelineConfig(cfg *Config) {
 		log.Info("L1 RPC:           (not configured — step E will be skipped)")
 	}
 	log.Infof("L2 Bridge:        %s", cfg.L2BridgeAddress.Hex())
-	log.Infof("Target Block:     %s", cfg.TargetBlock)
+	log.Infof("Target Block:     %s", cfg.TargetBlock.String())
 	log.Infof("L2 Network ID:    %d", cfg.L2NetworkID)
 	log.Infof("Exit Address:     %s", cfg.ExitAddress.Hex())
 	log.Infof("Dest Network:     %d", cfg.DestinationNetwork)

--- a/tools/exit_certificate/run_test.go
+++ b/tools/exit_certificate/run_test.go
@@ -45,26 +45,6 @@ func TestParseStepList(t *testing.T) {
 	}
 }
 
-func TestParseBlockNumber_Decimal(t *testing.T) {
-	t.Parallel()
-	n, err := parseBlockNumber("12345")
-	require.NoError(t, err)
-	require.Equal(t, uint64(12345), n)
-}
-
-func TestParseBlockNumber_Hex(t *testing.T) {
-	t.Parallel()
-	n, err := parseBlockNumber("0xff")
-	require.NoError(t, err)
-	require.Equal(t, uint64(255), n)
-}
-
-func TestParseBlockNumber_Invalid(t *testing.T) {
-	t.Parallel()
-	_, err := parseBlockNumber("abc")
-	require.Error(t, err)
-}
-
 func TestSaveAndLoadJSON(t *testing.T) {
 	t.Parallel()
 

--- a/tools/exit_certificate/scripts/configuration_based_on_kurtosis.sh
+++ b/tools/exit_certificate/scripts/configuration_based_on_kurtosis.sh
@@ -461,3 +461,14 @@ PYEOF
 }
 
 update_vscode_launch
+
+# ---------------------------------------------------------------------------
+# Suggest clearing previous output
+# ---------------------------------------------------------------------------
+
+OUTPUT_KURTOSIS_DIR="$PROJECT_ROOT/tmp/output-kurtosis"
+if [[ -d "$OUTPUT_KURTOSIS_DIR" ]]; then
+    log_warn "Previous output directory exists: $OUTPUT_KURTOSIS_DIR"
+    log_warn "Consider removing it before running the tool to avoid stale intermediate files:"
+    log_warn "  rm -rf \"$OUTPUT_KURTOSIS_DIR\""
+fi

--- a/tools/exit_certificate/scripts/configuration_based_on_kurtosis.sh
+++ b/tools/exit_certificate/scripts/configuration_based_on_kurtosis.sh
@@ -362,7 +362,7 @@ cat > "$OUTPUT_PATH" <<EOF
     "l2BridgeAddress": "$BRIDGE_ADDR",
     "l1BridgeAddress": "$BRIDGE_ADDR",
     "l2NetworkId": $NETWORK_INDEX,
-    "targetBlock": "latest",
+    "targetBlock": "LatestBlock",
     "exitAddress": "$EXIT_ADDRESS",
     "destinationNetwork": 0,
 ${SOVEREIGN_ROLLUP_LINE}${L1_GLOBAL_EXIT_ROOT_LINE}${SIGNER_CONFIG_BLOCK}    "options": {

--- a/tools/exit_certificate/step_0.go
+++ b/tools/exit_certificate/step_0.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerbridgel2"
 	"github.com/agglayer/aggkit/log"
+	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -31,27 +32,36 @@ const (
 // RunStep0 generates the Local Balance Tree (LBT) by scanning the L2 bridge
 // for NewWrappedToken events and fetching each token's totalSupply.
 // This replaces the external getLBT tool.
-func RunStep0(ctx context.Context, cfg *Config) ([]LBTEntry, error) {
+func RunStep0(ctx context.Context, cfg *Config) (*Step0Result, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP 0 — Generate LBT (Local Balance Tree)")
 	log.Info("═══════════════════════════════════════════")
 
+	blockNum, err := resolveTargetBlockNumber(ctx, cfg.L2RPCURL, cfg.TargetBlock)
+	if err != nil {
+		return nil, fmt.Errorf("resolve target block: %w", err)
+	}
+	if !cfg.TargetBlock.IsConstant() {
+		log.Infof("Resolved targetBlock=%q → %d", cfg.TargetBlock.String(), blockNum)
+	}
+
 	rpcURL := cfg.L2RPCURL
 	bridgeAddr := cfg.L2BridgeAddress
-	blockTag := toBlockTag(cfg.ResolvedTargetBlock)
+
+	blockTag := toBlockTag(blockNum)
 
 	log.Infof("Bridge address: %s", bridgeAddr.Hex())
-	log.Infof("Block number:   %d", cfg.ResolvedTargetBlock)
+	log.Infof("Block number:   %d", blockNum)
 
 	// 1. Scan for NewWrappedToken events
-	events := fetchNewWrappedTokenEvents(ctx, cfg)
+	events := fetchNewWrappedTokenEvents(ctx, cfg, blockNum)
 	log.Infof("Found %d NewWrappedToken events", len(events))
 
 	// 2. Apply SetSovereignTokenAddress overrides: if the bridge manager remapped an origin
 	// token to a different ERC-20 after the original NewWrappedToken event, use the sovereign
 	// address instead. This keeps the LBT's wrapped addresses consistent with what
 	// getTokenWrappedAddress() returns on the live contract.
-	events = applySovereignTokenOverrides(ctx, cfg, events)
+	events = applySovereignTokenOverrides(ctx, cfg, blockNum, events)
 
 	// 3. Fetch totalSupply for each token concurrently
 	log.Infof("Fetching totalSupply for %d tokens...", len(events))
@@ -84,7 +94,7 @@ func RunStep0(ctx context.Context, cfg *Config) ([]LBTEntry, error) {
 	}
 
 	log.Infof("STEP 0 complete: %d LBT entries", len(entries))
-	return entries, nil
+	return &Step0Result{TargetBlock: blockNum, Entries: entries}, nil
 }
 
 // wrappedTokenEvent holds parsed NewWrappedToken event data.
@@ -97,10 +107,9 @@ type wrappedTokenEvent struct {
 }
 
 // fetchNewWrappedTokenEvents scans for NewWrappedToken events via a worker pool.
-func fetchNewWrappedTokenEvents(ctx context.Context, cfg *Config) []wrappedTokenEvent {
+func fetchNewWrappedTokenEvents(ctx context.Context, cfg *Config, toBlock uint64) []wrappedTokenEvent {
 	blockRange := cfg.Options.BlockRange
 	concurrency := cfg.Options.ConcurrencyLimit
-	toBlock := cfg.ResolvedTargetBlock
 
 	type blockRangeJob struct{ from, to uint64 }
 	var jobs []blockRangeJob
@@ -185,8 +194,10 @@ func fetchWrappedTokenEventsInRange(
 // token address for any origin tokens that have been remapped by the bridge manager.
 // When setSovereignTokenAddress is called on the bridge, getTokenWrappedAddress returns the
 // sovereign address instead of the original wrapped one, so the LBT must reflect the same.
-func applySovereignTokenOverrides(ctx context.Context, cfg *Config, events []wrappedTokenEvent) []wrappedTokenEvent {
-	overrides := fetchSetSovereignTokenEvents(ctx, cfg)
+func applySovereignTokenOverrides(
+	ctx context.Context, cfg *Config, toBlock uint64, events []wrappedTokenEvent,
+) []wrappedTokenEvent {
+	overrides := fetchSetSovereignTokenEvents(ctx, cfg, toBlock)
 	if len(overrides) == 0 {
 		return events
 	}
@@ -245,10 +256,9 @@ type sovereignTokenOverride struct {
 }
 
 // fetchSetSovereignTokenEvents scans for SetSovereignTokenAddress events via a worker pool.
-func fetchSetSovereignTokenEvents(ctx context.Context, cfg *Config) []sovereignTokenOverride {
+func fetchSetSovereignTokenEvents(ctx context.Context, cfg *Config, toBlock uint64) []sovereignTokenOverride {
 	blockRange := cfg.Options.BlockRange
 	concurrency := cfg.Options.ConcurrencyLimit
-	toBlock := cfg.ResolvedTargetBlock
 
 	type blockRangeJob struct{ from, to uint64 }
 	var jobs []blockRangeJob
@@ -533,4 +543,51 @@ func fetchWETHBalance(
 		OriginTokenAddress:  common.Address{},
 		Balance:             supply.String(),
 	}, nil
+}
+
+// resolveTargetBlockNumber resolves a BlockNumberFinality to a concrete block number.
+// Constant finalities are returned directly; named finalities (latest, finalized, safe,
+// pending) and any configured offset are resolved via the L2 RPC.
+func resolveTargetBlockNumber(
+	ctx context.Context, rpcURL string, finality aggkittypes.BlockNumberFinality,
+) (uint64, error) {
+	if finality.IsConstant() {
+		return finality.Specific, nil
+	}
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return 0, fmt.Errorf("dial L2 RPC: %w", err)
+	}
+	defer client.Close()
+	return finality.BlockNumber(ctx, &ethClientAdapter{client})
+}
+
+// ethClientAdapter wraps *ethclient.Client to satisfy aggkittypes.CustomEthereumClienter
+// for the sole purpose of resolving a BlockNumberFinality to a concrete block number.
+type ethClientAdapter struct {
+	*ethclient.Client
+}
+
+func (a *ethClientAdapter) CustomHeaderByNumber(
+	ctx context.Context, number *aggkittypes.BlockNumberFinality,
+) (*aggkittypes.BlockHeader, error) {
+	bigInt := number.ToBigInt()
+	if number.HasOffset() {
+		base, err := a.HeaderByNumber(ctx, number.Block.ToBigInt())
+		if err != nil {
+			return nil, err
+		}
+		bigInt = new(big.Int).SetUint64(number.CalculateBlockNumber(base.Number.Uint64()))
+	}
+	header, err := a.HeaderByNumber(ctx, bigInt)
+	if err != nil {
+		return nil, err
+	}
+	return &aggkittypes.BlockHeader{Number: header.Number.Uint64()}, nil
+}
+
+func (a *ethClientAdapter) RetrieveBlockHeaders(
+	_ context.Context, _ []uint64, _ int,
+) (*aggkittypes.BlockHeadersResult, error) {
+	return nil, fmt.Errorf("not implemented")
 }

--- a/tools/exit_certificate/step_a.go
+++ b/tools/exit_certificate/step_a.go
@@ -17,22 +17,22 @@ import (
 // debug_traceTransaction with prestateTracer + diffMode.
 // Blocks are scanned in windows of Options.BlockRange to bound peak memory usage:
 // at most one window of block headers and their tx hashes are in memory at a time.
-func RunStepA(ctx context.Context, cfg *Config) (*StepAResult, error) {
+func RunStepA(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResult, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP A — Collect addresses (prestateTracer)")
 	log.Info("═══════════════════════════════════════════")
 
 	windowSize := uint64(cfg.Options.BlockRange)
-	totalBlocks := cfg.ResolvedTargetBlock - cfg.Options.L2StartBlock + 1
+	totalBlocks := targetBlock - cfg.Options.L2StartBlock + 1
 	log.Infof("Scanning %d blocks in windows of %d (L2 %d → %d)...",
-		totalBlocks, windowSize, cfg.Options.L2StartBlock, cfg.ResolvedTargetBlock)
+		totalBlocks, windowSize, cfg.Options.L2StartBlock, targetBlock)
 
 	finalAddrs := make(map[common.Address]struct{})
 	var allFailed []common.Hash
 	stepStart := time.Now()
 
-	for start := cfg.Options.L2StartBlock; start <= cfg.ResolvedTargetBlock; start += windowSize {
-		end := min(start+windowSize-1, cfg.ResolvedTargetBlock)
+	for start := cfg.Options.L2StartBlock; start <= targetBlock; start += windowSize {
+		end := min(start+windowSize-1, targetBlock)
 
 		hashes, err := scanBlockHeaders(ctx, cfg.L2RPCURL, start, end,
 			cfg.Options.RPCBatchSize, cfg.Options.ConcurrencyLimit)
@@ -58,7 +58,7 @@ func RunStepA(ctx context.Context, cfg *Config) (*StepAResult, error) {
 		blocksProcessed := end - cfg.Options.L2StartBlock + 1
 		elapsed := time.Since(stepStart)
 		blocksPerSec := float64(blocksProcessed) / elapsed.Seconds()
-		remaining := cfg.ResolvedTargetBlock - end
+		remaining := targetBlock - end
 		var eta string
 		if blocksPerSec > 0 {
 			eta = (time.Duration(float64(remaining)/blocksPerSec) * time.Second).Round(time.Second).String()

--- a/tools/exit_certificate/step_a.go
+++ b/tools/exit_certificate/step_a.go
@@ -22,6 +22,10 @@ func RunStepA(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResul
 	log.Info(" STEP A — Collect addresses (prestateTracer)")
 	log.Info("═══════════════════════════════════════════")
 
+	if targetBlock < cfg.Options.L2StartBlock {
+		return nil, fmt.Errorf("targetBlock %d is before l2StartBlock %d", targetBlock, cfg.Options.L2StartBlock)
+	}
+
 	windowSize := uint64(cfg.Options.BlockRange)
 	totalBlocks := targetBlock - cfg.Options.L2StartBlock + 1
 	log.Infof("Scanning %d blocks in windows of %d (L2 %d → %d)...",

--- a/tools/exit_certificate/step_b.go
+++ b/tools/exit_certificate/step_b.go
@@ -24,13 +24,13 @@ const (
 
 // RunStepB classifies addresses as EOA vs contract, then collects ETH and wrapped
 // token balances at targetBlock for all EOAs.
-func RunStepB(ctx context.Context, cfg *Config, stepA *StepAResult) (*StepBResult, error) {
+func RunStepB(ctx context.Context, cfg *Config, targetBlock uint64, stepA *StepAResult) (*StepBResult, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP B — EOA balance checking")
 	log.Info("═══════════════════════════════════════════")
 
 	rpcURL := cfg.L2RPCURL
-	blockTag := toBlockTag(cfg.ResolvedTargetBlock)
+	blockTag := toBlockTag(targetBlock)
 	batchSize := cfg.Options.RPCBatchSize
 	concurrency := cfg.Options.ConcurrencyLimit
 

--- a/tools/exit_certificate/step_g.go
+++ b/tools/exit_certificate/step_g.go
@@ -77,11 +77,11 @@ type bridgeEventLog struct {
 }
 
 // RunStepG computes Certificate.NewLocalExitRoot by replaying all bridge exits
-// against an Anvil shadow-fork of the L2 chain at cfg.ResolvedTargetBlock.
+// against an Anvil shadow-fork of the L2 chain at targetBlock.
 // lbtEntries is the output of Step 0; when non-nil it is used as a lookup table for
 // wrapped token addresses so that getTokenWrappedAddress RPC calls are avoided.
 func RunStepG(
-	ctx context.Context, cfg *Config, certificate *agglayertypes.Certificate, lbtEntries []LBTEntry,
+	ctx context.Context, cfg *Config, targetBlock uint64, certificate *agglayertypes.Certificate, lbtEntries []LBTEntry,
 ) (*StepGResult, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP G - Calculate NewLocalExitRoot")
@@ -93,7 +93,7 @@ func RunStepG(
 
 	if len(certificate.BridgeExits) == 0 {
 		log.Info("No bridge exits — using EmptyLER")
-		initialLER, err := readLocalExitRoot(ctx, cfg.L2RPCURL, cfg.L2BridgeAddress, toBlockTag(cfg.ResolvedTargetBlock))
+		initialLER, err := readLocalExitRoot(ctx, cfg.L2RPCURL, cfg.L2BridgeAddress, toBlockTag(targetBlock))
 		if err != nil {
 			log.Warnf("Could not read initial LocalExitRoot: %v", err)
 		}
@@ -109,7 +109,7 @@ func RunStepG(
 		return nil, err
 	}
 
-	anvilURL, cleanup, err := startAnvil(ctx, cfg.L2RPCURL, cfg.ResolvedTargetBlock)
+	anvilURL, cleanup, err := startAnvil(ctx, cfg.L2RPCURL, targetBlock)
 	if err != nil {
 		return nil, fmt.Errorf("start anvil: %w", err)
 	}

--- a/tools/exit_certificate/types.go
+++ b/tools/exit_certificate/types.go
@@ -33,6 +33,12 @@ type LegacyToken struct {
 	Balance string         `json:"balance"`
 }
 
+// Step0Result holds the output of Step 0 (LBT generation).
+type Step0Result struct {
+	TargetBlock uint64     `json:"targetBlock"`
+	Entries     []LBTEntry `json:"entries"`
+}
+
 // LBTEntry is a single entry from the Local Balance Tree file exported by the getLBT tool.
 type LBTEntry struct {
 	WrappedTokenAddress common.Address `json:"wrappedTokenAddress"`


### PR DESCRIPTION
## 🔄 Changes Summary

- Changed `cfg.TargetBlock` type from `string` to `aggkittypes.BlockNumberFinality`, enabling finality keywords (`LatestBlock`, `FinalizedBlock`, `SafeBlock`, `PendingBlock`), decimal/hex block numbers, and offset notation (e.g. `LatestBlock/-10`).
- Added `Step0Result.TargetBlock uint64` — the concrete resolved block number is now part of the Step 0 output and persisted to `step-0-l2_target_block.json` (new file).
- Removed `ResolvedTargetBlock` from `Config`; the resolved block number is passed as an explicit `targetBlock uint64` parameter to `RunStepA`, `RunStepB`, and `RunStepG`.
- Single-step runners (`runSingleA/B/G`) load the block from `step-0-l2_target_block.json` via a new `loadTargetBlock` helper.
- Updated README with target-block resolution table and updated Step 0 output list.
- Added output-directory cleanup hint at the end of the kurtosis configuration script.

## ⚠️ Breaking Changes

- 🛠️ **Config — `targetBlock` values renamed**: existing `parameters.json` files must update their `targetBlock` field to use the new PascalCase keywords:
  - `"latest"` → `"LatestBlock"`
  - `"finalized"` → `"FinalizedBlock"`
  - `"safe"` → `"SafeBlock"`
  - `"pending"` → `"PendingBlock"`

  The default (empty string) still resolves to `LatestBlock`. Decimal and hex block numbers are unchanged.

- 🗑️ **New output file**: `step-0-l2_target_block.json` is a new file produced by Step 0. Note: `step-0-result.json` (from a previous PR) was already renamed to `step-0-lbt.json`; any tooling still reading `step-0-result.json` must be updated to `step-0-lbt.json`.

## 📋 Config Updates

```json
// Before
"targetBlock": "latest"

// After
"targetBlock": "LatestBlock"       // or "FinalizedBlock", "SafeBlock", "PendingBlock"
"targetBlock": "LatestBlock/-10"   // latest minus 10 blocks
"targetBlock": "12345678"          // decimal (unchanged)
"targetBlock": "0xBCDE34"          // hex (unchanged)
```

## ✅ Testing

- 🖱️ **Manual**: Run full pipeline with `targetBlock: "LatestBlock"` and verify `step-0-l2_target_block.json` is written with a valid block number; subsequent single-step runs for A, B, and G should pick it up automatically.

## 🐞 Issues

- Closes #1625

## 🔗 Related PRs

- Base branch: `feat/exit_certificate_f01_token_sclocked`