### PR TITLE
fix(ci): cherry-pick -dev images for release candidates and -no_shell aliases (#1674)

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -174,13 +174,19 @@ jobs:
         working-directory: /tmp/digests
         run: |
           TAG=${{ steps.vars.outputs.FULL_IMAGE }}
+          TAG_ARGS="-t $TAG"
+          # For the production (no-shell) image, also publish a -no_shell alias to
+          # ease the future migration to shell-by-default images (see #1671).
+          if [ "${{ matrix.variant.suffix }}" = "" ]; then
+            TAG_ARGS="$TAG_ARGS -t ${TAG}-no_shell"
+          fi
           DIGEST_ARGS=""
           # Only include digest files matching the current variant suffix
           for file in *${{ matrix.variant.suffix }}.txt; do
             ref=$(cat "$file")
             DIGEST_ARGS+=" $ref"
           done
-          docker buildx imagetools create -t "$TAG" $DIGEST_ARGS
+          docker buildx imagetools create $TAG_ARGS $DIGEST_ARGS
 
       - name: Inspect final ${{ matrix.variant.description }} image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},suffix=-no_shell
+            type=semver,pattern={{major}}.{{minor}},suffix=-no_shell
 
       - name: Docker meta (dev)
         id: meta_dev
@@ -76,8 +78,8 @@ jobs:
           tags: |
             type=ref,event=branch,suffix=-dev
             type=ref,event=pr,suffix=-dev
-            type=semver,pattern={{version}}-dev
-            type=semver,pattern={{major}}.{{minor}}-dev
+            type=semver,pattern={{version}},suffix=-dev
+            type=semver,pattern={{major}}.{{minor}},suffix=-dev
 
       - name: Image name builder (prod)
         id: image_builder_prod

--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,15 @@ $(GOBIN)/remove_ger: ## Build remove_ger tool
 
 .PHONY: build-docker
 build-docker: ## Builds a docker image with the aggkit binary
-	docker build -t aggkit:local -f ./Dockerfile .
+	docker build -t aggkit:local -t aggkit:local-no_shell -f ./Dockerfile .
 
 .PHONY: build-docker-ci
 build-docker-ci: ## Builds a docker image with the aggkit binary for CI (includes shell)
-	docker build --build-arg INCLUDE_SHELL=true -t aggkit:local -f ./Dockerfile .
+	docker build --build-arg INCLUDE_SHELL=true -t aggkit:local -t aggkit:local-dev -f ./Dockerfile .
 
 .PHONY: build-docker-nc
 build-docker-nc: ## Builds a docker image with the aggkit binary - but without build cache
-	docker build --no-cache=true -t aggkit:local -f ./Dockerfile .
+	docker build --no-cache=true -t aggkit:local -t aggkit:local-no_shell -f ./Dockerfile .
 
 .PHONY: build-docker-debug
 build-docker-debug: ## Builds a debug docker image (dlv headless on :40000, no optimizations)


### PR DESCRIPTION
## 🔄 Changes Summary
- Cherry-pick of #1674 onto `release/0.10`.
- **fix(ci)**: generate `-dev` docker images for release candidates. The dev variant embedded `-dev` inside the semver pattern, which `docker/metadata-action` ignores for pre-releases (falling back to `{{version}}`), so rc builds produced `X.Y.Z-rcN` instead of `X.Y.Z-rcN-dev`. Moved `-dev` to the `suffix=` attribute so rc tags now yield `X.Y.Z-rcN-dev`.
- **feat(ci)**: also tag production (no-shell) images with a `-no_shell` alias (`release.yml`, `build-push-docker-image.yml`, `Makefile`) to prepare for the shell-by-default flip (#1671).
- **feat(ci)**: also tag the shell (CI) docker image with `local-dev`.

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: CI workflows build the docker images.
- 🖱️ **Manual**: Verify rc tag builds produce `X.Y.Z-rcN-dev` images and prod builds produce `-no_shell` aliases.

## 🐞 Issues
- Closes #1640
- Refs #1671

## 🔗 Related PRs
- Cherry-pick of #1674 (merged to `develop`).

## 📝 Notes
- CI/Makefile-only change, applied cleanly with no conflicts (`git cherry-pick -x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
