### PR TITLE
fix: validate legacy checkpoint block against L1 in CheckValidBlock (#1638)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ data
 .vscode
 debug
 bin
+.claude/
+test.env

--- a/multidownloader/evm_multidownloader_reorg.go
+++ b/multidownloader/evm_multidownloader_reorg.go
@@ -37,7 +37,17 @@ func (dh *EVMMultidownloader) CheckValidBlock(ctx context.Context, blockNumber u
 			blockNumber, blockHash.Hex(), reorgID)
 		return false, reorgID, nil
 	}
-	// The block is neither stored nor recorded as reorged. This is the expected situation
+	if storedBlock != nil {
+		// We have a *different* block stored at this height and the requested hash is not recorded
+		// in blocks_reorged: this is a real (possibly undetected) reorg / inconsistent downloader DB.
+		// We must not validate it against L1 and accept it, otherwise we would mask a reorg without
+		// producing reorg data or stopping for repair.
+		return false, 0, fmt.Errorf(
+			"EVMMultidownloader.CheckValidBlock: blockNumber=%d, blockHash=%s not found in storage or blocks_reorged "+
+				"(a different block is stored at this height: %s)",
+			blockNumber, blockHash.Hex(), storedBlock.Hash.Hex())
+	}
+	// The block is absent from storage and not recorded as reorged. This is the expected situation
 	// after upgrading from the legacy syncer (issue #1638): the processor reports a checkpoint
 	// block that the legacy syncer downloaded and that this multidownloader storage never
 	// contained. Before treating it as an inconsistency, check against L1: if the block is at or

--- a/multidownloader/evm_multidownloader_reorg.go
+++ b/multidownloader/evm_multidownloader_reorg.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	mdrtypes "github.com/agglayer/aggkit/multidownloader/types"
+	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -36,10 +37,66 @@ func (dh *EVMMultidownloader) CheckValidBlock(ctx context.Context, blockNumber u
 			blockNumber, blockHash.Hex(), reorgID)
 		return false, reorgID, nil
 	}
