### PR TITLE
fix(exit-certificate): AET-01 replay external native tokens as ERC-20 in Step G

### DIFF
--- a/tools/exit_certificate/step_g2.go
+++ b/tools/exit_certificate/step_g2.go
@@ -972,11 +972,17 @@ func logReplayProgress(done, total int, start time.Time) {
 		done, total, float64(done)/float64(total)*percentMultiplier, rate, eta)
 }
 
+// isNativeBridgeExit reports whether a bridge exit is the local native gas token — the only asset
+// bridged via the native path (bridgeAsset with token=0x0 and msg.value). An exit is native only when
+// its origin identity matches the gas token's (network AND address), or when TokenInfo is nil (which
+// defaults to the gas token). A zero OriginTokenAddress alone is NOT sufficient: another network's
+// native asset is represented on this L2 as a wrapped ERC-20 with OriginTokenAddress=0x0 but a
+// non-local OriginNetwork, and must be replayed as an ERC-20 — matching on address alone would
+// misclassify it as the gas token and compute the LER from the wrong leaves.
 func isNativeBridgeExit(
 	ti *agglayertypes.TokenInfo, gasTokenNetwork uint32, gasTokenAddress common.Address,
 ) bool {
 	return ti == nil ||
-		ti.OriginTokenAddress == (common.Address{}) ||
 		(ti.OriginNetwork == gasTokenNetwork && ti.OriginTokenAddress == gasTokenAddress)
 }
 

--- a/tools/exit_certificate/step_g_events.go
+++ b/tools/exit_certificate/step_g_events.go
@@ -41,8 +41,12 @@ func buildLiteTreeFromCertificate(
 	leaves := make([]bridgesyncerlite.BridgeLeaf, len(exits))
 	metadatas := make([][]byte, len(exits))
 	for i, be := range exits {
+		// Native (gas token) exits take the gas token as origin; every other exit — including another
+		// network's native asset wrapped on this L2 (OriginTokenAddress=0x0 but non-local
+		// OriginNetwork) — takes its own TokenInfo origin. Using isNativeBridgeExit keeps this in lock
+		// step with the shadow-fork replay's native/ERC-20 decision.
 		originNetwork, originAddr := gasTokenNetwork, gasTokenAddress
-		if be.TokenInfo != nil && be.TokenInfo.OriginTokenAddress != (common.Address{}) {
+		if !isNativeBridgeExit(be.TokenInfo, gasTokenNetwork, gasTokenAddress) {
 			originNetwork = be.TokenInfo.OriginNetwork
 			originAddr = be.TokenInfo.OriginTokenAddress
 		}

--- a/tools/exit_certificate/step_g_test.go
+++ b/tools/exit_certificate/step_g_test.go
@@ -40,6 +40,14 @@ func TestIsNativeBridgeExit(t *testing.T) {
 			ti:     &agglayertypes.TokenInfo{OriginNetwork: 0, OriginTokenAddress: common.HexToAddress("0x1111")},
 			native: false,
 		},
+		{
+			// Regression (AET-01): another network's native asset is a wrapped ERC-20 on this L2 with
+			// OriginTokenAddress=0x0 but a non-gas-token OriginNetwork. It must NOT be treated as the
+			// local gas token, otherwise Step G replays it natively and computes the LER from wrong leaves.
+			name:   "external native token (zero addr, non-gas-token network) is not native",
+			ti:     &agglayertypes.TokenInfo{OriginNetwork: 5, OriginTokenAddress: common.Address{}},
+			native: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## 🔄 Changes Summary
- Step G misclassified bridge exits for **external native tokens** (another network's native asset, represented on this L2 as a wrapped ERC-20 with `OriginTokenAddress=0x0` but a non-local `OriginNetwork`) as the **local gas token**, computing `NewLocalExitRoot` from the wrong leaves. The internal consistency check still passed because both the shadow-fork replay and the off-chain tree builder made the same misclassification.
- `isNativeBridgeExit` (`step_g2.go`): removed the standalone `OriginTokenAddress == 0x0` condition. An exit is now native only when `TokenInfo == nil` or its origin identity (network **and** address) matches the gas token's.
- `buildLiteTreeFromCertificate` (`step_g_events.go`): the off-chain tree builder now selects the leaf origin via `isNativeBridgeExit` instead of an address-only check, keeping it in lock step with the shadow-fork replay's native/ERC-20 decision.
- `resolveTokenAddresses` already delegated to `isNativeBridgeExit`, so external native tokens now correctly resolve their L2 wrapped address instead of being skipped.

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: Added AET-01 regression case to `TestIsNativeBridgeExit` (`(OriginNetwork=5, OriginTokenAddress=0x0)` must not be native). Full package suite passes: `go test ./tools/exit_certificate/`. `golangci-lint run ./tools/exit_certificate/...` clean.

## 🐞 Issues
- Closes #1693

## 📝 Notes
- The tool only supports ETH-gas-token chains (Step CHECK #7), so in practice `gasToken` is `(network=0, addr=0x0)`; the fix is general regardless of gas token identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)