### PR TITLE
feat: test(exit-certificate): add E2E harness, bridge/status scripts and CI workflow

### DIFF
--- a/.github/workflows/test-e2e-exit_cenrtificate_tool.yml
+++ b/.github/workflows/test-e2e-exit_cenrtificate_tool.yml
@@ -1,0 +1,52 @@
+# Runs the exit-certificate tool E2E test.
+# Triggers only when a PR touches files under tools/exit_certificate/** (or the
+# test harness / this workflow itself). The test spins up a Kurtosis CDK
+# network, prepares a settled certificate and runs the exit_certificate tool.
+name: Test E2E exit-certificate tool
+
+on:
+  pull_request:
+    paths:
+      - "tools/exit_certificate/**"
+      - "test/e2e-exit_certificate/**"
+      - ".github/workflows/test-e2e-exit_cenrtificate_tool.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-e2e-exit-certificate:
+    name: Exit-certificate tool E2E
+    runs-on: amd-runner-2204
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.7
+
+      - name: Install Foundry (cast/forge)
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install Kurtosis CLI
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" \
+            | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install -y kurtosis-cli
+          kurtosis analytics disable
+          kurtosis version
+
+      - name: Run exit-certificate E2E test
+        run: ./test/e2e-exit_certificate/run_e2e_test.sh
+
+      - name: Stop Kurtosis enclave
+        if: always()
+        run: ./test/e2e-exit_certificate/run_network.sh stop || true

--- a/.github/workflows/test-e2e-exit_cenrtificate_tool.yml
+++ b/.github/workflows/test-e2e-exit_cenrtificate_tool.yml
@@ -33,7 +33,7 @@ jobs:
           go-version: 1.25.7
 
       - name: Install Foundry (cast/forge)
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Install Kurtosis CLI
         run: |

--- a/.github/workflows/test-e2e-exit_cenrtificate_tool.yml
+++ b/.github/workflows/test-e2e-exit_cenrtificate_tool.yml
@@ -45,6 +45,8 @@ jobs:
           kurtosis version
 
       - name: Run exit-certificate E2E test
+        env:
+          VERBOSE: "1"
         run: ./test/e2e-exit_certificate/run_e2e_test.sh
 
       - name: Stop Kurtosis enclave

