### PR TITLE
feat(exit-certificate): step A fallback via receipt recovery + legacy rollup diagnostics

### DIFF
--- a/tools/exit_certificate/rpc.go
+++ b/tools/exit_certificate/rpc.go
@@ -78,47 +78,92 @@ type RPCCall struct {
 }
 
 // batchRPC sends a batch of JSON-RPC calls in a single HTTP POST.
-// Returns ordered results; individual RPC errors are logged and become nil entries.
-// Returns an error if any individual response contained an RPC-level error.
+// Returns ordered results matching the input calls slice. Per-item RPC errors are retried
+// up to retries times. Returns an error if any call still fails after all retries.
 func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]json.RawMessage, error) {
 	if retries <= 0 {
 		retries = defaultRetries
 	}
 
-	requests := make([]jsonRPCRequest, len(calls))
-	for i, c := range calls {
-		requests[i] = jsonRPCRequest{JSONRPC: "2.0", Method: c.Method, Params: c.Params, ID: i + 1}
-	}
-
-	body, err := json.Marshal(requests)
-	if err != nil {
-		return nil, fmt.Errorf("marshal batch request: %w", err)
-	}
-
-	responses, err := doRPCWithRetry(ctx, url, body, retries, "")
-	if err != nil {
-		return nil, err
-	}
-	if len(responses) == 1 && responses[0].Error != nil {
-		e := responses[0].Error
-		return nil, &RPCExecutionError{Code: e.Code, Message: e.Message, Data: e.Data}
-	}
-	if len(responses) != len(calls) {
-		return nil, fmt.Errorf("RPC response count %d does not match request count %d", len(responses), len(calls))
-	}
-
 	results := make([]json.RawMessage, len(calls))
-	for _, r := range responses {
-		idx := r.ID - 1
-		if idx < 0 || idx >= len(results) {
-			continue
-		}
-		if r.Error != nil {
-			log.Warnf("RPC error for request id=%d: [%d] %s", r.ID, r.Error.Code, r.Error.Message)
-			continue
-		}
-		results[idx] = r.Result
+	pendingIdxs := make([]int, len(calls))
+	for i := range pendingIdxs {
+		pendingIdxs[i] = i
 	}
+
+	for attempt := 1; attempt <= retries && len(pendingIdxs) > 0; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if attempt > 1 {
+			log.Warnf("batchRPC: retrying %d/%d failed calls (attempt %d/%d)",
+				len(pendingIdxs), len(calls), attempt, retries)
+			sleepWithBackoff(ctx, attempt-1)
+		}
+
+		subCalls := make([]RPCCall, len(pendingIdxs))
+		for i, origIdx := range pendingIdxs {
+			subCalls[i] = calls[origIdx]
+		}
+
+		requests := make([]jsonRPCRequest, len(subCalls))
+		for i, c := range subCalls {
+			requests[i] = jsonRPCRequest{JSONRPC: "2.0", Method: c.Method, Params: c.Params, ID: i + 1}
+		}
+
+		body, err := json.Marshal(requests)
+		if err != nil {
+			return nil, fmt.Errorf("marshal batch request: %w", err)
+		}
+
+		responses, err := doRPCWithRetry(ctx, url, body, 1, "")
+		if err != nil {
+			if attempt == retries {
+				return nil, err
+			}
+			log.Warnf("batchRPC attempt %d/%d HTTP error: %v", attempt, retries, err)
+			continue
+		}
+
+		// Whole-batch rejection: node returned a single error object for multiple pending calls.
+		if len(responses) == 1 && responses[0].Error != nil && len(subCalls) > 1 {
+			e := responses[0].Error
+			if attempt == retries {
+				return nil, &RPCExecutionError{Code: e.Code, Message: e.Message, Data: e.Data}
+			}
+			log.Warnf("batchRPC attempt %d/%d: node rejected batch of %d calls [%d] %s — retrying",
+				attempt, retries, len(subCalls), e.Code, e.Message)
+			continue
+		}
+
+		if len(responses) != len(subCalls) {
+			return nil, fmt.Errorf("RPC response count %d does not match request count %d",
+				len(responses), len(subCalls))
+		}
+
+		var nextPending []int
+		for _, r := range responses {
+			localIdx := r.ID - 1
+			if localIdx < 0 || localIdx >= len(pendingIdxs) {
+				continue
+			}
+			origIdx := pendingIdxs[localIdx]
+			if r.Error != nil {
+				log.Warnf("RPC error for %s id=%d (attempt %d/%d): [%d] %s",
+					calls[origIdx].Method, origIdx+1, attempt, retries, r.Error.Code, r.Error.Message)
+				nextPending = append(nextPending, origIdx)
+				continue
+			}
+			results[origIdx] = r.Result
+		}
+		pendingIdxs = nextPending
+	}
+
+	if len(pendingIdxs) > 0 {
+		return nil, fmt.Errorf("batchRPC: %d/%d calls still failing after %d attempts",
+			len(pendingIdxs), len(calls), retries)
+	}
+
 	return results, nil
 }
 

