### PR TITLE
fix: honor MaxL2BlockNumber in aggchain flow

### DIFF
--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -253,7 +253,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 		flow: flows.NewPPBuilderFlow(logger,
 			flows.NewBaseFlow(logger, mockL2BridgeQuerier, mockStorage,
 				mockL1Querier, bridgetypes.EmptyLER, nil, flows.NewBaseFlowConfigDefault()),
-			mockStorage, mockL1Querier, mockL2BridgeQuerier, signer, true, 0),
+			mockStorage, mockL1Querier, mockL2BridgeQuerier, signer, true, 0, 0),
 	}
 
 	mockStorage.EXPECT().GetLastSentCertificateHeader().Return(&aggsendertypes.CertificateHeader{
@@ -869,7 +869,7 @@ func newAggsenderTestData(t *testing.T, creationFlags testDataFlags) *aggsenderT
 		flow: flows.NewPPBuilderFlow(logger,
 			flows.NewBaseFlow(logger, l2BridgeQuerier, storage,
 				l1InfoTreeQuerierMock, bridgetypes.EmptyLER, nil, flows.NewBaseFlowConfigDefault()),
-			storage, l1InfoTreeQuerierMock, l2BridgeQuerier, signer, true, 0),
+			storage, l1InfoTreeQuerierMock, l2BridgeQuerier, signer, true, 0, 0),
 	}
 	var flowMock *mocks.AggsenderBuilderFlow
 	if creationFlags&testDataFlagMockFlow != 0 {

--- a/aggsender/config/config.go
+++ b/aggsender/config/config.go
@@ -126,6 +126,9 @@ type Config struct {
 	// MaxL2BlockNumber is the last L2 block number that is going to be included in a certificate
 	// 0 means disabled
 	MaxL2BlockNumber uint64 `mapstructure:"MaxL2BlockNumber"`
+	// MaxL2BlockRange is the maximum L2 block range allowed in a certificate (ToBlock - FromBlock)
+	// 0 means disabled
+	MaxL2BlockRange uint64 `mapstructure:"MaxL2BlockRange"`
 	// StopOnFinishedSendingAllCertificates is a flag to stop the AggSender when it finishes sending all certificates
 	// up to MaxL2BlockNumber
 	StopOnFinishedSendingAllCertificates bool `mapstructure:"StopOnFinishedSendingAllCertificates"`

--- a/aggsender/flows/adjust_block_range.go
+++ b/aggsender/flows/adjust_block_range.go
@@ -16,6 +16,8 @@ import (
 var (
 	ErrMaxL2BlockNumberExceededInARetryCert = errors.New("maxL2BlockNumberLimiter. " +
 		"Max L2 block number exceeded in a retry certificate")
+	ErrMaxL2BlockRangeExceededInARetryCert = errors.New("maxL2BlockRangeLimiter. " +
+		"Max L2 block range exceeded in a retry certificate")
 	ErrComplete = errors.New("maxL2BlockNumberLimiter. " +
 		"All certs send, no more certificates can be sent")
 	ErrBuildParamsIsNil = errors.New("maxL2BlockNumberLimiter. BuildParams is nil")
@@ -43,7 +45,12 @@ func (f *baseFlow) AdjustBlockRange(
 	current := buildParams
 	cache := newGERValidationCache()
 
-	current, err := f.adjustMaxL2BlockRange(current, options)
+	current, err := f.adjustMaxL2BlockNumber(current, options)
+	if err != nil {
+		return nil, err
+	}
+
+	current, err = f.adjustMaxL2BlockRange(current, options)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +81,7 @@ func (f *baseFlow) AdjustBlockRange(
 	return current, nil
 }
 
-func (f *baseFlow) adjustMaxL2BlockRange(
+func (f *baseFlow) adjustMaxL2BlockNumber(
 	buildParams *types.CertificateBuildParams,
 	options types.BlockRangeAdjustmentOptions,
 ) (*types.CertificateBuildParams, error) {
@@ -125,6 +132,51 @@ func (f *baseFlow) adjustMaxL2BlockRange(
 		f.log.Warnf("Nothing to do. We have submitted all permitted certificate for maxL2BlockNumber: %d",
 			options.MaxL2BlockNumber)
 		return nil, ErrComplete
+	}
+
+	return adjusted, nil
+}
+
+func (f *baseFlow) adjustMaxL2BlockRange(
+	buildParams *types.CertificateBuildParams,
+	options types.BlockRangeAdjustmentOptions,
+) (*types.CertificateBuildParams, error) {
+	if options.MaxL2BlockRange == 0 || buildParams.ToBlock <= buildParams.FromBlock ||
+		buildParams.ToBlock-buildParams.FromBlock <= options.MaxL2BlockRange {
+		return buildParams, nil
+	}
+
+	newToBlock := buildParams.FromBlock + options.MaxL2BlockRange
+	f.log.Infof("adjustBlockRange. Applying maxL2BlockRange=%d to cert range [%d,%d]",
+		options.MaxL2BlockRange, buildParams.FromBlock, buildParams.ToBlock)
+
+	if buildParams.IsARetry() && !options.AllowResizeRetryCert {
+		return nil, fmt.Errorf("adjustBlockRange can't adapt the retry certificate, "+
+			"the block range %d is greater than the maxL2BlockRange %d. Err: %w",
+			buildParams.ToBlock-buildParams.FromBlock, options.MaxL2BlockRange,
+			ErrMaxL2BlockRangeExceededInARetryCert)
+	}
+
+	adjusted, err := cloneCertificateBuildParamsWithRange(buildParams, buildParams.FromBlock, newToBlock)
+	if err != nil {
+		return nil, fmt.Errorf("adjustBlockRange error adjusting the ToBlock of the certificate %d -> %d: %w",
+			buildParams.ToBlock, newToBlock, err)
+	}
+
+	if !options.RequireOneBridgeInCertificate && adjusted.IsEmpty() {
+		return adjusted, nil
+	}
+
+	if options.RequireOneBridgeInCertificate && adjusted.NumberOfBridges() == 0 {
+		if adjusted.NumberOfClaims() > 0 {
+			return nil, fmt.Errorf("adjustBlockRange can't send cert. maxL2BlockRange: %d. "+
+				"the current reduced range [%d to %d] has no bridges but has %d imported bridges",
+				options.MaxL2BlockRange, adjusted.FromBlock, adjusted.ToBlock, adjusted.NumberOfClaims())
+		}
+
+		return nil, fmt.Errorf("adjustBlockRange can't send cert. maxL2BlockRange: %d. "+
+			"the current reduced range [%d to %d] has no bridges",
+			options.MaxL2BlockRange, adjusted.FromBlock, adjusted.ToBlock)
 	}
 
 	return adjusted, nil

--- a/aggsender/flows/adjust_block_range.go
+++ b/aggsender/flows/adjust_block_range.go
@@ -112,29 +112,8 @@ func (f *baseFlow) adjustMaxL2BlockNumber(
 			options.MaxL2BlockNumber, buildParams.FromBlock, ErrComplete)
 	}
 
-	adjusted, err := cloneCertificateBuildParamsWithRange(buildParams, buildParams.FromBlock, options.MaxL2BlockNumber)
-	if err != nil {
-		return nil, fmt.Errorf("adjustBlockRange error adjusting the ToBlock of the certificate %d -> %d: %w",
-			buildParams.ToBlock, options.MaxL2BlockNumber, err)
-	}
-
-	if !options.RequireOneBridgeInCertificate && adjusted.IsEmpty() {
-		return adjusted, nil
-	}
-
-	if options.RequireOneBridgeInCertificate && adjusted.NumberOfBridges() == 0 {
-		if adjusted.NumberOfClaims() > 0 {
-			return nil, fmt.Errorf("adjustBlockRange can't send cert. maxL2BlockNumber: %d. "+
-				"the current reduced range [%d to %d] has no bridges but has %d imported bridges",
-				options.MaxL2BlockNumber, adjusted.FromBlock, adjusted.ToBlock, adjusted.NumberOfClaims())
-		}
-
-		f.log.Warnf("Nothing to do. We have submitted all permitted certificate for maxL2BlockNumber: %d",
-			options.MaxL2BlockNumber)
-		return nil, ErrComplete
-	}
-
-	return adjusted, nil
+	return f.adjustToMaxL2Block(buildParams, options, options.MaxL2BlockNumber, "maxL2BlockNumber",
+		options.MaxL2BlockNumber, true)
 }
 
 func (f *baseFlow) adjustMaxL2BlockRange(
@@ -157,10 +136,21 @@ func (f *baseFlow) adjustMaxL2BlockRange(
 			ErrMaxL2BlockRangeExceededInARetryCert)
 	}
 
-	adjusted, err := cloneCertificateBuildParamsWithRange(buildParams, buildParams.FromBlock, newToBlock)
+	return f.adjustToMaxL2Block(buildParams, options, newToBlock, "maxL2BlockRange", options.MaxL2BlockRange, false)
+}
+
+func (f *baseFlow) adjustToMaxL2Block(
+	buildParams *types.CertificateBuildParams,
+	options types.BlockRangeAdjustmentOptions,
+	maxL2BlockNumber uint64,
+	limitName string,
+	limitValue uint64,
+	completeOnEmptyRequiredBridge bool,
+) (*types.CertificateBuildParams, error) {
+	adjusted, err := cloneCertificateBuildParamsWithRange(buildParams, buildParams.FromBlock, maxL2BlockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("adjustBlockRange error adjusting the ToBlock of the certificate %d -> %d: %w",
-			buildParams.ToBlock, newToBlock, err)
+			buildParams.ToBlock, maxL2BlockNumber, err)
 	}
 
 	if !options.RequireOneBridgeInCertificate && adjusted.IsEmpty() {
@@ -169,14 +159,20 @@ func (f *baseFlow) adjustMaxL2BlockRange(
 
 	if options.RequireOneBridgeInCertificate && adjusted.NumberOfBridges() == 0 {
 		if adjusted.NumberOfClaims() > 0 {
-			return nil, fmt.Errorf("adjustBlockRange can't send cert. maxL2BlockRange: %d. "+
+			return nil, fmt.Errorf("adjustBlockRange can't send cert. %s: %d. "+
 				"the current reduced range [%d to %d] has no bridges but has %d imported bridges",
-				options.MaxL2BlockRange, adjusted.FromBlock, adjusted.ToBlock, adjusted.NumberOfClaims())
+				limitName, limitValue, adjusted.FromBlock, adjusted.ToBlock, adjusted.NumberOfClaims())
 		}
 
-		return nil, fmt.Errorf("adjustBlockRange can't send cert. maxL2BlockRange: %d. "+
+		if completeOnEmptyRequiredBridge {
+			f.log.Warnf("Nothing to do. We have submitted all permitted certificate for %s: %d",
+				limitName, limitValue)
+			return nil, ErrComplete
+		}
+
+		return nil, fmt.Errorf("adjustBlockRange can't send cert. %s: %d. "+
 			"the current reduced range [%d to %d] has no bridges",
-			options.MaxL2BlockRange, adjusted.FromBlock, adjusted.ToBlock)
+			limitName, limitValue, adjusted.FromBlock, adjusted.ToBlock)
 	}
 
 	return adjusted, nil

--- a/aggsender/flows/adjust_block_range_test.go
+++ b/aggsender/flows/adjust_block_range_test.go
@@ -29,7 +29,7 @@ func Test_baseFlow_AdjustBlockRange_NilBuildParams(t *testing.T) {
 	require.Nil(t, result)
 }
 
-func Test_baseFlow_adjustMaxL2BlockRange(t *testing.T) {
+func Test_baseFlow_adjustMaxL2BlockNumber(t *testing.T) {
 	t.Parallel()
 
 	lastSentCert := &types.CertificateHeader{CertificateID: common.HexToHash("0x1")}
@@ -174,6 +174,166 @@ func Test_baseFlow_adjustMaxL2BlockRange(t *testing.T) {
 			},
 			options:       types.BlockRangeAdjustmentOptions{MaxL2BlockNumber: 9, RequireOneBridgeInCertificate: true},
 			expectedError: ErrComplete,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := &baseFlow{log: log.WithFields("test", t.Name())}
+
+			result, err := f.adjustMaxL2BlockNumber(tc.buildParams, tc.options)
+
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				require.Nil(t, result)
+				return
+			}
+			if tc.errorContains != "" {
+				require.ErrorContains(t, err, tc.errorContains)
+				require.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			tc.checkResult(t, result)
+		})
+	}
+}
+
+func Test_baseFlow_adjustMaxL2BlockRange(t *testing.T) {
+	t.Parallel()
+
+	lastSentCert := &types.CertificateHeader{CertificateID: common.HexToHash("0x1")}
+	aggchainProof := &types.AggchainProof{EndBlock: 12}
+
+	tests := []struct {
+		name          string
+		buildParams   *types.CertificateBuildParams
+		options       types.BlockRangeAdjustmentOptions
+		checkResult   func(t *testing.T, result *types.CertificateBuildParams)
+		expectedError error
+		errorContains string
+	}{
+		{
+			name: "no max l2 block range configured keeps original certificate",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 5,
+				ToBlock:   12,
+			},
+			options: types.BlockRangeAdjustmentOptions{},
+			checkResult: func(t *testing.T, result *types.CertificateBuildParams) {
+				t.Helper()
+				require.Equal(t, uint64(5), result.FromBlock)
+				require.Equal(t, uint64(12), result.ToBlock)
+			},
+		},
+		{
+			name: "range already within limit keeps original certificate",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 5,
+				ToBlock:   8,
+			},
+			options: types.BlockRangeAdjustmentOptions{MaxL2BlockRange: 3},
+			checkResult: func(t *testing.T, result *types.CertificateBuildParams) {
+				t.Helper()
+				require.Equal(t, uint64(5), result.FromBlock)
+				require.Equal(t, uint64(8), result.ToBlock)
+			},
+		},
+		{
+			name: "single block range is always within limit",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 5,
+				ToBlock:   5,
+			},
+			options: types.BlockRangeAdjustmentOptions{MaxL2BlockRange: 1},
+			checkResult: func(t *testing.T, result *types.CertificateBuildParams) {
+				t.Helper()
+				require.Equal(t, uint64(5), result.FromBlock)
+				require.Equal(t, uint64(5), result.ToBlock)
+			},
+		},
+		{
+			name: "retry certificate cannot be resized when disabled",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock:                      5,
+				ToBlock:                        12,
+				RetryCount:                     1,
+				LastSentCertificate:            lastSentCert,
+				CertificateType:                types.CertificateTypeFEP,
+				L1InfoTreeLeafCount:            5,
+				AggchainProof:                  aggchainProof,
+				ExtraData:                      "keep-me",
+				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x11"),
+			},
+			options:       types.BlockRangeAdjustmentOptions{MaxL2BlockRange: 3},
+			expectedError: ErrMaxL2BlockRangeExceededInARetryCert,
+		},
+		{
+			name: "shrinks range and preserves metadata",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock:                      5,
+				ToBlock:                        12,
+				Bridges:                        []bridgesync.Bridge{{BlockNum: 5, DepositCount: 1}, {BlockNum: 8, DepositCount: 2}, {BlockNum: 9, DepositCount: 3}},
+				Claims:                         []claimsynctypes.Claim{{BlockNum: 7}, {BlockNum: 9}},
+				Unclaims:                       []claimsynctypes.Unclaim{{BlockNumber: 8}, {BlockNumber: 10}},
+				CreatedAt:                      99,
+				RetryCount:                     1,
+				LastSentCertificate:            lastSentCert,
+				L1InfoTreeRootFromWhichToProve: common.HexToHash("0x22"),
+				L1InfoTreeLeafCount:            12,
+				AggchainProof:                  aggchainProof,
+				CertificateType:                types.CertificateTypePP,
+				ExtraData:                      "extra",
+			},
+			options: types.BlockRangeAdjustmentOptions{MaxL2BlockRange: 3, AllowResizeRetryCert: true},
+			checkResult: func(t *testing.T, result *types.CertificateBuildParams) {
+				t.Helper()
+				require.Equal(t, uint64(5), result.FromBlock)
+				require.Equal(t, uint64(8), result.ToBlock)
+				require.Len(t, result.Bridges, 2)
+				require.Len(t, result.Claims, 1)
+				require.Len(t, result.Unclaims, 1)
+				require.Equal(t, uint32(99), result.CreatedAt)
+				require.Equal(t, 1, result.RetryCount)
+				require.Same(t, lastSentCert, result.LastSentCertificate)
+				require.Equal(t, common.HexToHash("0x22"), result.L1InfoTreeRootFromWhichToProve)
+				require.Equal(t, uint32(12), result.L1InfoTreeLeafCount)
+				require.Same(t, aggchainProof, result.AggchainProof)
+				require.Equal(t, types.CertificateTypePP, result.CertificateType)
+				require.Equal(t, "extra", result.ExtraData)
+			},
+		},
+		{
+			name: "allow empty certificate when bridges are not required",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 5,
+				ToBlock:   12,
+				Bridges:   []bridgesync.Bridge{{BlockNum: 12}},
+			},
+			options: types.BlockRangeAdjustmentOptions{MaxL2BlockRange: 3},
+			checkResult: func(t *testing.T, result *types.CertificateBuildParams) {
+				t.Helper()
+				require.Equal(t, uint64(5), result.FromBlock)
+				require.Equal(t, uint64(8), result.ToBlock)
+				require.Empty(t, result.Bridges)
+				require.Empty(t, result.Claims)
+			},
+		},
+		{
+			name: "required bridge with remaining claims returns error",
+			buildParams: &types.CertificateBuildParams{
+				FromBlock: 5,
+				ToBlock:   12,
+				Bridges:   []bridgesync.Bridge{{BlockNum: 12}},
+				Claims:    []claimsynctypes.Claim{{BlockNum: 7}},
+			},
+			options:       types.BlockRangeAdjustmentOptions{MaxL2BlockRange: 3, RequireOneBridgeInCertificate: true},
+			errorContains: "has no bridges but has 1 imported bridges",
 		},
 	}
 