--- a/test/e2e-exit_certificate/claim_exit_certificate_funds.sh
+++ b/test/e2e-exit_certificate/claim_exit_certificate_funds.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Claims the exit-certificate funds on L1 after the L2 network has been halted.
+#
+# Two steps:
+#   1. Build and start the exit_certificate_claimer HTTP service, deriving its
+#      config from the exit_certificate config produced earlier
+#      (tmp/exit_certificate-kurtosis.json). The service only binds its port once
+#      its L1 Info Tree is synced up to the certificate's settlement GER, so we
+#      poll /claimer/v1/health until it is ready.
+#   2. Run tools/exit_certificate_claimer/scripts/claim-all.sh against it, which
+#      claims every pending bridge exit for all tracked addresses (the EOAs plus
+#      the config's exitAddress).
+#
+# The background service is always stopped on exit.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helper.sh"
+
+AGGKIT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CLAIMER_SCRIPT_DIR="${AGGKIT_DIR}/tools/exit_certificate_claimer/scripts"
+CLAIMER_BIN="${AGGKIT_DIR}/target/exit_certificate_claimer"
+EXIT_CERT_CONFIG="${EXIT_CERT_CONFIG:-${AGGKIT_DIR}/tmp/exit_certificate-kurtosis.json}"
+
+# Bind host/port for the claimer. Defaults match claim-all.sh's CLAIMER_URL.
+CLAIMER_HOST="${CLAIMER_HOST:-127.0.0.1}"
+CLAIMER_PORT="${CLAIMER_PORT:-7080}"
+CLAIMER_URL="http://${CLAIMER_HOST}:${CLAIMER_PORT}"
+# How long to wait for the claimer to finish its initial L1 sync and bind.
+CLAIMER_READY_TIMEOUT="${CLAIMER_READY_TIMEOUT:-300}"
+
+CLAIMER_PID=""
+CLAIMER_LOG="$(mktemp -t exit_certificate_claimer.XXXXXX.log)"
+
+cleanup() {
+    if [[ -n "$CLAIMER_PID" ]] && kill -0 "$CLAIMER_PID" 2>/dev/null; then
+        log_info "🛑 Stopping exit_certificate_claimer service (pid $CLAIMER_PID)"
+        kill "$CLAIMER_PID" 2>/dev/null || true
+        wait "$CLAIMER_PID" 2>/dev/null || true
+    fi
+    rm -f "$CLAIMER_LOG"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$EXIT_CERT_CONFIG" ]]; then
+    log_error "exit_certificate config not found: $EXIT_CERT_CONFIG"
+    log_error "Run the exit tool first (run_exit_tool.sh) to generate it."
+    exit 1
+fi
+
+log_info "🛠️ Build exit_certificate_claimer"
+pushd "${AGGKIT_DIR}" >/dev/null
+run_quiet make build-exit_certificate_claimer
+popd >/dev/null
+
+log_info "🚀 Start exit_certificate_claimer service on ${CLAIMER_URL}"
+log_info "   config (derived from): $EXIT_CERT_CONFIG"
+log_info "   logs:                  $CLAIMER_LOG"
+"$CLAIMER_BIN" \
+    --exit-certificate-config "$EXIT_CERT_CONFIG" \
+    --address "$CLAIMER_HOST" \
+    --port "$CLAIMER_PORT" \
+    >"$CLAIMER_LOG" 2>&1 &
+CLAIMER_PID=$!
+
+log_info "⏳ Wait for the claimer to sync L1 and become ready (timeout ${CLAIMER_READY_TIMEOUT}s)"
+health_url="${CLAIMER_URL}/claimer/v1/health"
+ready=0
+for (( i=0; i<CLAIMER_READY_TIMEOUT; i++ )); do
+    if ! kill -0 "$CLAIMER_PID" 2>/dev/null; then
+        log_error "Claimer process exited before becoming ready. Logs:"
+        cat "$CLAIMER_LOG" >&2
+        exit 1
+    fi
+    if curl -sf "$health_url" >/dev/null 2>&1; then
+        ready=1
+        break
+    fi
+    sleep 1
+done
+
+if [[ "$ready" -ne 1 ]]; then
+    log_error "Claimer did not become ready within ${CLAIMER_READY_TIMEOUT}s. Logs:"
+    cat "$CLAIMER_LOG" >&2
+    exit 1
+fi
+log_info "✅ Claimer is ready: $health_url"
+
+log_info "💰 Claim all pending bridge exits"
+CLAIMER_URL="$CLAIMER_URL" ASSUME_YES=1 \
+    "${CLAIMER_SCRIPT_DIR}/claim-all.sh" "$EXIT_CERT_CONFIG"
+
+log_info "✅ Done, exit-certificate funds claimed."

--- a/test/e2e-exit_certificate/helper.sh
+++ b/test/e2e-exit_certificate/helper.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Shared helpers for the e2e-exit_certificate scripts: colors and logging.
+# Source it from a script with:
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/helper.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+log_warn() { echo -e "${ORANGE}[WARN]${NC} $*" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# Number of trailing output lines shown live by run_quiet.
+RUN_QUIET_TAIL="${RUN_QUIET_TAIL:-3}"
+
+# run_quiet runs a command capturing all its output (stdout + stderr) to a temp
+# file. While it runs, the last RUN_QUIET_TAIL emitted lines are shown in a
+# fixed block that is redrawn in place (ANSI) on each new line. On success it
+# clears the block; on failure it dumps the whole output and propagates the
+# exit code.
+# Set VERBOSE=1 to disable all of this: the command's output is shown in full
+# as it runs, with no temp file and no fixed block.
+run_quiet() {
+    # VERBOSE=1: show every line as it comes, no hidden tail block and no temp
+    # file. Output streams straight through; we just propagate the exit code.
+    if [[ "${VERBOSE:-}" == "1" ]]; then
+        local rc=0
+        "$@" || rc=$?
+        (( rc != 0 )) && log_error "Command failed: $*"
+        return "$rc"
+    fi
+    local out rc cols n
+    out="$(mktemp)"
+    cols=$(tput cols 2>/dev/null || echo 80)
+    n=$RUN_QUIET_TAIL
+    # Pipe through a reader that saves every line and live-prints the last n.
+    # Inside `if` so `set -e` doesn't abort on a failing command; pipefail makes
+    # the pipeline status reflect the command (the reader always exits 0).
+    if "$@" 2>&1 | {
+        local -a last=()
+        local k pad
+        # Reserve n lines so the block always exists (even with no output yet),
+        # which keeps the cursor math identical on every redraw and on cleanup.
+        [[ -t 2 ]] && printf '\n%.0s' $(seq "$n") >&2
+        while IFS= read -r line; do
+            printf '%s\n' "$line" >>"$out"
+            if [[ -t 2 ]]; then
+                last+=("$line")
+                (( ${#last[@]} > n )) && last=("${last[@]:1}")
+                # Move to the top of the block, then redraw exactly n lines.
+                printf '\033[%dA' "$n" >&2
+                pad=$(( n - ${#last[@]} ))
+                for (( k=0; k<n; k++ )); do
+                    if (( k < pad )); then
+                        # \r col 0, \033[K clears the line; blank padding line.
+                        printf '\r\033[K\n' >&2
+                    else
+                        printf '\r\033[K\t --- %.*s\n' "$cols" "${last[k-pad]}" >&2
+                    fi
+                done
+            fi
+        done
+    }; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [[ $rc -eq 0 ]]; then
+        # Move up over the block and erase it to the end of the screen.
+        [[ -t 2 ]] && printf '\033[%dA\033[J' "$n" >&2
+        tail -n 1 "$out"
+        rm -f "$out"
+    else
+        [[ -t 2 ]] && printf '\033[%dA\033[J' "$n" >&2
+        log_error "Command failed: $*"
+        cat "$out" >&2
+        rm -f "$out"
+        return "$rc"
+    fi
+}

--- a/test/e2e-exit_certificate/prepare_network.sh
+++ b/test/e2e-exit_certificate/prepare_network.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helper.sh"
+
+EXIT_CETIFICATE_SCRIPT_DIR="${SCRIPT_DIR}/../../tools/exit_certificate/scripts"
+
+#
+# First we need a settled certificate, for that we need
+# a bridge L2 -> L1 to produce this certificate. 
+# for that we need first a L1 -> L2 to don't run underbalance tree error
+
+log_info "🛠️ Set kurtosis env variables"
+source <("${EXIT_CETIFICATE_SCRIPT_DIR}/export_kurtosis_env.sh" 1)
+
+log_info "🔗 Run L1 -> L2 bridge to have funds in L2 (autoclaimed by zkevm-bridge-service)"
+run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/bridge_l1_to_l2.sh" --amount 98476876062940103 --wait
+
+log_info "🔗 Run L2 -> L1 bridge to produce a certificate"
+run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/bridge_l2_to_l1.sh" --amount 1
+
+log_info "⏳ Wait for the certificate to be settled"
+run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/agglayer_certificate_status.sh" --wait
+
+log_info "🛑 Stop aggsender to avoid new certificates to be produced"
+kurtosis service stop aggkit aggkit-001
+
+log_info "✅ Done, the network is ready for exit-certificate tests"

--- a/test/e2e-exit_certificate/prepare_network.sh
+++ b/test/e2e-exit_certificate/prepare_network.sh
@@ -23,7 +23,4 @@ run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/bridge_l2_to_l1.sh" --amount 1
 log_info "⏳ Wait for the certificate to be settled"
 run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/agglayer_certificate_status.sh" --wait
 
-log_info "🛑 Stop aggsender to avoid new certificates to be produced"
-kurtosis service stop aggkit aggkit-001
-
 log_info "✅ Done, the network is ready for exit-certificate tests"

--- a/test/e2e-exit_certificate/run_e2e_test.sh
+++ b/test/e2e-exit_certificate/run_e2e_test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helper.sh"
+
+log_info "🛠️ Run network"
+run_quiet "${SCRIPT_DIR}/run_network.sh" restart
+
+log_info "🛠️ Prepare network for exit-certificate tests"
+run_quiet "${SCRIPT_DIR}/prepare_network.sh"
+
+log_info "🌇 sunset network"
+run_quiet "${SCRIPT_DIR}/run_exit_tool.sh"

--- a/test/e2e-exit_certificate/run_e2e_test.sh
+++ b/test/e2e-exit_certificate/run_e2e_test.sh
@@ -4,11 +4,51 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helper.sh"
 
-log_info "🛠️ Run network"
-run_quiet "${SCRIPT_DIR}/run_network.sh" restart
+SKIP_RUN_NETWORK=0
+
+usage() {
+    cat >&2 <<EOF
+Usage: ${0##*/} [options]
+
+Options:
+  -s, --skip-run-network  Skip the "Run network" step (run_network.sh restart).
+  -h, --help              Show this help message and exit.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -s|--skip-run-network)
+            SKIP_RUN_NETWORK=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_error "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "${SKIP_RUN_NETWORK}" == "1" ]]; then
+    log_warn "⏭️  Skipping 'Run network' step"
+else
+    log_info "🛠️ Run network"
+    run_quiet "${SCRIPT_DIR}/run_network.sh" restart
+fi
 
 log_info "🛠️ Prepare network for exit-certificate tests"
 run_quiet "${SCRIPT_DIR}/prepare_network.sh"
 
 log_info "🌇 sunset network"
 run_quiet "${SCRIPT_DIR}/run_exit_tool.sh"
+
+log_info "Stop sequencer"
+run_quiet "${SCRIPT_DIR}/stop_sequencer.sh"
+
+log_info "Claim funds"
+run_quiet "${SCRIPT_DIR}/claim_exit_certificate_funds.sh"

--- a/test/e2e-exit_certificate/run_exit_tool.sh
+++ b/test/e2e-exit_certificate/run_exit_tool.sh
@@ -17,6 +17,14 @@ log_info "📖 Create configuration"
 run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/configuration_based_on_kurtosis.sh"
 
 log_info "🌇 Execute tool to sunset kurtosis network"
-run_quiet "${AGGKIT_DIR}/target/exit_certificate" --config tmp/exit_certificate-kurtosis.json 
+run_quiet "${AGGKIT_DIR}/target/exit_certificate" --config tmp/exit_certificate-kurtosis.json
+
+# runAll stops at SIGN; SUBMIT and WAIT must be requested explicitly. Submit the
+# signed exit certificate to agglayer and wait for it to settle on L1 — this is
+# what produces step-submit-result.json and step-wait-result.json, the L1
+# settlement record the claimer anchors the claim to. Done here, while agglayer
+# and L1 are fully operational, before the L2 network is stopped.
+log_info "📤 Submit exit certificate to agglayer and wait for L1 settlement"
+run_quiet "${AGGKIT_DIR}/target/exit_certificate" --config tmp/exit_certificate-kurtosis.json --step submit,wait
 
 

--- a/test/e2e-exit_certificate/run_exit_tool.sh
+++ b/test/e2e-exit_certificate/run_exit_tool.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helper.sh"
+
+AGGKIT_DIR="${SCRIPT_DIR}/../../"
+EXIT_CETIFICATE_SCRIPT_DIR="${SCRIPT_DIR}/../../tools/exit_certificate/scripts"
+
+
+log_info "🛠️ Build exit_tool"
+pushd "${AGGKIT_DIR}" >/dev/null
+run_quiet make build-exit_certificate
+popd >/dev/null
+
+log_info "📖 Create configuration"
+run_quiet "${EXIT_CETIFICATE_SCRIPT_DIR}/configuration_based_on_kurtosis.sh"
+
+log_info "🌇 Execute tool to sunset kurtosis network"
+run_quiet "${AGGKIT_DIR}/target/exit_certificate" --config tmp/exit_certificate-kurtosis.json 
+
+

--- a/test/e2e-exit_certificate/run_network.sh
+++ b/test/e2e-exit_certificate/run_network.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helper.sh"
+
+# Pinned Kurtosis CDK commit for the exit-certificate environment.
+KURTOSIS_CDK_COMMIT="507e4e8e6581ab5ecbb44444f9b7f1d05e3dcd1c"
+KURTOSIS_CDK_REPO_URL="https://github.com/0xPolygon/kurtosis-cdk.git"
+ENCLAVE_NAME="aggkit"
+ARGS_FILE="$SCRIPT_DIR/single_op_pessimistic_args.json"
+
+# Variable for the temporary clone
+TEMP_KURTOSIS_DIR=""
+
+trap 'log_error "Script failed at line $LINENO"' ERR
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 <command>
+
+Manage the exit-certificate Kurtosis environment.
+
+Commands:
+  start   Clone Kurtosis CDK (pinned commit) if needed and run the
+          '$ENCLAVE_NAME' enclave with $(basename "$ARGS_FILE").
+          Does nothing if the enclave already exists.
+  stop    Remove the '$ENCLAVE_NAME' enclave if it exists.
+  restart Remove the '$ENCLAVE_NAME' enclave (if any) and start it again.
+  status  Show whether the '$ENCLAVE_NAME' enclave exists and, if so,
+          print 'kurtosis enclave inspect $ENCLAVE_NAME'.
+
+Examples:
+  $0 start
+  $0 stop
+  $0 restart
+  $0 status
+EOF
+    exit 1
+}
+
+name_temp_kurtosis_dir() {
+    local _commit="$1"
+    echo "${TMPDIR:-/tmp}/kurtosis_${_commit}"
+}
+
+# Return 0 if the Kurtosis enclave exists, 1 otherwise
+enclave_exists() {
+    kurtosis enclave inspect "$ENCLAVE_NAME" >/dev/null 2>&1
+}
+
+# Clone Kurtosis CDK repo to temporary directory at the pinned commit
+clone_kurtosis_repo() {
+    local expected_commit="$1"
+    local dir
+    dir=$(name_temp_kurtosis_dir "$expected_commit")
+
+    if [ -d "$dir" ]; then
+        log_info "Temporary directory for Kurtosis already exists: $dir"
+        log_info "Reusing existing directory..."
+        echo "$dir"
+        return
+    fi
+    TEMP_KURTOSIS_DIR="$dir"
+    mkdir -p "$TEMP_KURTOSIS_DIR"
+    log_info "Cloning Kurtosis CDK repo to temporary directory..."
+    log_info "Temporary directory: $TEMP_KURTOSIS_DIR"
+
+    if ! git clone --quiet "$KURTOSIS_CDK_REPO_URL" "$TEMP_KURTOSIS_DIR"; then
+        log_error "Failed to clone Kurtosis CDK repository"
+        exit 1
+    fi
+
+    log_info "Successfully cloned Kurtosis CDK repository"
+    log_info "Checking out commit $expected_commit..."
+
+    if ! git -C "$TEMP_KURTOSIS_DIR" checkout --quiet "$expected_commit"; then
+        log_error "Failed to checkout commit $expected_commit"
+        exit 1
+    fi
+
+    log_info "Successfully checked out expected commit"
+    echo "$TEMP_KURTOSIS_DIR"
+}
+
+start_environment() {
+    log_info "Starting exit-certificate Kurtosis environment..."
+
+    if enclave_exists; then
+        log_warn "Enclave '$ENCLAVE_NAME' already exists. Nothing to do."
+        log_warn "Run '$0 stop' first if you want to recreate it."
+        return
+    fi
+
+    if [ ! -f "$ARGS_FILE" ]; then
+        log_error "Args file not found: $ARGS_FILE"
+        exit 1
+    fi
+
+    local kurtosis_repo_path
+    local kurtosis_repo_status
+    local default_dir
+    default_dir=$(name_temp_kurtosis_dir "$KURTOSIS_CDK_COMMIT")
+    if [ -d "$default_dir" ]; then
+        log_info "Found existing Kurtosis CDK repo at default location: $default_dir"
+        kurtosis_repo_path="$default_dir"
+        kurtosis_repo_status="reused (already present, not cloned)"
+    else
+        kurtosis_repo_path=$(clone_kurtosis_repo "$KURTOSIS_CDK_COMMIT")
+        if [ -n "$TEMP_KURTOSIS_DIR" ]; then
+            kurtosis_repo_status="cloned (commit $KURTOSIS_CDK_COMMIT)"
+        else
+            kurtosis_repo_status="reused (already present, not cloned)"
+        fi
+    fi
+
+    log_info "Using Kurtosis CDK repo at: $kurtosis_repo_path"
+
+    # Sync local aggkit-config.toml into the Kurtosis template if it exists locally.
+    local local_config_file="$SCRIPT_DIR/config/aggkit-config.toml"
+    local kurtosis_template_file="$kurtosis_repo_path/static_files/chain/shared/aggkit/config.toml"
+    local config_overwritten="no"
+    local config_source="-"
+
+    if [ -f "$local_config_file" ]; then
+        if [ -f "$kurtosis_template_file" ]; then
+            log_warn "OVERWRITING Kurtosis aggkit-config.toml template with local config:"
+            log_warn "  source (local):       $local_config_file"
+            log_warn "  destination (kurtosis): $kurtosis_template_file"
+            cp "$local_config_file" "$kurtosis_template_file"
+            log_info "Kurtosis aggkit-config.toml template overwritten successfully."
+            config_overwritten="yes"
+            config_source="$local_config_file"
+        else
+            log_warn "Kurtosis template not found at: $kurtosis_template_file"
+            log_warn "Skipping aggkit-config.toml sync."
+        fi
+    else
+        log_info "No local aggkit-config.toml found at: $local_config_file"
+        log_info "Using the Kurtosis CDK default aggkit-config.toml template."
+    fi
+
+    pushd "$kurtosis_repo_path" >/dev/null
+    log_info "Starting Kurtosis enclave '$ENCLAVE_NAME' with args file: $ARGS_FILE"
+    kurtosis run --enclave "$ENCLAVE_NAME" --args-file "$ARGS_FILE" . 
+    log_info "$ENCLAVE_NAME enclave started successfully."
+    popd >/dev/null
+
+    # Summary of what was set up
+    log_info "================ Environment summary ================"
+    log_info "Kurtosis CDK repo path : $kurtosis_repo_path"
+    log_info "Kurtosis CDK repo      : $kurtosis_repo_status"
+    if [ "$config_overwritten" = "yes" ]; then
+        log_info "aggkit config          : OVERWRITTEN"
+        log_info "  with local file      : $config_source"
+        log_info "  into kurtosis file   : $kurtosis_template_file"
+    else
+        log_info "aggkit config          : NOT overwritten (using Kurtosis default)"
+    fi
+    log_info "===================================================="
+}
+
+stop_environment() {
+    log_info "Stopping exit-certificate Kurtosis environment..."
+
+    if ! enclave_exists; then
+        log_warn "Enclave '$ENCLAVE_NAME' does not exist. Nothing to do."
+        return
+    fi
+
+    log_info "Removing enclave '$ENCLAVE_NAME'..."
+    kurtosis enclave rm --force "$ENCLAVE_NAME"
+    kurtosis clean
+    log_info "Enclave '$ENCLAVE_NAME' removed successfully."
+}
+
+restart_environment() {
+    log_info "Restarting exit-certificate Kurtosis environment..."
+    stop_environment
+    start_environment
+}
+
+status_environment() {
+    if enclave_exists; then
+        log_info "Enclave '$ENCLAVE_NAME' exists."
+        kurtosis enclave inspect "$ENCLAVE_NAME"
+    else
+        log_warn "Enclave '$ENCLAVE_NAME' does not exist."
+    fi
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+case "$1" in
+    start)
+        start_environment
+        ;;
+    stop)
+        stop_environment
+        ;;
+    restart)
+        restart_environment
+        ;;
+    status)
+        status_environment
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/test/e2e-exit_certificate/run_network.sh
+++ b/test/e2e-exit_certificate/run_network.sh
@@ -163,15 +163,9 @@ start_environment() {
 stop_environment() {
     log_info "Stopping exit-certificate Kurtosis environment..."
 
-    if ! enclave_exists; then
-        log_warn "Enclave '$ENCLAVE_NAME' does not exist. Nothing to do."
-        return
-    fi
-
-    log_info "Removing enclave '$ENCLAVE_NAME'..."
-    kurtosis enclave rm --force "$ENCLAVE_NAME"
-    kurtosis clean
-    log_info "Enclave '$ENCLAVE_NAME' removed successfully."
+    log_info "Removing all enclaves"
+    kurtosis clean --all
+    log_info "All enclaves removed successfully."
 }
 
 restart_environment() {

--- a/test/e2e-exit_certificate/single_op_pessimistic_args.json
+++ b/test/e2e-exit_certificate/single_op_pessimistic_args.json
@@ -1,0 +1,34 @@
+{
+  "deployment_stages": {
+    "deploy_op_succinct": false,
+    "deploy_cdk_bridge_infra": true
+  },
+  "args": {
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.8.3-rc3",
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.5.0",
+    "zkevm_bridge_service_image": "ghcr.io/0xpolygon/zkevm-bridge-service:v0.6.3",
+    "consensus_contract_type": "ecdsa-multisig",
+    "use_agg_sender_validator": false,
+    "agg_sender_multisig_threshold": 1,
+    "agg_sender_validator_total_number": 0,
+    "log_level": "debug",
+    "additional_services": [],
+    "binary_name": "aggkit",
+    "aggkit_components": "aggsender,aggoracle",
+    "l2_chain_id": 20201,
+    "l2_network_id": 1
+  },
+  "optimism_package": {
+    "predeployed_contracts": true,
+    "chains": {
+      "001": {
+        "proposer_params": {
+          "enabled": false
+        },
+        "network_params": {
+          "network_id": "20201"
+        }
+      }
+    }
+  }
+}

--- a/test/e2e-exit_certificate/stop_sequencer.sh
+++ b/test/e2e-exit_certificate/stop_sequencer.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Stops the whole L2 OP stack (execution client, consensus/op-node, batcher and
+# proposer) of a running Kurtosis enclave to simulate that the L2 network has
+# been deprecated and halted. The exit-certificate claim flow must keep working
+# against L1 even though the L2 is no longer producing blocks nor reachable.
+#
+# Services are discovered dynamically from the enclave: every service whose name
+# matches the OP stack pattern for the target network is stopped. This is robust
+# against naming variations between Kurtosis package versions.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helper.sh"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [OPTIONS] [NETWORK_INDEX]
+
+Stops the whole L2 OP stack (op-el, op-cl/op-node, op-batcher, op-proposer) of a
+running Kurtosis enclave to simulate a deprecated/halted L2 network.
+
+Arguments:
+  NETWORK_INDEX   L2 network index to target (default: 1 -> service suffix 001)
+
+Options:
+  -e, --enclave   ENCLAVE    Kurtosis enclave name (default: \$KURTOSIS_ENCLAVE or "aggkit")
+  -h, --help                 Show this help
+
+Environment variables (override defaults):
+  KURTOSIS_ENCLAVE      Enclave name (default: aggkit)
+  L2_SERVICE_PATTERN    Regex matching the L2 OP stack service names to stop
+                        (default: ^op-.*-NNN\$, where NNN is the network suffix)
+
+Examples:
+  $0                          # Network 1, enclave "aggkit"
+  $0 2                        # Network 2 (services *-002)
+  $0 --enclave op 1
+EOF
+    exit 1
+}
+
+KURTOSIS_ENCLAVE="${KURTOSIS_ENCLAVE:-aggkit}"
+NETWORK_INDEX=1
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage ;;
+        -e|--enclave)
+            [[ $# -lt 2 ]] && { log_error "--enclave requires a value"; usage; }
+            KURTOSIS_ENCLAVE="$2"; shift 2 ;;
+        [0-9]*)
+            NETWORK_INDEX="$1"; shift ;;
+        *)
+            log_error "Unknown argument: $1"; usage ;;
+    esac
+done
+
+command -v kurtosis &>/dev/null || { log_error "Missing required tool: kurtosis"; exit 1; }
+
+NETWORK_SUFFIX=$(printf '%03d' "$NETWORK_INDEX")
+# By default match every OP stack service for this network: op-el-*, op-cl-*,
+# op-batcher-*, op-proposer-*, ... all sharing the -NNN suffix.
+L2_SERVICE_PATTERN="${L2_SERVICE_PATTERN:-^op-.*-${NETWORK_SUFFIX}\$}"
+
+log_info "Enclave:         $KURTOSIS_ENCLAVE"
+log_info "Network suffix:  $NETWORK_SUFFIX"
+log_info "Service pattern: $L2_SERVICE_PATTERN"
+
+if ! kurtosis enclave inspect "$KURTOSIS_ENCLAVE" >/dev/null 2>&1; then
+    log_error "Enclave '$KURTOSIS_ENCLAVE' does not exist or is not running."
+    log_error "Check with: kurtosis enclave ls"
+    exit 1
+fi
+
+# Discover the L2 OP stack services from the "User Services" table of
+# kurtosis enclave inspect. Service rows start with a 12-hex UUID in column 1
+# and the service name in column 2 (multi-port continuation lines have no UUID,
+# so they are skipped). Restrict to the User Services section to avoid matching
+# the Files Artifacts table, then filter by pattern.
+mapfile -t SERVICES < <(
+    kurtosis enclave inspect "$KURTOSIS_ENCLAVE" 2>/dev/null \
+        | sed -n '/User Services/,$p' \
+        | awk 'NF && $1 ~ /^[0-9a-f]{12}$/ {print $2}' \
+        | grep -E "$L2_SERVICE_PATTERN" || true
+)
+
+if [[ ${#SERVICES[@]} -eq 0 ]]; then
+    log_warn "No services matching '$L2_SERVICE_PATTERN' found in enclave '$KURTOSIS_ENCLAVE'."
+    log_warn "Nothing to stop. Inspect with: kurtosis enclave inspect $KURTOSIS_ENCLAVE"
+    exit 0
+fi
+
+log_info "🛑 Stopping ${#SERVICES[@]} L2 service(s) to simulate a deprecated/halted network:"
+for svc in "${SERVICES[@]}"; do
+    log_info "  - $svc"
+done
+
+failed=0
+for svc in "${SERVICES[@]}"; do
+    if kurtosis service stop "$KURTOSIS_ENCLAVE" "$svc"; then
+        log_info "Stopped '$svc'."
+    else
+        log_error "Failed to stop service '$svc'."
+        failed=1
+    fi
+done
+
+if [[ $failed -ne 0 ]]; then
+    log_error "One or more L2 services could not be stopped."
+    exit 1
+fi
+
+log_info "✅ L2 network stopped: all matching OP stack services have been halted."

--- a/tools/exit_certificate/scripts/agglayer_certificate_status.sh
+++ b/tools/exit_certificate/scripts/agglayer_certificate_status.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Shows the status and height of the latest agglayer certificate for an L2 network,
+# using the same agglayer gRPC client as the exit_certificate tool (so it works even
+# when the agglayer node's gRPC reflection is incomplete). With --wait it polls until
+# the latest certificate settles.
+#
+# Connection info is taken from the environment — this script never talks to Kurtosis.
+# Populate the variables first with:
+#   source <(tools/exit_certificate/scripts/export_kurtosis_env.sh 1)
+# Requires: go (the helper is run via `go run`).
+#
+# Required environment variables:
+#   AGGLAYER_GRPC_URL   agglayer gRPC endpoint (e.g. http://localhost:PORT)
+# Optional:
+#   NETWORK_INDEX       default L2 network id (overridden by -n/--network)
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [OPTIONS]
+
+Shows the status and height of the latest agglayer certificate for an L2 network.
+Uses the agglayer gRPC client (GetLatestCertificateHeader + GetNetworkInfo).
+
+Options:
+  -n, --network   NETWORK_ID   L2 network id (default: \$NETWORK_INDEX or 1)
+  -w, --wait                   Poll until the latest certificate is Settled
+  -i, --interval  DURATION     Poll interval with --wait (default: 5s)
+  -t, --timeout   DURATION     Max time to wait with --wait, 0 = no limit (default: 10m)
+      --tls                    Use TLS for the gRPC connection
+  -h, --help                   Show this help
+
+DURATION accepts Go duration syntax (e.g. 5s, 1m, 10m, 1h).
+
+Required environment variables:
+  AGGLAYER_GRPC_URL            agglayer gRPC endpoint (e.g. http://localhost:PORT)
+  Tip: source <(tools/exit_certificate/scripts/export_kurtosis_env.sh NETWORK_ID)
+
+Examples:
+  source <(tools/exit_certificate/scripts/export_kurtosis_env.sh 1)
+  $0                       # Show latest certificate status + height for network 1
+  $0 -n 2                  # Network 2
+  $0 --wait                # Wait until the latest certificate settles
+  $0 --wait --timeout 0    # Wait forever
+EOF
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Defaults / args
+# ---------------------------------------------------------------------------
+
+NETWORK_ID="${NETWORK_INDEX:-1}"
+WAIT_FOR_SETTLED=false
+POLL_INTERVAL="5s"
+POLL_TIMEOUT="10m"
+USE_TLS=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage ;;
+        -n|--network)
+            [[ $# -lt 2 ]] && { log_error "--network requires a value"; usage; }
+            NETWORK_ID="$2"; shift 2 ;;
+        -w|--wait)
+            WAIT_FOR_SETTLED=true; shift ;;
+        -i|--interval)
+            [[ $# -lt 2 ]] && { log_error "--interval requires a value"; usage; }
+            POLL_INTERVAL="$2"; shift 2 ;;
+        -t|--timeout)
+            [[ $# -lt 2 ]] && { log_error "--timeout requires a value"; usage; }
+            POLL_TIMEOUT="$2"; shift 2 ;;
+        --tls)
+            USE_TLS=true; shift ;;
+        *)
+            log_error "Unknown argument: $1"; usage ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+if ! command -v go &>/dev/null; then
+    log_error "Missing required tool: go"
+    exit 1
+fi
+
+if [[ -z "${AGGLAYER_GRPC_URL:-}" ]]; then
+    log_error "Missing required environment variable: AGGLAYER_GRPC_URL"
+    log_error "Populate it with: source <(tools/exit_certificate/scripts/export_kurtosis_env.sh $NETWORK_ID)"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run the Go helper
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+ARGS=(-grpc "$AGGLAYER_GRPC_URL" -network "$NETWORK_ID")
+[[ "$USE_TLS" == "true" ]] && ARGS+=(-tls)
+if [[ "$WAIT_FOR_SETTLED" == "true" ]]; then
+    ARGS+=(-wait -interval "$POLL_INTERVAL" -timeout "$POLL_TIMEOUT")
+fi
+
+cd "$REPO_ROOT"
+exec go run ./tools/exit_certificate/scripts/agglayer_status "${ARGS[@]}"

--- a/tools/exit_certificate/scripts/agglayer_status/main.go
+++ b/tools/exit_certificate/scripts/agglayer_status/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	"github.com/agglayer/aggkit/log"
 )
@@ -31,14 +32,20 @@ const (
 	defaultWaitTimeout = 10 * time.Minute
 )
 
+// clientFactory builds an agglayer client. It matches agglayer.NewAgglayerClient and is
+// injectable so run can be exercised in tests without a live endpoint.
+type clientFactory func(agglayer.ClientConfig, aggkitcommon.Logger) (agglayer.AgglayerClientInterface, error)
+
 func main() {
-	if err := run(); err != nil {
+	if err := run(os.Args[1:], agglayer.NewAgglayerClient); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run() error {
+func run(args []string, newClient clientFactory) error {
+	fs := flag.NewFlagSet("agglayer_status", flag.ContinueOnError)
+
 	defGRPC := os.Getenv("AGGLAYER_GRPC_URL")
 	defNetwork := uint(1)
 	if v := os.Getenv("NETWORK_INDEX"); v != "" {
@@ -47,13 +54,15 @@ func run() error {
 		}
 	}
 
-	grpcURL := flag.String("grpc", defGRPC, "agglayer gRPC endpoint (default: $AGGLAYER_GRPC_URL)")
-	networkID := flag.Uint("network", defNetwork, "L2 network id (default: $NETWORK_INDEX or 1)")
-	useTLS := flag.Bool("tls", false, "use TLS for the gRPC connection")
-	wait := flag.Bool("wait", false, "poll until the latest certificate is Settled")
-	interval := flag.Duration("interval", defaultPollInterval, "poll interval when -wait is set")
-	timeout := flag.Duration("timeout", defaultWaitTimeout, "max time to wait with -wait (0 = no limit)")
-	flag.Parse()
+	grpcURL := fs.String("grpc", defGRPC, "agglayer gRPC endpoint (default: $AGGLAYER_GRPC_URL)")
+	networkID := fs.Uint("network", defNetwork, "L2 network id (default: $NETWORK_INDEX or 1)")
+	useTLS := fs.Bool("tls", false, "use TLS for the gRPC connection")
+	wait := fs.Bool("wait", false, "poll until the latest certificate is Settled")
+	interval := fs.Duration("interval", defaultPollInterval, "poll interval when -wait is set")
+	timeout := fs.Duration("timeout", defaultWaitTimeout, "max time to wait with -wait (0 = no limit)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 
 	if *grpcURL == "" {
 		return errors.New("agglayer gRPC URL is required (set AGGLAYER_GRPC_URL or pass -grpc)")
@@ -65,7 +74,7 @@ func run() error {
 	grpcCfg.URL = *grpcURL
 	grpcCfg.UseTLS = *useTLS
 
-	client, err := agglayer.NewAgglayerClient(agglayer.ClientConfig{GRPC: grpcCfg}, logger)
+	client, err := newClient(agglayer.ClientConfig{GRPC: grpcCfg}, logger)
 	if err != nil {
 		return fmt.Errorf("create agglayer client: %w", err)
 	}

--- a/tools/exit_certificate/scripts/agglayer_status/main.go
+++ b/tools/exit_certificate/scripts/agglayer_status/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -23,7 +24,21 @@ import (
 	"github.com/agglayer/aggkit/log"
 )
 
+const (
+	// defaultPollInterval is how often -wait polls the agglayer for settlement.
+	defaultPollInterval = 5 * time.Second
+	// defaultWaitTimeout is the maximum time -wait blocks before giving up.
+	defaultWaitTimeout = 10 * time.Minute
+)
+
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	defGRPC := os.Getenv("AGGLAYER_GRPC_URL")
 	defNetwork := uint(1)
 	if v := os.Getenv("NETWORK_INDEX"); v != "" {
@@ -36,13 +51,12 @@ func main() {
 	networkID := flag.Uint("network", defNetwork, "L2 network id (default: $NETWORK_INDEX or 1)")
 	useTLS := flag.Bool("tls", false, "use TLS for the gRPC connection")
 	wait := flag.Bool("wait", false, "poll until the latest certificate is Settled")
-	interval := flag.Duration("interval", 5*time.Second, "poll interval when -wait is set")
-	timeout := flag.Duration("timeout", 10*time.Minute, "max time to wait with -wait (0 = no limit)")
+	interval := flag.Duration("interval", defaultPollInterval, "poll interval when -wait is set")
+	timeout := flag.Duration("timeout", defaultWaitTimeout, "max time to wait with -wait (0 = no limit)")
 	flag.Parse()
 
 	if *grpcURL == "" {
-		fmt.Fprintln(os.Stderr, "ERROR: agglayer gRPC URL is required (set AGGLAYER_GRPC_URL or pass -grpc)")
-		os.Exit(1)
+		return errors.New("agglayer gRPC URL is required (set AGGLAYER_GRPC_URL or pass -grpc)")
 	}
 
 	logger := log.WithFields("module", "agglayer_status")
@@ -53,8 +67,7 @@ func main() {
 
 	client, err := agglayer.NewAgglayerClient(agglayer.ClientConfig{GRPC: grpcCfg}, logger)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: create agglayer client: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("create agglayer client: %w", err)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -65,17 +78,10 @@ func main() {
 	fmt.Printf("Network id:    %d\n", netID)
 
 	if !*wait {
-		if err := printStatus(ctx, client, netID); err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-			os.Exit(1)
-		}
-		return
+		return printStatus(ctx, client, netID)
 	}
 
-	if err := waitForSettled(ctx, client, netID, *interval, *timeout); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-		os.Exit(1)
-	}
+	return waitForSettled(ctx, client, netID, *interval, *timeout)
 }
 
 // printStatus shows the latest certificate (pending if any, otherwise settled).
@@ -164,16 +170,14 @@ func waitForSettled(
 				return fmt.Errorf("latest certificate (height %s) is in error state", height)
 			case status.IsSettled():
 				fmt.Printf("Certificate settled (height %s).\n", height)
-				printStatus(ctx, client, netID)
-				return nil
+				return printStatus(ctx, client, netID)
 			default:
 				fmt.Printf("  height=%s status=%s — still waiting... (%s elapsed)\n", height, status.String(), elapsed)
 			}
 		} else {
 			// No open pending certificate: whatever was submitted has settled.
 			fmt.Printf("No pending certificate — latest is settled. (%s elapsed)\n", elapsed)
-			printStatus(ctx, client, netID)
-			return nil
+			return printStatus(ctx, client, netID)
 		}
 
 		select {

--- a/tools/exit_certificate/scripts/agglayer_status/main.go
+++ b/tools/exit_certificate/scripts/agglayer_status/main.go
@@ -1,0 +1,221 @@
+// Command agglayer_status prints the status and height of the latest agglayer
+// certificate for an L2 network, using the same agglayer gRPC client as the
+// exit_certificate tool. With -wait it polls until the latest certificate settles.
+//
+// Connection info is taken from the environment (AGGLAYER_GRPC_URL) so it composes
+// with tools/exit_certificate/scripts/export_kurtosis_env.sh. It is normally invoked
+// through the agglayer_certificate_status.sh wrapper.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/agglayer/aggkit/agglayer"
+	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	aggkitgrpc "github.com/agglayer/aggkit/grpc"
+	"github.com/agglayer/aggkit/log"
+)
+
+func main() {
+	defGRPC := os.Getenv("AGGLAYER_GRPC_URL")
+	defNetwork := uint(1)
+	if v := os.Getenv("NETWORK_INDEX"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			defNetwork = uint(n)
+		}
+	}
+
+	grpcURL := flag.String("grpc", defGRPC, "agglayer gRPC endpoint (default: $AGGLAYER_GRPC_URL)")
+	networkID := flag.Uint("network", defNetwork, "L2 network id (default: $NETWORK_INDEX or 1)")
+	useTLS := flag.Bool("tls", false, "use TLS for the gRPC connection")
+	wait := flag.Bool("wait", false, "poll until the latest certificate is Settled")
+	interval := flag.Duration("interval", 5*time.Second, "poll interval when -wait is set")
+	timeout := flag.Duration("timeout", 10*time.Minute, "max time to wait with -wait (0 = no limit)")
+	flag.Parse()
+
+	if *grpcURL == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: agglayer gRPC URL is required (set AGGLAYER_GRPC_URL or pass -grpc)")
+		os.Exit(1)
+	}
+
+	logger := log.WithFields("module", "agglayer_status")
+
+	grpcCfg := aggkitgrpc.DefaultConfig()
+	grpcCfg.URL = *grpcURL
+	grpcCfg.UseTLS = *useTLS
+
+	client, err := agglayer.NewAgglayerClient(agglayer.ClientConfig{GRPC: grpcCfg}, logger)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: create agglayer client: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	netID := uint32(*networkID)
+	fmt.Printf("Agglayer gRPC: %s\n", *grpcURL)
+	fmt.Printf("Network id:    %d\n", netID)
+
+	if !*wait {
+		if err := printStatus(ctx, client, netID); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := waitForSettled(ctx, client, netID, *interval, *timeout); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// printStatus shows the latest certificate (pending if any, otherwise settled) plus
+// a settled/pending summary from GetNetworkInfo.
+func printStatus(ctx context.Context, client agglayer.AgglayerClientInterface, netID uint32) error {
+	header, label, err := latestHeader(ctx, client, netID)
+	if err != nil {
+		return err
+	}
+	if header == nil {
+		fmt.Printf("No certificate found for network %d yet.\n", netID)
+	} else {
+		printHeader(header, label)
+	}
+	printNetworkInfo(ctx, client, netID)
+	return nil
+}
+
+// latestHeader returns the latest pending certificate header if one exists, else the
+// latest settled one. The returned label describes which was found.
+func latestHeader(
+	ctx context.Context, client agglayer.AgglayerClientInterface, netID uint32,
+) (*agglayertypes.CertificateHeader, string, error) {
+	pending, err := client.GetLatestPendingCertificateHeader(ctx, netID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get latest pending certificate header: %w", err)
+	}
+	if pending != nil {
+		return pending, "Latest certificate (pending):", nil
+	}
+	settled, err := client.GetLatestSettledCertificateHeader(ctx, netID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get latest settled certificate header: %w", err)
+	}
+	if settled != nil {
+		return settled, "Latest certificate (settled):", nil
+	}
+	return nil, "", nil
+}
+
+func printHeader(h *agglayertypes.CertificateHeader, label string) {
+	fmt.Println(label)
+	fmt.Printf("  Status:               %s\n", h.Status.String())
+	fmt.Printf("  Height:               %d\n", h.Height)
+	fmt.Printf("  Certificate ID:       %s\n", h.CertificateID.Hex())
+	fmt.Printf("  Epoch / Index:        %s / %s\n", u64ptr(h.EpochNumber), u64ptr(h.CertificateIndex))
+	fmt.Printf("  New local exit root:  %s\n", h.NewLocalExitRoot.Hex())
+	if h.PreviousLocalExitRoot != nil {
+		fmt.Printf("  Prev local exit root: %s\n", h.PreviousLocalExitRoot.Hex())
+	}
+	if h.SettlementTxHash != nil {
+		fmt.Printf("  Settlement tx hash:   %s\n", h.SettlementTxHash.Hex())
+	}
+	if h.Error != nil {
+		fmt.Printf("  Error:                %s\n", h.Error.Error())
+	}
+}
+
+func printNetworkInfo(ctx context.Context, client agglayer.AgglayerClientInterface, netID uint32) {
+	info, err := client.GetNetworkInfo(ctx, netID)
+	if err != nil {
+		// Non-fatal: the header above is the primary output.
+		fmt.Fprintf(os.Stderr, "WARN: get network info: %v\n", err)
+		return
+	}
+	fmt.Printf("Network info (network %d):\n", netID)
+	fmt.Printf("  Settled height:       %s\n", u64ptr(info.SettledHeight))
+	pendingStatus := "—"
+	if info.LatestPendingStatus != nil {
+		pendingStatus = info.LatestPendingStatus.String()
+	}
+	fmt.Printf("  Pending height:       %s (status: %s)\n", u64ptr(info.LatestPendingHeight), pendingStatus)
+	if info.LatestPendingError != "" {
+		fmt.Printf("  Pending error:        %s\n", info.LatestPendingError)
+	}
+}
+
+// waitForSettled polls GetNetworkInfo until the latest certificate is settled (no open
+// pending certificate). Returns an error if a pending certificate is in error state or
+// the timeout elapses.
+func waitForSettled(
+	ctx context.Context, client agglayer.AgglayerClientInterface,
+	netID uint32, interval, timeout time.Duration,
+) error {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	fmt.Printf("Waiting until the latest certificate is settled (interval=%s, timeout=%s)...\n",
+		interval, durStr(timeout))
+
+	start := time.Now()
+	for {
+		info, err := client.GetNetworkInfo(ctx, netID)
+		if err != nil {
+			return fmt.Errorf("get network info: %w", err)
+		}
+
+		elapsed := time.Since(start).Round(time.Second)
+		if info.LatestPendingStatus != nil {
+			status := *info.LatestPendingStatus
+			height := u64ptr(info.LatestPendingHeight)
+			switch {
+			case status.IsInError():
+				printNetworkInfo(ctx, client, netID)
+				return fmt.Errorf("latest certificate (height %s) is in error state", height)
+			case status.IsSettled():
+				fmt.Printf("Certificate settled (height %s).\n", height)
+				printStatus(ctx, client, netID)
+				return nil
+			default:
+				fmt.Printf("  height=%s status=%s — still waiting... (%s elapsed)\n", height, status.String(), elapsed)
+			}
+		} else {
+			// No open pending certificate: whatever was submitted has settled.
+			fmt.Printf("No pending certificate — latest is settled. (%s elapsed)\n", elapsed)
+			printStatus(ctx, client, netID)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for settlement after %s", durStr(timeout))
+		case <-time.After(interval):
+		}
+	}
+}
+
+func u64ptr(p *uint64) string {
+	if p == nil {
+		return "—"
+	}
+	return strconv.FormatUint(*p, 10)
+}
+
+func durStr(d time.Duration) string {
+	if d == 0 {
+		return "none"
+	}
+	return d.String()
+}

--- a/tools/exit_certificate/scripts/agglayer_status/main.go
+++ b/tools/exit_certificate/scripts/agglayer_status/main.go
@@ -78,8 +78,7 @@ func main() {
 	}
 }
 
-// printStatus shows the latest certificate (pending if any, otherwise settled) plus
-// a settled/pending summary from GetNetworkInfo.
+// printStatus shows the latest certificate (pending if any, otherwise settled).
 func printStatus(ctx context.Context, client agglayer.AgglayerClientInterface, netID uint32) error {
 	header, label, err := latestHeader(ctx, client, netID)
 	if err != nil {
@@ -90,7 +89,6 @@ func printStatus(ctx context.Context, client agglayer.AgglayerClientInterface, n
 	} else {
 		printHeader(header, label)
 	}
-	printNetworkInfo(ctx, client, netID)
 	return nil
 }
 
@@ -134,25 +132,6 @@ func printHeader(h *agglayertypes.CertificateHeader, label string) {
 	}
 }
 
-func printNetworkInfo(ctx context.Context, client agglayer.AgglayerClientInterface, netID uint32) {
-	info, err := client.GetNetworkInfo(ctx, netID)
-	if err != nil {
-		// Non-fatal: the header above is the primary output.
-		fmt.Fprintf(os.Stderr, "WARN: get network info: %v\n", err)
-		return
-	}
-	fmt.Printf("Network info (network %d):\n", netID)
-	fmt.Printf("  Settled height:       %s\n", u64ptr(info.SettledHeight))
-	pendingStatus := "—"
-	if info.LatestPendingStatus != nil {
-		pendingStatus = info.LatestPendingStatus.String()
-	}
-	fmt.Printf("  Pending height:       %s (status: %s)\n", u64ptr(info.LatestPendingHeight), pendingStatus)
-	if info.LatestPendingError != "" {
-		fmt.Printf("  Pending error:        %s\n", info.LatestPendingError)
-	}
-}
-
 // waitForSettled polls GetNetworkInfo until the latest certificate is settled (no open
 // pending certificate). Returns an error if a pending certificate is in error state or
 // the timeout elapses.
@@ -182,7 +161,6 @@ func waitForSettled(
 			height := u64ptr(info.LatestPendingHeight)
 			switch {
 			case status.IsInError():
-				printNetworkInfo(ctx, client, netID)
 				return fmt.Errorf("latest certificate (height %s) is in error state", height)
 			case status.IsSettled():
 				fmt.Printf("Certificate settled (height %s).\n", height)

--- a/tools/exit_certificate/scripts/agglayer_status/main_test.go
+++ b/tools/exit_certificate/scripts/agglayer_status/main_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agglayer/aggkit/agglayer"
 	"github.com/agglayer/aggkit/agglayer/mocks"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -226,6 +228,60 @@ func TestWaitForSettled(t *testing.T) {
 		err := waitForSettled(context.Background(), client, 1, interval, 20*time.Millisecond)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "timed out waiting for settlement")
+	})
+}
+
+func TestRun(t *testing.T) {
+	// okFactory returns a clientFactory that always yields the given mock client,
+	// ignoring the config/logger so run can be driven without a live endpoint.
+	okFactory := func(c agglayer.AgglayerClientInterface) clientFactory {
+		return func(agglayer.ClientConfig, aggkitcommon.Logger) (agglayer.AgglayerClientInterface, error) {
+			return c, nil
+		}
+	}
+
+	t.Run("missing grpc url", func(t *testing.T) {
+		t.Setenv("AGGLAYER_GRPC_URL", "")
+		err := run(nil, func(agglayer.ClientConfig, aggkitcommon.Logger) (agglayer.AgglayerClientInterface, error) {
+			t.Fatal("client factory must not be called when the URL is missing")
+			return nil, nil
+		})
+		require.EqualError(t, err, "agglayer gRPC URL is required (set AGGLAYER_GRPC_URL or pass -grpc)")
+	})
+
+	t.Run("invalid flag", func(t *testing.T) {
+		err := run([]string{"-does-not-exist"}, okFactory(mocks.NewAgglayerClientMock(t)))
+		require.Error(t, err)
+	})
+
+	t.Run("client factory fails", func(t *testing.T) {
+		err := run([]string{"-grpc", "localhost:1"},
+			func(agglayer.ClientConfig, aggkitcommon.Logger) (agglayer.AgglayerClientInterface, error) {
+				return nil, errors.New("dial boom")
+			})
+		require.EqualError(t, err, "create agglayer client: dial boom")
+	})
+
+	t.Run("status path without wait", func(t *testing.T) {
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(fullHeader(), nil)
+		require.NoError(t, run([]string{"-grpc", "localhost:1"}, okFactory(client)))
+	})
+
+	t.Run("network index from env", func(t *testing.T) {
+		t.Setenv("NETWORK_INDEX", "2")
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(2)).Return(fullHeader(), nil)
+		require.NoError(t, run([]string{"-grpc", "localhost:1"}, okFactory(client)))
+	})
+
+	t.Run("wait path settles", func(t *testing.T) {
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).
+			Return(agglayertypes.NetworkInfo{LatestPendingStatus: nil}, nil)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+		client.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+		require.NoError(t, run([]string{"-grpc", "localhost:1", "-wait", "-interval", "5ms"}, okFactory(client)))
 	})
 }
 

--- a/tools/exit_certificate/scripts/agglayer_status/main_test.go
+++ b/tools/exit_certificate/scripts/agglayer_status/main_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/agglayer/mocks"
+	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func ptrUint64(v uint64) *uint64 { return &v }
+
+func ptrStatus(s agglayertypes.CertificateStatus) *agglayertypes.CertificateStatus { return &s }
+
+// fullHeader returns a header with every optional field populated so printHeader
+// exercises all of its branches.
+func fullHeader() *agglayertypes.CertificateHeader {
+	prev := common.HexToHash("0x01")
+	settleTx := common.HexToHash("0x02")
+	return &agglayertypes.CertificateHeader{
+		NetworkID:             1,
+		Height:                7,
+		EpochNumber:           ptrUint64(3),
+		CertificateIndex:      ptrUint64(4),
+		CertificateID:         common.HexToHash("0xaa"),
+		PreviousLocalExitRoot: &prev,
+		NewLocalExitRoot:      common.HexToHash("0xbb"),
+		Status:                agglayertypes.Settled,
+		SettlementTxHash:      &settleTx,
+		Error:                 errors.New("boom"),
+	}
+}
+
+func TestLatestHeader(t *testing.T) {
+	t.Parallel()
+
+	pending := &agglayertypes.CertificateHeader{Height: 10, Status: agglayertypes.Pending}
+	settled := &agglayertypes.CertificateHeader{Height: 9, Status: agglayertypes.Settled}
+	errPending := errors.New("pending failed")
+	errSettled := errors.New("settled failed")
+
+	tests := []struct {
+		name          string
+		setup         func(m *mocks.AgglayerClientMock)
+		expectedHdr   *agglayertypes.CertificateHeader
+		expectedLabel string
+		expectedErr   string
+	}{
+		{
+			name: "pending found",
+			setup: func(m *mocks.AgglayerClientMock) {
+				m.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(pending, nil)
+			},
+			expectedHdr:   pending,
+			expectedLabel: "Latest certificate (pending):",
+		},
+		{
+			name: "no pending, settled found",
+			setup: func(m *mocks.AgglayerClientMock) {
+				m.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+				m.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(settled, nil)
+			},
+			expectedHdr:   settled,
+			expectedLabel: "Latest certificate (settled):",
+		},
+		{
+			name: "no certificate at all",
+			setup: func(m *mocks.AgglayerClientMock) {
+				m.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+				m.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+			},
+			expectedHdr:   nil,
+			expectedLabel: "",
+		},
+		{
+			name: "pending query fails",
+			setup: func(m *mocks.AgglayerClientMock) {
+				m.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, errPending)
+			},
+			expectedErr: "get latest pending certificate header: pending failed",
+		},
+		{
+			name: "settled query fails",
+			setup: func(m *mocks.AgglayerClientMock) {
+				m.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+				m.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(nil, errSettled)
+			},
+			expectedErr: "get latest settled certificate header: settled failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := mocks.NewAgglayerClientMock(t)
+			tt.setup(client)
+
+			hdr, label, err := latestHeader(context.Background(), client, 1)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				require.Nil(t, hdr)
+				require.Empty(t, label)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedHdr, hdr)
+			require.Equal(t, tt.expectedLabel, label)
+		})
+	}
+}
+
+func TestPrintStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no certificate", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(2)).Return(nil, nil)
+		client.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(2)).Return(nil, nil)
+
+		require.NoError(t, printStatus(context.Background(), client, 2))
+	})
+
+	t.Run("prints header", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(fullHeader(), nil)
+
+		require.NoError(t, printStatus(context.Background(), client, 1))
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).
+			Return(nil, errors.New("rpc down"))
+
+		require.EqualError(t, printStatus(context.Background(), client, 1),
+			"get latest pending certificate header: rpc down")
+	})
+}
+
+func TestWaitForSettled(t *testing.T) {
+	t.Parallel()
+
+	const interval = 5 * time.Millisecond
+
+	t.Run("no pending certificate settles immediately", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).
+			Return(agglayertypes.NetworkInfo{LatestPendingStatus: nil}, nil)
+		// printStatus is invoked after settlement.
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+		client.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+
+		require.NoError(t, waitForSettled(context.Background(), client, 1, interval, time.Minute))
+	})
+
+	t.Run("pending already settled", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).Return(agglayertypes.NetworkInfo{
+			LatestPendingHeight: ptrUint64(5),
+			LatestPendingStatus: ptrStatus(agglayertypes.Settled),
+		}, nil)
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+		client.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+
+		require.NoError(t, waitForSettled(context.Background(), client, 1, interval, time.Minute))
+	})
+
+	t.Run("pending in error", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).Return(agglayertypes.NetworkInfo{
+			LatestPendingHeight: ptrUint64(8),
+			LatestPendingStatus: ptrStatus(agglayertypes.InError),
+		}, nil)
+
+		err := waitForSettled(context.Background(), client, 1, interval, time.Minute)
+		require.EqualError(t, err, "latest certificate (height 8) is in error state")
+	})
+
+	t.Run("get network info fails", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).
+			Return(agglayertypes.NetworkInfo{}, errors.New("conn refused"))
+
+		err := waitForSettled(context.Background(), client, 1, interval, time.Minute)
+		require.EqualError(t, err, "get network info: conn refused")
+	})
+
+	t.Run("polls until settled", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		// First poll: still proving. Second poll: settled.
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).Return(agglayertypes.NetworkInfo{
+			LatestPendingHeight: ptrUint64(5),
+			LatestPendingStatus: ptrStatus(agglayertypes.Proven),
+		}, nil).Once()
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).Return(agglayertypes.NetworkInfo{
+			LatestPendingHeight: ptrUint64(5),
+			LatestPendingStatus: ptrStatus(agglayertypes.Settled),
+		}, nil).Once()
+		client.EXPECT().GetLatestPendingCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+		client.EXPECT().GetLatestSettledCertificateHeader(mockCtx(), uint32(1)).Return(nil, nil)
+
+		require.NoError(t, waitForSettled(context.Background(), client, 1, interval, time.Minute))
+	})
+
+	t.Run("times out while still pending", func(t *testing.T) {
+		t.Parallel()
+		client := mocks.NewAgglayerClientMock(t)
+		client.EXPECT().GetNetworkInfo(mockCtx(), uint32(1)).Return(agglayertypes.NetworkInfo{
+			LatestPendingHeight: ptrUint64(5),
+			LatestPendingStatus: ptrStatus(agglayertypes.Proven),
+		}, nil)
+
+		err := waitForSettled(context.Background(), client, 1, interval, 20*time.Millisecond)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timed out waiting for settlement")
+	})
+}
+
+func TestU64Ptr(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "—", u64ptr(nil))
+	require.Equal(t, "42", u64ptr(ptrUint64(42)))
+}
+
+func TestDurStr(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "none", durStr(0))
+	require.Equal(t, "5s", durStr(5*time.Second))
+}
+
+// mockCtx matches any context.Context argument.
+func mockCtx() any {
+	return mock.Anything
+}

