### PR TITLE
fix(exit-certificate): AET-12 :`step E` prevent uint64 overflow panic in decodeABIString

### DIFF
--- a/tools/exit_certificate/step_e.go
+++ b/tools/exit_certificate/step_e.go
@@ -348,11 +348,18 @@ func decodeABIString(data []byte) string {
 	if len(data) < twoABIWords {
 		return ""
 	}
-	strLen := new(big.Int).SetBytes(data[32:64]).Uint64()
-	if 64+strLen > uint64(len(data)) {
+	lenField := new(big.Int).SetBytes(data[abiWordBytes:twoABIWords])
+	// Reject lengths that don't fit in uint64; the payload can never be that large anyway.
+	if !lenField.IsUint64() {
 		return ""
 	}
-	return string(data[64 : 64+strLen])
+	strLen := lenField.Uint64()
+	// Compare against the remaining bytes without computing twoABIWords+strLen, which would
+	// overflow uint64 for a maliciously oversized length field and wrap past this guard.
+	if strLen > uint64(len(data))-twoABIWords {
+		return ""
+	}
+	return string(data[twoABIWords : twoABIWords+strLen])
 }
 
 // formatTokenAmount formats an amount using the token's decimals.

--- a/tools/exit_certificate/step_e_test.go
+++ b/tools/exit_certificate/step_e_test.go
@@ -230,3 +230,63 @@ func TestStepE_MergeCertificateExits(t *testing.T) {
 	require.Equal(t, big.NewInt(100), finalCert.BridgeExits[0].Amount)
 	require.Equal(t, big.NewInt(200), finalCert.BridgeExits[1].Amount)
 }
+
+func TestDecodeABIString(t *testing.T) {
+	t.Parallel()
+
+	// abiString builds a well-formed ABI-encoded string: 32-byte offset, 32-byte length, padded data.
+	abiString := func(s string) []byte {
+		out := make([]byte, twoABIWords)
+		out[abiWordBytes-1] = 0x20 // offset = 32
+		lenBytes := big.NewInt(int64(len(s))).Bytes()
+		copy(out[twoABIWords-len(lenBytes):twoABIWords], lenBytes)
+		data := []byte(s)
+		// pad to a multiple of the ABI word size
+		padded := make([]byte, ((len(data)+abiWordBytes-1)/abiWordBytes)*abiWordBytes)
+		copy(padded, data)
+		return append(out, padded...)
+	}
+
+	// header builds just the 64-byte offset+length header with an explicit raw length field.
+	header := func(lenField []byte) []byte {
+		out := make([]byte, twoABIWords)
+		out[abiWordBytes-1] = 0x20
+		copy(out[twoABIWords-len(lenField):twoABIWords], lenField)
+		return out
+	}
+
+	maxUint64 := make([]byte, 8)
+	for i := range maxUint64 {
+		maxUint64[i] = 0xFF
+	}
+	overUint64 := make([]byte, abiWordBytes) // full 32-byte 0xFF... > MaxUint64
+	for i := range overUint64 {
+		overUint64[i] = 0xFF
+	}
+
+	tests := []struct {
+		name     string
+		data     []byte
+		expected string
+	}{
+		{name: "empty", data: nil, expected: ""},
+		{name: "too short", data: make([]byte, twoABIWords-1), expected: ""},
+		{name: "valid string", data: abiString("DAI"), expected: "DAI"},
+		{name: "empty string payload", data: abiString(""), expected: ""},
+		{name: "length exceeds data", data: header([]byte{0x40}), expected: ""},
+		// Regression: a length field near MaxUint64 makes twoABIWords+strLen overflow uint64
+		// and wrap past the bounds guard, causing a slice out-of-range panic with the old code.
+		{name: "uint64 overflow length", data: header(maxUint64), expected: ""},
+		{name: "length larger than uint64", data: header(overUint64), expected: ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, func() {
+				require.Equal(t, tc.expected, decodeABIString(tc.data))
+			})
+		})
+	}
+}

--- a/tools/exit_certificate/step_e_test.go
+++ b/tools/exit_certificate/step_e_test.go
@@ -236,15 +236,15 @@ func TestDecodeABIString(t *testing.T) {
 
 	// abiString builds a well-formed ABI-encoded string: 32-byte offset, 32-byte length, padded data.
 	abiString := func(s string) []byte {
-		out := make([]byte, twoABIWords)
+		data := []byte(s)
+		// pad the data to a multiple of the ABI word size
+		paddedLen := ((len(data) + abiWordBytes - 1) / abiWordBytes) * abiWordBytes
+		out := make([]byte, twoABIWords+paddedLen)
 		out[abiWordBytes-1] = 0x20 // offset = 32
 		lenBytes := big.NewInt(int64(len(s))).Bytes()
 		copy(out[twoABIWords-len(lenBytes):twoABIWords], lenBytes)
-		data := []byte(s)
-		// pad to a multiple of the ABI word size
-		padded := make([]byte, ((len(data)+abiWordBytes-1)/abiWordBytes)*abiWordBytes)
-		copy(padded, data)
-		return append(out, padded...)
+		copy(out[twoABIWords:], data)
+		return out
 	}
 
 	// header builds just the 64-byte offset+length header with an explicit raw length field.
@@ -281,7 +281,6 @@ func TestDecodeABIString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.NotPanics(t, func() {


### PR DESCRIPTION
## 🔄 Changes Summary
- Fix a uint64 integer overflow in `step_e.decodeABIString()` (SP002). A maliciously crafted L1 ERC-20 whose `name()`/`symbol()` returns an oversized ABI length field could make `64+strLen` wrap past `MaxUint64` to a small value, bypassing the bounds guard and triggering a slice out-of-range **panic** that aborts the exit certificate tool for any chain with an unclaimed L1→L2 deposit of such a token.
- Reject length fields that don't fit in `uint64` (`big.Int.IsUint64()`) and compare `strLen` against the remaining byte count without the overflowing addition (`strLen > uint64(len(data))-twoABIWords`, safe since `len(data) >= 64`).

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: Added `TestDecodeABIString` with regression cases — `MaxUint64` length field (the overflow case) and a length field larger than `uint64` — asserting no panic and `""` return, plus valid/empty/too-short/length-exceeds-data cases. Full `go test ./tools/exit_certificate/...` passes; `go vet` and `gofmt` clean.
- 🖱️ **Manual**: n/a (deterministic decode logic covered by unit test).

## 🐞 Issues
- Closes #1680

## 📝 Notes
- The guard now also rejects length fields exceeding `uint64` range, which `big.Int.Uint64()` would have silently truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)