### PR TITLE
feat(exit-certificate): Step B2/B3 - ERC-20 detection and extra contract holder decomposition

### DIFF
--- a/tools/exit_certificate/CLAUDE.md
+++ b/tools/exit_certificate/CLAUDE.md
@@ -72,15 +72,37 @@ All checks run regardless of individual failures. A combined error lists every f
 - **Output:** `step-a-addresses.json` (`[]common.Address`), `step-a-failed-traces.json` (`[]common.Hash`)
 - **Option:** `continueOnTraceError=true` skips failed traces instead of aborting.
 
-### Step B — EOA balance checking
+### Step B — EOA balance checking + ERC-20 detection
 
-Three phases:
+Three sub-steps: B1, B2, B3. Running `--step b` executes all three.
+
+#### Step B1 — EOA classification and balance fetching
 
 1. `eth_getCode` → classify each address as EOA or contract
 2. `eth_getBalance` for all EOAs at `targetBlock`
 3. `balanceOf(address)` per wrapped token × per EOA (token list from LBT)
 
 - **Output:** `step-b-eoa-balances.json` (`[]EOABalance`), `step-b-accumulated.json` (`[]AccumulatedBalance`), `step-b-contract-addresses.json` (`[]common.Address`)
+
+#### Step B2 — ERC-20 detection in contracts
+
+Probes each contract address with `totalSupply()` / `balanceOf(address(0))` to confirm the ERC-20 interface. For each detected ERC-20, calls `balanceOf(contractAddr)` on every tracked wrapped token and `eth_getBalance` to find which tracked tokens it holds.
+
+- Holds ≥ 1 tracked token → `DetectedERC20` (relevant)
+- Holds none → `DiscardedERC20` (irrelevant)
+
+- **Output:** `step-b2-detected-erc20s.json` (`[]DetectedERC20`), `step-b2-discarded-erc20s.json` (`[]DiscardedERC20`)
+
+#### Step B3 — Extra ERC-20 holder decomposition
+
+Iterates over `options.extraErc20Contracts`. For each address:
+
+- If Step B2 already populated `Holders` for it, copies those holders and marks `AlreadyFromB2=true` — no RPC call.
+- Otherwise, calls `fetchTokenBalances` (one RPC batch of `balanceOf` for every EOA from Step A).
+
+Skipped automatically when `options.extraErc20Contracts` is empty.
+
+- **Output:** `step-b3-erc20-holders.json` (`[]ERC20HolderBreakdown`)
 
 ### Step C — SC-locked value
 

--- a/tools/exit_certificate/README.md
+++ b/tools/exit_certificate/README.md
@@ -86,6 +86,7 @@ cp parameters.json.example parameters.json
 | `ignoreUnclaimed` | `false` | When `true`, Step E detects and logs unclaimed deposits but leaves the certificate unchanged. When `false` (default), any unclaimed asset deposit causes the pipeline to error. |
 | `bridgeServiceURL` | `""` | Base URL of the bridge service REST API. When set, Step E cross-checks its unclaimed deposit set against the bridge service and returns an error on any discrepancy. |
 | `bridgeServiceType` | `"aggkit"` | Bridge service API flavour. `"aggkit"` uses `GET /bridge/v1/bridges` (aggkit bridge service); `"zkevm"` uses `GET /pending-bridges` (zkevm-bridge-service). |
+| `extraErc20Contracts` | `[]` | Optional list of ERC-20 contract addresses to decompose into individual holder balances in Step B3. For each address the tool calls `balanceOf` for every EOA collected in Step A. Example: `["0xAbc...123", "0xDef...456"]`. |
 
 ### Important configuration notes
 
@@ -193,7 +194,7 @@ Runs all steps sequentially: CHECK → 0 → A → B → C → D → E → F →
 | CHECK | Verify prerequisites | Checks Anvil, L1 RPC, network type (PP only), threshold = 1, no custom gas token. |
 | 0 | Generate LBT | Resolves `targetBlock` to a concrete block number, then scans `NewWrappedToken` events and fetches `totalSupply` per wrapped token at that block. |
 | A | Collect addresses | Traces every L2 transaction via `debug_traceTransaction` and collects all addresses that touched state. |
-| B | EOA balances | Classifies addresses as EOA vs contract; fetches ETH balance and every wrapped-token balance for each EOA at `targetBlock`. |
+| B | EOA balances + ERC-20 detection | B1: classifies addresses and fetches ETH/token balances for EOAs. B2: probes contracts for the ERC-20 interface and checks if they hold tracked wrapped tokens. B3: fetches holder breakdowns for `extraErc20Contracts` (skips any already processed by B2). |
 | C | SC-locked value | Computes value locked in contracts: `SC_locked = LBT_totalSupply − EOA_accumulated` per token. |
 | D | Build certificate | Creates the `Certificate` with `BridgeExit` entries for every (EOA, token) pair and every token with SC-locked value. |
 | E | Unclaimed deposits | Scans L1 for unclaimed `BridgeEvent` deposits targeting L2. Message deposits (`leaf_type=1`) are saved to `step-e-unclaimed-messages.json` and never added to the certificate. Asset deposits (`leaf_type=0`): if none are found the certificate is passed through unchanged; if any are found and `ignoreUnclaimed=true` they are logged but the certificate remains unchanged; if found and `ignoreUnclaimed=false` the pipeline errors (Merkle proof support not yet implemented). Optionally cross-checks against a bridge service. |
@@ -226,7 +227,7 @@ Spaces around commas are ignored. Execution stops at the first step that fails.
 | Flag | Short | Default | Description |
 | :--: | :---: | :-----: | :---------: |
 | `--config` | `-c` | `parameters.json` | Path to the config file. |
-| `--step` | — | `all` | Step(s) to run: `all`, a single step name, or a comma-separated list (e.g. `h,i,sign`). Valid names: `check`, `0`, `a`–`i`, `sign`, `submit`, `wait`. |
+| `--step` | — | `all` | Step(s) to run: `all`, a single step name, or a comma-separated list (e.g. `h,i,sign`). Valid names: `check`, `0`, `a`, `a1`, `a2`, `b`, `b1`, `b2`, `b3`, `c`–`i`, `sign`, `submit`, `wait`. The aliases `a` and `b` expand to their sub-steps. |
 | `--verbose` | — | `false` | Enable debug logging. Without this flag only `info`, `warn` and `error` messages are shown. |
 
 ## Pipeline steps
@@ -286,7 +287,11 @@ Scans all blocks from `l2StartBlock` to `targetBlock` and collects every address
 
 **Output:** `step-a-addresses.json`
 
-### Step B — EOA balance checking
+### Step B — EOA balance checking + ERC-20 detection
+
+Step B runs three sub-steps in sequence: B1, B2, and B3. Running `--step b` executes all three.
+
+#### Step B1 — EOA classification and balance fetching
 
 Classifies addresses as EOA vs contract, then queries ETH balance and every wrapped-token balance at `targetBlock` for all EOAs. The wrapped token list comes from the LBT data (Step 0).
 
@@ -294,9 +299,26 @@ Classifies addresses as EOA vs contract, then queries ETH balance and every wrap
 
 1. `eth_getCode` to classify EOA vs contract
 2. `eth_getBalance` for all EOAs
-3. `balanceOf` calls per token across all EOAs (token list from LBT)
+3. `balanceOf` calls per token × per EOA (token list from LBT)
 
 **Output:** `step-b-eoa-balances.json`, `step-b-accumulated.json`, `step-b-contract-addresses.json`
+
+#### Step B2 — ERC-20 detection in contracts
+
+Probes every contract address for the ERC-20 interface by calling `totalSupply()`. For each ERC-20 found, checks whether it holds any of the tracked wrapped tokens:
+
+- Holds at least one tracked token → **DetectedERC20** (relevant to the certificate)
+- Holds none → **DiscardedERC20** (no tracked value locked inside)
+
+**Output:** `step-b2-detected-erc20s.json`, `step-b2-discarded-erc20s.json`
+
+#### Step B3 — Extra ERC-20 holder decomposition
+
+Fetches the per-EOA token balance for each contract listed in `options.extraErc20Contracts`. These are ERC-20 contracts that should be decomposed into individual holder balances regardless of whether they were discovered by Step B2.
+
+Skipped automatically when `options.extraErc20Contracts` is empty.
+
+**Output:** `step-b3-erc20-holders.json`
 
 ### Step C — SC-locked value extraction
 

--- a/tools/exit_certificate/config-examples/zkevm-cardona.json
+++ b/tools/exit_certificate/config-examples/zkevm-cardona.json
@@ -7,6 +7,7 @@
     "targetBlock": "LatestBlock",
     "exitAddress": "0x0000000000000000000000000000000000001234",
     "sovereignRollupAddr": "0xA13Ddb14437A8F34897131367ad3ca78416d6bCa",
+    "l1GlobalExitRootAddress": "<L1_GLOBAL_EXIT_ROOT_ADDRESS>",
     "destinationNetwork": 0,
     "signerConfig": {
         "Method": "local",
@@ -21,12 +22,19 @@
         "rpcDelayMs": 10,
         "outputDir": "./output-cardona",
         "l1StartBlock": 5157692,
+        "continueOnTraceError": false,
+        "abortOnGenesisBalance": true,
+        "ignoreUnclaimed": false,
+        "continueIfBalanceMismatch": false,
+        "extraErc20Contracts": [],
         "bridgeServiceURL": "https://bridge-api.cardona.zkevm-rpc.com",
         "bridgeServiceType": "zkevm",
         "agglayerClient": {
             "GRPC": {
                 "URL": "<AGGLAYER_GRPC_URL>"
             }
-        }
+        },
+        "agglayerAdminURL": "<AGGLAYER_ADMIN_URL>",
+        "agglayerAdminToken": "<JWT>"
     }
 }

--- a/tools/exit_certificate/config-examples/zkevm-mainnet.json
+++ b/tools/exit_certificate/config-examples/zkevm-mainnet.json
@@ -3,9 +3,11 @@
     "l2RpcUrl": "https://zkevm-rpc.com/",
     "l1BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
     "l2BridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
-    "l2NetworkId": 20,
+    "l2NetworkId": 1,
     "targetBlock": "LatestBlock",
-    "exitAddress": "0x0000000000000000000000000000000000001234",
+    "exitAddress": "<PUBLIC_ADDRESS_TO_RECEIVE_SC_EXIT>",
+    "sovereignRollupAddr": "0x519E42c24163192Dca44CD3fBDCEBF6be9130987",
+    "l1GlobalExitRootAddress": "<L1_GLOBAL_EXIT_ROOT_ADDRESS>",
     "destinationNetwork": 0,
     "signerConfig": {
         "Method": "local",
@@ -14,8 +16,8 @@
     },
     "options": {
         "blockRange": 10000,
-        "stepAWindowSize": 10000,
-        "concurrencyLimit": 10,
+        "stepAWindowSize": 20000,
+        "concurrencyLimit": 200,
         "rpcBatchSize": 99,
         "rpcDelayMs": 10,
         "outputDir": "./output-mainnet",
@@ -23,10 +25,15 @@
         "continueOnTraceError": false,
         "abortOnGenesisBalance": true,
         "ignoreUnclaimed": false,
+        "continueIfBalanceMismatch": false,
+        "extraErc20Contracts": ["0x4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9"],
         "agglayerClient": {
             "GRPC": {
-                "URL": "<AGGLAYER_GRPC_URL>"
+                "URL": "<AGGLAYER_GRPC_URL>",
+                "UseTLS": true
             }
-        }
+        },
+        "agglayerAdminURL": "<AGGLAYER_ADMIN_URL>",
+        "agglayerAdminToken": "<JWT>"
     }
 }