--- a/tools/exit_certificate/scripts/bridge_l1_to_l2.sh
+++ b/tools/exit_certificate/scripts/bridge_l1_to_l2.sh
@@ -378,6 +378,9 @@ elif [[ "$TX_STATUS" == *"success"* ]]; then
 else
     log_error "Receipt: status=REVERTED blockNumber=$TX_BLOCK"
     log_error "Replaying transaction to get revert reason..."
+    echo "---- execution ---- " 
+    cast run --rpc-url "$L1_RPC_URL" "$TX_HASH" 2>&1
+    echo "---- revert reason ---- "  
     cast run --rpc-url "$L1_RPC_URL" "$TX_HASH" 2>&1 | grep -E "revert|Revert|error|Error|←" | head -20 >&2
     exit 1
 fi

--- a/tools/exit_certificate/scripts/bridge_l1_to_l2.sh
+++ b/tools/exit_certificate/scripts/bridge_l1_to_l2.sh
@@ -373,7 +373,12 @@ TX_STATUS=$(cast receipt --rpc-url "$L1_RPC_URL" "$TX_HASH" status 2>/dev/null |
 TX_BLOCK=$(cast receipt --rpc-url "$L1_RPC_URL" "$TX_HASH" blockNumber 2>/dev/null || true)
 if [[ -z "$TX_STATUS" ]]; then
     log_warn "Could not fetch receipt for $TX_HASH"
-elif [[ "$TX_STATUS" == *"success"* ]]; then
+# `cast receipt <hash> status` formats the status differently across versions:
+# foundry <=1.5 prints "1 (success)" / "0 (failed)", foundry >=1.7 prints the raw
+# bool "true" / "false". Accept every success spelling so a healthy tx is never
+# misreported as REVERTED.
+elif [[ "$TX_STATUS" == *"success"* || "$TX_STATUS" == "true" \
+     || "$TX_STATUS" == "1" || "$TX_STATUS" == "0x1" ]]; then
     log_info "Receipt: status=success blockNumber=$TX_BLOCK"
 else
     log_error "Receipt: status=REVERTED blockNumber=$TX_BLOCK"

--- a/tools/exit_certificate/scripts/bridge_l2_to_l1.sh
+++ b/tools/exit_certificate/scripts/bridge_l2_to_l1.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Bridges ETH (or an ERC-20) from L1 to L2 by calling bridgeAsset on the L1 bridge
+# Bridges ETH (or an ERC-20) from L2 to L1 by calling bridgeAsset on the L2 bridge
 # contract. Connection info is taken entirely from the environment — this script
 # never talks to Kurtosis. Populate the variables first with:
 #   source <(tools/exit_certificate/scripts/export_kurtosis_env.sh 1)
 # Requires: cast (Foundry).
 #
 # Required environment variables:
-#   L1_RPC_URL    L1 JSON-RPC URL
-#   BRIDGE_ADDR   Bridge contract address on L1
-#   L2_RPC_URL    L2 JSON-RPC URL (only required with --wait)
+#   L2_RPC_URL    L2 JSON-RPC URL (where bridgeAsset is sent)
+#   BRIDGE_ADDR   Bridge contract address (same address on L1 and L2)
+#   L1_RPC_URL    L1 JSON-RPC URL (only required with --wait)
 set -euo pipefail
 
 GREEN='\033[0;32m'
@@ -22,40 +22,44 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 usage() {
     cat >&2 <<EOF
-Usage: $0 [OPTIONS] [NETWORK_INDEX]
+Usage: $0 [OPTIONS] [L2_NETWORK_INDEX]
 
-Bridges ETH from L1 to L2 by calling bridgeAsset on the L1 bridge contract.
-Connection info comes from the environment (see export_kurtosis_env.sh).
+Bridges ETH from L2 to L1 by calling bridgeAsset on the L2 bridge contract.
+The destination network is L1 (network 0). Connection info comes from the
+environment (see export_kurtosis_env.sh).
 
 Arguments:
-  NETWORK_INDEX   Destination L2 network index (default: 1)
+  L2_NETWORK_INDEX   Source L2 network index (default: 1). Used as the source
+                     network when checking isClaimed on L1 with --wait.
 
 Options:
   -a, --amount    AMOUNT_WEI   Amount to bridge in wei (default: 1234567890)
-  -d, --dest      ADDRESS      Destination address on L2 (default: sender address)
+  -d, --dest      ADDRESS      Destination address on L1 (default: sender address)
   -t, --token     ADDRESS      ERC-20 token address to bridge (default: 0x0 = native ETH)
   -k, --key       PRIVATE_KEY  Sender private key (default: \$PRIVATE_KEY or Foundry test key)
-  -w, --wait                   Wait for the deposit to be claimed on L2 (polls isClaimed)
-  -T, --timeout   SECS         Seconds to wait for the claim with --wait (default: 300)
+  -w, --wait                   Wait for the deposit to be claimed on L1 (polls isClaimed)
   -h, --help                   Show this help
 
 Required environment variables:
-  L1_RPC_URL                  L1 JSON-RPC URL
-  BRIDGE_ADDR                 Bridge contract address on L1
-  L2_RPC_URL                  L2 JSON-RPC URL (only required with --wait)
-  Tip: source <(tools/exit_certificate/scripts/export_kurtosis_env.sh NETWORK_INDEX)
+  L2_RPC_URL                  L2 JSON-RPC URL (where bridgeAsset is sent)
+  BRIDGE_ADDR                 Bridge contract address (same on L1 and L2)
+  L1_RPC_URL                  L1 JSON-RPC URL (only required with --wait)
+  Tip: source <(tools/exit_certificate/scripts/export_kurtosis_env.sh L2_NETWORK_INDEX)
 
 Optional environment variables (override defaults):
   PRIVATE_KEY                 Sender private key
-  DEST_ADDRESS                Destination address on L2
+  DEST_ADDRESS                Destination address on L1
   TOKEN_ADDRESS               ERC-20 token address (0x0 for ETH)
 
 Examples:
   source <(tools/exit_certificate/scripts/export_kurtosis_env.sh 1)
-  $0                              # Bridge 0.01 ETH to network 1
-  $0 2                            # Bridge to network 2
+  $0                              # Bridge 0.01 ETH from L2 network 1 to L1
+  $0 2                            # Bridge from L2 network 2 to L1
   $0 --amount 1000000000000000000 # Bridge 1 ETH
   $0 --dest 0xABCD... --wait      # Bridge to specific address and wait for claim
+
+Note: L2 -> L1 deposits usually require a manual claim with a proof from the
+agglayer, so --wait may never observe an auto-claim in most setups.
 EOF
     exit 1
 }
@@ -64,8 +68,8 @@ EOF
 # Defaults
 # ---------------------------------------------------------------------------
 
-# Default sender is the Kurtosis L1 faucet (1,000,000,000 ETH on L1 in local
-# enclaves). Override with PRIVATE_KEY env var or --key flag for other environments.
+# Default sender is the Kurtosis prefunded test account. Override with the
+# PRIVATE_KEY env var or --key flag for other environments.
 PRIVATE_KEY="${PRIVATE_KEY:-0x04b9f63ecf84210c5366c66d68fa1f5da1fa4f634fad6dfc86178e4d79ff9e59}"
 
 # Default amount in wei; override with --amount on the command line.
@@ -75,9 +79,10 @@ BRIDGE_AMOUNT="1234567890"
 TOKEN_ADDRESS="${TOKEN_ADDRESS:-0x0000000000000000000000000000000000000000}"
 
 DEST_ADDRESS="${DEST_ADDRESS:-}"
-NETWORK_INDEX=1
+L2_NETWORK_INDEX=1
+# bridgeAsset destinationNetwork: L1 is always network 0.
+DEST_NETWORK=0
 WAIT_FOR_CLAIM=false
-CLAIM_TIMEOUT_SECS=300
 
 # Connection info: provided by the environment (e.g. via export_kurtosis_env.sh).
 L1_RPC_URL="${L1_RPC_URL:-}"
@@ -105,12 +110,8 @@ while [[ $# -gt 0 ]]; do
             PRIVATE_KEY="$2"; shift 2 ;;
         -w|--wait)
             WAIT_FOR_CLAIM=true; shift ;;
-        -T|--timeout)
-            [[ $# -lt 2 ]] && { log_error "--timeout requires a value"; usage; }
-            [[ "$2" =~ ^[0-9]+$ ]] || { log_error "--timeout must be a positive integer (seconds)"; usage; }
-            CLAIM_TIMEOUT_SECS="$2"; shift 2 ;;
         [0-9]*)
-            NETWORK_INDEX="$1"; shift ;;
+            L2_NETWORK_INDEX="$1"; shift ;;
         *)
             log_error "Unknown argument: $1"; usage ;;
     esac
@@ -130,12 +131,12 @@ check_deps() {
 
 check_env() {
     local missing=()
-    [[ -z "$L1_RPC_URL" ]]  && missing+=("L1_RPC_URL")
+    [[ -z "$L2_RPC_URL" ]]  && missing+=("L2_RPC_URL")
     [[ -z "$BRIDGE_ADDR" ]] && missing+=("BRIDGE_ADDR")
-    [[ "$WAIT_FOR_CLAIM" == "true" && -z "$L2_RPC_URL" ]] && missing+=("L2_RPC_URL (required with --wait)")
+    [[ "$WAIT_FOR_CLAIM" == "true" && -z "$L1_RPC_URL" ]] && missing+=("L1_RPC_URL (required with --wait)")
     if [[ ${#missing[@]} -gt 0 ]]; then
         log_error "Missing required environment variables: ${missing[*]}"
-        log_error "Populate them with: source <(tools/exit_certificate/scripts/export_kurtosis_env.sh $NETWORK_INDEX)"
+        log_error "Populate them with: source <(tools/exit_certificate/scripts/export_kurtosis_env.sh $L2_NETWORK_INDEX)"
         exit 1
     fi
 }
@@ -153,41 +154,44 @@ check_env() {
 # ) external payable
 # ---------------------------------------------------------------------------
 
-# wait_for_claim polls isClaimed(depositCount, sourceBridgeNetwork=0) on the L2 bridge.
+# wait_for_claim polls isClaimed(depositCount, sourceBridgeNetwork) on the L1 bridge.
+# For an L2 -> L1 bridge the source network is the L2 network index.
 # depositCount is extracted from the DepositCount field of the BridgeEvent emitted in the tx.
 wait_for_claim() {
-    local l2_rpc="$1"
-    local l2_bridge="$2"
+    local l1_rpc="$1"
+    local l1_bridge="$2"
     local deposit_count="$3"
-    local timeout_secs="${4:-300}"
+    local source_network="$4"
+    local timeout_secs="${5:-300}"
     local poll_secs=5
 
     # isClaimed(uint32 leafIndex, uint32 sourceBridgeNetwork) — selector: 0xcc461632
     local leaf_idx_hex
     local src_net_hex
     leaf_idx_hex=$(printf '%064x' "$deposit_count")
-    src_net_hex=$(printf '%064x' 0)
+    src_net_hex=$(printf '%064x' "$source_network")
     local calldata="0xcc461632${leaf_idx_hex}${src_net_hex}"
 
-    log_info "Waiting for claim on L2 (depositCount=$deposit_count, timeout=${timeout_secs}s)..."
+    log_info "Waiting for claim on L1 (depositCount=$deposit_count, sourceNetwork=$source_network, timeout=${timeout_secs}s)..."
 
     local elapsed=0
     while [[ $elapsed -lt $timeout_secs ]]; do
         local result
-        result=$(cast call --rpc-url "$l2_rpc" "$l2_bridge" "$calldata" 2>/dev/null || true)
+        result=$(cast call --rpc-url "$l1_rpc" "$l1_bridge" "$calldata" 2>/dev/null || true)
         # isClaimed returns a non-zero uint256 when claimed
         local val
         val=$(cast --to-dec "${result:-0x0}" 2>/dev/null || echo "0")
         if [[ "$val" != "0" ]]; then
-            log_info "Deposit claimed on L2! (depositCount=$deposit_count)"
+            log_info "Deposit claimed on L1! (depositCount=$deposit_count)"
             return 0
         fi
         sleep "$poll_secs"
         elapsed=$((elapsed + poll_secs))
-        log_info "  Still waiting auto-claim (depositCount=$deposit_count)... ${elapsed}s / ${timeout_secs}s"
+        log_info "  Still waiting... ${elapsed}s / ${timeout_secs}s"
     done
 
     log_warn "Timed out waiting for claim after ${timeout_secs}s"
+    log_warn "L2 -> L1 deposits usually require a manual claim with an agglayer proof."
     return 1
 }
 
@@ -195,12 +199,12 @@ wait_for_claim() {
 # BridgeEvent topic: keccak256("BridgeEvent(uint8,uint32,address,uint32,address,uint256,bytes,uint32)")
 extract_deposit_count() {
     local tx_hash="$1"
-    local l1_rpc="$2"
+    local rpc="$2"
 
     local bridge_event_topic="0x501781209a1f8899323b96b4ef08b168df93e0a90c673d1e4cce39366cb62f9b"
 
     local receipt
-    receipt=$(cast receipt --rpc-url "$l1_rpc" "$tx_hash" --json 2>/dev/null || true)
+    receipt=$(cast receipt --rpc-url "$rpc" "$tx_hash" --json 2>/dev/null || true)
     if [[ -z "$receipt" ]]; then
         log_warn "Could not fetch receipt for $tx_hash — skipping claim wait"
         echo ""
@@ -242,11 +246,12 @@ for log in receipt.get('logs', []):
 check_deps
 check_env
 
-log_info "Network index:    $NETWORK_INDEX"
-log_info "Amount:           $BRIDGE_AMOUNT wei"
-log_info "Token:            $TOKEN_ADDRESS"
-log_info "L1 RPC URL:       $L1_RPC_URL"
-log_info "Bridge address:   $BRIDGE_ADDR"
+log_info "Source L2 network: $L2_NETWORK_INDEX"
+log_info "Destination:       L1 (network $DEST_NETWORK)"
+log_info "Amount:            $BRIDGE_AMOUNT wei"
+log_info "Token:             $TOKEN_ADDRESS"
+log_info "L2 RPC URL:        $L2_RPC_URL"
+log_info "Bridge address:    $BRIDGE_ADDR"
 
 # Derive sender address from private key
 SENDER_ADDR=$(cast wallet address --private-key "$PRIVATE_KEY")
@@ -256,33 +261,34 @@ log_info "Sender address: $SENDER_ADDR"
 if [[ -z "$DEST_ADDRESS" ]]; then
     DEST_ADDRESS="$SENDER_ADDR"
 fi
-log_info "Destination:      $DEST_ADDRESS (network $NETWORK_INDEX)"
+log_info "Destination:       $DEST_ADDRESS (network $DEST_NETWORK)"
 
-# Check sender balance
-SENDER_BALANCE=$(cast balance --rpc-url "$L1_RPC_URL" "$SENDER_ADDR")
+# Check sender balance on L2
+SENDER_BALANCE=$(cast balance --rpc-url "$L2_RPC_URL" "$SENDER_ADDR")
 SENDER_BALANCE_ETH=$(cast --from-wei "$SENDER_BALANCE" ether)
-log_info "Sender L1 balance: $SENDER_BALANCE_ETH ETH ($SENDER_BALANCE wei)"
+log_info "Sender L2 balance: $SENDER_BALANCE_ETH ETH ($SENDER_BALANCE wei)"
 
 IS_ETH_BRIDGE="false"
 if [[ "$TOKEN_ADDRESS" == "0x0000000000000000000000000000000000000000" ]]; then
     IS_ETH_BRIDGE="true"
 fi
 
-# The sender always needs some L1 gas-token balance to pay fees, regardless of
+# The sender always needs some L2 gas-token balance to pay fees, regardless of
 # whether it bridges native ETH or an ERC-20. A balance of 0 is the usual cause
-# of "gas required exceeds allowance (0)".
+# of "gas required exceeds allowance (0)" — e.g. using the L1 faucet key (which
+# is unfunded on L2) for an L2 -> L1 bridge.
 if [[ "$SENDER_BALANCE" == "0" ]]; then
-    log_error "Sender has 0 balance on L1 — cannot pay transaction fees."
+    log_error "Sender has 0 gas-token balance on L2 — cannot pay transaction fees."
     log_error "  Sender: $SENDER_ADDR"
-    log_error "This causes 'gas required exceeds allowance (0)'. Use an L1-funded"
-    log_error "account with --key (or \$PRIVATE_KEY), or fund this address on L1 first."
+    log_error "This causes 'gas required exceeds allowance (0)'. Use an L2-funded"
+    log_error "account with --key (or \$PRIVATE_KEY), or fund this address on L2 first."
     exit 1
 fi
 
 # Estimate the gas headroom the tx needs so we can fail early with a clear message
 # instead of a raw 'gas required exceeds allowance (0)' from the node. bridgeAsset
 # (plus an approve for ERC-20) fits comfortably under ~300k gas.
-GAS_PRICE=$(cast gas-price --rpc-url "$L1_RPC_URL" 2>/dev/null || echo "0")
+GAS_PRICE=$(cast gas-price --rpc-url "$L2_RPC_URL" 2>/dev/null || echo "0")
 GAS_RESERVE=$(python3 -c "print($GAS_PRICE * 300000)" 2>/dev/null || echo "0")
 
 # bash integer arithmetic overflows for wei values > 2^63; use python3 for comparisons.
@@ -301,7 +307,7 @@ elif python3 -c "import sys; sys.exit(0 if int('$SENDER_BALANCE') < int('$GAS_RE
     # sender still needs native gas-token balance for approve + bridgeAsset.
     GAS_RESERVE_ETH=$(cast --from-wei "$GAS_RESERVE" ether)
     log_error "Insufficient gas-token balance: sender has $SENDER_BALANCE_ETH ETH,"
-    log_error "  needs ~$GAS_RESERVE_ETH ETH to cover approve + bridgeAsset gas on L1."
+    log_error "  needs ~$GAS_RESERVE_ETH ETH to cover approve + bridgeAsset gas on L2."
     exit 1
 fi
 
@@ -312,7 +318,7 @@ fi
 if [[ "$IS_ETH_BRIDGE" != "true" ]]; then
     log_info "ERC-20 bridge: approving bridge contract to spend $BRIDGE_AMOUNT of $TOKEN_ADDRESS..."
     APPROVE_TX=$(cast send \
-        --rpc-url "$L1_RPC_URL" \
+        --rpc-url "$L2_RPC_URL" \
         --private-key "$PRIVATE_KEY" \
         "$TOKEN_ADDRESS" \
         "approve(address,uint256)" \
@@ -325,7 +331,7 @@ fi
 # Call bridgeAsset
 #
 #   bridgeAsset(
-#     uint32  destinationNetwork,   → NETWORK_INDEX
+#     uint32  destinationNetwork,   → DEST_NETWORK (0 = L1)
 #     address destinationAddress,   → DEST_ADDRESS
 #     uint256 amount,               → BRIDGE_AMOUNT
 #     address token,                → TOKEN_ADDRESS (0x0 for ETH)
@@ -335,17 +341,17 @@ fi
 #   msg.value = BRIDGE_AMOUNT for ETH; 0 for ERC-20
 # ---------------------------------------------------------------------------
 
-log_info "Calling bridgeAsset on L1 bridge..."
+log_info "Calling bridgeAsset on L2 bridge..."
 
 if [[ "$IS_ETH_BRIDGE" == "true" ]]; then
     TX_HASH=$(cast send \
-        --rpc-url "$L1_RPC_URL" \
+        --rpc-url "$L2_RPC_URL" \
         --private-key "$PRIVATE_KEY" \
         --value "$BRIDGE_AMOUNT" \
         --json \
         "$BRIDGE_ADDR" \
         "bridgeAsset(uint32,address,uint256,address,bool,bytes)" \
-        "$NETWORK_INDEX" \
+        "$DEST_NETWORK" \
         "$DEST_ADDRESS" \
         "$BRIDGE_AMOUNT" \
         "0x0000000000000000000000000000000000000000" \
@@ -353,12 +359,12 @@ if [[ "$IS_ETH_BRIDGE" == "true" ]]; then
         "0x" | python3 -c "import sys,json; print(json.load(sys.stdin)['transactionHash'])")
 else
     TX_HASH=$(cast send \
-        --rpc-url "$L1_RPC_URL" \
+        --rpc-url "$L2_RPC_URL" \
         --private-key "$PRIVATE_KEY" \
         --json \
         "$BRIDGE_ADDR" \
         "bridgeAsset(uint32,address,uint256,address,bool,bytes)" \
-        "$NETWORK_INDEX" \
+        "$DEST_NETWORK" \
         "$DEST_ADDRESS" \
         "$BRIDGE_AMOUNT" \
         "$TOKEN_ADDRESS" \
@@ -369,8 +375,8 @@ fi
 log_info "Bridge tx hash: $TX_HASH"
 
 log_info "Waiting for receipt..."
-TX_STATUS=$(cast receipt --rpc-url "$L1_RPC_URL" "$TX_HASH" status 2>/dev/null || true)
-TX_BLOCK=$(cast receipt --rpc-url "$L1_RPC_URL" "$TX_HASH" blockNumber 2>/dev/null || true)
+TX_STATUS=$(cast receipt --rpc-url "$L2_RPC_URL" "$TX_HASH" status 2>/dev/null || true)
+TX_BLOCK=$(cast receipt --rpc-url "$L2_RPC_URL" "$TX_HASH" blockNumber 2>/dev/null || true)
 if [[ -z "$TX_STATUS" ]]; then
     log_warn "Could not fetch receipt for $TX_HASH"
 elif [[ "$TX_STATUS" == *"success"* ]]; then
@@ -378,27 +384,27 @@ elif [[ "$TX_STATUS" == *"success"* ]]; then
 else
     log_error "Receipt: status=REVERTED blockNumber=$TX_BLOCK"
     log_error "Replaying transaction to get revert reason..."
-    cast run --rpc-url "$L1_RPC_URL" "$TX_HASH" 2>&1 | grep -E "revert|Revert|error|Error|←" | head -20 >&2
+    cast run --rpc-url "$L2_RPC_URL" "$TX_HASH" 2>&1 | grep -E "revert|Revert|error|Error|←" | head -20 >&2
     exit 1
 fi
 
-log_info "Bridge from L1 to L2 network $NETWORK_INDEX submitted successfully."
+log_info "Bridge from L2 network $L2_NETWORK_INDEX to L1 submitted successfully."
 log_info "  Sender:       $SENDER_ADDR"
-log_info "  Destination:  $DEST_ADDRESS"
+log_info "  Destination:  $DEST_ADDRESS (network $DEST_NETWORK)"
 log_info "  Amount:       $BRIDGE_AMOUNT wei"
 log_info "  Token:        $TOKEN_ADDRESS"
 log_info "  Bridge:       $BRIDGE_ADDR"
 
 # ---------------------------------------------------------------------------
-# Optionally wait for the deposit to be auto-claimed on L2
+# Optionally wait for the deposit to be claimed on L1
 # ---------------------------------------------------------------------------
 
 if [[ "$WAIT_FOR_CLAIM" == "true" ]]; then
-    log_info "L2 RPC URL: $L2_RPC_URL"
+    log_info "L1 RPC URL: $L1_RPC_URL"
 
-    DEPOSIT_COUNT=$(extract_deposit_count "$TX_HASH" "$L1_RPC_URL")
+    DEPOSIT_COUNT=$(extract_deposit_count "$TX_HASH" "$L2_RPC_URL")
     if [[ -n "$DEPOSIT_COUNT" ]]; then
-        wait_for_claim "$L2_RPC_URL" "$BRIDGE_ADDR" "$DEPOSIT_COUNT" "$CLAIM_TIMEOUT_SECS"
+        wait_for_claim "$L1_RPC_URL" "$BRIDGE_ADDR" "$DEPOSIT_COUNT" "$L2_NETWORK_INDEX" 300
     else
         log_warn "Could not determine depositCount — skipping claim check"
     fi

--- a/tools/exit_certificate/scripts/bridge_l2_to_l1.sh
+++ b/tools/exit_certificate/scripts/bridge_l2_to_l1.sh
@@ -379,7 +379,12 @@ TX_STATUS=$(cast receipt --rpc-url "$L2_RPC_URL" "$TX_HASH" status 2>/dev/null |
 TX_BLOCK=$(cast receipt --rpc-url "$L2_RPC_URL" "$TX_HASH" blockNumber 2>/dev/null || true)
 if [[ -z "$TX_STATUS" ]]; then
     log_warn "Could not fetch receipt for $TX_HASH"
-elif [[ "$TX_STATUS" == *"success"* ]]; then
+# `cast receipt <hash> status` formats the status differently across versions:
+# foundry <=1.5 prints "1 (success)" / "0 (failed)", foundry >=1.7 prints the raw
+# bool "true" / "false". Accept every success spelling so a healthy tx is never
+# misreported as REVERTED.
+elif [[ "$TX_STATUS" == *"success"* || "$TX_STATUS" == "true" \
+     || "$TX_STATUS" == "1" || "$TX_STATUS" == "0x1" ]]; then
     log_info "Receipt: status=success blockNumber=$TX_BLOCK"
 else
     log_error "Receipt: status=REVERTED blockNumber=$TX_BLOCK"

--- a/tools/exit_certificate/scripts/export_kurtosis_env.sh
+++ b/tools/exit_certificate/scripts/export_kurtosis_env.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Resolves connection info (RPC URLs, bridge address, agglayer URLs, ...) from a
+# running Kurtosis enclave and prints `export VAR=value` lines on stdout so they
+# can be loaded into the current shell. Logs go to stderr.
+#
+# Usage (load the variables into your shell):
+#   source <(tools/exit_certificate/scripts/export_kurtosis_env.sh 1)
+#   # or:
+#   eval "$(tools/exit_certificate/scripts/export_kurtosis_env.sh 1)"
+#
+# Afterwards bridge_l1_to_l2.sh (and other scripts) reuse L1_RPC_URL, L2_RPC_URL,
+# BRIDGE_ADDR, ... directly instead of querying Kurtosis again.
+#
+# Requires: kurtosis.
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+log_warn()  { echo -e "${ORANGE}[WARN]${NC} $*" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [OPTIONS] [NETWORK_INDEX]
+
+Resolves Kurtosis connection info and prints \`export VAR=value\` lines on stdout.
+Load it into your shell with: source <($0 NETWORK_INDEX)
+
+Arguments:
+  NETWORK_INDEX   L2 network index to target (default: 1 → service suffix 001)
+
+Options:
+  -e, --enclave   ENCLAVE    Kurtosis enclave name (default: \$KURTOSIS_ENCLAVE or "aggkit")
+  -h, --help                 Show this help
+
+Environment variables (override defaults):
+  KURTOSIS_ENCLAVE                  Enclave name
+  KURTOSIS_ARTIFACT_AGGKIT_CONFIG   Aggkit config artifact name (default: aggkit-config)
+  L1_SERVICE                        Kurtosis L1 execution service (default: el-1-geth-lighthouse)
+  L2_SERVICE_PREFIX                 Kurtosis L2 execution service prefix (default: op-el-1-op-geth-op-node)
+  AGGLAYER_SERVICE                  Kurtosis agglayer service name (default: agglayer)
+
+Exported variables:
+  KURTOSIS_ENCLAVE   NETWORK_INDEX   L1_RPC_URL   L2_RPC_URL   BRIDGE_ADDR
+  AGGLAYER_ADMIN_URL   AGGLAYER_GRPC_URL
+
+Examples:
+  source <($0)                # Network 1, enclave "aggkit"
+  source <($0 2)              # Network 2 (service op-geth-002)
+  eval "\$($0 --enclave op 1)"
+EOF
+    exit 1
+}
+
+# Defaults (can be overridden by env vars)
+KURTOSIS_ENCLAVE="${KURTOSIS_ENCLAVE:-aggkit}"
+KURTOSIS_ARTIFACT_AGGKIT_CONFIG="${KURTOSIS_ARTIFACT_AGGKIT_CONFIG:-aggkit-config}"
+L1_SERVICE="${L1_SERVICE:-el-1-geth-lighthouse}"
+L2_SERVICE_PREFIX="${L2_SERVICE_PREFIX:-op-el-1-op-geth-op-node}"
+AGGLAYER_SERVICE="${AGGLAYER_SERVICE:-agglayer}"
+NETWORK_INDEX=1
+
+# Parse flags and positional args
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage ;;
+        -e|--enclave)
+            [[ $# -lt 2 ]] && { log_error "--enclave requires a value"; usage; }
+            KURTOSIS_ENCLAVE="$2"; shift 2 ;;
+        [0-9]*)
+            NETWORK_INDEX="$1"; shift ;;
+        *)
+            log_error "Unknown argument: $1"; usage ;;
+    esac
+done
+
+NETWORK_SUFFIX=$(printf '%03d' "$NETWORK_INDEX")
+L2_SERVICE="${L2_SERVICE_PREFIX}-${NETWORK_SUFFIX}"
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+command -v kurtosis &>/dev/null || { log_error "Missing required tool: kurtosis"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Kurtosis helpers
+# ---------------------------------------------------------------------------
+
+# kurtosis port print returns something like "http://127.0.0.1:PORT" — extract
+# the port and rebuild as http://localhost:PORT.
+port_to_localhost_url() {
+    local raw_url="$1"
+    local port
+    port=$(echo "$raw_url" | sed -E 's|^[a-zA-Z]+://||' | cut -f2 -d':')
+    echo "http://localhost:${port}"
+}
+
+get_l1_rpc_url() {
+    local raw
+    if ! raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$L1_SERVICE" rpc 2>/dev/null); then
+        log_error "Failed to get L1 RPC port from service '$L1_SERVICE' in enclave '$KURTOSIS_ENCLAVE'"
+        log_error "Ensure the enclave is running: kurtosis enclave inspect $KURTOSIS_ENCLAVE"
+        exit 1
+    fi
+    port_to_localhost_url "$raw"
+}
+
+get_l2_rpc_url() {
+    local raw
+    if ! raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$L2_SERVICE" rpc 2>/dev/null); then
+        log_error "Failed to get L2 RPC port from service '$L2_SERVICE' in enclave '$KURTOSIS_ENCLAVE'"
+        log_error "To use a different prefix, set L2_SERVICE_PREFIX"
+        exit 1
+    fi
+    port_to_localhost_url "$raw"
+}
+
+get_agglayer_admin_url() {
+    local raw
+    if ! raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$AGGLAYER_SERVICE" aglr-admin 2>/dev/null); then
+        return 1
+    fi
+    port_to_localhost_url "$raw"
+}
+
+get_agglayer_grpc_url() {
+    local raw port
+    if ! raw=$(kurtosis port print "$KURTOSIS_ENCLAVE" "$AGGLAYER_SERVICE" aglr-grpc 2>/dev/null); then
+        return 1
+    fi
+    # kurtosis returns grpc://host:PORT — rebuild as http://localhost:PORT (insecure gRPC)
+    port=$(echo "$raw" | sed -E 's|^[a-zA-Z]+://||' | cut -f2 -d':')
+    echo "http://localhost:${port}"
+}
+
+get_bridge_address() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp_dir'" RETURN
+
+    local artifact_name="${KURTOSIS_ARTIFACT_AGGKIT_CONFIG}-${NETWORK_SUFFIX}"
+    if ! kurtosis files download "$KURTOSIS_ENCLAVE" "$artifact_name" "$tmp_dir" &>/dev/null; then
+        log_warn "Artifact '$artifact_name' not found, trying '$KURTOSIS_ARTIFACT_AGGKIT_CONFIG'..."
+        artifact_name="$KURTOSIS_ARTIFACT_AGGKIT_CONFIG"
+        if ! kurtosis files download "$KURTOSIS_ENCLAVE" "$artifact_name" "$tmp_dir" &>/dev/null; then
+            log_error "Could not download artifact '$artifact_name' from enclave '$KURTOSIS_ENCLAVE'"
+            exit 1
+        fi
+    fi
+
+    local config_file="$tmp_dir/config.toml"
+    if [[ ! -f "$config_file" ]]; then
+        log_error "config.toml not found in downloaded artifact '$artifact_name'"
+        exit 1
+    fi
+
+    local addr
+    addr=$(grep 'BridgeAddr' "$config_file" | head -1 | tr -d '[:space:]' | cut -f2 -d'=' | tr -d '"')
+    if [[ -z "$addr" ]]; then
+        log_error "BridgeAddr not found in $config_file"
+        exit 1
+    fi
+    echo "$addr"
+}
+
+# ---------------------------------------------------------------------------
+# Resolve
+# ---------------------------------------------------------------------------
+
+log_info "Enclave:        $KURTOSIS_ENCLAVE"
+log_info "Network index:  $NETWORK_INDEX (suffix: $NETWORK_SUFFIX)"
+log_info "L1 service:     $L1_SERVICE"
+log_info "L2 service:     $L2_SERVICE"
+
+log_info "Getting L1 RPC URL..."
+L1_RPC_URL=$(get_l1_rpc_url)
+log_info "L1 RPC URL: $L1_RPC_URL"
+
+log_info "Getting L2 RPC URL..."
+L2_RPC_URL=$(get_l2_rpc_url)
+log_info "L2 RPC URL: $L2_RPC_URL"
+
+log_info "Getting bridge address from aggkit config artifact..."
+BRIDGE_ADDR=$(get_bridge_address)
+log_info "Bridge address: $BRIDGE_ADDR"
+
+log_info "Getting agglayer URLs..."
+AGGLAYER_ADMIN_URL=""
+if AGGLAYER_ADMIN_URL=$(get_agglayer_admin_url); then
+    log_info "Agglayer admin URL: $AGGLAYER_ADMIN_URL"
+else
+    log_warn "Service '$AGGLAYER_SERVICE' (aglr-admin) not found — AGGLAYER_ADMIN_URL will be empty"
+fi
+AGGLAYER_GRPC_URL=""
+if AGGLAYER_GRPC_URL=$(get_agglayer_grpc_url); then
+    log_info "Agglayer gRPC URL:  $AGGLAYER_GRPC_URL"
+else
+    log_warn "Service '$AGGLAYER_SERVICE' (aglr-grpc) not found — AGGLAYER_GRPC_URL will be empty"
+fi
+
+# ---------------------------------------------------------------------------
+# Emit export statements on stdout
+# ---------------------------------------------------------------------------
+
+cat <<EOF
+export KURTOSIS_ENCLAVE="$KURTOSIS_ENCLAVE"
+export NETWORK_INDEX="$NETWORK_INDEX"
+export L1_RPC_URL="$L1_RPC_URL"
+export L2_RPC_URL="$L2_RPC_URL"
+export BRIDGE_ADDR="$BRIDGE_ADDR"
+export AGGLAYER_ADMIN_URL="$AGGLAYER_ADMIN_URL"
+export AGGLAYER_GRPC_URL="$AGGLAYER_GRPC_URL"
+EOF
+
+log_info "Run: source <($0 $NETWORK_INDEX)   to load these into your shell."


### PR DESCRIPTION
## 🔄 Changes Summary
- Add the **exit-certificate E2E test harness** under `test/e2e-exit_certificate/`: spins up a Kurtosis CDK network (`run_network.sh`), prepares a settled certificate (`prepare_network.sh`), and runs the `exit_certificate` tool (`run_exit_tool.sh`), orchestrated by `run_e2e_test.sh` (+ `helper.sh`, `single_op_pessimistic_args.json`, `README.md`).
- Add supporting scripts under `tools/exit_certificate/scripts/`:
  - `bridge_l2_to_l1.sh` — L2→L1 bridge to produce a certificate.
  - `agglayer_certificate_status.sh` — poll/wait for certificate settlement.
  - `export_kurtosis_env.sh` — export Kurtosis env vars for the scripts.
  - `agglayer_status/main.go` — agglayer status helper.
  - Update `bridge_l1_to_l2.sh`.
- Add CI workflow `.github/workflows/test-e2e-exit_cenrtificate_tool.yml` that runs the E2E test on PRs touching `tools/exit_certificate/**` (also `workflow_dispatch`).

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: New GitHub Actions workflow runs `test/e2e-exit_certificate/run_e2e_test.sh` on PRs that modify `tools/exit_certificate/**` (Kurtosis CDK network → settled certificate → exit_certificate tool).
- 🖱️ **Manual**: `./test/e2e-exit_certificate/run_e2e_test.sh` locally (requires Docker, Kurtosis CLI, Foundry `cast`, Go).

## 🐞 Issues
- N/A

## 🔗 Related PRs
- #1654 (feat: subtract genesis preload from EOA balances in Step B)

## 📝 Notes
- The E2E harness clones a pinned Kurtosis CDK commit and manages its own `aggkit` enclave; the workflow stops the enclave on completion.