### PR TITLE
feat(exit-certificate): execution traceability — startup banner and build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(GOBIN)/remove_ger:
 
 .PHONY: $(GOBIN)/exit_certificate
 $(GOBIN)/exit_certificate:
-	$(GOENVVARS) go build -o $(GOBIN)/exit_certificate ./tools/exit_certificate/cmd
+	$(GOENVVARS) go build -ldflags "all=$(LDFLAGS)" -o $(GOBIN)/exit_certificate ./tools/exit_certificate/cmd
 
 .PHONY: $(GOBIN)/exit_certificate_claimer
 $(GOBIN)/exit_certificate_claimer:

--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/agglayer/aggkit"
 	"github.com/hermeznetwork/tracerr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -85,7 +86,8 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 	zapCfg.Level = level
 	zapCfg.OutputPaths = cfg.Outputs
 	zapCfg.InitialFields = map[string]interface{}{
-		"pid": os.Getpid(),
+		"version": aggkit.Version,
+		"pid":     os.Getpid(),
 	}
 
 	logger, err := zapCfg.Build()

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/agglayer/aggkit"
 	"github.com/hermeznetwork/tracerr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -86,8 +85,7 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 	zapCfg.Level = level
 	zapCfg.OutputPaths = cfg.Outputs
 	zapCfg.InitialFields = map[string]interface{}{
-		"version": aggkit.Version,
-		"pid":     os.Getpid(),
+		"pid": os.Getpid(),
 	}
 
 	logger, err := zapCfg.Build()