--- a/tools/exit_certificate/config.go
+++ b/tools/exit_certificate/config.go
@@ -47,6 +47,10 @@ type Options struct {
 	// IgnoreUnclaimed skips adding unclaimed L1→L2 deposits to the certificate in Step E.
 	// The step still detects and warns about any unclaimed deposits, but the certificate is left unchanged.
 	IgnoreUnclaimed bool `json:"ignoreUnclaimed"`
+	// ExtraERC20Contracts is an optional list of ERC-20 contract addresses whose token holders
+	// are decomposed in Step B3. Each contract is queried with balanceOf for every EOA address
+	// collected in Step A.
+	ExtraERC20Contracts []common.Address `json:"extraErc20Contracts,omitempty"`
 	// BridgeServiceURL is the base URL of the bridge service REST API.
 	// When set, Step E queries the bridge service for pending bridges targeting this L2 and returns an
 	// error if any unclaimed deposits are found.
@@ -77,7 +81,7 @@ type Config struct {
 
 const (
 	defaultBlockRange       = 5000
-	defaultStepAWindowSize  = 5000
+	defaultStepAWindowSize  = 150000
 	defaultConcurrencyLimit = 20
 	defaultRPCBatchSize     = 200
 )
@@ -279,6 +283,13 @@ func mergeOptions(raw *rawOpts, configDir string) Options {
 	if raw.IgnoreUnclaimed != nil {
 		opts.IgnoreUnclaimed = *raw.IgnoreUnclaimed
 	}
+	if len(raw.ExtraERC20Contracts) > 0 {
+		addrs := make([]common.Address, 0, len(raw.ExtraERC20Contracts))
+		for _, s := range raw.ExtraERC20Contracts {
+			addrs = append(addrs, common.HexToAddress(s))
+		}
+		opts.ExtraERC20Contracts = addrs
+	}
 	if raw.BridgeServiceURL != "" {
 		opts.BridgeServiceURL = raw.BridgeServiceURL
 	}
@@ -319,7 +330,8 @@ type rawOpts struct {
 	AbortOnGenesisBalance     *bool                  `json:"abortOnGenesisBalance"`
 	ContinueOnTraceError      *bool                  `json:"continueOnTraceError"`
 	ContinueIfBalanceMismatch *bool                  `json:"continueIfBalanceMismatch"`
-	IgnoreUnclaimed           *bool                  `json:"ignoreUnclaimed"`
+	IgnoreUnclaimed     *bool    `json:"ignoreUnclaimed"`
+	ExtraERC20Contracts []string `json:"extraErc20Contracts"`
 	BridgeServiceURL          string                 `json:"bridgeServiceURL"`
 	BridgeServiceType         string                 `json:"bridgeServiceType"`
 }

--- a/tools/exit_certificate/config.go
+++ b/tools/exit_certificate/config.go
@@ -330,8 +330,8 @@ type rawOpts struct {
 	AbortOnGenesisBalance     *bool                  `json:"abortOnGenesisBalance"`
 	ContinueOnTraceError      *bool                  `json:"continueOnTraceError"`
 	ContinueIfBalanceMismatch *bool                  `json:"continueIfBalanceMismatch"`
-	IgnoreUnclaimed     *bool    `json:"ignoreUnclaimed"`
-	ExtraERC20Contracts []string `json:"extraErc20Contracts"`
+	IgnoreUnclaimed           *bool                  `json:"ignoreUnclaimed"`
+	ExtraERC20Contracts       []string               `json:"extraErc20Contracts"`
 	BridgeServiceURL          string                 `json:"bridgeServiceURL"`
 	BridgeServiceType         string                 `json:"bridgeServiceType"`
 }

--- a/tools/exit_certificate/config_test.go
+++ b/tools/exit_certificate/config_test.go
@@ -125,7 +125,7 @@ func TestLoadConfig_DefaultOptions(t *testing.T) {
 	cfg, err := LoadConfig(path)
 	require.NoError(t, err)
 	require.Equal(t, 5000, cfg.Options.BlockRange)
-	require.Equal(t, 5000, cfg.Options.StepAWindowSize)
+	require.Equal(t, 150000, cfg.Options.StepAWindowSize)
 	require.Equal(t, 20, cfg.Options.ConcurrencyLimit)
 	require.Equal(t, 200, cfg.Options.RPCBatchSize)
 	require.Equal(t, 0, cfg.Options.RPCDelayMs)

--- a/tools/exit_certificate/integration_test.go
+++ b/tools/exit_certificate/integration_test.go
@@ -71,12 +71,12 @@ func TestStepD_WithProductionLikeData(t *testing.T) {
 	stepC := &StepCResult{
 		SCLockedValues: []SCLockedValue{
 			{
-				WrappedTokenAddress: common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
-				OriginNetwork:       0,
-				OriginTokenAddress:  common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
-				LBTBalance:          "5000000000",
-				EOAAccumulated:      "1000000000",
-				PendingSCLockedBalance:     "4000000000",
+				WrappedTokenAddress:    common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+				OriginNetwork:          0,
+				OriginTokenAddress:     common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+				LBTBalance:             "5000000000",
+				EOAAccumulated:         "1000000000",
+				PendingSCLockedBalance: "4000000000",
 			},
 		},
 	}

--- a/tools/exit_certificate/integration_test.go
+++ b/tools/exit_certificate/integration_test.go
@@ -76,7 +76,7 @@ func TestStepD_WithProductionLikeData(t *testing.T) {
 				OriginTokenAddress:  common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
 				LBTBalance:          "5000000000",
 				EOAAccumulated:      "1000000000",
-				SCLockedBalance:     "4000000000",
+				PendingSCLockedBalance:     "4000000000",
 			},
 		},
 	}

--- a/tools/exit_certificate/parameters.json.example
+++ b/tools/exit_certificate/parameters.json.example
@@ -7,15 +7,35 @@
     "targetBlock": "LatestBlock",
     "exitAddress": "0x0000000000000000000000000000000000000001",
     "destinationNetwork": 0,
+    "sovereignRollupAddr": "<SOVEREIGN_ROLLUP_ADDR>",
+    "l1GlobalExitRootAddress": "<L1_GLOBAL_EXIT_ROOT_ADDRESS>",
     "options": {
         "blockRange": 10000,
+        "stepAWindowSize": 150000,
         "concurrencyLimit": 200,
         "rpcBatchSize": 200,
         "rpcDelayMs": 10,
         "outputDir": "./output",
         "l1StartBlock": 0,
-        "extraErc20Contracts": []
+        "continueOnTraceError": false,
+        "abortOnGenesisBalance": true,
+        "ignoreUnclaimed": false,
+        "continueIfBalanceMismatch": false,
+        "extraErc20Contracts": [],
+        "bridgeServiceURL": "",
+        "bridgeServiceType": "aggkit",
+        "agglayerClient": {
+            "GRPC": {
+                "URL": "<AGGLAYER_GRPC_URL>",
+                "UseTLS": false
+            }
+        },
+        "agglayerAdminURL": "<AGGLAYER_ADMIN_URL>",
+        "agglayerAdminToken": "<JWT>"
     },
-    "signerKeyPath": "/path/to/keystore.json",
-    "signerKeyPassword": "keystore-password"
+    "signerConfig": {
+        "Method": "local",
+        "Path": "/path/to/keystore.json",
+        "Password": "<PASSWORD>"
+    }
 }

--- a/tools/exit_certificate/parameters.json.example
+++ b/tools/exit_certificate/parameters.json.example
@@ -13,7 +13,8 @@
         "rpcBatchSize": 200,
         "rpcDelayMs": 10,
         "outputDir": "./output",
-        "l1StartBlock": 0
+        "l1StartBlock": 0,
+        "extraErc20Contracts": []
     },
     "signerKeyPath": "/path/to/keystore.json",
     "signerKeyPassword": "keystore-password"

--- a/tools/exit_certificate/rpc.go
+++ b/tools/exit_certificate/rpc.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/agglayer/aggkit/log"
@@ -77,6 +78,16 @@ type RPCCall struct {
 	Params []any
 }
 
+// isRevertError returns true for errors that represent a contract revert —
+// code 3 per EIP-1474, or any message containing "revert". These should not
+// be retried because the same call will revert again.
+func isRevertError(e *jsonRPCError) bool {
+	if e.Code == 3 {
+		return true
+	}
+	return strings.Contains(strings.ToLower(e.Message), "revert")
+}
+
 // batchRPC sends a batch of JSON-RPC calls in a single HTTP POST.
 // Returns ordered results matching the input calls slice. Per-item RPC errors are retried
 // up to retries times. Returns an error if any call still fails after all retries.
@@ -90,6 +101,7 @@ func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]
 	for i := range pendingIdxs {
 		pendingIdxs[i] = i
 	}
+	var permanentlyFailed []int
 
 	for attempt := 1; attempt <= retries && len(pendingIdxs) > 0; attempt++ {
 		if ctx.Err() != nil {
@@ -149,6 +161,12 @@ func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]
 			}
 			origIdx := pendingIdxs[localIdx]
 			if r.Error != nil {
+				if isRevertError(r.Error) {
+					log.Warnf("RPC call %s id=%d reverted (not retrying): [%d] %s",
+						calls[origIdx].Method, origIdx+1, r.Error.Code, r.Error.Message)
+					permanentlyFailed = append(permanentlyFailed, origIdx)
+					continue
+				}
 				log.Warnf("RPC error for %s id=%d (attempt %d/%d): [%d] %s",
 					calls[origIdx].Method, origIdx+1, attempt, retries, r.Error.Code, r.Error.Message)
 				nextPending = append(nextPending, origIdx)
@@ -159,6 +177,9 @@ func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]
 		pendingIdxs = nextPending
 	}
 
