### PR TITLE
fix(exit-certificate): AET-10 `step E`: use configured l2NetworkId for zkevm pending-bridges `dest_net`

### DIFF
--- a/tools/exit_certificate/step_e.go
+++ b/tools/exit_certificate/step_e.go
@@ -429,7 +429,7 @@ func checkBridgeServicePendingBridges(ctx context.Context, cfg *Config, unclaime
 		label = "zkevm bridge service"
 		log.Infof("Querying zkevm bridge service for pending bridges (url=%s, l2NetworkID=%d)", baseURL, cfg.L2NetworkID)
 		var fetchErr error
-		svcCounts, fetchErr = fetchZkevmPendingBridges(ctx, baseURL, leafTypeAsset)
+		svcCounts, fetchErr = fetchZkevmPendingBridges(ctx, baseURL, cfg.L2NetworkID, leafTypeAsset)
 		if fetchErr != nil {
 			return fetchErr
 		}
@@ -588,15 +588,17 @@ type zkevmPendingBridgesResponse struct {
 
 // checkZkevmPendingBridges fetches pending (unclaimed, ready-to-claim) deposits from the
 // zkevm-bridge-service (GET /pending-bridges, both leaf types) and compares against the L1 scan.
-// fetchZkevmPendingBridges pages through GET /pending-bridges for the given leafType and
-// returns the set of deposit counts reported as pending by the zkevm bridge service.
-func fetchZkevmPendingBridges(ctx context.Context, baseURL string, leafType uint32) (map[uint32]struct{}, error) {
+// fetchZkevmPendingBridges pages through GET /pending-bridges for the given destNet and leafType
+// and returns the set of deposit counts reported as pending by the zkevm bridge service.
+func fetchZkevmPendingBridges(
+	ctx context.Context, baseURL string, destNet, leafType uint32,
+) (map[uint32]struct{}, error) {
 	svcCounts := make(map[uint32]struct{})
 
 	var offset uint32
 	for {
-		reqURL := fmt.Sprintf("%s/pending-bridges?dest_net=1&leaf_type=%d&limit=%d&offset=%d",
-			baseURL, leafType, bridgeSvcPageSize, offset)
+		reqURL := fmt.Sprintf("%s/pending-bridges?dest_net=%d&leaf_type=%d&limit=%d&offset=%d",
+			baseURL, destNet, leafType, bridgeSvcPageSize, offset)
 
 		body, err := httpGetJSON(ctx, reqURL)
 		if err != nil {

--- a/tools/exit_certificate/step_e_rpc_test.go
+++ b/tools/exit_certificate/step_e_rpc_test.go
@@ -209,6 +209,7 @@ func TestFetchZkevmPendingBridges(t *testing.T) {
 	t.Parallel()
 	// two pages: total_cnt=3, page size capped so the loop iterates.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "5", r.URL.Query().Get("dest_net"), "dest_net must use the configured l2NetworkId")
 		offset := r.URL.Query().Get("offset")
 		var deposits []map[string]any
 		if offset == "0" {
@@ -222,7 +223,7 @@ func TestFetchZkevmPendingBridges(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	got, err := fetchZkevmPendingBridges(context.Background(), srv.URL, leafTypeAsset)
+	got, err := fetchZkevmPendingBridges(context.Background(), srv.URL, 5, leafTypeAsset)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 	for _, dc := range []uint32{10, 11, 12} {
@@ -298,6 +299,6 @@ func TestFetchZkevmPendingBridgesHTTPError(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	t.Cleanup(srv.Close)
-	_, err := fetchZkevmPendingBridges(context.Background(), srv.URL, leafTypeAsset)
+	_, err := fetchZkevmPendingBridges(context.Background(), srv.URL, 1, leafTypeAsset)
 	require.Error(t, err)
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- `step_e.fetchZkevmPendingBridges()` hardcoded `dest_net=1` in the `GET /pending-bridges` query string. For any L2 chain whose network ID is not `1`, Step E's bridge service cross-check queried deposits targeting a different chain, causing the check to silently pass or spuriously fail against the wrong deposit set.
- The function now takes a `destNet` parameter and the caller passes `cfg.L2NetworkID`.

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `TestFetchZkevmPendingBridges` now asserts the request's `dest_net` query param matches the configured network ID (locking the fix). All `tools/exit_certificate` unit tests pass.

## 🐞 Issues
- Closes #1681

## 📝 Notes
- The aggkit bridge service path already filtered by `cfg.L2NetworkID` (`destination_network`); only the zkevm path was affected.