-	// Not found anywhere, consider invalid
+	// The block is neither stored nor recorded as reorged. This is the expected situation
+	// after upgrading from the legacy syncer (issue #1638): the processor reports a checkpoint
+	// block that the legacy syncer downloaded and that this multidownloader storage never
+	// contained. Before treating it as an inconsistency, check against L1: if the block is at or
+	// below the finalized block it should be a stable, immutable block, so we can ask the RPC for
+	// the canonical block at that height and compare hashes.
+	return dh.checkValidBlockAgainstL1(ctx, blockNumber, blockHash)
+}
+
+// checkValidBlockAgainstL1 is the fallback for a block that is not present in the local storage
+// (neither in `blocks` nor in `blocks_reorged`). If the block is at or below the finalized block,
+// it queries L1 for the canonical block at that height and compares the hashes:
+//   - hashes match  -> the block is canonical, it just was never downloaded by this multidownloader
+//     (e.g. a legacy checkpoint after an upgrade, or a pruned block) -> valid.
+//   - hashes differ -> the requested block is on an orphaned branch of a finalized height,
+//     which is a severe inconsistency that requires manual intervention -> error.
+//
+// If the block is above the finalized block it is not stable yet, so we keep treating it as an
+// inconsistency and let the caller retry.
+func (dh *EVMMultidownloader) checkValidBlockAgainstL1(ctx context.Context, blockNumber uint64,
+	blockHash common.Hash) (bool, uint64, error) {
+	finalizedBlockNumber, err := dh.GetFinalizedBlockNumber(ctx)
+	if err != nil {
+		return true, 0, fmt.Errorf(
+			"EVMMultidownloader.CheckValidBlock: cannot get finalized block number for blockNumber=%d: %w",
+			blockNumber, err)
+	}
+	if blockNumber > finalizedBlockNumber {
+		// Not stable yet, can't safely validate against L1 by hash.
+		return false, 0, fmt.Errorf(
+			"EVMMultidownloader.CheckValidBlock: blockNumber=%d, blockHash=%s not found in storage or blocks_reorged "+
+				"(block is above finalized block %d)",
+			blockNumber, blockHash.Hex(), finalizedBlockNumber)
+	}
+
+	canonicalHeader, err := dh.ethClient.CustomHeaderByNumber(ctx, aggkittypes.NewBlockNumber(blockNumber))
+	if err != nil {
+		return true, 0, fmt.Errorf(
+			"EVMMultidownloader.CheckValidBlock: cannot get canonical header from L1 for blockNumber=%d: %w",
+			blockNumber, err)
+	}
+	if canonicalHeader == nil {
+		return true, 0, fmt.Errorf(
+			"EVMMultidownloader.CheckValidBlock: got nil canonical header from L1 for blockNumber=%d", blockNumber)
+	}
+
+	if canonicalHeader.Hash == blockHash {
+		dh.log.Infof("EVMMultidownloader.CheckValidBlock: blockNumber=%d, blockHash=%s not in storage but matches the "+
+			"canonical finalized block on L1; treating as valid (likely a legacy checkpoint after upgrade)",
+			blockNumber, blockHash.Hex())
+		return true, 0, nil
+	}
+
+	// The hash does not match the canonical finalized block: the requested block is on an orphaned
+	// branch of a finalized height. The multidownloader never observed this reorg, so it cannot
+	// produce reorg data; surface it as an error requiring manual intervention.
 	return false, 0, fmt.Errorf(
-		"EVMMultidownloader.CheckValidBlock: blockNumber=%d, blockHash=%s not found in storage or blocks_reorged",
-		blockNumber, blockHash.Hex())
+		"EVMMultidownloader.CheckValidBlock: blockNumber=%d, blockHash=%s does not match the canonical finalized "+
+			"block on L1 (canonical hash=%s); inconsistent state requires manual intervention",
+		blockNumber, blockHash.Hex(), canonicalHeader.Hash.Hex())
 }
 
 func (dh *EVMMultidownloader) GetReorgedDataByReorgID(ctx context.Context,

--- a/multidownloader/evm_multidownloader_reorg_test.go
+++ b/multidownloader/evm_multidownloader_reorg_test.go
@@ -241,6 +241,54 @@ func TestEVMMultidownloader_CheckValidBlock_LegacyCheckpointAfterUpgrade(t *test
 		require.False(t, isValid)
 		require.Equal(t, uint64(0), reorgID)
 	})