--- a/tools/exit_certificate/rpc_test.go
+++ b/tools/exit_certificate/rpc_test.go
@@ -45,7 +45,8 @@ func TestBatchRPC_Success(t *testing.T) {
 }
 
 func TestBatchRPC_RPCError(t *testing.T) {
-	// Single-call batch where the response is an RPC error: batchRPC propagates it as an error.
+	// Single-call batch where the node always returns a per-item RPC error.
+	// batchRPC exhausts retries and returns an error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		responses := []jsonRPCResponse{
 			{JSONRPC: "2.0", ID: 1, Error: &jsonRPCError{Code: -32000, Message: "not found"}},
@@ -62,18 +63,22 @@ func TestBatchRPC_RPCError(t *testing.T) {
 
 	_, err := batchRPC(ctx, server.URL, calls, 1)
 	require.Error(t, err)
-	var rpcErr *RPCExecutionError
-	require.ErrorAs(t, err, &rpcErr)
-	require.Equal(t, -32000, rpcErr.Code)
-	require.Contains(t, rpcErr.Message, "not found")
+	require.Contains(t, err.Error(), "1/1 calls still failing")
 }
 
 func TestBatchRPC_MultipleCallsOneError(t *testing.T) {
-	// Two-call batch: first succeeds, second has an RPC error → nil at that index, no error returned.
+	// Two-call batch where the second call always returns a per-item RPC error.
+	// batchRPC exhausts retries and returns an error — no nil slots are silently accepted.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		responses := []jsonRPCResponse{
-			{JSONRPC: "2.0", ID: 1, Result: json.RawMessage(`"0x1"`)},
-			{JSONRPC: "2.0", ID: 2, Error: &jsonRPCError{Code: -32000, Message: "not found"}},
+		var requests []jsonRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requests))
+		responses := make([]jsonRPCResponse, len(requests))
+		for i, req := range requests {
+			if req.Method == "eth_getBlockByNumber" {
+				responses[i] = jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &jsonRPCError{Code: -32000, Message: "not found"}}
+			} else {
+				responses[i] = jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`"0x1"`)}
+			}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(responses))
@@ -86,11 +91,44 @@ func TestBatchRPC_MultipleCallsOneError(t *testing.T) {
 		{Method: "eth_getBlockByNumber", Params: []any{"0x999", false}},
 	}
 