+	if len(permanentlyFailed) > 0 {
+		return nil, fmt.Errorf("batchRPC: %d/%d calls reverted (not retried)", len(permanentlyFailed), len(calls))
+	}
 	if len(pendingIdxs) > 0 {
 		return nil, fmt.Errorf("batchRPC: %d/%d calls still failing after %d attempts",
 			len(pendingIdxs), len(calls), retries)

--- a/tools/exit_certificate/rpc.go
+++ b/tools/exit_certificate/rpc.go
@@ -23,6 +23,8 @@ const (
 	idleConnTimeoutSec  = 90
 	httpTimeoutSec      = 120
 	maxIdleConnsPerHost = 100
+	// eip1474RevertCode is the JSON-RPC error code for a contract revert per EIP-1474.
+	eip1474RevertCode = 3
 )
 
 // httpClient keeps a large per-host idle connection pool to avoid throttling
@@ -82,7 +84,7 @@ type RPCCall struct {
 // code 3 per EIP-1474, or any message containing "revert". These should not
 // be retried because the same call will revert again.
 func isRevertError(e *jsonRPCError) bool {
-	if e.Code == 3 {
+	if e.Code == eip1474RevertCode {
 		return true
 	}
 	return strings.Contains(strings.ToLower(e.Message), "revert")

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -78,8 +78,8 @@ const lastAutoStep = "sign"
 // "f-"   → ["f", "g", "h", "i", "sign", "submit", "wait"]
 // "h, i, sign" → ["h", "i", "sign"]
 // "a"    → ["a1", "a2"] (alias for both sub-steps)
-// "b"    → ["b1", "b2"] (alias for both sub-steps)
-// "a-b"  → ["a1", "a2", "b1", "b2"] ("a"→"a1" start, "b"→"b2" end)
+// "b"    → ["b1", "b2", "b3"] (alias for all three sub-steps)
+// "a-b"  → ["a1", "a2", "b1", "b2", "b3"] ("a"→"a1" start, "b"→"b3" end)
 // "0-a"  → ["0", "a1", "a2"] ("a" expands to "a2" as range end)
 func parseStepList(raw string) ([]string, error) {
 	var steps []string

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -64,8 +64,10 @@ func Run(c *cli.Context) error {
 }
 
 // orderedSteps is the canonical pipeline order used for range expansion.
-// "a" is an alias for "a1,a2" and is handled in parseStepList; it is not listed here.
-var orderedSteps = []string{"check", "0", "a1", "a2", "b", "c", "d", "e", "f", "g", "h", "i", "sign", "submit", "wait"}
+// "a" and "b" are aliases for their sub-steps and are handled in parseStepList; not listed here.
+var orderedSteps = []string{
+	"check", "0", "a1", "a2", "b1", "b2", "b3", "c", "d", "e", "f", "g", "h", "i", "sign", "submit", "wait",
+}
 
 // lastAutoStep is the implicit end for open ranges (X-).
 // "submit" and "wait" must always be specified explicitly.
@@ -76,7 +78,8 @@ const lastAutoStep = "sign"
 // "f-"   → ["f", "g", "h", "i", "sign", "submit", "wait"]
 // "h, i, sign" → ["h", "i", "sign"]
 // "a"    → ["a1", "a2"] (alias for both sub-steps)
-// "a-b"  → ["a1", "a2", "b"] ("a" expands to "a1" as range start)
+// "b"    → ["b1", "b2"] (alias for both sub-steps)
+// "a-b"  → ["a1", "a2", "b1", "b2"] ("a"→"a1" start, "b"→"b2" end)
 // "0-a"  → ["0", "a1", "a2"] ("a" expands to "a2" as range end)
 func parseStepList(raw string) ([]string, error) {
 	var steps []string
@@ -86,7 +89,7 @@ func parseStepList(raw string) ([]string, error) {
 			continue
 		}
 		if strings.Contains(token, "-") {
-			// Map "a" to "a1" (range start) or "a2" (range end) before expanding.
+			// Map "a"/"b" to their sub-step boundaries before expanding ranges.
 			parts := strings.SplitN(token, "-", splitInTwo)
 			from, to := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 			if from == "a" {
@@ -95,6 +98,12 @@ func parseStepList(raw string) ([]string, error) {
 			if to == "a" {
 				to = "a2"
 			}
+			if from == "b" {
+				from = "b1"
+			}
+			if to == "b" {
+				to = "b3"
+			}
 			expanded, err := expandStepRange(from + "-" + to)
 			if err != nil {
 				return nil, err
@@ -102,6 +111,8 @@ func parseStepList(raw string) ([]string, error) {
 			steps = append(steps, expanded...)
 		} else if token == "a" {
 			steps = append(steps, "a1", "a2")
+		} else if token == "b" {
+			steps = append(steps, "b1", "b2", "b3")
 		} else {
 			steps = append(steps, token)
 		}
@@ -291,6 +302,9 @@ func runAllStepB(
 	saveJSON(dir, "step-b-eoa-balances.json", stepBResult.EOABalances)
 	saveJSON(dir, "step-b-accumulated.json", stepBResult.Accumulated)
 	saveJSON(dir, "step-b-contract-addresses.json", stepBResult.ContractAddresses)
+	saveJSON(dir, "step-b2-detected-erc20s.json", stepBResult.DetectedERC20s)
+	saveJSON(dir, "step-b2-discarded-erc20s.json", stepBResult.DiscardedERC20s)
+	saveJSON(dir, "step-b3-erc20-holders.json", stepBResult.ERC20HolderBreakdowns)
 	return stepBResult, nil
 }
 
@@ -304,6 +318,7 @@ func runAllStepC(dir string, lbtEntries []LBTEntry, stepBResult *StepBResult) (*
 		return nil, fmt.Errorf("step C: %w", err)
 	}
 	saveJSON(dir, "step-c-sc-locked-values.json", stepCResult.SCLockedValues)
+	saveJSON(dir, "step-c-holder-bridges.json", stepCResult.HolderBridges)
 	return stepCResult, nil
 }
 
@@ -317,10 +332,8 @@ func runAllStepF(
 	if err != nil {
 		return nil, fmt.Errorf("step F: %w", err)
 	}
-	if !result.Skipped {
-		saveJSON(dir, "step-f-token-balances.json", result.TokenBalances)
-		saveJSON(dir, "step-f-checks.json", result.Checks)
-	}
+	saveJSON(dir, "step-f-token-balances.json", result.TokenBalances)
+	saveJSON(dir, "step-f-checks.json", result.Checks)
 	if result.CappedCertificate != nil {
 		// Apply the same per-token caps to the final certificate (which may include step E exits).
 		cappedFinal := *finalCert
@@ -455,6 +468,12 @@ func runSingleStep(ctx context.Context, step string, cfg *Config) error {
 		return runSingleA2(ctx, cfg, dir)
 	case "b":
 		return runSingleB(ctx, cfg, dir)
+	case "b1":
+		return runSingleB1(ctx, cfg, dir)
+	case "b2":
+		return runSingleB2(ctx, cfg, dir)
+	case "b3":
+		return runSingleB3(ctx, cfg, dir)
 	case "c":
 		return runSingleC(dir)
 	case "d":
@@ -476,8 +495,10 @@ func runSingleStep(ctx context.Context, step string, cfg *Config) error {
 	case "wait":
 		return runSingleWait(ctx, cfg, dir)
 	default:
-		return fmt.Errorf("unknown step: %s (use check, 0, a, a1, a2, b, c, d, e, f, g, h, i, sign, submit, wait, or all)",
-			step)
+		return fmt.Errorf(
+			"unknown step: %s (use check, 0, a, a1, a2, b, b1, b2, b3, c, d, e, f, g, h, i, sign, submit, wait, or all)",
+			step,
+		)
 	}
 }
 
@@ -542,6 +563,7 @@ func runSingleA2(ctx context.Context, cfg *Config, dir string) error {
 	if err := loadJSON(dir, "step-a1-addresses.json", &a1Addresses); err != nil {
 		return fmt.Errorf("load step A1 addresses: %w", err)
 	}
+	log.Debugf("STEP A2 merging %d A2 addresses with %d A1 addresses", len(a2Result.Addresses), len(a1Addresses))
 	combined := mergeAddresses(a1Addresses, a2Result.Addresses)
 	log.Infof("STEP A complete: %d addresses (A1: %d, A2 new: %d)",
 		len(combined), len(a1Addresses), len(combined)-len(a1Addresses))
@@ -573,7 +595,20 @@ func migrateStepAToA1(dir string) error {
 	return rename("step-a-failed-traces.json", "step-a1-failed-traces.json")
 }
 
+// runSingleB runs B1 then B2 then B3, producing all step-b* output files.
 func runSingleB(ctx context.Context, cfg *Config, dir string) error {
+	if err := runSingleB1(ctx, cfg, dir); err != nil {
+		return err
+	}
+	if err := runSingleB2(ctx, cfg, dir); err != nil {
+		return err
+	}
+	return runSingleB3(ctx, cfg, dir)
+}
+
+// runSingleB1 runs Step B1 and writes step-b-eoa-balances.json,
+// step-b-accumulated.json, and step-b-contract-addresses.json.
+func runSingleB1(ctx context.Context, cfg *Config, dir string) error {
 	var addresses []common.Address
 	if err := loadJSON(dir, "step-a-addresses.json", &addresses); err != nil {
 		return fmt.Errorf("load step A output: %w", err)
@@ -588,7 +623,7 @@ func runSingleB(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	result, err := RunStepB(ctx, cfg, targetBlock, &StepAResult{
+	result, err := RunStepB1(ctx, cfg, targetBlock, &StepAResult{
 		Addresses:     addresses,
 		WrappedTokens: wrappedTokens,
 	})
@@ -601,6 +636,70 @@ func runSingleB(ctx context.Context, cfg *Config, dir string) error {
 	return nil
 }
 
+// runSingleB2 runs Step B2 and writes step-b2-detected-erc20s.json and
+// step-b2-discarded-erc20s.json.
+// Requires step-b-contract-addresses.json from B1, step-a-addresses.json, and step-0-lbt.json.
+func runSingleB2(ctx context.Context, cfg *Config, dir string) error {
+	var contractAddrs []common.Address
+	if err := loadJSON(dir, "step-b-contract-addresses.json", &contractAddrs); err != nil {
+		return fmt.Errorf("load step B1 contract addresses (run step b1 first): %w", err)
+	}
+	var allAddresses []common.Address
+	if err := loadJSON(dir, "step-a-addresses.json", &allAddresses); err != nil {
+		return fmt.Errorf("load step A addresses: %w", err)
+	}
+	eoaAddrs := filterEOAs(allAddresses, contractAddrs)
+
+	wrappedTokens, err := loadWrappedTokensFromLBT(dir)
+	if err != nil {
+		return err
+	}
+
+	targetBlock, err := loadTargetBlock(dir)
+	if err != nil {
+		return err
+	}
+	result, err := RunStepB2(ctx, cfg, targetBlock, contractAddrs, eoaAddrs, wrappedTokens)
+	if err != nil {
+		return err
+	}
+	saveJSON(dir, "step-b2-detected-erc20s.json", result.DetectedERC20s)
+	saveJSON(dir, "step-b2-discarded-erc20s.json", result.DiscardedERC20s)
+	return nil
+}
+
+// runSingleB3 runs Step B3 and writes step-b3-erc20-holders.json.
+// Requires step-b2-detected-erc20s.json from B2, step-b-contract-addresses.json from B1,
+// step-a-addresses.json, and step-0-l2_target_block.json.
+func runSingleB3(ctx context.Context, cfg *Config, dir string) error {
+	var contractAddrs []common.Address
+	if err := loadJSON(dir, "step-b-contract-addresses.json", &contractAddrs); err != nil {
+		return fmt.Errorf("load step B1 contract addresses (run step b1 first): %w", err)
+	}
+	var allAddresses []common.Address
+	if err := loadJSON(dir, "step-a-addresses.json", &allAddresses); err != nil {
+		return fmt.Errorf("load step A addresses: %w", err)
+	}
+	eoaAddrs := filterEOAs(allAddresses, contractAddrs)
+
+	var detectedERC20s []DetectedERC20
+	if err := loadJSON(dir, "step-b2-detected-erc20s.json", &detectedERC20s); err != nil {
+		return fmt.Errorf("load step B2 detected ERC-20s (run step b2 first): %w", err)
+	}
+	b2Result := &StepB2Result{DetectedERC20s: detectedERC20s}
+
+	targetBlock, err := loadTargetBlock(dir)
+	if err != nil {
+		return err
+	}
+	result, err := RunStepB3(ctx, cfg, targetBlock, eoaAddrs, b2Result)
+	if err != nil {
+		return err
+	}
+	saveJSON(dir, "step-b3-erc20-holders.json", result.Breakdowns)
+	return nil
+}
+
 func runSingleC(dir string) error {
 	var accumulated []AccumulatedBalance
 	if err := loadJSON(dir, "step-b-accumulated.json", &accumulated); err != nil {
@@ -610,11 +709,19 @@ func runSingleC(dir string) error {
 	if err := loadJSON(dir, "step-0-lbt.json", &lbtEntries); err != nil {
 		return fmt.Errorf("load LBT data (step 0): %w", err)
 	}
-	result, err := RunStepC(lbtEntries, &StepBResult{Accumulated: accumulated})
+	// Load holder breakdowns from B3 if available; absence is not an error.
+	var breakdowns []ERC20HolderBreakdown
+	_ = loadJSON(dir, "step-b3-erc20-holders.json", &breakdowns)
+
+	result, err := RunStepC(lbtEntries, &StepBResult{
+		Accumulated:           accumulated,
+		ERC20HolderBreakdowns: breakdowns,
+	})
 	if err != nil {
 		return err
 	}
 	saveJSON(dir, "step-c-sc-locked-values.json", result.SCLockedValues)
+	saveJSON(dir, "step-c-holder-bridges.json", result.HolderBridges)
 	return nil
 }
 
@@ -627,7 +734,13 @@ func runSingleD(cfg *Config, dir string) error {
 	if err := loadJSON(dir, "step-c-sc-locked-values.json", &scLockedValues); err != nil {
 		return fmt.Errorf("load step C output: %w", err)
 	}
-	result, err := RunStepD(cfg, &StepBResult{EOABalances: eoaBalances}, &StepCResult{SCLockedValues: scLockedValues})
+	var holderBridges []HolderBridge
+	_ = loadJSON(dir, "step-c-holder-bridges.json", &holderBridges)
+
+	result, err := RunStepD(cfg, &StepBResult{EOABalances: eoaBalances}, &StepCResult{
+		SCLockedValues: scLockedValues,
+		HolderBridges:  holderBridges,
+	})
 	if err != nil {
 		return err
 	}
@@ -706,10 +819,8 @@ func runSingleF(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	if !result.Skipped {
-		saveJSON(dir, "step-f-token-balances.json", result.TokenBalances)
-		saveJSON(dir, "step-f-checks.json", result.Checks)
-	}
+	saveJSON(dir, "step-f-token-balances.json", result.TokenBalances)
+	saveJSON(dir, "step-f-checks.json", result.Checks)
 	if result.CappedCertificate != nil {
 		saveJSON(dir, "step-f-capped-certificate.json", result.CappedCertificate)
 	}

--- a/tools/exit_certificate/run_test.go
+++ b/tools/exit_certificate/run_test.go
@@ -29,10 +29,12 @@ func TestParseStepList(t *testing.T) {
 		{"reversed range error", "i-f", nil, true},
 		{"unknown from step", "z-i", nil, true},
 		{"unknown to step", "f-z", nil, true},
-		// Step A alias and sub-step expansion.
+		// Step A and B alias and sub-step expansion.
 		{"a alias expands to a1 a2", "a", []string{"a1", "a2"}, false},
-		{"a-b expands a to a1 a2 then b", "a-b", []string{"a1", "a2", "b"}, false},
-		{"a2-b range", "a2-b", []string{"a2", "b"}, false},
+		{"b alias expands to b1 b2", "b", []string{"b1", "b2"}, false},
+		{"a-b expands a to a1 a2 and b to b1 b2", "a-b", []string{"a1", "a2", "b1", "b2"}, false},
+		{"a2-b range expands b to b1 b2", "a2-b", []string{"a2", "b1", "b2"}, false},
+		{"b-c range expands b to b1 b2", "b-c", []string{"b1", "b2", "c"}, false},
 	}
 
 	for _, tc := range tests {

--- a/tools/exit_certificate/run_test.go
+++ b/tools/exit_certificate/run_test.go
@@ -31,10 +31,10 @@ func TestParseStepList(t *testing.T) {
 		{"unknown to step", "f-z", nil, true},
 		// Step A and B alias and sub-step expansion.
 		{"a alias expands to a1 a2", "a", []string{"a1", "a2"}, false},
-		{"b alias expands to b1 b2", "b", []string{"b1", "b2"}, false},
-		{"a-b expands a to a1 a2 and b to b1 b2", "a-b", []string{"a1", "a2", "b1", "b2"}, false},
-		{"a2-b range expands b to b1 b2", "a2-b", []string{"a2", "b1", "b2"}, false},
-		{"b-c range expands b to b1 b2", "b-c", []string{"b1", "b2", "c"}, false},
+		{"b alias expands to b1 b2 b3", "b", []string{"b1", "b2", "b3"}, false},
+		{"a-b expands a to a1 a2 and b to b1 b2 b3", "a-b", []string{"a1", "a2", "b1", "b2", "b3"}, false},
+		{"a2-b range expands b to b1 b2 b3", "a2-b", []string{"a2", "b1", "b2", "b3"}, false},
+		{"b-c range expands b to b1 b2 b3", "b-c", []string{"b1", "b2", "b3", "c"}, false},
 	}
 
 	for _, tc := range tests {

--- a/tools/exit_certificate/step_b.go
+++ b/tools/exit_certificate/step_b.go
@@ -39,8 +39,9 @@ func RunStepB(ctx context.Context, cfg *Config, targetBlock uint64, stepA *StepA
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("STEP B complete: %d EOAs, %d token accumulations, %d ERC-20 contracts detected, %d ERC-20 holder breakdowns",
-		len(b1Result.EOABalances), len(b1Result.Accumulated), len(b2Result.DetectedERC20s), len(b3Result.Breakdowns))
+	log.Infof("STEP B complete: %d EOAs, %d token accumulations, %d ERC-20 detected, %d ERC-20 holder breakdowns",
+		len(b1Result.EOABalances), len(b1Result.Accumulated),
+		len(b2Result.DetectedERC20s), len(b3Result.Breakdowns))
 	return &StepBResult{
 		EOABalances:           b1Result.EOABalances,
 		Accumulated:           b1Result.Accumulated,

--- a/tools/exit_certificate/step_b.go
+++ b/tools/exit_certificate/step_b.go
@@ -22,11 +22,40 @@ const (
 	abiWordSize = 32
 )
 
-// RunStepB classifies addresses as EOA vs contract, then collects ETH and wrapped
-// token balances at targetBlock for all EOAs.
+// RunStepB runs Step B1, B2, and B3 and returns the combined result.
+// B1 classifies addresses and collects balances; B2 detects ERC-20 contracts;
+// B3 fetches holder breakdowns for the contracts listed in ExtraERC20Contracts.
 func RunStepB(ctx context.Context, cfg *Config, targetBlock uint64, stepA *StepAResult) (*StepBResult, error) {
+	b1Result, err := RunStepB1(ctx, cfg, targetBlock, stepA)
+	if err != nil {
+		return nil, err
+	}
+	eoaAddrs := filterEOAs(stepA.Addresses, b1Result.ContractAddresses)
+	b2Result, err := RunStepB2(ctx, cfg, targetBlock, b1Result.ContractAddresses, eoaAddrs, stepA.WrappedTokens)
+	if err != nil {
+		return nil, err
+	}
+	b3Result, err := RunStepB3(ctx, cfg, targetBlock, eoaAddrs, b2Result)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("STEP B complete: %d EOAs, %d token accumulations, %d ERC-20 contracts detected, %d ERC-20 holder breakdowns",
+		len(b1Result.EOABalances), len(b1Result.Accumulated), len(b2Result.DetectedERC20s), len(b3Result.Breakdowns))
+	return &StepBResult{
+		EOABalances:           b1Result.EOABalances,
+		Accumulated:           b1Result.Accumulated,
+		ContractAddresses:     b1Result.ContractAddresses,
+		DetectedERC20s:        b2Result.DetectedERC20s,
+		DiscardedERC20s:       b2Result.DiscardedERC20s,
+		ERC20HolderBreakdowns: b3Result.Breakdowns,
+	}, nil
+}
+
+// RunStepB1 classifies addresses as EOA vs contract, then collects ETH and wrapped
+// token balances at targetBlock for all EOAs.
+func RunStepB1(ctx context.Context, cfg *Config, targetBlock uint64, stepA *StepAResult) (*StepB1Result, error) {
 	log.Info("═══════════════════════════════════════════")
-	log.Info(" STEP B — EOA balance checking")
+	log.Info(" STEP B1 — EOA balance checking")
 	log.Info("═══════════════════════════════════════════")
 
 	rpcURL := cfg.L2RPCURL
@@ -69,14 +98,29 @@ func RunStepB(ctx context.Context, cfg *Config, targetBlock uint64, stepA *StepA
 		log.Warnf("Genesis balance check failed (abortOnGenesisBalance=false, continuing): %v", err)
 	}
 
-	log.Infof("STEP B complete: %d EOAs with balances, %d token accumulations",
+	log.Infof("STEP B1 complete: %d EOAs with balances, %d token accumulations",
 		len(eoaBalances), len(accumulated))
 
-	return &StepBResult{
+	return &StepB1Result{
 		EOABalances:       eoaBalances,
 		Accumulated:       accumulated,
 		ContractAddresses: contractAddrs,
 	}, nil
+}
+
+// filterEOAs returns all addresses in addrs that do not appear in contracts.
+func filterEOAs(addrs, contracts []common.Address) []common.Address {
+	contractSet := make(map[common.Address]struct{}, len(contracts))
+	for _, c := range contracts {
+		contractSet[c] = struct{}{}
+	}
+	eoas := make([]common.Address, 0, len(addrs)-len(contracts))
+	for _, a := range addrs {
+		if _, isContract := contractSet[a]; !isContract {
+			eoas = append(eoas, a)
+		}
+	}
+	return eoas
 }
 
 func padLeft(s string, length int) string {

--- a/tools/exit_certificate/step_b2.go
+++ b/tools/exit_certificate/step_b2.go
@@ -1,0 +1,294 @@
+package exit_certificate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sync"
+	"sync/atomic"
+
+	"github.com/agglayer/aggkit/log"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// RunStepB2 probes the contract addresses from Step B1 for the ERC-20 interface.
+// For each contract that responds to totalSupply() with a non-zero value it checks
+// whether it holds any of the tracked wrapped tokens:
+//   - holds at least one → DetectedERC20 (relevant to the certificate)
+//   - holds none         → DiscardedERC20 (no tracked value locked inside)
+//
+// RPC execution errors on totalSupply() calls are silently treated as "not ERC-20".
+func RunStepB2(
+	ctx context.Context, cfg *Config, targetBlock uint64,
+	contractAddrs, eoaAddrs []common.Address,
+	wrappedTokens []WrappedToken,
+) (*StepB2Result, error) {
+	log.Info("═══════════════════════════════════════════")
+	log.Info(" STEP B2 — ERC-20 detection in contracts")
+	log.Info("═══════════════════════════════════════════")
+
+	if len(contractAddrs) == 0 {
+		log.Info("No contract addresses to probe")
+		log.Info("STEP B2 complete: 0 ERC-20 contracts detected")
+		return &StepB2Result{}, nil
+	}
+
+	blockTag := toBlockTag(targetBlock)
+	batchSize := cfg.Options.RPCBatchSize
+	concurrency := cfg.Options.ConcurrencyLimit
+
+	log.Infof("Probing %d contracts for ERC-20 totalSupply()...", len(contractAddrs))
+	erc20Supplies := detectERC20Contracts(ctx, cfg.L2RPCURL, contractAddrs, blockTag, concurrency)
+	log.Infof("%d/%d contracts responded to ERC20 totalSupply()", len(erc20Supplies), len(contractAddrs))
+
+	if len(erc20Supplies) == 0 {
+		log.Info("STEP B2 complete: 0 ERC-20 contracts detected")
+		return &StepB2Result{}, nil
+	}
+
+	jobs := make([]erc20ProbeJob, 0, len(erc20Supplies))
+	for addr, info := range erc20Supplies {
+		jobs = append(jobs, erc20ProbeJob{addr: addr, info: info})
+	}
+
+	detected := make([]DetectedERC20, 0, len(erc20Supplies))
+	var discarded []DiscardedERC20
+
+	err := runWorkerPool(
+		ctx, jobs, concurrency,
+		func(j erc20ProbeJob) (erc20ProbeResult, error) {
+			tokenLabel := j.info.name
+			if tokenLabel == "" {
+				tokenLabel = j.info.symbol
+			}
+			wrappedBalances, err := checkWrappedTokenBalances(
+				ctx, cfg.L2RPCURL, j.addr, wrappedTokens, blockTag, batchSize, concurrency, tokenLabel, true,
+			)
+			if err != nil {
+				return erc20ProbeResult{}, fmt.Errorf("check wrapped balances for ERC-20 %s: %w", j.addr.Hex(), err)
+			}
+
+			if len(wrappedBalances) == 0 {
+				log.Debugf("  discarded %s %q (%s) (no tracked wrapped tokens held)", j.addr.Hex(), j.info.name, j.info.symbol)
+				return erc20ProbeResult{discarded: &DiscardedERC20{
+					Address:     j.addr,
+					Name:        j.info.name,
+					Symbol:      j.info.symbol,
+					TotalSupply: j.info.supply.String(),
+				}}, nil
+			}
+
+			log.Infof("⚠  ERC-20 %s %q (%s) locks tracked wrapped tokens:", j.addr.Hex(), j.info.name, j.info.symbol)
+			for _, wb := range wrappedBalances {
+				log.Infof("     → %s : %s", wb.Token.WrappedTokenAddress.Hex(), wb.Balance)
+			}
+
+			return erc20ProbeResult{detected: &DetectedERC20{
+				Address:              j.addr,
+				Name:                 j.info.name,
+				Symbol:               j.info.symbol,
+				TotalSupply:          j.info.supply.String(),
+				WrappedTokenBalances: wrappedBalances,
+			}}, nil
+		},
+		func(r erc20ProbeResult) {
+			if r.detected != nil {
+				detected = append(detected, *r.detected)
+			} else {
+				discarded = append(discarded, *r.discarded)
+			}
+		},
+		"step_b2: ERC-20 probe",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("STEP B2 complete: %d relevant ERC-20(s), %d discarded", len(detected), len(discarded))
+
+	return &StepB2Result{
+		DetectedERC20s:  detected,
+		DiscardedERC20s: discarded,
+	}, nil
+}
+
+// checkWrappedTokenBalances calls balanceOf(contractAddr) on each wrapped token contract
+// and eth_getBalance for native ETH. Returns only entries where the balance is > 0.
+// ETH is represented as the zero-address token (OriginNetwork=0, OriginTokenAddress=0x0,
+// WrappedTokenAddress=0x0). Pass silent=true to suppress progress logs (recommended when
+// called concurrently).
+func checkWrappedTokenBalances(
+	ctx context.Context, rpcURL string,
+	contractAddr common.Address, wrappedTokens []WrappedToken,
+	blockTag string, batchSize, concurrency int, tokenLabel string, silent bool,
+) ([]WrappedTokenBalance, error) {
+	// calls = [balanceOf(t0), ..., balanceOf(tN), eth_getBalance]
+	calls := make([]RPCCall, len(wrappedTokens)+1)
+	for i, t := range wrappedTokens {
+		calls[i] = RPCCall{
+			Method: "eth_call",
+			Params: []any{
+				map[string]string{
+					"to":   t.WrappedTokenAddress.Hex(),
+					"data": encodeBalanceOf(contractAddr),
+				},
+				blockTag,
+			},
+		}
+	}
+	calls[len(wrappedTokens)] = RPCCall{
+		Method: "eth_getBalance",
+		Params: []any{contractAddr.Hex(), blockTag},
+	}
+
+	label := fmt.Sprintf("step_b2: %-20.20s wrappedBalances", tokenLabel)
+	if silent {
+		label = ""
+	}
+	results, err := concurrentBatchRPC(ctx, rpcURL, calls, batchSize, concurrency, label)
+	if err != nil {
+		return nil, err
+	}
+
+	var balances []WrappedTokenBalance
+	for i, result := range results[:len(wrappedTokens)] {
+		bal := unmarshalHexBigInt(result)
+		if bal != nil && bal.Sign() > 0 {
+			balances = append(balances, WrappedTokenBalance{
+				Token:   wrappedTokens[i],
+				Balance: bal.String(),
+			})
+		}
+	}
+	if ethBal := unmarshalHexBigInt(results[len(wrappedTokens)]); ethBal != nil && ethBal.Sign() > 0 {
+		balances = append(balances, WrappedTokenBalance{
+			Token:   WrappedToken{}, // zero address = native ETH
+			Balance: ethBal.String(),
+		})
+	}
+	return balances, nil
+}
+
+// probeProgressPct is the granularity for progress logging in detectERC20Contracts.
+const probeProgressPct = 10
+
+// nameSelector is the function selector for ERC-20 name().
+const nameSelector = "0x06fdde03"
+
+// symbolSelector is the function selector for ERC-20 symbol().
+const symbolSelector = "0x95d89b41"
+
+// erc20Info holds the data fetched per contract during the ERC-20 probe.
+type erc20Info struct {
+	supply *big.Int
+	name   string
+	symbol string
+}
+
+type erc20ProbeJob struct {
+	addr common.Address
+	info erc20Info
+}
+
+type erc20ProbeResult struct {
+	detected  *DetectedERC20
+	discarded *DiscardedERC20
+}
+
+// detectERC20Contracts calls totalSupply() on each contract in parallel.
+// For contracts with supply > 0 it also fetches name().
+// RPC execution errors (e.g. reverts on non-ERC-20 contracts) are silently ignored.
+func detectERC20Contracts(
+	ctx context.Context, rpcURL string, contracts []common.Address,
+	blockTag string, concurrency int,
+) map[common.Address]erc20Info {
+	type result struct {
+		addr common.Address
+		info erc20Info
+	}
+
+	total := len(contracts)
+	resultCh := make(chan result, total)
+	sem := make(chan struct{}, concurrency)
+
+	var done, detected atomic.Int32
+	var wg sync.WaitGroup
+	for _, addr := range contracts {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(a common.Address) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			raw, err := singleRPC(ctx, rpcURL, "eth_call", []any{
+				map[string]string{"to": a.Hex(), "data": totalSupplySelector},
+				blockTag,
+			}, defaultRetries)
+
+			var info erc20Info
+			if err == nil {
+				info.supply = unmarshalHexBigInt(raw)
+			}
+
+			if info.supply != nil && info.supply.Sign() > 0 {
+				// Verify balanceOf(address(0)) succeeds to confirm the ERC-20 interface.
+				// Contracts that happen to match the totalSupply() selector but are not
+				// real ERC-20s will revert here.
+				_, balErr := singleRPC(ctx, rpcURL, "eth_call", []any{
+					map[string]string{"to": a.Hex(), "data": encodeBalanceOf(common.Address{})},
+					blockTag,
+				}, defaultRetries)
+				if balErr != nil {
+					info.supply = nil
+				}
+			}
+
+			if info.supply != nil && info.supply.Sign() > 0 {
+				detected.Add(1)
+				nameRaw, nameErr := singleRPC(ctx, rpcURL, "eth_call", []any{
+					map[string]string{"to": a.Hex(), "data": nameSelector},
+					blockTag,
+				}, defaultRetries)
+				if nameErr == nil {
+					var nameHex string
+					if json.Unmarshal(nameRaw, &nameHex) == nil {
+						info.name = decodeABIString(common.FromHex(nameHex))
+					}
+				}
+
+				symbolRaw, symbolErr := singleRPC(ctx, rpcURL, "eth_call", []any{
+					map[string]string{"to": a.Hex(), "data": symbolSelector},
+					blockTag,
+				}, defaultRetries)
+				if symbolErr == nil {
+					var symbolHex string
+					if json.Unmarshal(symbolRaw, &symbolHex) == nil {
+						info.symbol = decodeABIString(common.FromHex(symbolHex))
+					}
+				}
+			}
+
+			n := int(done.Add(1))
+			prevPct := (n - 1) * probeProgressPct / total
+			currPct := n * probeProgressPct / total
+			if currPct > prevPct || n == total {
+				log.Infof("  B2 ERC-20 probe: %d/%d (%d%%) — %d ERC-20(s) detected",
+					n, total, currPct*probeProgressPct, detected.Load())
+			}
+
+			resultCh <- result{addr: a, info: info}
+		}(addr)
+	}
+
+	wg.Wait()
+	close(resultCh)
+
+	erc20s := make(map[common.Address]erc20Info)
+	for r := range resultCh {
+		if r.info.supply != nil && r.info.supply.Sign() > 0 {
+			erc20s[r.addr] = r.info
+		}
+	}
+	return erc20s
+}

--- a/tools/exit_certificate/step_b2.go
+++ b/tools/exit_certificate/step_b2.go
@@ -58,12 +58,8 @@ func RunStepB2(
 	err := runWorkerPool(
 		ctx, jobs, concurrency,
 		func(j erc20ProbeJob) (erc20ProbeResult, error) {
-			tokenLabel := j.info.name
-			if tokenLabel == "" {
-				tokenLabel = j.info.symbol
-			}
 			wrappedBalances, err := checkWrappedTokenBalances(
-				ctx, cfg.L2RPCURL, j.addr, wrappedTokens, blockTag, batchSize, concurrency, tokenLabel, true,
+				ctx, cfg.L2RPCURL, j.addr, wrappedTokens, blockTag, batchSize, concurrency,
 			)
 			if err != nil {
 				return erc20ProbeResult{}, fmt.Errorf("check wrapped balances for ERC-20 %s: %w", j.addr.Hex(), err)
@@ -116,12 +112,11 @@ func RunStepB2(
 // checkWrappedTokenBalances calls balanceOf(contractAddr) on each wrapped token contract
 // and eth_getBalance for native ETH. Returns only entries where the balance is > 0.
 // ETH is represented as the zero-address token (OriginNetwork=0, OriginTokenAddress=0x0,
-// WrappedTokenAddress=0x0). Pass silent=true to suppress progress logs (recommended when
-// called concurrently).
+// WrappedTokenAddress=0x0).
 func checkWrappedTokenBalances(
 	ctx context.Context, rpcURL string,
 	contractAddr common.Address, wrappedTokens []WrappedToken,
-	blockTag string, batchSize, concurrency int, tokenLabel string, silent bool,
+	blockTag string, batchSize, concurrency int,
 ) ([]WrappedTokenBalance, error) {
 	// calls = [balanceOf(t0), ..., balanceOf(tN), eth_getBalance]
 	calls := make([]RPCCall, len(wrappedTokens)+1)
@@ -142,11 +137,7 @@ func checkWrappedTokenBalances(
 		Params: []any{contractAddr.Hex(), blockTag},
 	}
 
-	label := fmt.Sprintf("step_b2: %-20.20s wrappedBalances", tokenLabel)
-	if silent {
-		label = ""
-	}
-	results, err := concurrentBatchRPC(ctx, rpcURL, calls, batchSize, concurrency, label)
+	results, err := concurrentBatchRPC(ctx, rpcURL, calls, batchSize, concurrency, "")
 	if err != nil {
 		return nil, err
 	}

--- a/tools/exit_certificate/step_b2_test.go
+++ b/tools/exit_certificate/step_b2_test.go
@@ -1,0 +1,437 @@
+package exit_certificate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// rpcTestCall holds the decoded parts of a single JSON-RPC request
+// received by a test server.
+type rpcTestCall struct {
+	Method   string // "eth_call", "eth_getBalance", …
+	To       string // lowercase hex addr
+	Selector string // first 10 chars of data ("0x" + 8 hex)
+	FullData string // lowercase data without "0x"
+}
+
+// newEthCallServer creates a test server that handles both single and batch
+// JSON-RPC requests. respond is called once per sub-request; returning a
+// non-nil *jsonRPCError sends an RPC error in the response.
+func newEthCallServer(t *testing.T, respond func(rpcTestCall) (json.RawMessage, *jsonRPCError)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+
+		decode := func(raw json.RawMessage) jsonRPCResponse {
+			var req struct {
+				Method string            `json:"method"`
+				Params []json.RawMessage `json:"params"`
+				ID     int               `json:"id"`
+			}
+			_ = json.Unmarshal(raw, &req)
+			tc := rpcTestCall{Method: req.Method}
+			if len(req.Params) > 0 {
+				switch req.Method {
+				case "eth_call":
+					var obj struct {
+						To   string `json:"to"`
+						Data string `json:"data"`
+					}
+					_ = json.Unmarshal(req.Params[0], &obj)
+					tc.To = strings.ToLower(obj.To)
+					tc.FullData = strings.ToLower(strings.TrimPrefix(obj.Data, "0x"))
+					if len(obj.Data) >= 10 {
+						tc.Selector = strings.ToLower(obj.Data[:10])
+					}
+				case "eth_getBalance":
+					var addr string
+					_ = json.Unmarshal(req.Params[0], &addr)
+					tc.To = strings.ToLower(addr)
+				}
+			}
+			result, rpcErr := respond(tc)
+			if rpcErr != nil {
+				return jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: rpcErr}
+			}
+			return jsonRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+		}
+
+		trimmed := bytes.TrimSpace(body)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			var rawReqs []json.RawMessage
+			require.NoError(t, json.Unmarshal(body, &rawReqs))
+			resps := make([]jsonRPCResponse, len(rawReqs))
+			for i, raw := range rawReqs {
+				resps[i] = decode(raw)
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(resps))
+		} else {
+			resp := decode(json.RawMessage(body))
+			require.NoError(t, json.NewEncoder(w).Encode(resp))
+		}
+	}))
+}
+
+// abiUint256 ABI-encodes n as a 32-byte hex JSON string.
+func abiUint256(n *big.Int) json.RawMessage {
+	b := common.LeftPadBytes(n.Bytes(), 32)
+	return json.RawMessage(`"0x` + common.Bytes2Hex(b) + `"`)
+}
+
+// abiZero returns an ABI-encoded zero uint256.
+func abiZero() json.RawMessage { return abiUint256(new(big.Int)) }
+
+// abiString ABI-encodes s as a dynamic string return value (offset | length | data).
+func abiString(s string) json.RawMessage {
+	offset := "0000000000000000000000000000000000000000000000000000000000000020"
+	length := fmt.Sprintf("%064x", len(s))
+	data := common.Bytes2Hex([]byte(s))
+	for len(data)%64 != 0 {
+		data += "00"
+	}
+	return json.RawMessage(`"0x` + offset + length + data + `"`)
+}
+
+// revertErr returns an RPC error representing a contract revert (not retried by batchRPC).
+func revertErr() *jsonRPCError {
+	return &jsonRPCError{Code: 3, Message: "execution reverted"}
+}
+
+// addrLow returns the lowercase hex of addr, matching tc.To comparisons.
+func addrLow(addr common.Address) string { return strings.ToLower(addr.Hex()) }
+
+// eoaFromData extracts the queried address from a balanceOf call's FullData.
+// The parameter starts at offset 8 (after 8-char selector) and the last 40
+// chars encode the 20-byte address.
+func eoaFromData(fullData string) string {
+	if len(fullData) < 72 {
+		return ""
+	}
+	return "0x" + fullData[32:]
+}
+
+// --- checkWrappedTokenBalances ---
+
+func TestCheckWrappedTokenBalances_AllZeroReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	server := newEthCallServer(t, func(_ rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	balances, err := checkWrappedTokenBalances(
+		context.Background(), server.URL, contractAddr, nil, "latest", 200, 5, "test", true,
+	)
+	require.NoError(t, err)
+	require.Empty(t, balances)
+}
+
+func TestCheckWrappedTokenBalances_ETHBalanceOnly(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	ethBal := big.NewInt(5_000_000)
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.Method == "eth_getBalance" {
+			return abiUint256(ethBal), nil
+		}
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	balances, err := checkWrappedTokenBalances(
+		context.Background(), server.URL, contractAddr, nil, "latest", 200, 5, "test", true,
+	)
+	require.NoError(t, err)
+	require.Len(t, balances, 1)
+	require.Equal(t, common.Address{}, balances[0].Token.WrappedTokenAddress) // zero addr = native ETH
+	require.Equal(t, ethBal.String(), balances[0].Balance)
+}
+
+func TestCheckWrappedTokenBalances_WrappedTokenHeld(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	tokenAddr := common.HexToAddress("0xABCD000000000000000000000000000000000001")
+	tokenBal := big.NewInt(999_000)
+
+	wrappedTokens := []WrappedToken{{
+		WrappedTokenAddress: tokenAddr,
+		OriginNetwork:       1,
+		OriginTokenAddress:  common.HexToAddress("0x0101010101010101010101010101010101010101"),
+	}}
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.Method == "eth_call" && tc.To == addrLow(tokenAddr) {
+			return abiUint256(tokenBal), nil
+		}
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	balances, err := checkWrappedTokenBalances(
+		context.Background(), server.URL, contractAddr, wrappedTokens, "latest", 200, 5, "test", true,
+	)
+	require.NoError(t, err)
+	require.Len(t, balances, 1)
+	require.Equal(t, tokenAddr, balances[0].Token.WrappedTokenAddress)
+	require.Equal(t, uint32(1), balances[0].Token.OriginNetwork)
+	require.Equal(t, tokenBal.String(), balances[0].Balance)
+}
+
+func TestCheckWrappedTokenBalances_ETHAndTokenBothNonZero(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	tokenAddr := common.HexToAddress("0xABCD000000000000000000000000000000000002")
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.Method == "eth_getBalance" {
+			return abiUint256(big.NewInt(1_000_000)), nil
+		}
+		if tc.Method == "eth_call" && tc.To == addrLow(tokenAddr) {
+			return abiUint256(big.NewInt(500)), nil
+		}
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	balances, err := checkWrappedTokenBalances(
+		context.Background(), server.URL, contractAddr,
+		[]WrappedToken{{WrappedTokenAddress: tokenAddr}}, "latest", 200, 5, "test", true,
+	)
+	require.NoError(t, err)
+	require.Len(t, balances, 2)
+}
+
+// --- detectERC20Contracts ---
+
+func TestDetectERC20Contracts_Empty(t *testing.T) {
+	t.Parallel()
+
+	result := detectERC20Contracts(context.Background(), "http://unused", nil, "latest", 5)
+	require.Empty(t, result)
+}
+
+func TestDetectERC20Contracts_ZeroTotalSupply(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	server := newEthCallServer(t, func(_ rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		return abiZero(), nil // totalSupply = 0 → not ERC-20
+	})
+	defer server.Close()
+
+	result := detectERC20Contracts(context.Background(), server.URL, []common.Address{contractAddr}, "latest", 5)
+	require.Empty(t, result)
+}
+
+func TestDetectERC20Contracts_BalanceOfZeroReverts(t *testing.T) {
+	t.Parallel()
+
+	// Contracts that have a totalSupply-like selector but revert on balanceOf(address(0))
+	// should not be classified as ERC-20.
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.Selector == totalSupplySelector {
+			return abiUint256(big.NewInt(1000)), nil
+		}
+		return nil, revertErr()
+	})
+	defer server.Close()
+
+	result := detectERC20Contracts(context.Background(), server.URL, []common.Address{contractAddr}, "latest", 5)
+	require.Empty(t, result)
+}
+
+func TestDetectERC20Contracts_ValidERC20WithNameAndSymbol(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	supply := big.NewInt(1_000_000)
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		switch tc.Selector {
+		case totalSupplySelector:
+			return abiUint256(supply), nil
+		case nameSelector:
+			return abiString("MyToken"), nil
+		case symbolSelector:
+			return abiString("MTK"), nil
+		default:
+			return abiZero(), nil // balanceOf(address(0)) succeeds → confirms ERC-20
+		}
+	})
+	defer server.Close()
+
+	result := detectERC20Contracts(
+		context.Background(), server.URL, []common.Address{contractAddr}, "latest", 5,
+	)
+	require.Len(t, result, 1)
+	info, ok := result[contractAddr]
+	require.True(t, ok)
+	require.Equal(t, supply, info.supply)
+	require.Equal(t, "MyToken", info.name)
+	require.Equal(t, "MTK", info.symbol)
+}
+
+func TestDetectERC20Contracts_MultipleContracts(t *testing.T) {
+	t.Parallel()
+
+	erc20Addr := common.HexToAddress("0xAAAA000000000000000000000000000000000001")
+	nonERC20Addr := common.HexToAddress("0xBBBB000000000000000000000000000000000002")
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.To == addrLow(erc20Addr) && tc.Selector == totalSupplySelector {
+			return abiUint256(big.NewInt(500)), nil
+		}
+		if tc.To == addrLow(nonERC20Addr) && tc.Selector == totalSupplySelector {
+			return abiZero(), nil // zero supply → filtered out
+		}
+		return abiZero(), nil // balanceOf succeeds for erc20Addr
+	})
+	defer server.Close()
+
+	contracts := []common.Address{erc20Addr, nonERC20Addr}
+	result := detectERC20Contracts(context.Background(), server.URL, contracts, "latest", 5)
+	require.Len(t, result, 1)
+	_, ok := result[erc20Addr]
+	require.True(t, ok)
+}
+
+// --- RunStepB2 ---
+
+func TestRunStepB2_EmptyContractAddresses(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		L2RPCURL: "http://unused",
+		Options:  Options{RPCBatchSize: 200, ConcurrencyLimit: 5},
+	}
+	result, err := RunStepB2(context.Background(), cfg, 0, nil, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.DetectedERC20s)
+	require.Empty(t, result.DiscardedERC20s)
+}
+
+func TestRunStepB2_NoERC20sDetected(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	server := newEthCallServer(t, func(_ rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		return abiZero(), nil // totalSupply = 0 → no ERC-20s
+	})
+	defer server.Close()
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options:  Options{RPCBatchSize: 200, ConcurrencyLimit: 5},
+	}
+	result, err := RunStepB2(context.Background(), cfg, 0, []common.Address{contractAddr}, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.DetectedERC20s)
+	require.Empty(t, result.DiscardedERC20s)
+}
+
+func TestRunStepB2_DiscardedERC20_HoldsNoTrackedTokens(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		switch tc.Selector {
+		case totalSupplySelector:
+			return abiUint256(big.NewInt(1000)), nil
+		case nameSelector:
+			return abiString("VaultToken"), nil
+		case symbolSelector:
+			return abiString("VT"), nil
+		default:
+			return abiZero(), nil // balanceOf(0x0) ok; no tracked token held
+		}
+	})
+	defer server.Close()
+
+	wrappedTokens := []WrappedToken{{
+		WrappedTokenAddress: common.HexToAddress("0xDDDD000000000000000000000000000000000001"),
+	}}
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options:  Options{RPCBatchSize: 200, ConcurrencyLimit: 5},
+	}
+	result, err := RunStepB2(context.Background(), cfg, 0,
+		[]common.Address{contractAddr}, nil, wrappedTokens)
+	require.NoError(t, err)
+	require.Empty(t, result.DetectedERC20s)
+	require.Len(t, result.DiscardedERC20s, 1)
+	require.Equal(t, contractAddr, result.DiscardedERC20s[0].Address)
+	require.Equal(t, "VaultToken", result.DiscardedERC20s[0].Name)
+	require.Equal(t, "VT", result.DiscardedERC20s[0].Symbol)
+}
+
+func TestRunStepB2_DetectedERC20_HoldsTrackedToken(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xC001000000000000000000000000000000000001")
+	tokenAddr := common.HexToAddress("0xABCD000000000000000000000000000000000001")
+	tokenBal := big.NewInt(800_000)
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		switch {
+		case tc.To == addrLow(contractAddr) && tc.Selector == totalSupplySelector:
+			return abiUint256(big.NewInt(1000)), nil
+		case tc.To == addrLow(contractAddr) && tc.Selector == nameSelector:
+			return abiString("StakingPool"), nil
+		case tc.To == addrLow(contractAddr) && tc.Selector == symbolSelector:
+			return abiString("SP"), nil
+		case tc.To == addrLow(tokenAddr) && tc.Selector == balanceOfSelector:
+			// balanceOf(contractAddr) on the wrapped token: contract holds tokenBal
+			return abiUint256(tokenBal), nil
+		default:
+			return abiZero(), nil
+		}
+	})
+	defer server.Close()
+
+	wrappedTokens := []WrappedToken{{
+		WrappedTokenAddress: tokenAddr,
+		OriginNetwork:       0,
+		OriginTokenAddress:  common.HexToAddress("0x0202020202020202020202020202020202020202"),
+	}}
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options:  Options{RPCBatchSize: 200, ConcurrencyLimit: 5},
+	}
+	result, err := RunStepB2(context.Background(), cfg, 0,
+		[]common.Address{contractAddr}, nil, wrappedTokens)
+	require.NoError(t, err)
+	require.Empty(t, result.DiscardedERC20s)
+	require.Len(t, result.DetectedERC20s, 1)
+
+	d := result.DetectedERC20s[0]
+	require.Equal(t, contractAddr, d.Address)
+	require.Equal(t, "StakingPool", d.Name)
+	require.Equal(t, "SP", d.Symbol)
+	require.Len(t, d.WrappedTokenBalances, 1)
+	require.Equal(t, tokenAddr, d.WrappedTokenBalances[0].Token.WrappedTokenAddress)
+	require.Equal(t, tokenBal.String(), d.WrappedTokenBalances[0].Balance)
+}
+

--- a/tools/exit_certificate/step_b2_test.go
+++ b/tools/exit_certificate/step_b2_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	rpcMethodEthCall       = "eth_call"
+	rpcMethodEthGetBalance = "eth_getBalance"
+)
+
 // rpcTestCall holds the decoded parts of a single JSON-RPC request
 // received by a test server.
 type rpcTestCall struct {
@@ -45,7 +50,7 @@ func newEthCallServer(t *testing.T, respond func(rpcTestCall) (json.RawMessage, 
 			tc := rpcTestCall{Method: req.Method}
 			if len(req.Params) > 0 {
 				switch req.Method {
-				case "eth_call":
+				case rpcMethodEthCall:
 					var obj struct {
 						To   string `json:"to"`
 						Data string `json:"data"`
@@ -56,7 +61,7 @@ func newEthCallServer(t *testing.T, respond func(rpcTestCall) (json.RawMessage, 
 					if len(obj.Data) >= 10 {
 						tc.Selector = strings.ToLower(obj.Data[:10])
 					}
-				case "eth_getBalance":
+				case rpcMethodEthGetBalance:
 					var addr string
 					_ = json.Unmarshal(req.Params[0], &addr)
 					tc.To = strings.ToLower(addr)
@@ -135,7 +140,7 @@ func TestCheckWrappedTokenBalances_AllZeroReturnEmpty(t *testing.T) {
 	defer server.Close()
 
 	balances, err := checkWrappedTokenBalances(
-		context.Background(), server.URL, contractAddr, nil, "latest", 200, 5, "test", true,
+		context.Background(), server.URL, contractAddr, nil, "latest", 200, 5,
 	)
 	require.NoError(t, err)
 	require.Empty(t, balances)
@@ -148,7 +153,7 @@ func TestCheckWrappedTokenBalances_ETHBalanceOnly(t *testing.T) {
 	ethBal := big.NewInt(5_000_000)
 
 	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
-		if tc.Method == "eth_getBalance" {
+		if tc.Method == rpcMethodEthGetBalance {
 			return abiUint256(ethBal), nil
 		}
 		return abiZero(), nil
@@ -156,7 +161,7 @@ func TestCheckWrappedTokenBalances_ETHBalanceOnly(t *testing.T) {
 	defer server.Close()
 
 	balances, err := checkWrappedTokenBalances(
-		context.Background(), server.URL, contractAddr, nil, "latest", 200, 5, "test", true,
+		context.Background(), server.URL, contractAddr, nil, "latest", 200, 5,
 	)
 	require.NoError(t, err)
 	require.Len(t, balances, 1)
@@ -178,7 +183,7 @@ func TestCheckWrappedTokenBalances_WrappedTokenHeld(t *testing.T) {
 	}}
 
 	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
-		if tc.Method == "eth_call" && tc.To == addrLow(tokenAddr) {
+		if tc.Method == rpcMethodEthCall && tc.To == addrLow(tokenAddr) {
 			return abiUint256(tokenBal), nil
 		}
 		return abiZero(), nil
@@ -186,7 +191,7 @@ func TestCheckWrappedTokenBalances_WrappedTokenHeld(t *testing.T) {
 	defer server.Close()
 
 	balances, err := checkWrappedTokenBalances(
-		context.Background(), server.URL, contractAddr, wrappedTokens, "latest", 200, 5, "test", true,
+		context.Background(), server.URL, contractAddr, wrappedTokens, "latest", 200, 5,
 	)
 	require.NoError(t, err)
 	require.Len(t, balances, 1)
@@ -202,10 +207,10 @@ func TestCheckWrappedTokenBalances_ETHAndTokenBothNonZero(t *testing.T) {
 	tokenAddr := common.HexToAddress("0xABCD000000000000000000000000000000000002")
 
 	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
-		if tc.Method == "eth_getBalance" {
+		if tc.Method == rpcMethodEthGetBalance {
 			return abiUint256(big.NewInt(1_000_000)), nil
 		}
-		if tc.Method == "eth_call" && tc.To == addrLow(tokenAddr) {
+		if tc.Method == rpcMethodEthCall && tc.To == addrLow(tokenAddr) {
 			return abiUint256(big.NewInt(500)), nil
 		}
 		return abiZero(), nil
@@ -214,7 +219,7 @@ func TestCheckWrappedTokenBalances_ETHAndTokenBothNonZero(t *testing.T) {
 
 	balances, err := checkWrappedTokenBalances(
 		context.Background(), server.URL, contractAddr,
-		[]WrappedToken{{WrappedTokenAddress: tokenAddr}}, "latest", 200, 5, "test", true,
+		[]WrappedToken{{WrappedTokenAddress: tokenAddr}}, "latest", 200, 5,
 	)
 	require.NoError(t, err)
 	require.Len(t, balances, 2)
@@ -434,4 +439,3 @@ func TestRunStepB2_DetectedERC20_HoldsTrackedToken(t *testing.T) {
 	require.Equal(t, tokenAddr, d.WrappedTokenBalances[0].Token.WrappedTokenAddress)
 	require.Equal(t, tokenBal.String(), d.WrappedTokenBalances[0].Balance)
 }
-

--- a/tools/exit_certificate/step_b3.go
+++ b/tools/exit_certificate/step_b3.go
@@ -1,0 +1,68 @@
+package exit_certificate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agglayer/aggkit/log"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// RunStepB3 fetches the per-EOA token balance for each contract listed in
+// cfg.Options.ExtraERC20Contracts. For each address, balanceOf is called for
+// every EOA collected in Step A. Collateral info (tracked wrapped tokens held)
+// is attached from the B2 detected list when available.
+func RunStepB3(
+	ctx context.Context, cfg *Config, targetBlock uint64,
+	eoaAddrs []common.Address,
+	b2Result *StepB2Result,
+) (*StepB3Result, error) {
+	log.Info("═══════════════════════════════════════════")
+	log.Info(" STEP B3 — Extra ERC-20 holder decomposition")
+	log.Info("═══════════════════════════════════════════")
+
+	if len(cfg.Options.ExtraERC20Contracts) == 0 {
+		log.Info("No extra ERC-20 contracts configured — STEP B3 skipped")
+		return &StepB3Result{}, nil
+	}
+
+	blockTag := toBlockTag(targetBlock)
+	batchSize := cfg.Options.RPCBatchSize
+	concurrency := cfg.Options.ConcurrencyLimit
+
+	// Index all B2 detected contracts by address to attach collateral info.
+	b2Detected := make(map[common.Address]*DetectedERC20, len(b2Result.DetectedERC20s))
+	for i := range b2Result.DetectedERC20s {
+		d := &b2Result.DetectedERC20s[i]
+		b2Detected[d.Address] = d
+	}
+
+	log.Infof("Processing %d extra ERC-20 contract(s) against %d EOA(s)",
+		len(cfg.Options.ExtraERC20Contracts), len(eoaAddrs))
+
+	breakdowns := make([]ERC20HolderBreakdown, 0, len(cfg.Options.ExtraERC20Contracts))
+	for _, addr := range cfg.Options.ExtraERC20Contracts {
+		log.Infof("  %s — fetching balances for %d EOA(s)...", addr.Hex(), len(eoaAddrs))
+		holderBalances, err := fetchTokenBalances(
+			ctx, cfg.L2RPCURL, addr, eoaAddrs, blockTag, batchSize, concurrency,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("fetchTokenBalances for ERC-20 %s: %w", addr.Hex(), err)
+		}
+
+		holders := make([]ERC20Holder, 0, len(holderBalances))
+		for holderAddr, bal := range holderBalances {
+			holders = append(holders, ERC20Holder{Address: holderAddr, Balance: bal.String()})
+		}
+		log.Infof("  %s — %d holder(s) found", addr.Hex(), len(holders))
+
+		breakdowns = append(breakdowns, ERC20HolderBreakdown{
+			Address:  addr,
+			Holders:  holders,
+			Detected: b2Detected[addr], // nil when not in B2 detected list
+		})
+	}
+
+	log.Infof("STEP B3 complete: %d contract(s) processed", len(breakdowns))
+	return &StepB3Result{Breakdowns: breakdowns}, nil
+}

--- a/tools/exit_certificate/step_b3_test.go
+++ b/tools/exit_certificate/step_b3_test.go
@@ -1,0 +1,211 @@
+package exit_certificate
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunStepB3_EmptyConfig_Skipped(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		L2RPCURL: "http://unused",
+		Options: Options{
+			RPCBatchSize:     200,
+			ConcurrencyLimit: 5,
+		},
+	}
+	result, err := RunStepB3(context.Background(), cfg, 0, nil, &StepB2Result{})
+	require.NoError(t, err)
+	require.Empty(t, result.Breakdowns)
+}
+
+func TestRunStepB3_DetectedFieldPopulated_FromB2(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xAAAA000000000000000000000000000000000001")
+	eoa1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.To == addrLow(contractAddr) && tc.Selector == balanceOfSelector {
+			if strings.ToLower(eoaFromData(tc.FullData)) == addrLow(eoa1) {
+				return abiUint256(big.NewInt(150)), nil
+			}
+		}
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	b2Result := &StepB2Result{
+		DetectedERC20s: []DetectedERC20{
+			{Address: contractAddr, Name: "StakedToken", Symbol: "ST", TotalSupply: "1000"},
+		},
+	}
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options: Options{
+			RPCBatchSize:        200,
+			ConcurrencyLimit:    5,
+			ExtraERC20Contracts: []common.Address{contractAddr},
+		},
+	}
+	result, err := RunStepB3(context.Background(), cfg, 0, []common.Address{eoa1}, b2Result)
+	require.NoError(t, err)
+	require.Len(t, result.Breakdowns, 1)
+	bd := result.Breakdowns[0]
+	require.Len(t, bd.Holders, 1)
+	require.Equal(t, "150", bd.Holders[0].Balance)
+	require.NotNil(t, bd.Detected, "collateral info must be populated when contract is in B2 detected list")
+	require.Equal(t, "StakedToken", bd.Detected.Name)
+	require.Equal(t, "ST", bd.Detected.Symbol)
+}
+
+func TestRunStepB3_FetchesHolders_NotInB2(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xCCCC000000000000000000000000000000000001")
+	eoa1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	eoa2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.To == addrLow(contractAddr) && tc.Selector == balanceOfSelector {
+			queried := strings.ToLower(eoaFromData(tc.FullData))
+			switch queried {
+			case addrLow(eoa1):
+				return abiUint256(big.NewInt(400)), nil
+			case addrLow(eoa2):
+				return abiZero(), nil // zero balance → not in result
+			}
+		}
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options: Options{
+			RPCBatchSize:        200,
+			ConcurrencyLimit:    5,
+			ExtraERC20Contracts: []common.Address{contractAddr},
+		},
+	}
+	result, err := RunStepB3(context.Background(), cfg, 0, []common.Address{eoa1, eoa2}, &StepB2Result{})
+	require.NoError(t, err)
+	require.Len(t, result.Breakdowns, 1)
+
+	bd := result.Breakdowns[0]
+	require.Equal(t, contractAddr, bd.Address)
+	require.Nil(t, bd.Detected, "no collateral info when contract was not in B2 detected list")
+	require.Len(t, bd.Holders, 1, "only eoa1 has non-zero balance")
+	require.Equal(t, eoa1, bd.Holders[0].Address)
+	require.Equal(t, "400", bd.Holders[0].Balance)
+}
+
+func TestRunStepB3_NoEOAs_EmptyHolders(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xCCCC000000000000000000000000000000000001")
+	server := newEthCallServer(t, func(_ rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options: Options{
+			RPCBatchSize:        200,
+			ConcurrencyLimit:    5,
+			ExtraERC20Contracts: []common.Address{contractAddr},
+		},
+	}
+	result, err := RunStepB3(context.Background(), cfg, 0, nil, &StepB2Result{})
+	require.NoError(t, err)
+	require.Len(t, result.Breakdowns, 1)
+	require.Empty(t, result.Breakdowns[0].Holders)
+}
+
+func TestRunStepB3_RPCError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0xCCCC000000000000000000000000000000000001")
+	eoa1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	// Server always returns HTTP 500. The context timeout cuts the backoff short
+	// so the test finishes in milliseconds instead of waiting for all retries.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options: Options{
+			RPCBatchSize:        1,
+			ConcurrencyLimit:    1,
+			ExtraERC20Contracts: []common.Address{contractAddr},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := RunStepB3(ctx, cfg, 0, []common.Address{eoa1}, &StepB2Result{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), contractAddr.Hex())
+}
+
+func TestRunStepB3_MixedContracts(t *testing.T) {
+	t.Parallel()
+
+	// addr1: in B2 detected list → Detected != nil
+	// addr2: not in B2            → Detected == nil
+	addr1 := common.HexToAddress("0xAAAA000000000000000000000000000000000001")
+	addr2 := common.HexToAddress("0xBBBB000000000000000000000000000000000002")
+	eoa1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	server := newEthCallServer(t, func(tc rpcTestCall) (json.RawMessage, *jsonRPCError) {
+		if tc.Selector == balanceOfSelector {
+			return abiUint256(big.NewInt(50)), nil
+		}
+		return abiZero(), nil
+	})
+	defer server.Close()
+
+	b2Result := &StepB2Result{
+		DetectedERC20s: []DetectedERC20{
+			{Address: addr1, Name: "TokenA"},
+		},
+	}
+
+	cfg := &Config{
+		L2RPCURL: server.URL,
+		Options: Options{
+			RPCBatchSize:        200,
+			ConcurrencyLimit:    5,
+			ExtraERC20Contracts: []common.Address{addr1, addr2},
+		},
+	}
+	result, err := RunStepB3(context.Background(), cfg, 0, []common.Address{eoa1}, b2Result)
+	require.NoError(t, err)
+	require.Len(t, result.Breakdowns, 2)
+
+	byAddr := make(map[common.Address]ERC20HolderBreakdown, 2)
+	for _, bd := range result.Breakdowns {
+		byAddr[bd.Address] = bd
+	}
+
+	require.NotNil(t, byAddr[addr1].Detected)
+	require.Equal(t, "TokenA", byAddr[addr1].Detected.Name)
+	require.Len(t, byAddr[addr1].Holders, 1)
+
+	require.Nil(t, byAddr[addr2].Detected)
+	require.Len(t, byAddr[addr2].Holders, 1)
+}

--- a/tools/exit_certificate/step_c.go
+++ b/tools/exit_certificate/step_c.go
@@ -1,6 +1,7 @@
 package exit_certificate
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -11,13 +12,16 @@ import (
 //
 // Formula: SC_locked = LBT_totalSupply − accumulated_EOA_balances
 //
-// The LBT gives total supply per token. The accumulated EOA balances (Step B)
-// tell us how much is held by EOAs. The difference is held by smart contracts.
+// When ERC20HolderBreakdowns are present (from Step B3), the portion of each token
+// held by a vault/staking contract is distributed proportionally to its holders as
+// individual HolderBridge exits instead of a single exit to exitAddress. The
+// corresponding SC_locked value is reduced by the amount distributed.
 func RunStepC(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP C — SC-locked value extraction")
 	log.Info("═══════════════════════════════════════════")
 	log.Infof("LBT has %d entries", len(lbtEntries))
+	log.Infof("ERC-20 contracts to distribute as individual bridges: %d", len(stepB.ERC20HolderBreakdowns))
 
 	lbtByToken := indexByAddress(lbtEntries)
 
@@ -27,7 +31,15 @@ func RunStepC(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
 		eoaByToken[key] = parseDecimalBigInt(entry.TotalBalance)
 	}
 
-	scLockedValues, nonZeroCount := computeSCLocked(lbtByToken, eoaByToken)
+	holderBridges, covered, err := processBreakdowns(stepB.ERC20HolderBreakdowns)
+	if err != nil {
+		return nil, err
+	}
+
+	scLockedValues, nonZeroCount, err := computeSCLocked(lbtByToken, eoaByToken, covered)
+	if err != nil {
+		return nil, err
+	}
 
 	for tokenKey, eoaTotal := range eoaByToken {
 		if _, exists := lbtByToken[tokenKey]; !exists && eoaTotal.Sign() > 0 {
@@ -35,13 +47,84 @@ func RunStepC(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
 		}
 	}
 
-	log.Infof("STEP C complete: %d tokens analyzed, %d have SC-locked value",
-		len(scLockedValues), nonZeroCount)
+	log.Infof("STEP C complete: %d tokens analyzed, %d have SC-locked value, %d holder bridge exits",
+		len(scLockedValues), nonZeroCount, len(holderBridges))
 
-	return &StepCResult{SCLockedValues: scLockedValues}, nil
+	return &StepCResult{SCLockedValues: scLockedValues, HolderBridges: holderBridges}, nil
 }
 
-func computeSCLocked(lbtByToken map[string]LBTEntry, eoaByToken map[string]*big.Int) ([]SCLockedValue, int) {
+// processBreakdowns computes HolderBridge entries from ERC-20 holder breakdowns (Step B3).
+// The collateral token and each holder's balance are treated as 1:1: each holder receives
+// exactly their vault-token balance as the collateral token amount — no proportional
+// scaling against totalSupply.
+//
+// Returns an error if the sum of holder amounts exceeds the vault's actual holdings
+// (over-distribution), which would indicate corrupt balance data.
+func processBreakdowns(breakdowns []ERC20HolderBreakdown) ([]HolderBridge, map[string]*big.Int, error) {
+	var holderBridges []HolderBridge
+	covered := make(map[string]*big.Int) // wrappedToken lowercaseHex → total covered
+
+	for _, bd := range breakdowns {
+		if bd.Detected == nil || len(bd.Detected.WrappedTokenBalances) == 0 {
+			continue
+		}
+
+		for _, wtb := range bd.Detected.WrappedTokenBalances {
+			contractHolds := parseDecimalBigInt(wtb.Balance)
+			if contractHolds.Sign() == 0 {
+				continue
+			}
+
+			tokenKey := strings.ToLower(wtb.Token.WrappedTokenAddress.Hex())
+
+			distributed := new(big.Int)
+			for _, h := range bd.Holders {
+				amount := parseDecimalBigInt(h.Balance)
+				if amount.Sign() <= 0 {
+					continue
+				}
+				holderBridges = append(holderBridges, HolderBridge{
+					VaultAddress:        bd.Address,
+					WrappedTokenAddress: wtb.Token.WrappedTokenAddress,
+					OriginNetwork:       wtb.Token.OriginNetwork,
+					OriginTokenAddress:  wtb.Token.OriginTokenAddress,
+					HolderAddress:       h.Address,
+					Amount:              amount.String(),
+				})
+				distributed.Add(distributed, amount)
+			}
+
+			if distributed.Cmp(contractHolds) > 0 {
+				return nil, nil, fmt.Errorf(
+					"vault %s: holder balances sum (%s) exceeds vault holdings (%s) for token %s — corrupt balance data",
+					bd.Address.Hex(), distributed, contractHolds, wtb.Token.WrappedTokenAddress.Hex(),
+				)
+			}
+
+			remainder := new(big.Int).Sub(contractHolds, distributed)
+			log.Infof("  vault %s | token %s | total=%s | individual_bridges=%s (%d holder(s)) | to_exit_addr=%s",
+				bd.Address.Hex(), wtb.Token.WrappedTokenAddress.Hex(),
+				contractHolds, distributed, len(bd.Holders), remainder)
+			if remainder.Sign() > 0 {
+				log.Infof("    ↳ %s unattributed (contract holders not in EOA list) → will flow to exitAddress as SC-locked",
+					remainder)
+			}
+
+			if covered[tokenKey] == nil {
+				covered[tokenKey] = new(big.Int)
+			}
+			covered[tokenKey].Add(covered[tokenKey], distributed)
+		}
+	}
+
+	return holderBridges, covered, nil
+}
+
+func computeSCLocked(
+	lbtByToken map[string]LBTEntry,
+	eoaByToken map[string]*big.Int,
+	covered map[string]*big.Int,
+) ([]SCLockedValue, int, error) {
 	scLockedValues := make([]SCLockedValue, 0, len(lbtByToken))
 	nonZeroCount := 0
 
@@ -59,21 +142,46 @@ func computeSCLocked(lbtByToken map[string]LBTEntry, eoaByToken map[string]*big.
 			locked = new(big.Int)
 		}
 
+		holdersCovered := new(big.Int)
+		if coveredAmt, ok := covered[tokenKey]; ok {
+			beforeCoverage := new(big.Int).Set(locked)
+			locked.Sub(locked, coveredAmt)
+			if locked.Sign() < 0 {
+				return nil, 0, fmt.Errorf(
+					"token %s: holder bridge coverage (%s) exceeds SC-locked balance (%s); possible LBT or EOA data inconsistency",
+					lbt.WrappedTokenAddress.Hex(), coveredAmt,
+					new(big.Int).Add(locked, coveredAmt),
+				)
+			}
+			holdersCovered.Set(coveredAmt)
+			log.Infof("  SC_locked[%s]: %s → %s (-%s to holder bridges; %s vault remainder → SCLockedValues → exitAddress)",
+				lbt.WrappedTokenAddress.Hex(), beforeCoverage, locked, coveredAmt, locked)
+		}
+
 		if locked.Sign() > 0 {
 			nonZeroCount++
 		}
 
+		holdersCoveredStr := ""
+		if holdersCovered.Sign() > 0 {
+			holdersCoveredStr = holdersCovered.String()
+		}
+
+		totalLocked := new(big.Int).Add(locked, holdersCovered)
+
 		scLockedValues = append(scLockedValues, SCLockedValue{
-			WrappedTokenAddress: lbt.WrappedTokenAddress,
-			OriginNetwork:       lbt.OriginNetwork,
-			OriginTokenAddress:  lbt.OriginTokenAddress,
-			LBTBalance:          lbtBalance.String(),
-			EOAAccumulated:      eoaTotal.String(),
-			SCLockedBalance:     locked.String(),
+			WrappedTokenAddress:    lbt.WrappedTokenAddress,
+			OriginNetwork:          lbt.OriginNetwork,
+			OriginTokenAddress:     lbt.OriginTokenAddress,
+			LBTBalance:             lbtBalance.String(),
+			EOAAccumulated:         eoaTotal.String(),
+			ERC20HoldersCovered:    holdersCoveredStr,
+			TotalSCLockedBalance:   totalLocked.String(),
+			PendingSCLockedBalance: locked.String(),
 		})
 	}
 
-	return scLockedValues, nonZeroCount
+	return scLockedValues, nonZeroCount, nil
 }
 
 // indexByAddress indexes LBT entries by lowercased hex address.

--- a/tools/exit_certificate/step_c_test.go
+++ b/tools/exit_certificate/step_c_test.go
@@ -38,7 +38,7 @@ func TestRunStepC_Basic(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.SCLockedValues, 1)
 
-	scLocked, ok := new(big.Int).SetString(result.SCLockedValues[0].SCLockedBalance, 10)
+	scLocked, ok := new(big.Int).SetString(result.SCLockedValues[0].PendingSCLockedBalance, 10)
 	require.True(t, ok)
 	require.Equal(t, big.NewInt(400000), scLocked)
 }
@@ -74,7 +74,7 @@ func TestRunStepC_EOAExceedsLBT(t *testing.T) {
 	require.Len(t, result.SCLockedValues, 1)
 
 	// SC-locked should be clamped to 0 when EOA exceeds LBT
-	require.Equal(t, "0", result.SCLockedValues[0].SCLockedBalance)
+	require.Equal(t, "0", result.SCLockedValues[0].PendingSCLockedBalance)
 }
 
 func TestRunStepC_EmptyLBT(t *testing.T) {
@@ -111,11 +111,152 @@ func TestRunStepC_MultipleTokens(t *testing.T) {
 
 	scLockedMap := make(map[common.Address]string)
 	for _, v := range result.SCLockedValues {
-		scLockedMap[v.WrappedTokenAddress] = v.SCLockedBalance
+		scLockedMap[v.WrappedTokenAddress] = v.PendingSCLockedBalance
 	}
 
 	require.Equal(t, "700000", scLockedMap[token1])
 	require.Equal(t, "1500000", scLockedMap[token2])
+}
+
+// --- ERC20HolderBreakdown tests ---
+
+// fixture used by the breakdown tests:
+//   LBT[token] = 2000, EOA_accumulated[token] = 1000
+//   → raw SC_locked = 1000 (the vault's holdings are inside this)
+//   vault holds 900 of token
+func breakdownFixture() (tokenAddr, originAddr, vaultAddr, alice, bob common.Address, lbtEntries []LBTEntry, accumulated []AccumulatedBalance) {
+	tokenAddr = common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	originAddr = common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+	vaultAddr = common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
+	alice = common.HexToAddress("0x1111111111111111111111111111111111111111")
+	bob = common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	lbtEntries = []LBTEntry{
+		{WrappedTokenAddress: tokenAddr, OriginNetwork: 0, OriginTokenAddress: originAddr, Balance: "2000"},
+	}
+	accumulated = []AccumulatedBalance{
+		{WrappedTokenAddress: tokenAddr, OriginNetwork: 0, OriginTokenAddress: originAddr, TotalBalance: "1000"},
+	}
+	return
+}
+
+func TestRunStepC_BreakdownCreatesHolderBridges(t *testing.T) {
+	t.Parallel()
+
+	tokenAddr, originAddr, vaultAddr, alice, bob, lbtEntries, accumulated := breakdownFixture()
+	// vault holds 900, alice=400 + bob=500 = 900 → full coverage, no remainder
+	breakdowns := []ERC20HolderBreakdown{{
+		Address: vaultAddr,
+		Holders: []ERC20Holder{
+			{Address: alice, Balance: "400"},
+			{Address: bob, Balance: "500"},
+		},
+		Detected: &DetectedERC20{
+			WrappedTokenBalances: []WrappedTokenBalance{{
+				Token:   WrappedToken{WrappedTokenAddress: tokenAddr, OriginNetwork: 0, OriginTokenAddress: originAddr},
+				Balance: "900",
+			}},
+		},
+	}}
+
+	result, err := RunStepC(lbtEntries, &StepBResult{Accumulated: accumulated, ERC20HolderBreakdowns: breakdowns})
+	require.NoError(t, err)
+
+	// Two individual holder bridges (1:1 with holder balances)
+	require.Len(t, result.HolderBridges, 2)
+	holderMap := make(map[common.Address]string)
+	for _, hb := range result.HolderBridges {
+		require.Equal(t, vaultAddr, hb.VaultAddress)
+		require.Equal(t, tokenAddr, hb.WrappedTokenAddress)
+		holderMap[hb.HolderAddress] = hb.Amount
+	}
+	require.Equal(t, "400", holderMap[alice])
+	require.Equal(t, "500", holderMap[bob])
+
+	// SC_locked = (2000 - 1000) - 900 = 100 (other contracts not in breakdown)
+	require.Len(t, result.SCLockedValues, 1)
+	require.Equal(t, "100", result.SCLockedValues[0].PendingSCLockedBalance)
+}
+
+func TestRunStepC_UnattributedRemainderGoesToSCLocked(t *testing.T) {
+	t.Parallel()
+
+	// alice=300 + bob=400 = 700 < 900 → remainder=200 unattributed
+	// Those 200 stay in SC_locked and flow to exitAddress — no error
+	tokenAddr, originAddr, vaultAddr, alice, bob, lbtEntries, accumulated := breakdownFixture()
+	breakdowns := []ERC20HolderBreakdown{{
+		Address: vaultAddr,
+		Holders: []ERC20Holder{
+			{Address: alice, Balance: "300"},
+			{Address: bob, Balance: "400"},
+		},
+		Detected: &DetectedERC20{
+			WrappedTokenBalances: []WrappedTokenBalance{{
+				Token:   WrappedToken{WrappedTokenAddress: tokenAddr, OriginNetwork: 0, OriginTokenAddress: originAddr},
+				Balance: "900",
+			}},
+		},
+	}}
+
+	result, err := RunStepC(lbtEntries, &StepBResult{Accumulated: accumulated, ERC20HolderBreakdowns: breakdowns})
+	require.NoError(t, err)
+
+	// Only known-holder bridges are created (700 total distributed)
+	require.Len(t, result.HolderBridges, 2)
+
+	// SC_locked = (2000 - 1000) - 700 = 300
+	// (200 of the vault's 900 are unattributed and remain as SC_locked)
+	require.Len(t, result.SCLockedValues, 1)
+	require.Equal(t, "300", result.SCLockedValues[0].PendingSCLockedBalance)
+}
+
+func TestRunStepC_HolderBalancesExceedVaultHoldings_Error(t *testing.T) {
+	t.Parallel()
+
+	// alice=300 + bob=400 = 700 > 500 (vault holds) → corrupt data → error
+	tokenAddr, originAddr, vaultAddr, alice, bob, lbtEntries, accumulated := breakdownFixture()
+	breakdowns := []ERC20HolderBreakdown{{
+		Address: vaultAddr,
+		Holders: []ERC20Holder{
+			{Address: alice, Balance: "300"},
+			{Address: bob, Balance: "400"},
+		},
+		Detected: &DetectedERC20{
+			WrappedTokenBalances: []WrappedTokenBalance{{
+				Token:   WrappedToken{WrappedTokenAddress: tokenAddr, OriginNetwork: 0, OriginTokenAddress: originAddr},
+				Balance: "500",
+			}},
+		},
+	}}
+
+	_, err := RunStepC(lbtEntries, &StepBResult{Accumulated: accumulated, ERC20HolderBreakdowns: breakdowns})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), vaultAddr.Hex())
+	require.Contains(t, err.Error(), "exceeds vault holdings")
+}
+
+func TestRunStepC_BreakdownWithoutDetected_Skipped(t *testing.T) {
+	t.Parallel()
+
+	tokenAddr, originAddr, _, alice, _, lbtEntries, accumulated := breakdownFixture()
+	vaultAddr := common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
+
+	// Breakdown has no Detected → skipped entirely
+	breakdowns := []ERC20HolderBreakdown{{
+		Address:  vaultAddr,
+		Holders:  []ERC20Holder{{Address: alice, Balance: "400"}},
+		Detected: nil,
+	}}
+
+	result, err := RunStepC(lbtEntries, &StepBResult{Accumulated: accumulated, ERC20HolderBreakdowns: breakdowns})
+	require.NoError(t, err)
+	require.Empty(t, result.HolderBridges)
+	// SC_locked unchanged: 2000 - 1000 = 1000
+	require.Len(t, result.SCLockedValues, 1)
+	require.Equal(t, "1000", result.SCLockedValues[0].PendingSCLockedBalance)
+
+	_ = tokenAddr
+	_ = originAddr
 }
 
 func TestRunStepC_TokenNotInLBT(t *testing.T) {
@@ -140,5 +281,5 @@ func TestRunStepC_TokenNotInLBT(t *testing.T) {
 	require.NoError(t, err)
 	// Only token1 is in LBT, so only 1 SC-locked entry
 	require.Len(t, result.SCLockedValues, 1)
-	require.Equal(t, "700000", result.SCLockedValues[0].SCLockedBalance)
+	require.Equal(t, "700000", result.SCLockedValues[0].PendingSCLockedBalance)
 }

--- a/tools/exit_certificate/step_c_test.go
+++ b/tools/exit_certificate/step_c_test.go
@@ -121,9 +121,10 @@ func TestRunStepC_MultipleTokens(t *testing.T) {
 // --- ERC20HolderBreakdown tests ---
 
 // fixture used by the breakdown tests:
-//   LBT[token] = 2000, EOA_accumulated[token] = 1000
-//   → raw SC_locked = 1000 (the vault's holdings are inside this)
-//   vault holds 900 of token
+//
+//	LBT[token] = 2000, EOA_accumulated[token] = 1000
+//	→ raw SC_locked = 1000 (the vault's holdings are inside this)
+//	vault holds 900 of token
 func breakdownFixture() (tokenAddr, originAddr, vaultAddr, alice, bob common.Address, lbtEntries []LBTEntry, accumulated []AccumulatedBalance) {
 	tokenAddr = common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 	originAddr = common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")

--- a/tools/exit_certificate/step_d.go
+++ b/tools/exit_certificate/step_d.go
@@ -13,7 +13,8 @@ import (
 //
 // Creates BridgeExit entries for:
 //  1. Every (EOA, token) pair with a non-zero balance
-//  2. Every token with SC-locked value, directed to exitAddress
+//  2. Every holder of an ERC-20 vault/staking contract (from Step C HolderBridges)
+//  3. Every token with remaining SC-locked value, directed to exitAddress
 func RunStepD(cfg *Config, stepB *StepBResult, stepC *StepCResult) (*StepDResult, error) {
 	log.Info("═══════════════════════════════════════════")
 	log.Info(" STEP D — Build exit certificate")
@@ -25,11 +26,15 @@ func RunStepD(cfg *Config, stepB *StepBResult, stepC *StepCResult) (*StepDResult
 	eoaExits := buildEOAExits(stepB, destNetwork)
 	log.Infof("EOA exits: %d", len(eoaExits))
 
+	holderExits := buildHolderBridgeExits(stepC, destNetwork)
+	log.Infof("Holder exits: %d", len(holderExits))
+
 	scExits := buildSCLockedExits(stepC, destNetwork, exitAddr)
 	log.Infof("SC-locked exits: %d", len(scExits))
 
-	bridgeExits := make([]*agglayertypes.BridgeExit, 0, len(eoaExits)+len(scExits))
+	bridgeExits := make([]*agglayertypes.BridgeExit, 0, len(eoaExits)+len(holderExits)+len(scExits))
 	bridgeExits = append(bridgeExits, eoaExits...)
+	bridgeExits = append(bridgeExits, holderExits...)
 	bridgeExits = append(bridgeExits, scExits...)
 
 	certificate := &agglayertypes.Certificate{
@@ -39,8 +44,8 @@ func RunStepD(cfg *Config, stepB *StepBResult, stepC *StepCResult) (*StepDResult
 		BridgeExits:       bridgeExits,
 	}
 
-	log.Infof("STEP D complete: certificate has %d bridge exits (%d EOA + %d SC-locked)",
-		len(bridgeExits), len(eoaExits), len(scExits))
+	log.Infof("STEP D complete: certificate has %d bridge exits (%d EOA + %d holder + %d SC-locked)",
+		len(bridgeExits), len(eoaExits), len(holderExits), len(scExits))
 
 	return &StepDResult{Certificate: certificate}, nil
 }
@@ -75,6 +80,18 @@ func eoaToExits(eoa EOABalance, destNetwork uint32) []*agglayertypes.BridgeExit 
 	return exits
 }
 
+func buildHolderBridgeExits(stepC *StepCResult, destNetwork uint32) []*agglayertypes.BridgeExit {
+	exits := make([]*agglayertypes.BridgeExit, 0, len(stepC.HolderBridges))
+	for _, hb := range stepC.HolderBridges {
+		amount := parseDecimalBigInt(hb.Amount)
+		if amount.Sign() <= 0 {
+			continue
+		}
+		exits = append(exits, makeBridgeExit(hb.OriginNetwork, hb.OriginTokenAddress, destNetwork, hb.HolderAddress, amount))
+	}
+	return exits
+}
+
 func buildSCLockedExits(
 	stepC *StepCResult, destNetwork uint32, exitAddr common.Address,
 ) []*agglayertypes.BridgeExit {
@@ -82,7 +99,7 @@ func buildSCLockedExits(
 
 	exits := make([]*agglayertypes.BridgeExit, 0, len(stepC.SCLockedValues))
 	for _, entry := range stepC.SCLockedValues {
-		amount := parseDecimalBigInt(entry.SCLockedBalance)
+		amount := parseDecimalBigInt(entry.PendingSCLockedBalance)
 		if amount.Sign() <= 0 {
 			continue
 		}

--- a/tools/exit_certificate/step_d_test.go
+++ b/tools/exit_certificate/step_d_test.go
@@ -84,20 +84,20 @@ func TestRunStepD_WithSCLockedValues(t *testing.T) {
 	stepC := &StepCResult{
 		SCLockedValues: []SCLockedValue{
 			{
-				WrappedTokenAddress: common.HexToAddress("0xBBBB"),
-				OriginNetwork:       0,
-				OriginTokenAddress:  tokenOriginAddr,
-				LBTBalance:          "1000000",
-				EOAAccumulated:      "300000",
-				PendingSCLockedBalance:     "700000",
+				WrappedTokenAddress:    common.HexToAddress("0xBBBB"),
+				OriginNetwork:          0,
+				OriginTokenAddress:     tokenOriginAddr,
+				LBTBalance:             "1000000",
+				EOAAccumulated:         "300000",
+				PendingSCLockedBalance: "700000",
 			},
 			{
-				WrappedTokenAddress: common.HexToAddress("0xCCCC"),
-				OriginNetwork:       1,
-				OriginTokenAddress:  common.HexToAddress("0xDDDD"),
-				LBTBalance:          "500000",
-				EOAAccumulated:      "500000",
-				PendingSCLockedBalance:     "0",
+				WrappedTokenAddress:    common.HexToAddress("0xCCCC"),
+				OriginNetwork:          1,
+				OriginTokenAddress:     common.HexToAddress("0xDDDD"),
+				LBTBalance:             "500000",
+				EOAAccumulated:         "500000",
+				PendingSCLockedBalance: "0",
 			},
 		},
 	}
@@ -167,10 +167,10 @@ func TestRunStepD_CombinedEOAAndSCLocked(t *testing.T) {
 	stepC := &StepCResult{
 		SCLockedValues: []SCLockedValue{
 			{
-				WrappedTokenAddress: common.HexToAddress("0xAAAA"),
-				OriginNetwork:       0,
-				OriginTokenAddress:  common.HexToAddress("0xBBBB"),
-				PendingSCLockedBalance:     "500000",
+				WrappedTokenAddress:    common.HexToAddress("0xAAAA"),
+				OriginNetwork:          0,
+				OriginTokenAddress:     common.HexToAddress("0xBBBB"),
+				PendingSCLockedBalance: "500000",
 			},
 		},
 	}

--- a/tools/exit_certificate/step_d_test.go
+++ b/tools/exit_certificate/step_d_test.go
@@ -89,7 +89,7 @@ func TestRunStepD_WithSCLockedValues(t *testing.T) {
 				OriginTokenAddress:  tokenOriginAddr,
 				LBTBalance:          "1000000",
 				EOAAccumulated:      "300000",
-				SCLockedBalance:     "700000",
+				PendingSCLockedBalance:     "700000",
 			},
 			{
 				WrappedTokenAddress: common.HexToAddress("0xCCCC"),
@@ -97,7 +97,7 @@ func TestRunStepD_WithSCLockedValues(t *testing.T) {
 				OriginTokenAddress:  common.HexToAddress("0xDDDD"),
 				LBTBalance:          "500000",
 				EOAAccumulated:      "500000",
-				SCLockedBalance:     "0",
+				PendingSCLockedBalance:     "0",
 			},
 		},
 	}
@@ -170,7 +170,7 @@ func TestRunStepD_CombinedEOAAndSCLocked(t *testing.T) {
 				WrappedTokenAddress: common.HexToAddress("0xAAAA"),
 				OriginNetwork:       0,
 				OriginTokenAddress:  common.HexToAddress("0xBBBB"),
-				SCLockedBalance:     "500000",
+				PendingSCLockedBalance:     "500000",
 			},
 		},
 	}

--- a/tools/exit_certificate/step_f.go
+++ b/tools/exit_certificate/step_f.go
@@ -33,7 +33,7 @@ type tokenKey struct {
 // RunStepF queries the agglayer admin API for token balances and performs a three-way comparison:
 // LBT (Step 0 total supplies) == agglayer balance == sum of certificate bridge exits.
 // lbtEntries may be nil when LBT data is unavailable; the check then falls back to two-way comparison.
-// Skipped when agglayerAdminURL is not set in options.
+// agglayerAdminURL is required; returns an error when not set.
 func RunStepF(
 	ctx context.Context, cfg *Config,
 	certificate *agglayertypes.Certificate,
@@ -44,8 +44,7 @@ func RunStepF(
 	log.Info("═══════════════════════════════════════════")
 
 	if cfg.Options.AgglayerAdminURL == "" {
-		log.Warn("STEP F skipped: agglayerAdminURL not set in options")
-		return &StepFResult{Skipped: true}, nil
+		return nil, fmt.Errorf("step F requires agglayerAdminURL to be set in options")
 	}
 
 	log.Infof("Querying %s (network %d)", cfg.Options.AgglayerAdminURL, cfg.L2NetworkID)

--- a/tools/exit_certificate/step_f_test.go
+++ b/tools/exit_certificate/step_f_test.go
@@ -37,16 +37,14 @@ func TestRunStepF_WithBearerToken(t *testing.T) {
 	result, err := RunStepF(context.Background(), cfg, &agglayertypes.Certificate{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.False(t, result.Skipped)
 }
 
-func TestRunStepF_Skipped(t *testing.T) {
+func TestRunStepF_MissingAdminURL_Error(t *testing.T) {
 	t.Parallel()
 
-	result, err := RunStepF(context.Background(), &Config{}, &agglayertypes.Certificate{}, nil)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.True(t, result.Skipped)
+	_, err := RunStepF(context.Background(), &Config{}, &agglayertypes.Certificate{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agglayerAdminURL")
 }
 
 func TestRunStepF_AllMatch(t *testing.T) {

--- a/tools/exit_certificate/types.go
+++ b/tools/exit_certificate/types.go
@@ -80,7 +80,16 @@ type SCLockedValue struct {
 	OriginTokenAddress  common.Address `json:"originTokenAddress"`
 	LBTBalance          string         `json:"lbtBalance"`
 	EOAAccumulated      string         `json:"eoaAccumulated"`
-	SCLockedBalance     string         `json:"scLockedBalance"`
+	// ERC20HoldersCovered is the portion of SC-locked value distributed as individual
+	// bridge exits to holders of ERC-20 vault contracts (from Step B3 breakdowns).
+	// Empty when no breakdown applies to this token.
+	ERC20HoldersCovered string `json:"erc20HoldersCovered,omitempty"`
+	// TotalSCLockedBalance is the gross value locked in smart contracts: LBT - EOA.
+	// It includes both the portion covered by ERC-20 holder bridges and the remainder.
+	TotalSCLockedBalance string `json:"totalSCLockedBalance"`
+	// PendingSCLockedBalance is the net SC-locked value that requires a bridge exit to
+	// exitAddress: TotalSCLockedBalance − ERC20HoldersCovered.
+	PendingSCLockedBalance string `json:"pendingSCLockedBalance"`
 }
 
 // FailedTrace pairs a transaction hash with the RPC error that caused its trace to fail.
@@ -101,16 +110,98 @@ type StepA2Result struct {
 	Addresses []common.Address `json:"addresses"`
 }
 
-// StepBResult holds the output of Step B.
-type StepBResult struct {
+// StepB1Result holds the output produced exclusively by Step B1
+// (address classification and balance fetching). It does not include
+// the ERC-20 detection data added by Step B2.
+type StepB1Result struct {
 	EOABalances       []EOABalance         `json:"eoaBalances"`
 	Accumulated       []AccumulatedBalance `json:"accumulated"`
 	ContractAddresses []common.Address     `json:"contractAddresses"`
 }
 
+// StepBResult holds the combined output of Step B (B1 + B2 + B3).
+type StepBResult struct {
+	EOABalances           []EOABalance           `json:"eoaBalances"`
+	Accumulated           []AccumulatedBalance   `json:"accumulated"`
+	ContractAddresses     []common.Address       `json:"contractAddresses"`
+	DetectedERC20s        []DetectedERC20        `json:"detectedErc20s,omitempty"`
+	DiscardedERC20s       []DiscardedERC20       `json:"discardedErc20s,omitempty"`
+	ERC20HolderBreakdowns []ERC20HolderBreakdown `json:"erc20HolderBreakdowns,omitempty"`
+}
+
+// ERC20HolderBreakdown holds the full holder decomposition for a single ERC-20 contract
+// produced by Step B3.
+type ERC20HolderBreakdown struct {
+	Address common.Address `json:"address"`
+	Holders []ERC20Holder  `json:"holders"`
+	// Detected is the collateral info from Step B2: which tracked wrapped tokens this
+	// contract holds, plus its name/symbol/totalSupply. Nil when the contract was not
+	// present in the B2 detected list (e.g. it holds no tracked wrapped tokens).
+	Detected *DetectedERC20 `json:"detected,omitempty"`
+}
+
+// StepB3Result holds the output of Step B3 (extra ERC-20 holder decomposition).
+type StepB3Result struct {
+	Breakdowns []ERC20HolderBreakdown `json:"breakdowns"`
+}
+
+// StepB2Result holds the output of Step B2.
+type StepB2Result struct {
+	// DetectedERC20s are contracts that hold at least one tracked wrapped token.
+	DetectedERC20s []DetectedERC20 `json:"detectedErc20s"`
+	// DiscardedERC20s are contracts that responded to totalSupply() but hold none
+	// of the tracked wrapped tokens and are therefore irrelevant to the certificate.
+	DiscardedERC20s []DiscardedERC20 `json:"discardedErc20s,omitempty"`
+}
+
+// DetectedERC20 holds an ERC-20 contract that holds at least one tracked wrapped token.
+type DetectedERC20 struct {
+	Address              common.Address        `json:"address"`
+	Name                 string                `json:"name,omitempty"`
+	Symbol               string                `json:"symbol,omitempty"`
+	TotalSupply          string                `json:"totalSupply"`
+	WrappedTokenBalances []WrappedTokenBalance `json:"wrappedTokenBalances"`
+}
+
+// DiscardedERC20 is an ERC-20 contract that holds none of the tracked wrapped tokens.
+type DiscardedERC20 struct {
+	Address     common.Address `json:"address"`
+	Name        string         `json:"name,omitempty"`
+	Symbol      string         `json:"symbol,omitempty"`
+	TotalSupply string         `json:"totalSupply"`
+}
+
+// WrappedTokenBalance is the balance of a tracked wrapped token held by an ERC-20 contract.
+type WrappedTokenBalance struct {
+	Token   WrappedToken `json:"token"`
+	Balance string       `json:"balance"`
+}
+
+// ERC20Holder is an (address, balance) pair produced by Step B2.
+type ERC20Holder struct {
+	Address common.Address `json:"address"`
+	Balance string         `json:"balance"`
+}
+
+// HolderBridge is an individual bridge exit for a holder of an ERC-20 vault/staking
+// contract, representing their proportional share of the tracked wrapped tokens locked
+// inside that contract. Produced by Step C from the Step B3 breakdown data.
+type HolderBridge struct {
+	VaultAddress        common.Address `json:"vaultAddress"`
+	WrappedTokenAddress common.Address `json:"wrappedTokenAddress"`
+	OriginNetwork       uint32         `json:"originNetwork"`
+	OriginTokenAddress  common.Address `json:"originTokenAddress"`
+	HolderAddress       common.Address `json:"holderAddress"`
+	Amount              string         `json:"amount"`
+}
+
 // StepCResult holds the output of Step C.
 type StepCResult struct {
 	SCLockedValues []SCLockedValue `json:"scLockedValues"`
+	// HolderBridges are individual bridge exits for holders of ERC-20 vault contracts
+	// whose breakdowns were provided by Step B3. These replace what would otherwise be a
+	// single SC-locked exit to exitAddress for the portion of value they cover.
+	HolderBridges []HolderBridge `json:"holderBridges,omitempty"`
 }
 
 // StepDResult holds the output of Step D.
@@ -167,7 +258,6 @@ type TokenBalanceCheck struct {
 
 // StepFResult holds the output of Step F (agglayer token balance check).
 type StepFResult struct {
-	Skipped       bool                `json:"skipped,omitempty"`
 	AllMatch      bool                `json:"allMatch,omitempty"`
 	TokenBalances json.RawMessage     `json:"tokenBalances,omitempty"`
 	Checks        []TokenBalanceCheck `json:"checks,omitempty"`

--- a/tools/exit_certificate/worker.go
+++ b/tools/exit_certificate/worker.go
@@ -126,7 +126,7 @@ func collectResults[R any](
 				log.Warnf("%s job failed: %v req: %+v", label, r.err, r.val)
 			} else {
 				collect(r.val)
-				if processed%logInterval == 0 || processed == total {
+				if label != "" && (processed%logInterval == 0 || processed == total) {
 					pct := float64(processed) / float64(total) * percentMultiplier
 					log.Infof("  %s: %d/%d [%.0f%%]", label, processed, total, pct)
 				}


### PR DESCRIPTION
## 🔄 Changes Summary
- **Step B2**: probes each contract address collected in Step A for the ERC-20 interface (`totalSupply`/`balanceOf`). Classifies contracts as `DetectedERC20` (holds ≥1 tracked wrapped token) or `DiscardedERC20`. Outputs `step-b2-detected-erc20s.json` and `step-b2-discarded-erc20s.json`.
- **Step B3**: iterates over `options.extraErc20Contracts`. Reuses B2 holder data when available; otherwise calls `balanceOf` for every EOA from Step A. Outputs `step-b3-erc20-holders.json`.
- **Step C**: extended to incorporate SC-locked values from B2 detected ERC-20s.
- **Step D**: generates `BridgeExit` entries for ERC-20-locked balances from B2/B3.
- **config**: added `extraErc20Contracts` option; increased `defaultStepAWindowSize` from 5 000 to 150 000.
- Pipeline (`run.go`) updated to execute B2 and B3 between B and C.
- New types, RPC helpers, unit tests, docs and example config for the new steps.

## ⚠️ Breaking Changes
- 🛠️ **Config**: new optional field `options.extraErc20Contracts` (array of addresses). No breaking change — defaults to empty.

## 📋 Config Updates
```json
"options": {
  "stepAWindowSize": 150000,
  "extraErc20Contracts": ["0xTokenAddress1", "0xTokenAddress2"]
}
```

## ✅ Testing
- 🤖 **Automatic**: unit tests added for Step B2 (`step_b2_test.go`) and Step B3 (`step_b3_test.go`); Step C tests extended.
- 🖱️ **Manual**: run full pipeline with `extraErc20Contracts` populated and verify `step-b2-detected-erc20s.json`, `step-b3-erc20-holders.json` outputs.

## 🐞 Issues
- Closes https://github.com/agglayer/pm/issues/341

## 📝 Notes
- Step B3 short-circuits when `extraErc20Contracts` is empty — no RPC calls made.
- `defaultStepAWindowSize` raised to 150 000 to reduce RPC round-trips on chains with large block ranges.