### PR TITLE
fix(ci): fix -dev images for release candidates and add -no_shell aliases

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -174,13 +174,19 @@ jobs:
         working-directory: /tmp/digests
         run: |
           TAG=${{ steps.vars.outputs.FULL_IMAGE }}
+          TAG_ARGS="-t $TAG"
+          # For the production (no-shell) image, also publish a -no_shell alias to
+          # ease the future migration to shell-by-default images (see #1671).
+          if [ "${{ matrix.variant.suffix }}" = "" ]; then
+            TAG_ARGS="$TAG_ARGS -t ${TAG}-no_shell"
+          fi
           DIGEST_ARGS=""
           # Only include digest files matching the current variant suffix
           for file in *${{ matrix.variant.suffix }}.txt; do
             ref=$(cat "$file")
             DIGEST_ARGS+=" $ref"
           done
-          docker buildx imagetools create -t "$TAG" $DIGEST_ARGS
+          docker buildx imagetools create $TAG_ARGS $DIGEST_ARGS
 
       - name: Inspect final ${{ matrix.variant.description }} image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
           tags: |
             type=ref,event=branch,suffix=-dev
             type=ref,event=pr,suffix=-dev
-            type=semver,pattern={{version}}-dev
-            type=semver,pattern={{major}}.{{minor}}-dev
+            type=semver,pattern={{version}},suffix=-dev
+            type=semver,pattern={{major}}.{{minor}},suffix=-dev
 
       - name: Image name builder (prod)
         id: image_builder_prod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},suffix=-no_shell
+            type=semver,pattern={{major}}.{{minor}},suffix=-no_shell
 
       - name: Docker meta (dev)
         id: meta_dev

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ $(GOBIN)/remove_ger: ## Build remove_ger tool
 
 .PHONY: build-docker
 build-docker: ## Builds a docker image with the aggkit binary
-	docker build -t aggkit:local -f ./Dockerfile .
+	docker build -t aggkit:local -t aggkit:local-no_shell -f ./Dockerfile .
 
 .PHONY: build-docker-ci
 build-docker-ci: ## Builds a docker image with the aggkit binary for CI (includes shell)
@@ -95,7 +95,7 @@ build-docker-ci: ## Builds a docker image with the aggkit binary for CI (include
 
 .PHONY: build-docker-nc
 build-docker-nc: ## Builds a docker image with the aggkit binary - but without build cache
-	docker build --no-cache=true -t aggkit:local -f ./Dockerfile .
+	docker build --no-cache=true -t aggkit:local -t aggkit:local-no_shell -f ./Dockerfile .
 
 .PHONY: build-docker-debug
 build-docker-debug: ## Builds a debug docker image (dlv headless on :40000, no optimizations)

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build-docker: ## Builds a docker image with the aggkit binary
 
 .PHONY: build-docker-ci
 build-docker-ci: ## Builds a docker image with the aggkit binary for CI (includes shell)
-	docker build --build-arg INCLUDE_SHELL=true -t aggkit:local -f ./Dockerfile .
+	docker build --build-arg INCLUDE_SHELL=true -t aggkit:local -t aggkit:local-dev -f ./Dockerfile .
 
 .PHONY: build-docker-nc
 build-docker-nc: ## Builds a docker image with the aggkit binary - but without build cache


### PR DESCRIPTION
## 🔄 Changes Summary

### 1. Fix `-dev` images for release candidates (Closes #1640)
- Release candidates (`vX.Y.Z-rcN`) did not publish the development (`-dev`, shell-enabled) image, unlike final releases.
- Root cause: the dev variant embedded `-dev` inside the semver pattern (`type=semver,pattern={{version}}-dev`). `docker/metadata-action` ignores a custom semver pattern for pre-releases and falls back to `{{version}}`, discarding the embedded `-dev`, so rc builds produced `X.Y.Z-rcN` instead of `X.Y.Z-rcN-dev`.
- Fix: move `-dev` to the `suffix=` attribute (`type=semver,pattern={{version}},suffix=-dev`). The suffix is applied via `setValue` even on the pre-release fallback path, so rc tags now yield `X.Y.Z-rcN-dev`. Final releases are unaffected, matching the convention already used by the `type=ref` entries.

### 2. Add `-no_shell` / `-dev` aliases (Refs #1671)
- Prepare the future migration to shell-by-default images (#1671) by publishing a `-no_shell` alias for the current production (no-shell) image now, so consumers that need the hardened image can switch to the `*-no_shell` name today and keep working after the flip.
- `release.yml`: add `suffix=-no_shell` semver tags to the prod metadata.
- `build-push-docker-image.yml`: publish a `-no_shell` alias for the prod manifest only.
- `Makefile`: tag the local prod images (`build-docker`, `build-docker-nc`) with `aggkit:local-no_shell`, and the shell CI image (`build-docker-ci`) with `aggkit:local-dev`. The debug image is left untouched.

## 🏷️ Resulting image tags

### `release.yml` — final release (e.g. tag `v0.10.0`)
| Variant | Shell | Tags |
|---|---|---|
| production | ❌ no | `0.10.0`, `0.10`, `0.10.0-no_shell`, `0.10-no_shell` |
| development | ✅ yes | `0.10.0-dev`, `0.10-dev` |

### `release.yml` — release candidate (e.g. tag `v0.10.0-rc3`)
| Variant | Shell | Tags |
|---|---|---|
| production | ❌ no | `0.10.0-rc3`, `0.10.0-rc3-no_shell` |
| development | ✅ yes | `0.10.0-rc3-dev` |

> Note: for pre-releases `docker/metadata-action` only extends `{{version}}`, so the `{{major}}.{{minor}}` tags (`0.10`, `0.10-*`) are intentionally not produced for rc.

### `build-push-docker-image.yml` — manual build (`workflow_dispatch`)
Base tag = `<branch>_<timestamp>_<sha>`
| Variant | Shell | Tags |
|---|---|---|
| production | ❌ no | `<base>`, `<base>-no_shell` |
| development | ✅ yes | `<base>-dev` |

### `Makefile` — local builds
| Target | Shell | Tags |
|---|---|---|
| `build-docker` | ❌ no | `aggkit:local`, `aggkit:local-no_shell` |
| `build-docker-nc` | ❌ no | `aggkit:local`, `aggkit:local-no_shell` |
| `build-docker-ci` | ✅ yes | `aggkit:local`, `aggkit:local-dev` |
| `build-docker-debug` | (debug) | `aggkit:local-debug` |

## ⚠️ Breaking Changes
- None. Only adds tags / fixes a missing tag.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: N/A (CI / build tooling change).
- 🖱️ **Manual**: Verified `docker/metadata-action`'s `procSemver` source: for pre-releases the custom pattern is dropped to `{{version}}` while prefix/suffix are still applied, confirming `suffix=-dev` / `suffix=-no_shell` produce `X.Y.Z-rcN-dev` / `X.Y.Z-rcN-no_shell`.

## 🐞 Issues
- Closes #1640
- Refs #1671

## 🔗 Related PRs
- N/A

## 📝 Notes
- The `-no_shell` aliases point to the **same** production image; no extra build is performed.
- `-no_shell` is added for both `{{version}}` and `{{major}}.{{minor}}` semver tags to keep the prod tag set symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)