### PR TITLE
fix(exit-certificate): AET-04: fail-fast when a token balanceOf batch errors in Step B

### DIFF
--- a/tools/exit_certificate/step_b.go
+++ b/tools/exit_certificate/step_b.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -79,7 +80,12 @@ func RunStepB1(ctx context.Context, cfg *Config, targetBlock uint64, stepA *Step
 	log.Infof("ETH: %d EOAs with non-zero balance", len(eoaEthBalances))
 
 	// Phase 3: fetch wrapped token balances (parallel across tokens)
-	tokenBalances := fetchAllTokenBalances(ctx, rpcURL, stepA.WrappedTokens, eoaAddrs, blockTag, batchSize, concurrency)
+	tokenBalances, err := fetchAllTokenBalances(
+		ctx, rpcURL, stepA.WrappedTokens, eoaAddrs, blockTag, batchSize, concurrency,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetch token balances: %w", err)
+	}
 
 	// Build outputs
 	tokenLookup := make(map[common.Address]WrappedToken, len(stepA.WrappedTokens))
@@ -253,31 +259,32 @@ func fetchETHBalances(
 }
 
 // fetchAllTokenBalances scans all wrapped tokens in parallel (limited by tokenConcurrency).
+//
+// It fails fast: if any token's balanceOf batch errors, the first error is returned and the
+// remaining scans are cancelled. Silently dropping a failed token would leave it absent from the
+// balance map, making Step C treat its entire LBT supply as SC-locked and misroute the whole
+// supply to exitAddress, excluding the real EOA holders from the certificate.
 func fetchAllTokenBalances(
 	ctx context.Context, rpcURL string, tokens []WrappedToken,
 	eoaAddresses []common.Address, blockTag string, batchSize, concurrency int,
-) map[common.Address]map[common.Address]*big.Int {
+) (map[common.Address]map[common.Address]*big.Int, error) {
 	log.Infof("Fetching balances for %d wrapped tokens × %d EOAs...", len(tokens), len(eoaAddresses))
 
 	var mu sync.Mutex
 	tokenBalances := make(map[common.Address]map[common.Address]*big.Int)
-	sem := make(chan struct{}, tokenConcurrency)
 
-	var wg sync.WaitGroup
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(tokenConcurrency)
+
 	for _, token := range tokens {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(tok WrappedToken) {
-			defer wg.Done()
-			defer func() { <-sem }()
-
+		tok := token
+		g.Go(func() error {
 			balances, err := fetchTokenBalances(
-				ctx, rpcURL, tok.WrappedTokenAddress,
+				gctx, rpcURL, tok.WrappedTokenAddress,
 				eoaAddresses, blockTag, batchSize, concurrency,
 			)
 			if err != nil {
-				log.Warnf("Failed to fetch balances for token %s: %v", tok.WrappedTokenAddress.Hex(), err)
-				return
+				return fmt.Errorf("fetch balances for token %s: %w", tok.WrappedTokenAddress.Hex(), err)
 			}
 			if len(balances) > 0 {
 				mu.Lock()
@@ -285,11 +292,15 @@ func fetchAllTokenBalances(
 				mu.Unlock()
 				log.Infof("  Token %s...: %d holders", tok.WrappedTokenAddress.Hex()[:12], len(balances))
 			}
-		}(token)
+			return nil
+		})
 	}
-	wg.Wait()
 
-	return tokenBalances
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return tokenBalances, nil
 }
 
 // fetchTokenBalances queries ERC20 balanceOf for all EOAs for a single token.

--- a/tools/exit_certificate/step_b_helpers_test.go
+++ b/tools/exit_certificate/step_b_helpers_test.go
@@ -169,6 +169,17 @@ func newBatchRPCServer(t *testing.T, resultFor func(method string, params []json
 	return srv.URL
 }
 
+// newErrorRPCServer returns the URL of a server that fails every RPC request with HTTP 500,
+// so any RPC batch sent to it errors out (after the client's retries are exhausted).
+func newErrorRPCServer(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rpc unavailable", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
 // firstAddr decodes the first JSON-RPC param as an address hex string.
 func firstAddr(t *testing.T, params []json.RawMessage) common.Address {
 	t.Helper()
@@ -238,10 +249,27 @@ func TestFetchAllTokenBalances(t *testing.T) {
 		return "0x0"
 	})
 
-	out := fetchAllTokenBalances(t.Context(), url,
+	out, err := fetchAllTokenBalances(t.Context(), url,
 		[]WrappedToken{token}, []common.Address{holder, other}, "latest", 10, 2)
+	require.NoError(t, err)
 	require.Len(t, out, 1)
 	require.Equal(t, big.NewInt(5), out[token.WrappedTokenAddress][holder])
+}
+
+// TestFetchAllTokenBalancesFailFast guards against the silent-drop regression: a failing
+// balanceOf batch for any token must abort the scan with an error rather than omitting the
+// token from the map (which would make Step C misroute its whole supply to exitAddress).
+func TestFetchAllTokenBalancesFailFast(t *testing.T) {
+	t.Parallel()
+	token := WrappedToken{WrappedTokenAddress: common.HexToAddress("0xtok"), OriginNetwork: 1}
+	holder := common.HexToAddress("0x01")
+
+	url := newErrorRPCServer(t)
+
+	out, err := fetchAllTokenBalances(t.Context(), url,
+		[]WrappedToken{token}, []common.Address{holder}, "latest", 10, 2)
+	require.Error(t, err)
+	require.Nil(t, out)
 }
 
 // blockTagOf decodes the second JSON-RPC param (the block tag) as a string.


### PR DESCRIPTION
## 🔄 Changes Summary
- **Fix (High):** `fetchAllTokenBalances` (Step B1) silently discarded per-token RPC errors (`log.Warnf` + `return`), leaving the failed token absent from the balance map. Step C then treated its entire LBT supply as SC-locked and Step D routed the whole supply to `exitAddress`, excluding the real EOA holders from the certificate.
- Made it **fail-fast**, consistent with its sibling helpers (`classifyAddresses`, `fetchETHBalances`): `fetchAllTokenBalances` now returns an `error` and uses `errgroup.WithContext` (limited to `tokenConcurrency`) to cancel the remaining scans on the first failure. `RunStepB1` propagates it and aborts the pipeline.
- Added a doc comment explaining why the error must not be dropped.

## ⚠️ Breaking Changes
- None. No config, API, or CLI changes. Behaviour change only: a persistent per-token RPC failure now aborts the pipeline (after the existing RPC retries) instead of producing a misrouted certificate.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic:** Added `TestFetchAllTokenBalancesFailFast` (a failing `balanceOf` batch must return an error, never omit the token). Updated `TestFetchAllTokenBalances` to the new signature. Full package suite passes (`go test ./tools/exit_certificate/`) and `golangci-lint` reports 0 issues.

## 🐞 Issues
- Closes #1679

## 🔗 Related PRs
- N/A

## 📝 Notes
- Chose fail-fast as the default without adding an opt-out flag (e.g. `ignoreTokenBalanceFetchError`) to keep the config surface minimal; can add one if a knowingly-degraded test mode is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)