--- a/tools/exit_certificate/cmd/main.go
+++ b/tools/exit_certificate/cmd/main.go
@@ -10,6 +10,10 @@ import (
 )
 
 func main() {
+	cli.VersionPrinter = func(*cli.Context) {
+		aggkit.PrintVersion(os.Stdout)
+	}
+
 	app := cli.NewApp()
 	app.Name = "exit-certificate"
 	app.Usage = "Generate exit certificates for zkEVM chain migration"

--- a/tools/exit_certificate/config.go
+++ b/tools/exit_certificate/config.go
@@ -1,6 +1,7 @@
 package exit_certificate
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -101,6 +102,12 @@ type Config struct {
 	RollupManagerAddress common.Address           `json:"rollupManagerAddress"`
 	Options              Options                  `json:"options"`
 	SignerConfig         signertypes.SignerConfig `json:"-"`
+
+	// ConfigPath is the path the config was loaded from, and ConfigSHA256 is the
+	// hex sha256 of the exact on-disk bytes that produced this Config. Both are set
+	// by LoadConfig and used by the startup traceability banner. Not serialized.
+	ConfigPath   string `json:"-"`
+	ConfigSHA256 string `json:"-"`
 }
 
 const (
@@ -127,37 +134,45 @@ var defaultOptions = Options{
 // LoadConfig reads and validates the config file. The format is selected by file extension:
 // ".toml" is parsed as TOML, anything else (".json" or no extension) as JSON.
 func LoadConfig(configPath string) (*Config, error) {
-	raw, err := readRawConfig(configPath)
+	raw, rawBytes, err := readRawConfig(configPath)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateRawConfig(raw); err != nil {
 		return nil, err
 	}
-	return buildConfig(raw, filepath.Dir(configPath))
+	cfg, err := buildConfig(raw, filepath.Dir(configPath))
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConfigPath = configPath
+	cfg.ConfigSHA256 = fmt.Sprintf("%x", sha256.Sum256(rawBytes))
+	return cfg, nil
 }
 
 // readRawConfig reads the config file at configPath, normalizing TOML to JSON so a single code path
 // handles both formats (including the signerConfig json.RawMessage and agglayerClient custom JSON
-// unmarshalling), then unmarshals it into a rawConfig.
-func readRawConfig(configPath string) (*rawConfig, error) {
-	data, err := os.ReadFile(configPath)
+// unmarshalling), then unmarshals it into a rawConfig. It also returns the original on-disk bytes
+// (before any TOML→JSON normalization) so callers can hash the exact file content that was loaded.
+func readRawConfig(configPath string) (*rawConfig, []byte, error) {
+	rawBytes, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("read config file %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("read config file %s: %w", configPath, err)
 	}
 
+	data := rawBytes
 	if strings.EqualFold(filepath.Ext(configPath), ".toml") {
-		data, err = tomlToJSON(data)
+		data, err = tomlToJSON(rawBytes)
 		if err != nil {
-			return nil, fmt.Errorf("parse config TOML %s: %w", configPath, err)
+			return nil, nil, fmt.Errorf("parse config TOML %s: %w", configPath, err)
 		}
 	}
 
 	var raw rawConfig
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parse config JSON: %w", err)
+		return nil, nil, fmt.Errorf("parse config JSON: %w", err)
 	}
-	return &raw, nil
+	return &raw, rawBytes, nil
 }
 
 // validateRawConfig checks the required parameters and the exitAddress format/value.

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -34,7 +34,7 @@ func printStartupBanner(configPath string) {
 	}
 
 	log.Info("╔═══════════════════════════════════════════╗")
-	log.Info("║   Exit Certificate Tool — Version         ║")
+	log.Info("║   Exit Certificate Tool — Traceability    ║")
 	log.Info("╚═══════════════════════════════════════════╝")
 	log.Infof("Version:      %s", v.Version)
 	log.Infof("Git revision: %s", v.GitRev)

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -2,7 +2,6 @@ package exit_certificate
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -22,16 +21,12 @@ const (
 	filePermissions = 0o600
 )
 
-// printStartupBanner logs a one-off banner with the build version info, the
-// sha256 of the config file and the raw command-line arguments. This replaces
-// the per-log-line "version" field that used to be attached to every trace.
-func printStartupBanner(configPath string) {
+// printStartupBanner logs a one-off traceability banner with the build version
+// info, the config file path + sha256, and the (shell-escaped) command line.
+// cfg.ConfigSHA256 is computed from the exact bytes LoadConfig parsed, so the
+// hash always matches the config actually used for the run.
+func printStartupBanner(cfg *Config) {
 	v := aggkit.GetVersion()
-
-	configSHA := "n/a"
-	if data, err := os.ReadFile(configPath); err == nil {
-		configSHA = fmt.Sprintf("%x", sha256.Sum256(data))
-	}
 
 	log.Info("╔═══════════════════════════════════════════╗")
 	log.Info("║   Exit Certificate Tool — Traceability    ║")
@@ -42,8 +37,35 @@ func printStartupBanner(configPath string) {
 	log.Infof("Built:        %s", v.BuildDate)
 	log.Infof("Go version:   %s", v.GoVersion)
 	log.Infof("OS/Arch:      %s/%s", v.OS, v.Arch)
-	log.Infof("Config file:  %s (sha256: %s)", configPath, configSHA)
-	log.Infof("Command line: %s", strings.Join(os.Args, " "))
+	log.Infof("Config file:  %s (sha256: %s)", cfg.ConfigPath, cfg.ConfigSHA256)
+	log.Infof("Command line: %s", shellQuoteArgs(os.Args))
+}
+
+// shellQuoteArgs joins argv into a single, copy-pasteable command line,
+// single-quoting any argument that contains characters the shell would
+// otherwise interpret (spaces, quotes, globs, …) so argument boundaries are
+// preserved. Empty arguments become ”.
+func shellQuoteArgs(args []string) string {
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = shellQuote(a)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote returns a POSIX-shell-safe representation of a single argument.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r == '_' || r == '-' || r == '.' || r == '/' || r == '=' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+	}) < 0 {
+		return s // only safe characters, no quoting needed
+	}
+	// Wrap in single quotes, escaping any embedded single quote as '\''.
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // Run is the CLI entry point.
@@ -60,12 +82,12 @@ func Run(c *cli.Context) error {
 		Outputs:     []string{"stderr"},
 	})
 
-	printStartupBanner(c.String("config"))
-
 	cfg, err := LoadConfig(c.String("config"))
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	printStartupBanner(cfg)
 
 	if err := os.MkdirAll(cfg.Options.OutputDir, dirPermissions); err != nil {
 		return fmt.Errorf("create output dir: %w", err)

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -58,14 +58,17 @@ func shellQuote(s string) string {
 	if s == "" {
 		return "''"
 	}
-	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r == '_' || r == '-' || r == '.' || r == '/' || r == '=' ||
-			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
-	}) < 0 {
+	if strings.IndexFunc(s, func(r rune) bool { return !isShellSafeRune(r) }) < 0 {
 		return s // only safe characters, no quoting needed
 	}
 	// Wrap in single quotes, escaping any embedded single quote as '\''.
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// isShellSafeRune reports whether r can appear unquoted in a POSIX shell word.
+func isShellSafeRune(r rune) bool {
+	return r == '_' || r == '-' || r == '.' || r == '/' || r == '=' ||
+		(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
 
 // Run is the CLI entry point.

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -2,6 +2,7 @@ package exit_certificate
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	aggkit "github.com/agglayer/aggkit"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/common"
@@ -19,6 +21,30 @@ const (
 	dirPermissions  = 0o755
 	filePermissions = 0o600
 )
+
+// printStartupBanner logs a one-off banner with the build version info, the
+// sha256 of the config file and the raw command-line arguments. This replaces
+// the per-log-line "version" field that used to be attached to every trace.
+func printStartupBanner(configPath string) {
+	v := aggkit.GetVersion()
+
+	configSHA := "n/a"
+	if data, err := os.ReadFile(configPath); err == nil {
+		configSHA = fmt.Sprintf("%x", sha256.Sum256(data))
+	}
+
+	log.Info("╔═══════════════════════════════════════════╗")
+	log.Info("║   Exit Certificate Tool — Version         ║")
+	log.Info("╚═══════════════════════════════════════════╝")
+	log.Infof("Version:      %s", v.Version)
+	log.Infof("Git revision: %s", v.GitRev)
+	log.Infof("Git branch:   %s", v.GitBranch)
+	log.Infof("Built:        %s", v.BuildDate)
+	log.Infof("Go version:   %s", v.GoVersion)
+	log.Infof("OS/Arch:      %s/%s", v.OS, v.Arch)
+	log.Infof("Config file:  %s (sha256: %s)", configPath, configSHA)
+	log.Infof("Command line: %s", strings.Join(os.Args, " "))
+}
 
 // Run is the CLI entry point.
 func Run(c *cli.Context) error {
@@ -33,6 +59,8 @@ func Run(c *cli.Context) error {
 		Level:       logLevel,
 		Outputs:     []string{"stderr"},
 	})
+
+	printStartupBanner(c.String("config"))
 
 	cfg, err := LoadConfig(c.String("config"))
 	if err != nil {

--- a/tools/exit_certificate/run_test.go
+++ b/tools/exit_certificate/run_test.go
@@ -1,7 +1,9 @@
 package exit_certificate
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -142,4 +144,48 @@ func TestSaveJSON_ComplexData(t *testing.T) {
 	var loaded map[string]any
 	require.NoError(t, json.Unmarshal(content, &loaded))
 	require.Equal(t, "1000000", loaded["balance"])
+}
+
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "''"},
+		{"plain", "plain"},
+		{"--config", "--config"},
+		{"a/b-c.json", "a/b-c.json"},
+		{"key=value", "key=value"},
+		{"a b", "'a b'"},
+		{"sign, submit", "'sign, submit'"},
+		{"it's", `'it'\''s'`},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, shellQuote(tt.in), "shellQuote(%q)", tt.in)
+	}
+
+	require.Equal(t, "exit --step 'a b'",
+		shellQuoteArgs([]string{"exit", "--step", "a b"}))
+}
+
+func TestLoadConfigSetsSHA256(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "parameters.json")
+	raw := []byte(`{
+  "l2RpcUrl": "http://localhost:8545",
+  "l2BridgeAddress": "0x0000000000000000000000000000000000000001",
+  "exitAddress": "0x000000000000000000000000000000000000dEaD",
+  "targetBlock": "100",
+  "options": { "useAgglayerAdminToStepFCheck": false }
+}`)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.Equal(t, path, cfg.ConfigPath)
+	require.Equal(t, fmt.Sprintf("%x", sha256.Sum256(raw)), cfg.ConfigSHA256)
 }


### PR DESCRIPTION
## 🔄 Changes Summary

**Goal:** make every `exit_certificate` run **traceable** — at a glance you can tell which build, which config and which exact command produced a given output/log.

To achieve that:
- **run.go**: logs an *execution traceability* banner line-by-line (same format as the rest of the logs) at the start of `Run`, reporting:
  - build version, git revision, git branch and build date,
  - Go version and OS/Arch,
  - the **sha256 of the config file** (so the exact parameters used can be verified),
  - the **command-line arguments** the tool was invoked with.
- **Makefile**: the `exit_certificate` build target now passes `-ldflags "all=$(LDFLAGS)"`, so `Version`, `GitRev`, `GitBranch` and `BuildDate` are injected into the binary (previously left at their defaults — without this the banner/`--version` would report placeholders).
- **cmd/main.go**: `--version` prints the full build info (version, git revision, branch, build date, Go version, OS/Arch) via a custom `cli.VersionPrinter` calling `aggkit.PrintVersion`.

### Output example:
```
2026-06-30T15:23:42.172+0200    INFO    exit_certificate/run.go:31      ╔═══════════════════════════════════════════╗   {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:32      ║   Exit Certificate Tool — Traceability    ║   {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:33      ╚═══════════════════════════════════════════╝   {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:34      Version:      v0.10.0-rc1-72-gfc332f25  {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:35      Git revision: fc332f25  {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:36      Git branch:   feat/exit-certificate-tool-version        {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:37      Built:        Tue, 30 Jun 2026 15:16:17 +0200   {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:38      Go version:   go1.25.7  {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:39      OS/Arch:      linux/amd64       {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:40      Config file:  tmp/exit_certificate-kurtosis.json (sha256: e2f0a892dcb070f888037f0f88bf47232e7667f61e6449419fca9c92ba77ce01)     {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
2026-06-30T15:23:42.173+0200    INFO    exit_certificate/run.go:41      Command line: ./target/exit_certificate -c tmp/exit_certificate-kurtosis.json   {"pid": 560596, "version": "v0.10.0-rc1-72-gfc332f25"}
```

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `make build-exit_certificate` builds with injected ldflags.
- 🖱️ **Manual**: `./target/exit_certificate --version` prints full build info; running any step logs the traceability banner (verified config sha256 + command line render correctly).

## 📝 Notes
- `log/log.go` is shared infrastructure and is intentionally left untouched; the per-trace `version` field stays as-is for all binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)