-	results, err := batchRPC(ctx, server.URL, calls, 1)
+	_, err := batchRPC(ctx, server.URL, calls, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "1/2 calls still failing")
+}
+
+func TestBatchRPC_RetriesFailedItems(t *testing.T) {
+	// Two-call batch: both fail on attempt 1, both succeed on attempt 2.
+	// batchRPC must retry only the failed items and return complete results with no error.
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var requests []jsonRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requests))
+		callCount++
+		responses := make([]jsonRPCResponse, len(requests))
+		for i, req := range requests {
+			if callCount == 1 {
+				responses[i] = jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &jsonRPCError{Code: -32000, Message: "overloaded"}}
+			} else {
+				responses[i] = jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`"0x1"`)}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(responses))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	calls := []RPCCall{
+		{Method: "eth_getBalance", Params: nil},
+		{Method: "eth_getBalance", Params: nil},
+	}
+
+	results, err := batchRPC(ctx, server.URL, calls, 2)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	require.NotNil(t, results[0])
-	require.Nil(t, results[1])
+	require.NotNil(t, results[1])
+	require.Equal(t, 2, callCount)
 }
 
 func TestBatchRPC_HTTPError(t *testing.T) {

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -39,6 +39,13 @@ func Run(c *cli.Context) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	if err := os.MkdirAll(cfg.Options.OutputDir, dirPermissions); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	if err := migrateStepAToA1(cfg.Options.OutputDir); err != nil {
+		return err
+	}
+
 	step := c.String("step")
 	if step == "" || step == "all" {
 		return runAll(ctx, cfg)
@@ -57,7 +64,8 @@ func Run(c *cli.Context) error {
 }
 
 // orderedSteps is the canonical pipeline order used for range expansion.
-var orderedSteps = []string{"check", "0", "a", "b", "c", "d", "e", "f", "g", "h", "i", "sign", "submit", "wait"}
+// "a" is an alias for "a1,a2" and is handled in parseStepList; it is not listed here.
+var orderedSteps = []string{"check", "0", "a1", "a2", "b", "c", "d", "e", "f", "g", "h", "i", "sign", "submit", "wait"}
 
 // lastAutoStep is the implicit end for open ranges (X-).
 // "submit" and "wait" must always be specified explicitly.
@@ -67,6 +75,9 @@ const lastAutoStep = "sign"
 // "f-i"  → ["f", "g", "h", "i"]
 // "f-"   → ["f", "g", "h", "i", "sign", "submit", "wait"]
 // "h, i, sign" → ["h", "i", "sign"]
+// "a"    → ["a1", "a2"] (alias for both sub-steps)
+// "a-b"  → ["a1", "a2", "b"] ("a" expands to "a1" as range start)
+// "0-a"  → ["0", "a1", "a2"] ("a" expands to "a2" as range end)
 func parseStepList(raw string) ([]string, error) {
 	var steps []string
 	for _, token := range strings.Split(raw, ",") {
@@ -75,11 +86,22 @@ func parseStepList(raw string) ([]string, error) {
 			continue
 		}
 		if strings.Contains(token, "-") {
-			expanded, err := expandStepRange(token)
+			// Map "a" to "a1" (range start) or "a2" (range end) before expanding.
+			parts := strings.SplitN(token, "-", splitInTwo)
+			from, to := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+			if from == "a" {
+				from = "a1"
+			}
+			if to == "a" {
+				to = "a2"
+			}
+			expanded, err := expandStepRange(from + "-" + to)
 			if err != nil {
 				return nil, err
 			}
 			steps = append(steps, expanded...)
+		} else if token == "a" {
+			steps = append(steps, "a1", "a2")
 		} else {
 			steps = append(steps, token)
 		}
@@ -230,17 +252,33 @@ func runAll(ctx context.Context, cfg *Config) error {
 func runAllStepA(
 	ctx context.Context, cfg *Config, dir string, targetBlock uint64, wrappedTokens []WrappedToken,
 ) (*StepAResult, error) {
-	stepAResult, err := RunStepA(ctx, cfg, targetBlock)
+	a1Result, err := RunStepA1(ctx, cfg, targetBlock)
 	if err != nil {
-		return nil, fmt.Errorf("step A: %w", err)
+		return nil, fmt.Errorf("step A1: %w", err)
 	}
-	saveJSON(dir, "step-a-addresses.json", stepAResult.Addresses)
-	saveJSON(dir, "step-a-failed-traces.json", stepAResult.FailedTraces)
-	stepAResult.WrappedTokens = wrappedTokens
+	saveJSON(dir, "step-a1-addresses.json", a1Result.Addresses)
+	saveJSON(dir, "step-a1-failed-traces.json", a1Result.FailedTraces)
+
+	a2Result, err := RunStepA2(ctx, cfg, a1Result.FailedTraces)
+	if err != nil {
+		return nil, fmt.Errorf("step A2: %w", err)
+	}
+	saveJSON(dir, "step-a2-addresses.json", a2Result.Addresses)
+
+	combined := mergeAddresses(a1Result.Addresses, a2Result.Addresses)
+	log.Infof("STEP A complete: %d addresses (A1: %d, A2 new: %d)",
+		len(combined), len(a1Result.Addresses), len(combined)-len(a1Result.Addresses))
+	saveJSON(dir, "step-a-addresses.json", combined)
+
+	result := &StepAResult{
+		Addresses:     combined,
+		FailedTraces:  a1Result.FailedTraces,
+		WrappedTokens: wrappedTokens,
+	}
 	if len(wrappedTokens) > 0 {
 		log.Infof("Using %d wrapped tokens for balance scanning", len(wrappedTokens))
 	}
-	return stepAResult, nil
+	return result, nil
 }
 
 func runAllStepB(
@@ -411,6 +449,10 @@ func runSingleStep(ctx context.Context, step string, cfg *Config) error {
 		return runSingle0(ctx, cfg, dir)
 	case "a":
 		return runSingleA(ctx, cfg, dir)
+	case "a1":
+		return runSingleA1(ctx, cfg, dir)
+	case "a2":
+		return runSingleA2(ctx, cfg, dir)
 	case "b":
 		return runSingleB(ctx, cfg, dir)
 	case "c":
@@ -434,7 +476,8 @@ func runSingleStep(ctx context.Context, step string, cfg *Config) error {
 	case "wait":
 		return runSingleWait(ctx, cfg, dir)
 	default:
-		return fmt.Errorf("unknown step: %s (use check, 0, a, b, c, d, e, f, g, h, i, sign, submit, wait, or all)", step)
+		return fmt.Errorf("unknown step: %s (use check, 0, a, a1, a2, b, c, d, e, f, g, h, i, sign, submit, wait, or all)",
+			step)
 	}
 }
 
@@ -457,18 +500,77 @@ func runSingle0(ctx context.Context, cfg *Config, dir string) error {
 	return nil
 }
 
+// runSingleA runs A1 then A2, producing all four output files.
 func runSingleA(ctx context.Context, cfg *Config, dir string) error {
+	if err := runSingleA1(ctx, cfg, dir); err != nil {
+		return err
+	}
+	return runSingleA2(ctx, cfg, dir)
+}
+
+// runSingleA1 runs Step A1 and writes step-a1-addresses.json and step-a1-failed-traces.json.
+func runSingleA1(ctx context.Context, cfg *Config, dir string) error {
 	targetBlock, err := loadTargetBlock(dir)
 	if err != nil {
 		return err
 	}
-	result, err := RunStepA(ctx, cfg, targetBlock)
+	result, err := RunStepA1(ctx, cfg, targetBlock)
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, "step-a-addresses.json", result.Addresses)
-	saveJSON(dir, "step-a-failed-traces.json", result.FailedTraces)
+	saveJSON(dir, "step-a1-addresses.json", result.Addresses)
+	saveJSON(dir, "step-a1-failed-traces.json", result.FailedTraces)
 	return nil
+}
+
+// runSingleA2 runs Step A2 and writes step-a2-addresses.json and step-a-addresses.json.
+// Legacy step-a-* files are migrated to step-a1-* at startup (see Run), so they will
+// already be in the correct location by the time this function is called.
+func runSingleA2(ctx context.Context, cfg *Config, dir string) error {
+	var failedTraces []FailedTrace
+	if err := loadJSON(dir, "step-a1-failed-traces.json", &failedTraces); err != nil {
+		return fmt.Errorf("load step A1 failed traces (run step a1 first): %w", err)
+	}
+
+	a2Result, err := RunStepA2(ctx, cfg, failedTraces)
+	if err != nil {
+		return err
+	}
+	saveJSON(dir, "step-a2-addresses.json", a2Result.Addresses)
+
+	var a1Addresses []common.Address
+	if err := loadJSON(dir, "step-a1-addresses.json", &a1Addresses); err != nil {
+		return fmt.Errorf("load step A1 addresses: %w", err)
+	}
+	combined := mergeAddresses(a1Addresses, a2Result.Addresses)
+	log.Infof("STEP A complete: %d addresses (A1: %d, A2 new: %d)",
+		len(combined), len(a1Addresses), len(combined)-len(a1Addresses))
+	saveJSON(dir, "step-a-addresses.json", combined)
+	return nil
+}
+
+// migrateStepAToA1 renames legacy step-a-* output files to step-a1-* when the A1 files
+// are absent. This allows step A2 to be run after a pipeline that predates the A1/A2 split.
+func migrateStepAToA1(dir string) error {
+	rename := func(oldName, newName string) error {
+		oldPath := filepath.Join(dir, oldName)
+		newPath := filepath.Join(dir, newName)
+		if _, err := os.Stat(newPath); err == nil {
+			return nil // new file already exists — nothing to do
+		}
+		if _, err := os.Stat(oldPath); err != nil {
+			return nil // old file also absent — nothing to do
+		}
+		log.Infof("Migrating %s → %s", oldName, newName)
+		if err := os.Rename(oldPath, newPath); err != nil {
+			return fmt.Errorf("rename %s: %w", oldName, err)
+		}
+		return nil
+	}
+	if err := rename("step-a-addresses.json", "step-a1-addresses.json"); err != nil {
+		return err
+	}
+	return rename("step-a-failed-traces.json", "step-a1-failed-traces.json")
 }
 
 func runSingleB(ctx context.Context, cfg *Config, dir string) error {

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -715,6 +715,7 @@ func loadTargetBlock(dir string) (uint64, error) {
 	return n, nil
 }
 
+
 // loadWrappedTokensFromLBT loads tokens from the step-0 output.
 func loadWrappedTokensFromLBT(dir string) ([]WrappedToken, error) {
 	tokens, err := LoadLBTWrappedTokens(filepath.Join(dir, "step-0-lbt.json"))

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -715,7 +715,6 @@ func loadTargetBlock(dir string) (uint64, error) {
 	return n, nil
 }
 
-
 // loadWrappedTokensFromLBT loads tokens from the step-0 output.
 func loadWrappedTokensFromLBT(dir string) ([]WrappedToken, error) {
 	tokens, err := LoadLBTWrappedTokens(filepath.Join(dir, "step-0-lbt.json"))

--- a/tools/exit_certificate/run_test.go
+++ b/tools/exit_certificate/run_test.go
@@ -29,6 +29,10 @@ func TestParseStepList(t *testing.T) {
 		{"reversed range error", "i-f", nil, true},
 		{"unknown from step", "z-i", nil, true},
 		{"unknown to step", "f-z", nil, true},
+		// Step A alias and sub-step expansion.
+		{"a alias expands to a1 a2", "a", []string{"a1", "a2"}, false},
+		{"a-b expands a to a1 a2 then b", "a-b", []string{"a1", "a2", "b"}, false},
+		{"a2-b range", "a2-b", []string{"a2", "b"}, false},
 	}
 
 	for _, tc := range tests {

--- a/tools/exit_certificate/step_a.go
+++ b/tools/exit_certificate/step_a.go
@@ -13,13 +13,34 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// RunStepA collects all touched addresses from genesis to targetBlock using
+// RunStepA runs Step A1 followed by Step A2 and returns the combined result.
+// Step A1 collects touched addresses via debug_traceTransaction (prestateTracer + diffMode).
+// Step A2 recovers additional addresses from tx receipts for any traces that failed in A1.
+func RunStepA(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResult, error) {
+	a1Result, err := RunStepA1(ctx, cfg, targetBlock)
+	if err != nil {
+		return nil, err
+	}
+	a2Result, err := RunStepA2(ctx, cfg, a1Result.FailedTraces)
+	if err != nil {
+		return nil, err
+	}
+	combined := mergeAddresses(a1Result.Addresses, a2Result.Addresses)
+	log.Infof("STEP A complete: %d addresses (A1: %d, A2 new: %d)",
+		len(combined), len(a1Result.Addresses), len(combined)-len(a1Result.Addresses))
+	return &StepAResult{
+		Addresses:    combined,
+		FailedTraces: a1Result.FailedTraces,
+	}, nil
+}
+
+// RunStepA1 collects all touched addresses from genesis to targetBlock using
 // debug_traceTransaction with prestateTracer + diffMode.
 // Blocks are scanned in windows of Options.StepAWindowSize to bound peak memory usage:
 // at most one window of block headers and their tx hashes are in memory at a time.
-func RunStepA(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResult, error) {
+func RunStepA1(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResult, error) {
 	log.Info("═══════════════════════════════════════════")
-	log.Info(" STEP A — Collect addresses (prestateTracer)")
+	log.Info(" STEP A1 — Collect addresses (prestateTracer)")
 	log.Info("═══════════════════════════════════════════")
 
 	if targetBlock < cfg.Options.L2StartBlock {
@@ -78,7 +99,7 @@ func RunStepA(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResul
 	delete(finalAddrs, common.Address{})
 
 	if len(finalAddrs) == 0 && len(allFailed) == 0 {
-		log.Info("STEP A complete: 0 unique addresses (no transactions found)")
+		log.Info("STEP A1 complete: 0 unique addresses (no transactions found)")
 		return &StepAResult{}, nil
 	}
 
@@ -91,11 +112,144 @@ func RunStepA(ctx context.Context, cfg *Config, targetBlock uint64) (*StepAResul
 	})
 
 	if len(allFailed) > 0 {
-		log.Warnf("STEP A complete: %d unique addresses (%d trace failures skipped)", len(addresses), len(allFailed))
+		log.Warnf("STEP A1 complete: %d unique addresses (%d trace failures — run step A2 to recover)",
+			len(addresses), len(allFailed))
 	} else {
-		log.Infof("STEP A complete: %d unique addresses", len(addresses))
+		log.Infof("STEP A1 complete: %d unique addresses", len(addresses))
 	}
 	return &StepAResult{Addresses: addresses, FailedTraces: allFailed}, nil
+}
+
+// RunStepA2 recovers addresses from tx receipts for traces that failed in Step A1.
+// For each FailedTrace it calls eth_getTransactionReceipt and extracts all addresses
+// found in the receipt: sender (from), recipient (to), created contract, and log emitters.
+// Failed receipt fetches are logged as warnings and skipped rather than aborting.
+func RunStepA2(ctx context.Context, cfg *Config, failedTraces []FailedTrace) (*StepA2Result, error) {
+	log.Info("═══════════════════════════════════════════")
+	log.Info(" STEP A2 — Recover addresses from tx receipts")
+	log.Info("═══════════════════════════════════════════")
+
+	if len(failedTraces) == 0 {
+		log.Info("STEP A2 complete: no failed traces — nothing to process")
+		return &StepA2Result{}, nil
+	}
+
+	log.Infof("Processing %d failed traces via eth_getTransactionReceipt...", len(failedTraces))
+
+	hashes := make([]common.Hash, len(failedTraces))
+	for i, ft := range failedTraces {
+		hashes[i] = ft.Hash
+	}
+
+	addrSet := make(map[common.Address]struct{})
+
+	err := runWorkerPool(
+		ctx, hashes, cfg.Options.ConcurrencyLimit,
+		func(hash common.Hash) ([]common.Address, error) {
+			addrs, fetchErr := receiptAddresses(ctx, cfg.L2RPCURL, hash)
+			if fetchErr != nil {
+				log.Warnf("STEP A2: receipt failed for %s (skipping): %v", hash.Hex(), fetchErr)
+				return nil, nil
+			}
+			return addrs, nil
+		},
+		func(addrs []common.Address) {
+			for _, addr := range addrs {
+				addrSet[addr] = struct{}{}
+			}
+		},
+		"Receipts",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetch receipts: %w", err)
+	}
+
+	delete(addrSet, common.Address{})
+
+	addresses := make([]common.Address, 0, len(addrSet))
+	for addr := range addrSet {
+		addresses = append(addresses, addr)
+	}
+	sort.Slice(addresses, func(i, j int) bool {
+		return strings.ToLower(addresses[i].Hex()) < strings.ToLower(addresses[j].Hex())
+	})
+
+	log.Infof("STEP A2 complete: %d addresses recovered from %d failed traces", len(addresses), len(failedTraces))
+	return &StepA2Result{Addresses: addresses}, nil
+}
+
+// receiptAddresses fetches eth_getTransactionReceipt for hash and returns all addresses
+// found in the receipt: sender (from), recipient (to), created contract, and log emitters.
+func receiptAddresses(ctx context.Context, rpcURL string, hash common.Hash) ([]common.Address, error) {
+	result, err := singleRPC(ctx, rpcURL, "eth_getTransactionReceipt", []any{hash.Hex()}, defaultRetries)
+	if err != nil {
+		return nil, fmt.Errorf("receipt %s: %w", hash.Hex(), err)
+	}
+
+	if len(result) == 0 || string(result) == "null" {
+		return nil, fmt.Errorf("receipt for %s is null", hash.Hex())
+	}
+
+	var receipt struct {
+		From            string  `json:"from"`
+		To              *string `json:"to"`
+		ContractAddress *string `json:"contractAddress"`
+		Logs            []struct {
+			Address string `json:"address"`
+		} `json:"logs"`
+	}
+	if err := json.Unmarshal(result, &receipt); err != nil {
+		return nil, fmt.Errorf("unmarshal receipt %s: %w", hash.Hex(), err)
+	}
+
+	addrSet := make(map[common.Address]struct{})
+	addHex := func(s string) {
+		if s == "" || s == "0x" {
+			return
+		}
+		addr := common.HexToAddress(s)
+		if addr != (common.Address{}) {
+			addrSet[addr] = struct{}{}
+		}
+	}
+
+	addHex(receipt.From)
+	if receipt.To != nil {
+		addHex(*receipt.To)
+	}
+	if receipt.ContractAddress != nil {
+		addHex(*receipt.ContractAddress)
+	}
+	for _, l := range receipt.Logs {
+		addHex(l.Address)
+	}
+
+	addresses := make([]common.Address, 0, len(addrSet))
+	for addr := range addrSet {
+		addresses = append(addresses, addr)
+	}
+	return addresses, nil
+}
+
+// mergeAddresses deduplicates and sorts the union of two address slices.
+func mergeAddresses(a, b []common.Address) []common.Address {
+	seen := make(map[common.Address]struct{}, len(a)+len(b))
+	for _, addr := range a {
+		seen[addr] = struct{}{}
+	}
+	for _, addr := range b {
+		seen[addr] = struct{}{}
+	}
+	delete(seen, common.Address{})
+
+	merged := make([]common.Address, 0, len(seen))
+	for addr := range seen {
+		merged = append(merged, addr)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return strings.ToLower(merged[i].Hex()) < strings.ToLower(merged[j].Hex())
+	})
+	return merged
 }
 
 func scanBlockHeaders(

--- a/tools/exit_certificate/step_check.go
+++ b/tools/exit_certificate/step_check.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/aggchainbase"
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayerbridgel2"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/polygonrollupmanagerpessimistic"
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -184,6 +185,8 @@ func checkContractPrereqs(
 		log.Infof("❌ %s", msg)
 		*failures = append(*failures, msg)
 		result.NetworkType = "unknown"
+		log.Info("   (AGGCHAINTYPE unavailable — contract may be pre-aggchainbase; attempting legacy rollup manager diagnostics)")
+		logLegacyRollupInfo(ctx, caller, cfg.SovereignRollupAddr, l1Client)
 	} else if aggchainType == aggchainTypePP {
 		result.NetworkType = "PP"
 		log.Info("✅ network type is Pessimistic Proof (PP) — supported")
@@ -256,4 +259,53 @@ func checkContractPrereqs(
 	} else {
 		log.Infof("   RollupManager address: %s", rollupManager.Hex())
 	}
+}
+
+// logLegacyRollupInfo gathers rollup manager diagnostics when AGGCHAINTYPE is unavailable
+// (pre-aggchainbase contracts). It does not modify check results or failures — it only logs.
+func logLegacyRollupInfo(
+	ctx context.Context,
+	caller *aggchainbase.AggchainbaseCaller,
+	sovereignRollupAddr common.Address,
+	l1Client *ethclient.Client,
+) {
+	callOpts := &bind.CallOpts{Context: ctx}
+
+	rollupManagerAddr, err := caller.RollupManager(callOpts)
+	if err != nil {
+		log.Infof("   (legacy diagnostics) RollupManager() failed: %v", err)
+		return
+	}
+	log.Infof("   (legacy diagnostics) RollupManager: %s", rollupManagerAddr.Hex())
+
+	rmCaller, err := polygonrollupmanagerpessimistic.NewPolygonrollupmanagerpessimisticCaller(rollupManagerAddr, l1Client)
+	if err != nil {
+		log.Infof("   (legacy diagnostics) create rollup manager caller: %v", err)
+		return
+	}
+
+	rollupID, err := rmCaller.RollupAddressToID(callOpts, sovereignRollupAddr)
+	if err != nil {
+		log.Infof("   (legacy diagnostics) RollupAddressToID(%s): %v", sovereignRollupAddr.Hex(), err)
+		return
+	}
+	log.Infof("   (legacy diagnostics) rollupID: %d", rollupID)
+
+	rollupData, err := rmCaller.RollupIDToRollupData(callOpts, rollupID)
+	if err != nil {
+		log.Infof("   (legacy diagnostics) RollupIDToRollupData(%d): %v", rollupID, err)
+		return
+	}
+	log.Infof("   (legacy diagnostics) rollupTypeID: %d  chainID: %d  forkID: %d  rollupVerifierType: %d",
+		rollupData.RollupTypeID, rollupData.ChainID, rollupData.ForkID, rollupData.RollupVerifierType)
+
+	typeInfo, err := rmCaller.RollupTypeMap(callOpts, uint32(rollupData.RollupTypeID))
+	if err != nil {
+		log.Infof("   (legacy diagnostics) RollupTypeMap(%d): %v", rollupData.RollupTypeID, err)
+		return
+	}
+	log.Infof("   (legacy diagnostics) rollupType: consensusImpl=%s  verifier=%s  forkID=%d  verifierType=%d  obsolete=%v",
+		typeInfo.ConsensusImplementation.Hex(), typeInfo.Verifier.Hex(), typeInfo.ForkID, typeInfo.RollupVerifierType, typeInfo.Obsolete)
+	log.Infof("   (legacy diagnostics) rollupType: genesis=%x  programVKey=%x",
+		typeInfo.Genesis, typeInfo.ProgramVKey)
 }

--- a/tools/exit_certificate/step_check.go
+++ b/tools/exit_certificate/step_check.go
@@ -185,7 +185,8 @@ func checkContractPrereqs(
 		log.Infof("❌ %s", msg)
 		*failures = append(*failures, msg)
 		result.NetworkType = "unknown"
-		log.Info("   (AGGCHAINTYPE unavailable — contract may be pre-aggchainbase; attempting legacy rollup manager diagnostics)")
+		log.Info("   (AGGCHAINTYPE unavailable — contract may be pre-aggchainbase;" +
+			" attempting legacy rollup manager diagnostics)")
 		logLegacyRollupInfo(ctx, caller, cfg.SovereignRollupAddr, l1Client)
 	} else if aggchainType == aggchainTypePP {
 		result.NetworkType = "PP"
@@ -305,7 +306,8 @@ func logLegacyRollupInfo(
 		return
 	}
 	log.Infof("   (legacy diagnostics) rollupType: consensusImpl=%s  verifier=%s  forkID=%d  verifierType=%d  obsolete=%v",
-		typeInfo.ConsensusImplementation.Hex(), typeInfo.Verifier.Hex(), typeInfo.ForkID, typeInfo.RollupVerifierType, typeInfo.Obsolete)
+		typeInfo.ConsensusImplementation.Hex(), typeInfo.Verifier.Hex(),
+		typeInfo.ForkID, typeInfo.RollupVerifierType, typeInfo.Obsolete)
 	log.Infof("   (legacy diagnostics) rollupType: genesis=%x  programVKey=%x",
 		typeInfo.Genesis, typeInfo.ProgramVKey)
 }

--- a/tools/exit_certificate/types.go
+++ b/tools/exit_certificate/types.go
@@ -89,11 +89,16 @@ type FailedTrace struct {
 	Error string      `json:"error"`
 }
 
-// StepAResult holds the output of Step A.
+// StepAResult holds the combined output of Step A (A1 + A2).
 type StepAResult struct {
 	Addresses     []common.Address `json:"addresses"`
 	FailedTraces  []FailedTrace    `json:"failedTraces"`
 	WrappedTokens []WrappedToken   `json:"-"`
+}
+
+// StepA2Result holds addresses recovered from tx receipts of failed traces (Step A2).
+type StepA2Result struct {
+	Addresses []common.Address `json:"addresses"`
 }
 
 // StepBResult holds the output of Step B.


### PR DESCRIPTION
## 🔄 Changes Summary

- **Step A → A1 + A2 split**: Step A is now two sub-steps. A1 runs `debug_traceTransaction` (prestateTracer + diffMode) as before and records failed hashes. A2 recovers addresses from `eth_getTransactionReceipt` for each A1 failure, extracting from/to/contractAddress/log emitters. The combined `step-a-addresses.json` is the union of both.
- **Step aliases**: `--step a` expands to `a1,a2`; both sub-steps are individually addressable (`--step a1`, `--step a2`). Range syntax works too (`a-b` → `a1,a2,b`).
- **Migration**: on startup, legacy `step-a-*` files are renamed to `step-a1-*` so existing output dirs remain usable without re-running A1.
- **Legacy rollup diagnostics**: when `AGGCHAINTYPE()` fails (pre-aggchainbase contract), `logLegacyRollupInfo` queries the rollup manager to surface `rollupID`, `rollupTypeID`, `chainID`, `forkID`, `rollupVerifierType`, and full `rollupTypeMap` info (consensusImpl, verifier, obsolete, genesis, programVKey) as diagnostic log lines.

## ⚠️ Breaking Changes

- 🔌 **CLI**: `--step a` still works as before (runs both sub-steps). `step-a1-addresses.json` and `step-a1-failed-traces.json` are the new canonical A1 outputs; `step-a-failed-traces.json` is no longer written directly (migrated from legacy on startup).

## ✅ Testing

- 🤖 **Automatic**: `TestParseStepList` extended with `a`, `a-b`, `a2-b` cases.
- 🖱️ **Manual**: run `--step a` on a chain with trace failures to verify A2 recovers addresses from receipts.

## 📝 Notes

- A2 never aborts on receipt failures — it logs a warning and skips, so the pipeline always produces a result even when receipts are also unavailable.
- The legacy rollup diagnostics path does not modify check failures or results; it is purely informational output to help diagnose pre-aggchainbase deployments.