+
+	t.Run("finalized block lookup fails -> error (assumed valid for retry)", func(t *testing.T) {
+		testData := newEVMMultidownloaderTestData(t, false)
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(uint64(0), fmt.Errorf("rpc down")).Once()
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(
+			context.Background(), legacyCheckpointBlock, legacyCheckpointHash)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot get finalized block number")
+		require.True(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
+
+	t.Run("canonical header lookup fails -> error (assumed valid for retry)", func(t *testing.T) {
+		testData := newEVMMultidownloaderTestData(t, false)
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(finalizedBlock, nil).Once()
+		testData.mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(legacyCheckpointBlock)).
+			Return(nil, fmt.Errorf("rpc down")).Once()
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(
+			context.Background(), legacyCheckpointBlock, legacyCheckpointHash)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot get canonical header from L1")
+		require.True(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
+
+	t.Run("canonical header is nil -> error (assumed valid for retry)", func(t *testing.T) {
+		testData := newEVMMultidownloaderTestData(t, false)
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(finalizedBlock, nil).Once()
+		testData.mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(legacyCheckpointBlock)).
+			Return(nil, nil).Once()
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(
+			context.Background(), legacyCheckpointBlock, legacyCheckpointHash)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "got nil canonical header from L1")
+		require.True(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
 }
 
 func TestEVMMultidownloader_GetReorgedDataByReorgID(t *testing.T) {

--- a/multidownloader/evm_multidownloader_reorg_test.go
+++ b/multidownloader/evm_multidownloader_reorg_test.go
@@ -74,7 +74,7 @@ func TestEVMMultidownloader_CheckValidBlock(t *testing.T) {
 		require.Equal(t, expectedReorgID, reorgID)
 	})
 
-	t.Run("returns false when block not stored and not in blocks_reorged", func(t *testing.T) {
+	t.Run("returns false when block not stored, not in blocks_reorged and above finalized", func(t *testing.T) {
 		testData := newEVMMultidownloaderTestData(t, true)
 		blockNumber := uint64(100)
 		blockHash := common.HexToHash("0x1234")
@@ -83,6 +83,9 @@ func TestEVMMultidownloader_CheckValidBlock(t *testing.T) {
 			Return(nil, mdrtypes.NotFinalized, nil).Once()
 		testData.mockStorage.EXPECT().GetBlockReorgedReorgID(mock.Anything, blockNumber, blockHash).
 			Return(uint64(0), false, nil).Once()
+		// Block is above finalized -> not stable, cannot validate against L1, stays an error.
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(blockNumber-1, nil).Once()
 
 		isValid, reorgID, err := testData.mdr.CheckValidBlock(context.Background(), blockNumber, blockHash)
 
@@ -136,6 +139,79 @@ func TestEVMMultidownloader_CheckValidBlock(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot check blocks_reorged")
 		require.True(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
+}
+
+// TestEVMMultidownloader_CheckValidBlock_LegacyCheckpointAfterUpgrade covers issue #1638.
+//
+// Scenario: before upgrading to the multidownloader-based implementation, the legacy
+// l1infotreesync stopped on an "empty" checkpoint block (a block with no events that the
+// legacy syncer persisted in its own `block` table just to track progress). After upgrading,
+// the multidownloader driver resumes by calling processor.GetLastProcessedBlockHeader, which
+// returns that legacy checkpoint block (number + hash). That block was downloaded by the legacy
+// syncer and therefore never existed in the multidownloader's own (freshly created, empty)
+// storage. checkReorgedBlock -> CheckValidBlock is then asked to validate it.
+//
+// The block is not in `blocks` and not in `blocks_reorged`. Since it is at or below the finalized
+// block, CheckValidBlock asks L1 for the canonical block at that height and compares hashes:
+//   - canonical hash matches -> valid (the block is canonical, just never downloaded by us).
+//   - canonical hash differs -> error (orphaned finalized block, manual intervention).
+//
+// issue: https://github.com/agglayer/aggkit/issues/1638
+func TestEVMMultidownloader_CheckValidBlock_LegacyCheckpointAfterUpgrade(t *testing.T) {
+	// The legacy checkpoint block reported by processor.GetLastProcessedBlockHeader.
+	// It is not present in the multidownloader storage (neither in `blocks` nor `blocks_reorged`).
+	legacyCheckpointBlock := uint64(10995066)
+	legacyCheckpointHash := common.HexToHash(
+		"0x132592000000000000000000000000000000000000000000000000000000000")
+	finalizedBlock := uint64(11000000) // checkpoint is below finalized -> stable
+
+	t.Run("canonical hash matches -> valid (resume sync)", func(t *testing.T) {
+		// Real, empty storage: mimics the multidownloader storage right after the upgrade.
+		testData := newEVMMultidownloaderTestData(t, false)
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(finalizedBlock, nil).Once()
+		testData.mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(legacyCheckpointBlock)).
+			Return(&aggkittypes.BlockHeader{Number: legacyCheckpointBlock, Hash: legacyCheckpointHash}, nil).Once()
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(
+			context.Background(), legacyCheckpointBlock, legacyCheckpointHash)
+
+		require.NoError(t, err)
+		require.True(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
+
+	t.Run("canonical hash differs -> error (orphaned finalized block)", func(t *testing.T) {
+		testData := newEVMMultidownloaderTestData(t, false)
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(finalizedBlock, nil).Once()
+		testData.mockEthClient.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(legacyCheckpointBlock)).
+			Return(&aggkittypes.BlockHeader{Number: legacyCheckpointBlock, Hash: common.HexToHash("0xdead")}, nil).Once()
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(
+			context.Background(), legacyCheckpointBlock, legacyCheckpointHash)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not match the canonical finalized")
+		require.False(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
+
+	t.Run("block above finalized -> error (not stable yet)", func(t *testing.T) {
+		testData := newEVMMultidownloaderTestData(t, false)
+		testData.mockBlockNotifierManager.EXPECT().
+			GetCurrentBlockNumber(mock.Anything, mock.Anything).Return(legacyCheckpointBlock-1, nil).Once()
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(
+			context.Background(), legacyCheckpointBlock, legacyCheckpointHash)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "above finalized block")
+		require.False(t, isValid)
 		require.Equal(t, uint64(0), reorgID)
 	})
 }

--- a/multidownloader/evm_multidownloader_reorg_test.go
+++ b/multidownloader/evm_multidownloader_reorg_test.go
@@ -95,6 +95,33 @@ func TestEVMMultidownloader_CheckValidBlock(t *testing.T) {
 		require.Equal(t, uint64(0), reorgID)
 	})
 
+	t.Run("returns error (no L1 fallback) when a different block is stored and not in blocks_reorged", func(t *testing.T) {
+		// A different block is stored at this height and the requested hash is not recorded as
+		// reorged: this is a real/undetected reorg or inconsistent DB. It must NOT be validated
+		// against L1 (no finalized/RPC lookup) and must surface as an error so it is repaired.
+		testData := newEVMMultidownloaderTestData(t, true)
+		blockNumber := uint64(100)
+		blockHash := common.HexToHash("0x1234")
+
+		storedBlock := &aggkittypes.BlockHeader{
+			Number: blockNumber,
+			Hash:   common.HexToHash("0x5678"), // Different hash
+		}
+
+		testData.mockStorage.EXPECT().GetBlockHeaderByNumber(mock.Anything, blockNumber).
+			Return(storedBlock, mdrtypes.Finalized, nil).Once()
+		testData.mockStorage.EXPECT().GetBlockReorgedReorgID(mock.Anything, blockNumber, blockHash).
+			Return(uint64(0), false, nil).Once()
+		// No GetCurrentBlockNumber / CustomHeaderByNumber expectations: the L1 fallback must not run.
+
+		isValid, reorgID, err := testData.mdr.CheckValidBlock(context.Background(), blockNumber, blockHash)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "a different block is stored at this height")
+		require.False(t, isValid)
+		require.Equal(t, uint64(0), reorgID)
+	})
+
 	t.Run("returns false with reorgID when stored block hash does not match", func(t *testing.T) {
 		testData := newEVMMultidownloaderTestData(t, true)
 		blockNumber := uint64(100)


### PR DESCRIPTION
## 🔄 Changes Summary
- Fixes a sync failure loop in `l1infotreesync` after upgrading from the legacy syncer (e.g. 0.8.x) to the multidownloader-based implementation (#1638).
- Root cause: on upgrade the processor reports a last-processed **checkpoint block** (an "empty" block the legacy syncer persisted to track progress) that the legacy syncer downloaded, but the multidownloader's own freshly-created storage never contained it. `EVMMultidownloader.CheckValidBlock` then failed with `not found in storage or blocks_reorged`, leaving the syncer stuck with no self-recovery (manual DB deletion was the only workaround).
- Fix: when a block is neither in `blocks` nor in `blocks_reorged` and is **at or below the finalized block**, `CheckValidBlock` now validates it against L1 by fetching the canonical header at that height and comparing hashes:
  - **match** → the block is canonical, it just was never downloaded by this multidownloader (legacy checkpoint after upgrade, or pruned block) → **valid**, the syncer resumes from `lastBlock+1`.
  - **differ** → the block is on an orphaned branch of a finalized height → **error** (severe inconsistency requiring manual intervention).
  - Blocks **above** the finalized block are not stable and keep the previous error behaviour.

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `TestEVMMultidownloader_CheckValidBlock_LegacyCheckpointAfterUpgrade` (real empty storage) covering the three paths: canonical hash matches → valid; canonical hash differs → error; block above finalized → error. Existing `CheckValidBlock` mock tests updated for the new finalized lookup.
- 🖱️ **Manual**: N/A.

## 🐞 Issues
- Closes #1638

## 🔗 Related PRs
- N/A

## 📝 Notes
- The fix lives in the multidownloader layer (`CheckValidBlock`), where the error surfaces. The validation is gated on `blockNumber <= finalized` so the extra RPC call only happens for stable blocks, and only while the missing block is being resolved (transient, during the legacy→multidownloader transition; once the first blocks are downloaded and stored, the processor advances into the known range and this branch no longer fires).
- On a canonical hash mismatch of a finalized block, the multidownloader cannot synthesize a reorg it never observed, so it surfaces a descriptive error rather than fabricating reorg data.