--- a/aggsender/flows/builder_flow_aggchain_prover.go
+++ b/aggsender/flows/builder_flow_aggchain_prover.go
@@ -51,20 +51,25 @@ func getL2StartBlock(sovereignRollupAddr common.Address, l1Client aggkittypes.Ba
 // AggchainProverFlowConfig holds the configuration for the AggchainProverFlow
 type AggchainProverFlowConfig struct {
 	maxL2BlockNumber uint64
+	maxL2BlockRange  uint64
 }
 
 // NewAggchainProverFlowConfigDefault returns a default configuration for the AggchainProverFlow
 func NewAggchainProverFlowConfigDefault() AggchainProverFlowConfig {
 	return AggchainProverFlowConfig{
 		maxL2BlockNumber: 0,
+		maxL2BlockRange:  0,
 	}
 }
 
 // NewAggchainProverFlowConfig creates a new AggchainProverFlowConfig with the given base flow config
 func NewAggchainProverFlowConfig(
-	maxL2BlockNumber uint64) AggchainProverFlowConfig {
+	maxL2BlockNumber uint64,
+	maxL2BlockRange uint64,
+) AggchainProverFlowConfig {
 	return AggchainProverFlowConfig{
 		maxL2BlockNumber: maxL2BlockNumber,
+		maxL2BlockRange:  maxL2BlockRange,
 	}
 }
 
@@ -390,6 +395,7 @@ func (a *AggchainProverBuilderFlow) UpdateAggchainData(
 func (a *AggchainProverBuilderFlow) adjustmentOptions(validateRootToProve bool) types.BlockRangeAdjustmentOptions {
 	return types.BlockRangeAdjustmentOptions{
 		MaxL2BlockNumber:              a.config.maxL2BlockNumber,
+		MaxL2BlockRange:               a.config.maxL2BlockRange,
 		AllowResizeRetryCert:          false,
 		RequireOneBridgeInCertificate: false,
 		ValidateRootToProve:           validateRootToProve,

--- a/aggsender/flows/builder_flow_aggchain_prover.go
+++ b/aggsender/flows/builder_flow_aggchain_prover.go
@@ -90,6 +90,7 @@ func NewAggchainProverBuilderFlow(
 		optimisticModeQuerier: optimisticModeQuerier,
 		aggchainProofQuerier:  aggchainProofQuerier,
 		baseFlow:              baseFlow,
+		config:                aggChainProverConfig,
 	}
 }
 

--- a/aggsender/flows/builder_flow_aggchain_prover_test.go
+++ b/aggsender/flows/builder_flow_aggchain_prover_test.go
@@ -687,6 +687,60 @@ func Test_AggchainProverFlow_getLastProvenBlock(t *testing.T) {
 	}
 }
 
+func Test_AggchainProverFlow_AdjustmentOptionsUsesConfiguredMaxL2BlockNumber(t *testing.T) {
+	t.Parallel()
+
+	const maxL2BlockNumber = uint64(2700000)
+
+	flow := NewAggchainProverBuilderFlow(
+		log.WithFields("flowManager", "Test_AggchainProverFlow_AdjustmentOptionsUsesConfiguredMaxL2BlockNumber"),
+		NewAggchainProverFlowConfig(maxL2BlockNumber),
+		nil, // baseFlow
+		nil, // storage
+		nil, // l1InfoTreeQuerier
+		nil, // l2BridgeQuerier
+		nil, // signer
+		nil, // optimisticModeQuerier
+		nil, // aggchainProofQuerier
+	)
+
+	tests := []struct {
+		name                string
+		validateRootToProve bool
+		expectedOptions     types.BlockRangeAdjustmentOptions
+	}{
+		{
+			name:                "builder path",
+			validateRootToProve: false,
+			expectedOptions: types.BlockRangeAdjustmentOptions{
+				MaxL2BlockNumber:              maxL2BlockNumber,
+				AllowResizeRetryCert:          false,
+				RequireOneBridgeInCertificate: false,
+			},
+		},
+		{
+			name:                "validator path",
+			validateRootToProve: true,
+			expectedOptions: types.BlockRangeAdjustmentOptions{
+				MaxL2BlockNumber:              maxL2BlockNumber,
+				AllowResizeRetryCert:          false,
+				RequireOneBridgeInCertificate: false,
+				ValidateRootToProve:           true,
+				DisableSizeLimit:              true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expectedOptions, flow.adjustmentOptions(tc.validateRootToProve))
+		})
+	}
+}
+
 func Test_AggchainProverFlow_BuildCertificate(t *testing.T) {
 	t.Parallel()
 

--- a/aggsender/flows/builder_flow_aggchain_prover_test.go
+++ b/aggsender/flows/builder_flow_aggchain_prover_test.go
@@ -691,10 +691,11 @@ func Test_AggchainProverFlow_AdjustmentOptionsUsesConfiguredMaxL2BlockNumber(t *
 	t.Parallel()
 
 	const maxL2BlockNumber = uint64(2700000)
+	const maxL2BlockRange = uint64(500)
 
 	flow := NewAggchainProverBuilderFlow(
 		log.WithFields("flowManager", "Test_AggchainProverFlow_AdjustmentOptionsUsesConfiguredMaxL2BlockNumber"),
-		NewAggchainProverFlowConfig(maxL2BlockNumber),
+		NewAggchainProverFlowConfig(maxL2BlockNumber, maxL2BlockRange),
 		nil, // baseFlow
 		nil, // storage
 		nil, // l1InfoTreeQuerier
@@ -714,6 +715,7 @@ func Test_AggchainProverFlow_AdjustmentOptionsUsesConfiguredMaxL2BlockNumber(t *
 			validateRootToProve: false,
 			expectedOptions: types.BlockRangeAdjustmentOptions{
 				MaxL2BlockNumber:              maxL2BlockNumber,
+				MaxL2BlockRange:               maxL2BlockRange,
 				AllowResizeRetryCert:          false,
 				RequireOneBridgeInCertificate: false,
 			},
@@ -723,6 +725,7 @@ func Test_AggchainProverFlow_AdjustmentOptionsUsesConfiguredMaxL2BlockNumber(t *
 			validateRootToProve: true,
 			expectedOptions: types.BlockRangeAdjustmentOptions{
 				MaxL2BlockNumber:              maxL2BlockNumber,
+				MaxL2BlockRange:               maxL2BlockRange,
 				AllowResizeRetryCert:          false,
 				RequireOneBridgeInCertificate: false,
 				ValidateRootToProve:           true,

--- a/aggsender/flows/builder_flow_factory.go
+++ b/aggsender/flows/builder_flow_factory.go
@@ -74,6 +74,7 @@ func NewBuilderFlow(
 			commonFlowComponents.Signer,
 			cfg.RequireOneBridgeInPPCertificate,
 			cfg.MaxL2BlockNumber,
+			cfg.MaxL2BlockRange,
 		), nil
 	case types.AggchainProofMode:
 		aggchainProofClient, err := aggchainproofclient.NewAggchainProofClient(cfg.AggkitProverClient)
@@ -134,7 +135,7 @@ func NewBuilderFlow(
 
 		return NewAggchainProverBuilderFlow(
 			logger,
-			NewAggchainProverFlowConfig(cfg.MaxL2BlockNumber),
+			NewAggchainProverFlowConfig(cfg.MaxL2BlockNumber, cfg.MaxL2BlockRange),
 			commonFlowComponents.BaseFlow,
 			storage,
 			commonFlowComponents.L1InfoTreeDataQuerier,

--- a/aggsender/flows/builder_flow_pp.go
+++ b/aggsender/flows/builder_flow_pp.go
@@ -22,6 +22,7 @@ type PPBuilderFlow struct {
 
 	forceOneBridgeExit bool
 	maxL2BlockNumber   uint64
+	maxL2BlockRange    uint64
 }
 
 // NewPPBuilderFlow returns a new instance of the PPBuilderFlow
@@ -32,7 +33,8 @@ func NewPPBuilderFlow(log types.Logger,
 	l2BridgeQuerier types.BridgeQuerier,
 	signer signertypes.Signer,
 	forceOneBridgeExit bool,
-	maxL2BlockNumber uint64) *PPBuilderFlow {
+	maxL2BlockNumber uint64,
+	maxL2BlockRange uint64) *PPBuilderFlow {
 	return &PPBuilderFlow{
 		certificateSigner:     signer,
 		log:                   log,
@@ -40,6 +42,7 @@ func NewPPBuilderFlow(log types.Logger,
 		baseFlow:              baseFlow,
 		forceOneBridgeExit:    forceOneBridgeExit,
 		maxL2BlockNumber:      maxL2BlockNumber,
+		maxL2BlockRange:       maxL2BlockRange,
 	}
 }
 
@@ -147,6 +150,7 @@ func (p *PPBuilderFlow) Signer() signertypes.Signer {
 func (p *PPBuilderFlow) adjustmentOptions(validateRootToProve bool) types.BlockRangeAdjustmentOptions {
 	return types.BlockRangeAdjustmentOptions{
 		MaxL2BlockNumber:              p.maxL2BlockNumber,
+		MaxL2BlockRange:               p.maxL2BlockRange,
 		AllowResizeRetryCert:          true,
 		RequireOneBridgeInCertificate: p.forceOneBridgeExit,
 		ValidateRootToProve:           validateRootToProve,

--- a/aggsender/flows/builder_flow_pp_test.go
+++ b/aggsender/flows/builder_flow_pp_test.go
@@ -535,7 +535,7 @@ func Test_PPFlow_GetCertificateBuildParams(t *testing.T) {
 			ppFlow := NewPPBuilderFlow(
 				logger,
 				baseFlow,
-				mockStorage, mockL1InfoTreeQuerier, mockL2BridgeQuerier, nil, tc.forceOneBridgeExit, 0)
+				mockStorage, mockL1InfoTreeQuerier, mockL2BridgeQuerier, nil, tc.forceOneBridgeExit, 0, 0)
 
 			tc.mockFn(mockStorage, mockL2BridgeQuerier, mockL1InfoTreeQuerier)
 			mockL1InfoTreeQuerier.EXPECT().GetProofForGER(mock.Anything, mock.Anything, mock.Anything).

--- a/aggsender/flows/verifier_flow_factory.go
+++ b/aggsender/flows/verifier_flow_factory.go
@@ -59,6 +59,7 @@ func NewVerifierFlow(
 			commonFlowComponents.Signer,
 			cfg.PPConfig.RequireOneBridgeInPPCertificate,
 			cfg.MaxL2BlockNumber,
+			cfg.MaxL2BlockRange,
 		)
 
 		return NewPPVerifierFlow(builderFlow), commonFlowComponents, nil
@@ -94,7 +95,7 @@ func NewVerifierFlow(
 
 		builderFlow := NewAggchainProverBuilderFlow(
 			logger,
-			NewAggchainProverFlowConfig(cfg.MaxL2BlockNumber),
+			NewAggchainProverFlowConfig(cfg.MaxL2BlockNumber, cfg.MaxL2BlockRange),
 			commonFlowComponents.BaseFlow,
 			nil, // storage is not used in validator
 			commonFlowComponents.L1InfoTreeDataQuerier,

--- a/aggsender/types/block_range_adjustment.go
+++ b/aggsender/types/block_range_adjustment.go
@@ -4,6 +4,7 @@ package types
 // the unified block-range adjuster.
 type BlockRangeAdjustmentOptions struct {
 	MaxL2BlockNumber              uint64
+	MaxL2BlockRange               uint64
 	AllowResizeRetryCert          bool
 	RequireOneBridgeInCertificate bool
 	ValidateRootToProve           bool

--- a/aggsender/validator/config.go
+++ b/aggsender/validator/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// MaxL2BlockNumber is the last L2 block number that is going to be included in a certificate
 	// 0 means disabled
 	MaxL2BlockNumber uint64 `mapstructure:"MaxL2BlockNumber"`
+	// MaxL2BlockRange is the maximum L2 block range allowed in a certificate (ToBlock - FromBlock)
+	// 0 means disabled
+	MaxL2BlockRange uint64 `mapstructure:"MaxL2BlockRange"`
 	// DelayBetweenRetries is the delay between retries:
 	//  is used on store Certificate and also in initial check
 	DelayBetweenRetries types.Duration `mapstructure:"DelayBetweenRetries"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,6 +75,8 @@ func TestLoadDefaultConfig(t *testing.T) {
 	require.Equal(t, cfg.AggSender.RollupManagerAddr, cfg.Validator.LerQuerier.RollupManagerAddr)
 	require.Equal(t, uint64(0), cfg.AggSender.UnsetClaimsMaxLogBlockRange)
 	require.Equal(t, cfg.AggSender.UnsetClaimsMaxLogBlockRange, cfg.Validator.UnsetClaimsMaxLogBlockRange)
+	require.Equal(t, uint64(0), cfg.AggSender.MaxL2BlockRange)
+	require.Equal(t, cfg.AggSender.MaxL2BlockRange, cfg.Validator.MaxL2BlockRange)
 	require.Equal(t, aggsendertypes.AutoMode, cfg.AggSender.Mode)
 	require.Equal(t, aggsendertypes.AutoMode, cfg.Validator.Mode)
 	require.Equal(t, cfg.AggSender.StorageRetainCertificatesPolicy.String(), "retain all certificates, keep history: true")

--- a/config/default.go
+++ b/config/default.go
@@ -252,6 +252,7 @@ RequireOneBridgeInPPCertificate = false
 RollupManagerAddr = "{{L1Config.polygonRollupManagerAddress}}"
 RollupCreationBlockL1 = {{rollupCreationBlockNumber}}
 MaxL2BlockNumber = 0
+MaxL2BlockRange = 0
 StopOnFinishedSendingAllCertificates = false
 RequireCommitteeMembershipCheck = false
 AgglayerBridgeL2Addr = "{{L2Config.BridgeAddr}}"
@@ -342,6 +343,7 @@ EnableRPC = false
 Signer = {{AggsenderPrivateKey}}
 MaxCertSize = "{{AggSender.MaxCertSize}}"
 MaxL2BlockNumber = "{{AggSender.MaxL2BlockNumber}}"
+MaxL2BlockRange = "{{AggSender.MaxL2BlockRange}}"
 DelayBetweenRetries = "{{AggSender.DelayBetweenRetries}}"
 # PessimisticProof, AggchainProof or Auto
 Mode = "{{AggSender.Mode}}"

--- a/docs/aggsender.md
+++ b/docs/aggsender.md
@@ -193,6 +193,7 @@ The certificate is the data submitted to `Agglayer`. Must be signed to be accept
 | OptimisticModeConfig              | [optimistic.Config](#optimisticconfig)                    | Configuration for optimistic mode (required by FEP mode).                                                       |
 | RequireOneBridgeInPPCertificate   | bool                                                      | If true, AggSender requires at least one bridge exit for Pessimistic Proof certificates                         |
 | MaxL2BlockNumber                  | uint64                    | Set the last block to be included in a certificate (0 = disabled)
+| MaxL2BlockRange                   | uint64                    | Maximum L2 block range allowed in a certificate, computed as `ToBlock - FromBlock` (0 = disabled)
 |StopOnFinishedSendingAllCertificates| bool                      | Stop when there are no more certificates to send due to MaxL2BlockNumber
 |StorageRetainCertificatesPolicy| [StorageRetainCertificatesPolicy](#storageretaincertificatespolicy) | Configure the certificate retain policy
 | UnsetClaimsMaxLogBlockRange       | uint64                    | Proactive max block range for `eth_getLogs` queries when fetching unset claims. 0 means disabled (fallback to reactive chunking on error)

--- a/docs/aggsender_validator.md
+++ b/docs/aggsender_validator.md
@@ -170,6 +170,7 @@ The validator is configured using a `.toml` file. Check the default values in th
 
 | Name                          | Type    | Description                                                                                                                              |
 |-------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------|
+| MaxL2BlockRange               | uint64  | Maximum L2 block range allowed in a certificate, computed as `ToBlock - FromBlock`. 0 means disabled                                     |
 | UnsetClaimsMaxLogBlockRange   | uint64  | Proactive max block range for `eth_getLogs` queries when fetching unset claims. 0 means disabled (fallback to reactive chunking on error) |
 
 ### Running the Validator


### PR DESCRIPTION
## 🔄 Changes Summary
- Preserve the aggchain prover flow config when constructing `AggchainProverBuilderFlow`.
- Ensure `AggSender.MaxL2BlockNumber` is passed into block-range adjustment for FEP and optimistic aggchain certificates.
- Add `MaxL2BlockRange` to cap each certificate range across PP, FEP, optimistic, builder, and validator flows.
- Add regression coverage for the shared block-range adjuster and aggchain builder options.

## ⚠️ Breaking Changes
- 🛠️ **Config**: None. `MaxL2BlockRange` is optional and defaults to `0` (disabled).
- 🔌 **API/CLI**: None.
- 🗑️ **Deprecated Features**: None.

## 📋 Config Updates
- 🧾 **Diff/Config snippet**:

```toml
[AggSender]
MaxL2BlockRange = 0

[Validator]
MaxL2BlockRange = "{{AggSender.MaxL2BlockRange}}"
```

## ✅ Testing
- 🤖 **Automatic**: `go test ./aggsender/flows`; `go test ./aggsender/...`; `go test ./config`
- 🖱️ **Manual**: Not run.

## 🐞 Issues
- Closes #1672

## 🔗 Related PRs
- None.

## 📝 Notes
- `MaxL2BlockNumber` caps the absolute last L2 block, while `MaxL2BlockRange` caps the per-certificate span computed as `ToBlock - FromBlock`.
- `MaxL2BlockRange = 0` is unlimited and is the default value.