### PR TITLE
fix: exit-certificate silent data loss on scan/decode failures 1713

### DIFF
--- a/tools/exit_certificate/extra_coverage_test.go
+++ b/tools/exit_certificate/extra_coverage_test.go
@@ -126,14 +126,14 @@ func TestSaveJSONErrorBranches(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	// Marshal failure: a channel cannot be JSON-encoded → logged, no panic, nothing written.
-	require.NotPanics(t, func() { saveJSON(dir, "bad.json", make(chan int)) })
+	// Marshal failure: a channel cannot be JSON-encoded → error returned, nothing written.
+	require.Error(t, saveJSON(dir, "bad.json", make(chan int)))
 	require.False(t, fileExists(filepath.Join(dir, "bad.json")))
 
 	// Write failure: using a regular file as the "directory" makes WriteFile fail.
 	notADir := filepath.Join(dir, "afile")
 	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o600))
-	require.NotPanics(t, func() { saveJSON(notADir, "out.json", map[string]int{"a": 1}) })
+	require.Error(t, saveJSON(notADir, "out.json", map[string]int{"a": 1}))
 }
 
 func TestFetchL2ChainID(t *testing.T) {
@@ -155,7 +155,8 @@ func TestBuildHolderBridgeExits(t *testing.T) {
 		{OriginNetwork: 1, OriginTokenAddress: common.HexToAddress("0xcc"),
 			HolderAddress: common.HexToAddress("0xdd"), Amount: "0"}, // zero → skipped
 	}}
-	exits := buildHolderBridgeExits(stepC, 0)
+	exits, err := buildHolderBridgeExits(stepC, 0)
+	require.NoError(t, err)
 	require.Len(t, exits, 1)
 	require.Equal(t, common.HexToAddress("0xbb"), exits[0].DestinationAddress)
 }

--- a/tools/exit_certificate/hex.go
+++ b/tools/exit_certificate/hex.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 )
 
 const (
 	hexBase         = 16
 	decimalBase     = 10
-	hexLetterOffset = 10
 	maxMetadataSize = 1 << 20 // 1 MB
 
 	abiWordBytes      = 32  // EVM ABI word size in bytes
@@ -42,22 +42,16 @@ func safeUint8(val *big.Int) (uint8, error) {
 }
 
 // hexToUint64 parses a hex string (with or without 0x prefix) to uint64.
-func hexToUint64(s string) uint64 {
-	s = strings.TrimPrefix(s, "0x")
-	s = strings.TrimPrefix(s, "0X")
-	var n uint64
-	for _, c := range s {
-		n <<= 4
-		switch {
-		case c >= '0' && c <= '9':
-			n |= uint64(c - '0')
-		case c >= 'a' && c <= 'f':
-			n |= uint64(c - 'a' + hexLetterOffset)
-		case c >= 'A' && c <= 'F':
-			n |= uint64(c - 'A' + hexLetterOffset)
-		}
+// Invalid characters, empty input and overflow are errors: the strings it parses
+// are RPC-provided block numbers, so a garbage value must never silently become
+// a plausible-looking number.
+func hexToUint64(s string) (uint64, error) {
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+	n, err := strconv.ParseUint(trimmed, hexBase, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse hex uint64 %q: %w", s, err)
 	}
-	return n
+	return n, nil
 }
 
 // hexToBigInt parses a 0x-prefixed hex string to a *big.Int. Returns zero on empty/invalid input.
@@ -79,14 +73,13 @@ func toBlockTag(blockNum uint64) string {
 	return fmt.Sprintf("0x%x", blockNum)
 }
 
-// parseDecimalBigInt parses a decimal string to *big.Int. Returns zero on empty/invalid input.
-func parseDecimalBigInt(s string) *big.Int {
-	if s == "" {
-		return new(big.Int)
-	}
+// parseDecimalBigInt parses a decimal string to *big.Int. Empty or invalid input is an error:
+// the strings it parses are tool-generated, so a failure always means corrupted intermediate
+// files and must never silently become a zero amount (which would drop a bridge exit).
+func parseDecimalBigInt(s string) (*big.Int, error) {
 	n, ok := new(big.Int).SetString(s, decimalBase)
 	if !ok {
-		return new(big.Int)
+		return nil, fmt.Errorf("parse decimal big int: invalid value %q", s)
 	}
-	return n
+	return n, nil
 }

--- a/tools/exit_certificate/hex_test.go
+++ b/tools/exit_certificate/hex_test.go
@@ -19,17 +19,37 @@ func TestToBlockTag(t *testing.T) {
 
 func TestParseDecimalBigInt_Valid(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, big.NewInt(12345), parseDecimalBigInt("12345"))
+	v, err := parseDecimalBigInt("12345")
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(12345), v)
 }
 
 func TestParseDecimalBigInt_Empty(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, new(big.Int), parseDecimalBigInt(""))
+	_, err := parseDecimalBigInt("")
+	require.Error(t, err)
 }
 
 func TestParseDecimalBigInt_Invalid(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, new(big.Int), parseDecimalBigInt("not-a-number"))
+	_, err := parseDecimalBigInt("not-a-number")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not-a-number")
+}
+
+func TestHexToUint64_Valid(t *testing.T) {
+	t.Parallel()
+	v, err := hexToUint64("0x1406f40")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x1406f40), v)
+}
+
+func TestHexToUint64_Invalid(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "0x", "0xzz", "not-hex", "0x10000000000000000"} {
+		_, err := hexToUint64(in)
+		require.Error(t, err, "input %q must not parse", in)
+	}
 }
 
 func TestSafeUint32_OK(t *testing.T) {

--- a/tools/exit_certificate/rpc.go
+++ b/tools/exit_certificate/rpc.go
@@ -185,7 +185,7 @@ func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]
 		for i, origIdx := range pendingIdxs {
 			if !answered[i] {
 				log.Warnf("batchRPC: no response for %s id=%d (attempt %d/%d) — re-queuing",
-					calls[origIdx].Method, i+1, attempt, retries)
+					calls[origIdx].Method, origIdx+1, attempt, retries)
 				nextPending = append(nextPending, origIdx)
 			}
 		}

--- a/tools/exit_certificate/rpc.go
+++ b/tools/exit_certificate/rpc.go
@@ -156,11 +156,14 @@ func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]
 		}
 
 		var nextPending []int
+		answered := make([]bool, len(pendingIdxs))
 		for _, r := range responses {
 			localIdx := r.ID - 1
 			if localIdx < 0 || localIdx >= len(pendingIdxs) {
+				log.Warnf("batchRPC: response ID %d outside expected range [1-%d] — ignoring", r.ID, len(pendingIdxs))
 				continue
 			}
+			answered[localIdx] = true
 			origIdx := pendingIdxs[localIdx]
 			if r.Error != nil {
 				if isRevertError(r.Error) {
@@ -175,6 +178,16 @@ func batchRPC(ctx context.Context, url string, calls []RPCCall, retries int) ([]
 				continue
 			}
 			results[origIdx] = r.Result
+		}
+		// Re-queue every pending call whose ID never showed up in the responses (e.g. a mismatched
+		// response ID): dropping it would leave a silent nil hole in results that callers may
+		// misread as a benign empty value.
+		for i, origIdx := range pendingIdxs {
+			if !answered[i] {
+				log.Warnf("batchRPC: no response for %s id=%d (attempt %d/%d) — re-queuing",
+					calls[origIdx].Method, i+1, attempt, retries)
+				nextPending = append(nextPending, origIdx)
+			}
 		}
 		pendingIdxs = nextPending
 	}

--- a/tools/exit_certificate/rpc_test.go
+++ b/tools/exit_certificate/rpc_test.go
@@ -44,6 +44,69 @@ func TestBatchRPC_Success(t *testing.T) {
 	require.Equal(t, "0xc8", val2)
 }
 
+// TestBatchRPC_MismatchedIDRequeuedThenFails covers AET-24: a response whose ID falls outside the
+// expected range must not leave a silent nil hole in the results — the unanswered call is re-queued
+// and, if it never gets a response, batchRPC errors out.
+func TestBatchRPC_MismatchedIDRequeuedThenFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var requests []jsonRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requests))
+		responses := make([]jsonRPCResponse, len(requests))
+		for i := range requests {
+			// First response gets a bogus out-of-range ID; the rest answer normally.
+			id := requests[i].ID
+			if i == 0 {
+				id = 999
+			}
+			responses[i] = jsonRPCResponse{JSONRPC: "2.0", ID: id, Result: json.RawMessage(`"0x1"`)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(responses))
+	}))
+	defer server.Close()
+
+	calls := []RPCCall{
+		{Method: "eth_blockNumber", Params: nil},
+		{Method: "eth_blockNumber", Params: nil},
+	}
+	_, err := batchRPC(context.Background(), server.URL, calls, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "still failing")
+}
+
+// TestBatchRPC_MismatchedIDRecoveredOnRetry checks the re-queued call succeeds when a later
+// attempt answers with the right ID, leaving no nil slot.
+func TestBatchRPC_MismatchedIDRecoveredOnRetry(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var requests []jsonRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requests))
+		attempts++
+		responses := make([]jsonRPCResponse, len(requests))
+		for i := range requests {
+			id := requests[i].ID
+			if attempts == 1 && i == 0 {
+				id = 999 // first attempt: bogus ID for the first call
+			}
+			responses[i] = jsonRPCResponse{JSONRPC: "2.0", ID: id, Result: json.RawMessage(`"0x1"`)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(responses))
+	}))
+	defer server.Close()
+
+	calls := []RPCCall{
+		{Method: "eth_blockNumber", Params: nil},
+		{Method: "eth_blockNumber", Params: nil},
+	}
+	results, err := batchRPC(context.Background(), server.URL, calls, 3)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	for i, res := range results {
+		require.NotNil(t, res, "result %d must not be a silent nil hole", i)
+	}
+}
+
 func TestBatchRPC_RPCError(t *testing.T) {
 	// Single-call batch where the node always returns a per-item RPC error.
 	// batchRPC exhausts retries and returns an error.

--- a/tools/exit_certificate/run.go
+++ b/tools/exit_certificate/run.go
@@ -3,6 +3,7 @@ package exit_certificate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -235,7 +236,7 @@ func resolveLatestBlock(ctx context.Context, rpcURL string) (uint64, error) {
 	if err := json.Unmarshal(result, &hex); err != nil {
 		return 0, fmt.Errorf("parse block number: %w", err)
 	}
-	return hexToUint64(hex), nil
+	return hexToUint64(hex)
 }
 
 // --- Full pipeline ---
@@ -254,7 +255,9 @@ func runAll(ctx context.Context, cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("step CHECK: %w", err)
 	}
-	saveJSON(dir, fileStepCheckResult, checkResult)
+	if err := saveJSON(dir, fileStepCheckResult, checkResult); err != nil {
+		return err
+	}
 
 	lbtEntries, wrappedTokens, targetBlock, err := resolveOrGenerateLBT(ctx, cfg, dir)
 	if err != nil {
@@ -310,7 +313,9 @@ func runAll(ctx context.Context, cfg *Config) error {
 		if err != nil {
 			return fmt.Errorf("step SIGN: %w", err)
 		}
-		saveJSON(dir, fileSignedCertificate, signedCert)
+		if err := saveJSON(dir, fileSignedCertificate, signedCert); err != nil {
+			return err
+		}
 	}
 
 	log.Info("")
@@ -331,7 +336,9 @@ func runAllStepA(
 	if err != nil {
 		return nil, fmt.Errorf("step A: %w", err)
 	}
-	saveJSON(dir, fileStepAAddresses, result.Addresses)
+	if err := saveJSON(dir, fileStepAAddresses, result.Addresses); err != nil {
+		return nil, err
+	}
 	if len(wrappedTokens) > 0 {
 		log.Infof("Using %d wrapped tokens for balance scanning", len(wrappedTokens))
 	}
@@ -345,13 +352,40 @@ func runAllStepB(
 	if err != nil {
 		return nil, fmt.Errorf("step B: %w", err)
 	}
-	saveJSON(dir, fileStepBEOABalances, stepBResult.EOABalances)
-	saveJSON(dir, fileStepBAccumulated, stepBResult.Accumulated)
-	saveJSON(dir, fileStepBContractAddresses, stepBResult.ContractAddresses)
-	saveJSON(dir, fileStepB2DetectedERC20s, stepBResult.DetectedERC20s)
-	saveJSON(dir, fileStepB2DiscardedERC20s, stepBResult.DiscardedERC20s)
-	saveJSON(dir, fileStepB3ERC20Holders, stepBResult.ERC20HolderBreakdowns)
+	if err := saveStepBFiles(dir, stepBResult); err != nil {
+		return nil, err
+	}
 	return stepBResult, nil
+}
+
+// saveStepBFiles persists every Step B output file (B1 + B2 + B3).
+func saveStepBFiles(dir string, stepBResult *StepBResult) error {
+	b1 := &StepB1Result{
+		EOABalances:       stepBResult.EOABalances,
+		Accumulated:       stepBResult.Accumulated,
+		ContractAddresses: stepBResult.ContractAddresses,
+	}
+	if err := saveStepB1Files(dir, b1); err != nil {
+		return err
+	}
+	if err := saveJSON(dir, fileStepB2DetectedERC20s, stepBResult.DetectedERC20s); err != nil {
+		return err
+	}
+	if err := saveJSON(dir, fileStepB2DiscardedERC20s, stepBResult.DiscardedERC20s); err != nil {
+		return err
+	}
+	return saveJSON(dir, fileStepB3ERC20Holders, stepBResult.ERC20HolderBreakdowns)
+}
+
+// saveStepB1Files persists the Step B1 output files.
+func saveStepB1Files(dir string, result *StepB1Result) error {
+	if err := saveJSON(dir, fileStepBEOABalances, result.EOABalances); err != nil {
+		return err
+	}
+	if err := saveJSON(dir, fileStepBAccumulated, result.Accumulated); err != nil {
+		return err
+	}
+	return saveJSON(dir, fileStepBContractAddresses, result.ContractAddresses)
 }
 
 func runAllStepC(
@@ -368,9 +402,18 @@ func runAllStepC(
 	if err != nil {
 		return nil, fmt.Errorf("step C: %w", err)
 	}
-	saveJSON(dir, fileStepCSCLockedValues, stepCResult.SCLockedValues)
-	saveJSON(dir, fileStepCHolderBridges, stepCResult.HolderBridges)
+	if err := saveStepCFiles(dir, stepCResult); err != nil {
+		return nil, err
+	}
 	return stepCResult, nil
+}
+
+// saveStepCFiles persists the Step C output files.
+func saveStepCFiles(dir string, stepCResult *StepCResult) error {
+	if err := saveJSON(dir, fileStepCSCLockedValues, stepCResult.SCLockedValues); err != nil {
+		return err
+	}
+	return saveJSON(dir, fileStepCHolderBridges, stepCResult.HolderBridges)
 }
 
 func runAllStepF(
@@ -386,9 +429,13 @@ func runAllStepF(
 		return nil, fmt.Errorf("step F: %w", err)
 	}
 	if result.TokenBalances != nil {
-		saveJSON(dir, fileStepFTokenBalances, result.TokenBalances)
+		if err := saveJSON(dir, fileStepFTokenBalances, result.TokenBalances); err != nil {
+			return nil, err
+		}
 	}
-	saveJSON(dir, fileStepFChecks, result.Checks)
+	if err := saveJSON(dir, fileStepFChecks, result.Checks); err != nil {
+		return nil, err
+	}
 	if result.CappedCertificate != nil {
 		// Apply the same per-token caps to the final certificate (which may include step E exits).
 		cappedFinal := *finalCert
@@ -397,7 +444,9 @@ func runAllStepF(
 			return nil, fmt.Errorf("step F: capping the final certificate: %w", err)
 		}
 		cappedFinal.BridgeExits = cappedExits
-		saveJSON(dir, fileStepFCappedCertificate, &cappedFinal)
+		if err := saveJSON(dir, fileStepFCappedCertificate, &cappedFinal); err != nil {
+			return nil, err
+		}
 		log.Infof("🔧 Capped final certificate saved (%d → %d bridge exits)",
 			len(finalCert.BridgeExits), len(cappedFinal.BridgeExits))
 		return &cappedFinal, nil
@@ -413,17 +462,23 @@ func runAllStepG(
 	if err != nil {
 		return nil, fmt.Errorf("step G1: %w", err)
 	}
-	saveJSON(dir, fileStepG1ShadowForkBlock, g1Result)
+	if err := saveJSON(dir, fileStepG1ShadowForkBlock, g1Result); err != nil {
+		return nil, err
+	}
 
 	result, err := RunStepG2(ctx, cfg, g1Result.ShadowForkBlock, certificate, lbtEntries)
 	if err != nil {
 		return nil, fmt.Errorf("step G2: %w", err)
 	}
-	saveJSON(dir, fileStepGNewLocalExitRoot, result)
+	if err := saveJSON(dir, fileStepGNewLocalExitRoot, result); err != nil {
+		return nil, err
+	}
 	// RunStepG2 keeps the certificate's deterministic exit order (it never reorders); persist the
 	// certificate as Step G left it for inspection and parity with single-step mode (the file name is
 	// kept for compatibility).
-	saveJSON(dir, fileStepGReorderedCertificate, certificate)
+	if err := saveJSON(dir, fileStepGReorderedCertificate, certificate); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -432,7 +487,9 @@ func runAllStepH(ctx context.Context, cfg *Config, dir string, gResult *StepGRes
 	if err != nil {
 		return nil, fmt.Errorf("step H: %w", err)
 	}
-	saveJSON(dir, fileStepHPreviousLocalExitRoot, result)
+	if err := saveJSON(dir, fileStepHPreviousLocalExitRoot, result); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -443,8 +500,7 @@ func runAllStepI(
 	if err := RunStepI(ctx, cfg, certificate, gResult, hResult); err != nil {
 		return fmt.Errorf("step I: %w", err)
 	}
-	saveJSON(dir, fileFinalCertificate, certificate)
-	return nil
+	return saveJSON(dir, fileFinalCertificate, certificate)
 }
 
 func runAllStepD(cfg *Config, dir string, stepBResult *StepBResult, stepCResult *StepCResult) (*StepDResult, error) {
@@ -452,21 +508,28 @@ func runAllStepD(cfg *Config, dir string, stepBResult *StepBResult, stepCResult 
 	if err != nil {
 		return nil, fmt.Errorf("step D: %w", err)
 	}
-	saveJSON(dir, fileStepDCertificate, stepDResult.Certificate)
+	if err := saveJSON(dir, fileStepDCertificate, stepDResult.Certificate); err != nil {
+		return nil, err
+	}
 	return stepDResult, nil
 }
 
 // saveStepEFiles persists step E outputs to disk. Always writes the unclaimed bridges and
 // messages files; only writes the certificate when it is non-nil.
-func saveStepEFiles(dir string, result *StepEResult) {
+func saveStepEFiles(dir string, result *StepEResult) error {
 	if result == nil {
-		return
+		return nil
 	}
-	saveJSON(dir, fileStepEUnclaimedBridges, result.UnclaimedBridges)
-	saveJSON(dir, fileStepEUnclaimedMsgs, result.UnclaimedMessages)
+	if err := saveJSON(dir, fileStepEUnclaimedBridges, result.UnclaimedBridges); err != nil {
+		return err
+	}
+	if err := saveJSON(dir, fileStepEUnclaimedMsgs, result.UnclaimedMessages); err != nil {
+		return err
+	}
 	if result.FinalCertificate != nil {
-		saveJSON(dir, fileStepECertificate, result.FinalCertificate)
+		return saveJSON(dir, fileStepECertificate, result.FinalCertificate)
 	}
+	return nil
 }
 
 func runAllStepE(
@@ -477,7 +540,9 @@ func runAllStepE(
 		return stepDCert, nil
 	}
 	result, err := RunStepE(ctx, cfg, stepDCert)
-	saveStepEFiles(dir, result)
+	if saveErr := saveStepEFiles(dir, result); saveErr != nil && err == nil {
+		return nil, fmt.Errorf("step E: %w", saveErr)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("step E: %w", err)
 	}
@@ -576,8 +641,7 @@ func runSingleCheck(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepCheckResult, result)
-	return nil
+	return saveJSON(dir, fileStepCheckResult, result)
 }
 
 func runSingle0(ctx context.Context, cfg *Config, dir string) error {
@@ -585,9 +649,10 @@ func runSingle0(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStep0TargetBlock, result.TargetBlock)
-	saveJSON(dir, fileStep0LBT, result.Entries)
-	return nil
+	if err := saveJSON(dir, fileStep0TargetBlock, result.TargetBlock); err != nil {
+		return err
+	}
+	return saveJSON(dir, fileStep0LBT, result.Entries)
 }
 
 // runSingleA runs Step A (state dump + Transfer logs) and writes step-a-addresses.json.
@@ -607,8 +672,7 @@ func runSingleA(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepAAddresses, result.Addresses)
-	return nil
+	return saveJSON(dir, fileStepAAddresses, result.Addresses)
 }
 
 // runSingleB runs B1 then B2 then B3, producing all step-b* output files.
@@ -646,10 +710,7 @@ func runSingleB1(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepBEOABalances, result.EOABalances)
-	saveJSON(dir, fileStepBAccumulated, result.Accumulated)
-	saveJSON(dir, fileStepBContractAddresses, result.ContractAddresses)
-	return nil
+	return saveStepB1Files(dir, result)
 }
 
 // runSingleB2 runs Step B2 and writes step-b2-detected-erc20s.json and
@@ -679,9 +740,10 @@ func runSingleB2(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepB2DetectedERC20s, result.DetectedERC20s)
-	saveJSON(dir, fileStepB2DiscardedERC20s, result.DiscardedERC20s)
-	return nil
+	if err := saveJSON(dir, fileStepB2DetectedERC20s, result.DetectedERC20s); err != nil {
+		return err
+	}
+	return saveJSON(dir, fileStepB2DiscardedERC20s, result.DiscardedERC20s)
 }
 
 // runSingleB3 runs Step B3 and writes step-b3-erc20-holders.json.
@@ -712,8 +774,7 @@ func runSingleB3(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepB3ERC20Holders, result.Breakdowns)
-	return nil
+	return saveJSON(dir, fileStepB3ERC20Holders, result.Breakdowns)
 }
 
 func runSingleC(ctx context.Context, cfg *Config, dir string) error {
@@ -725,9 +786,11 @@ func runSingleC(ctx context.Context, cfg *Config, dir string) error {
 	if err := loadJSON(dir, fileStep0LBT, &lbtEntries); err != nil {
 		return fmt.Errorf("load LBT data (step 0): %w", err)
 	}
-	// Load holder breakdowns from B3 if available; absence is not an error.
+	// Load holder breakdowns from B3 if available; absence is not an error, corruption is.
 	var breakdowns []ERC20HolderBreakdown
-	_ = loadJSON(dir, fileStepB3ERC20Holders, &breakdowns)
+	if err := loadOptionalJSON(dir, fileStepB3ERC20Holders, &breakdowns); err != nil {
+		return fmt.Errorf("load step B3 output: %w", err)
+	}
 
 	stepB := &StepBResult{Accumulated: accumulated, ERC20HolderBreakdowns: breakdowns}
 	if err := applyNativeContractLocked(ctx, cfg, dir, stepB); err != nil {
@@ -738,9 +801,7 @@ func runSingleC(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepCSCLockedValues, result.SCLockedValues)
-	saveJSON(dir, fileStepCHolderBridges, result.HolderBridges)
-	return nil
+	return saveStepCFiles(dir, result)
 }
 
 // applyNativeContractLocked computes the native token's SC-locked value from contract ETH balances
@@ -778,8 +839,11 @@ func runSingleD(cfg *Config, dir string) error {
 	if err := loadJSON(dir, fileStepCSCLockedValues, &scLockedValues); err != nil {
 		return fmt.Errorf("load step C output: %w", err)
 	}
+	// Holder bridges from Step C are optional; absence is not an error, corruption is.
 	var holderBridges []HolderBridge
-	_ = loadJSON(dir, fileStepCHolderBridges, &holderBridges)
+	if err := loadOptionalJSON(dir, fileStepCHolderBridges, &holderBridges); err != nil {
+		return fmt.Errorf("load step C holder bridges: %w", err)
+	}
 
 	result, err := RunStepD(cfg, &StepBResult{EOABalances: eoaBalances}, &StepCResult{
 		SCLockedValues: scLockedValues,
@@ -788,8 +852,7 @@ func runSingleD(cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepDCertificate, result.Certificate)
-	return nil
+	return saveJSON(dir, fileStepDCertificate, result.Certificate)
 }
 
 func runSingleE(ctx context.Context, cfg *Config, dir string) error {
@@ -800,8 +863,14 @@ func runSingleE(ctx context.Context, cfg *Config, dir string) error {
 	if err := loadJSON(dir, fileStepDCertificate, &cert); err != nil {
 		return fmt.Errorf("load step D output: %w", err)
 	}
-	result, err := RunStepE(ctx, cfg, cert.toAgglayerCertificate())
-	saveStepEFiles(dir, result)
+	aggCert, err := cert.toAgglayerCertificate()
+	if err != nil {
+		return fmt.Errorf("load step D certificate: %w", err)
+	}
+	result, err := RunStepE(ctx, cfg, aggCert)
+	if saveErr := saveStepEFiles(dir, result); saveErr != nil && err == nil {
+		return saveErr
+	}
 	return err
 }
 
@@ -814,8 +883,7 @@ func runSingleSign(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileSignedCertificate, signed)
-	return nil
+	return saveJSON(dir, fileSignedCertificate, signed)
 }
 
 func runSingleSubmit(ctx context.Context, cfg *Config, dir string) error {
@@ -827,8 +895,7 @@ func runSingleSubmit(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepSubmitResult, result)
-	return nil
+	return saveJSON(dir, fileStepSubmitResult, result)
 }
 
 func runSingleWait(ctx context.Context, cfg *Config, dir string) error {
@@ -840,8 +907,7 @@ func runSingleWait(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepWaitResult, result)
-	return nil
+	return saveJSON(dir, fileStepWaitResult, result)
 }
 
 func runSingleF(ctx context.Context, cfg *Config, dir string) error {
@@ -860,16 +926,26 @@ func runSingleF(ctx context.Context, cfg *Config, dir string) error {
 		log.Warnf("STEP F: LBT data not available, falling back to two-way comparison: %v", err)
 	}
 
-	result, err := RunStepF(ctx, cfg, cert.toAgglayerCertificate(), lbtEntries)
+	aggCert, err := cert.toAgglayerCertificate()
+	if err != nil {
+		return fmt.Errorf("load step D certificate: %w", err)
+	}
+	result, err := RunStepF(ctx, cfg, aggCert, lbtEntries)
 	if err != nil {
 		return err
 	}
 	if result.TokenBalances != nil {
-		saveJSON(dir, fileStepFTokenBalances, result.TokenBalances)
+		if err := saveJSON(dir, fileStepFTokenBalances, result.TokenBalances); err != nil {
+			return err
+		}
 	}
-	saveJSON(dir, fileStepFChecks, result.Checks)
+	if err := saveJSON(dir, fileStepFChecks, result.Checks); err != nil {
+		return err
+	}
 	if result.CappedCertificate != nil {
-		saveJSON(dir, fileStepFCappedCertificate, result.CappedCertificate)
+		if err := saveJSON(dir, fileStepFCappedCertificate, result.CappedCertificate); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -898,8 +974,7 @@ func runSingleG1(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepG1ShadowForkBlock, result)
-	return nil
+	return saveJSON(dir, fileStepG1ShadowForkBlock, result)
 }
 
 // runSingleG2 runs Step G2: it loads the shadow-fork block from G1, the certificate (capped from F
@@ -935,16 +1010,20 @@ func runSingleG2(ctx context.Context, cfg *Config, dir string) error {
 		log.Warnf("STEP G2: LBT not available, falling back to getTokenWrappedAddress: %v", err)
 	}
 
-	aggCert := cert.toAgglayerCertificate()
+	aggCert, err := cert.toAgglayerCertificate()
+	if err != nil {
+		return fmt.Errorf("load certificate for step G2: %w", err)
+	}
 	result, err := RunStepG2(ctx, cfg, g1Result.ShadowForkBlock, aggCert, lbtEntries)
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepGNewLocalExitRoot, result)
+	if err := saveJSON(dir, fileStepGNewLocalExitRoot, result); err != nil {
+		return err
+	}
 	// RunStepG2 keeps the exits' deterministic order but updates each exit's Metadata (hash). Persist
 	// it so the single-step Step I picks up the certificate that matches the computed NewLocalExitRoot.
-	saveJSON(dir, fileStepGReorderedCertificate, aggCert)
-	return nil
+	return saveJSON(dir, fileStepGReorderedCertificate, aggCert)
 }
 
 func runSingleH(ctx context.Context, cfg *Config, dir string) error {
@@ -956,8 +1035,7 @@ func runSingleH(ctx context.Context, cfg *Config, dir string) error {
 	if err != nil {
 		return err
 	}
-	saveJSON(dir, fileStepHPreviousLocalExitRoot, result)
-	return nil
+	return saveJSON(dir, fileStepHPreviousLocalExitRoot, result)
 }
 
 func runSingleI(ctx context.Context, cfg *Config, dir string) error {
@@ -978,12 +1056,14 @@ func runSingleI(ctx context.Context, cfg *Config, dir string) error {
 	if err := loadJSON(dir, fileStepHPreviousLocalExitRoot, &hResult); err != nil {
 		return fmt.Errorf("load step H result: %w", err)
 	}
-	aggCert := cert.toAgglayerCertificate()
+	aggCert, err := cert.toAgglayerCertificate()
+	if err != nil {
+		return fmt.Errorf("load step G reordered certificate: %w", err)
+	}
 	if err := RunStepI(ctx, cfg, aggCert, &gResult, &hResult); err != nil {
 		return err
 	}
-	saveJSON(dir, fileFinalCertificate, aggCert)
-	return nil
+	return saveJSON(dir, fileFinalCertificate, aggCert)
 }
 
 // --- LBT resolution ---
@@ -994,8 +1074,12 @@ func resolveOrGenerateLBT(ctx context.Context, cfg *Config, dir string) ([]LBTEn
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	saveJSON(dir, fileStep0TargetBlock, result.TargetBlock)
-	saveJSON(dir, fileStep0LBT, result.Entries)
+	if err := saveJSON(dir, fileStep0TargetBlock, result.TargetBlock); err != nil {
+		return nil, nil, 0, err
+	}
+	if err := saveJSON(dir, fileStep0LBT, result.Entries); err != nil {
+		return nil, nil, 0, err
+	}
 	return result.Entries, LBTEntriesToWrappedTokens(result.Entries), result.TargetBlock, nil
 }
 
@@ -1019,18 +1103,20 @@ func loadWrappedTokensFromLBT(dir string) ([]WrappedToken, error) {
 
 // --- JSON I/O ---
 
-func saveJSON(dir, filename string, data any) {
+// saveJSON marshals data and writes it to dir/filename. Marshal/write failures are returned (not
+// just logged): in split-step workflows a silently missing file would make the next step load a
+// stale or absent input.
+func saveJSON(dir, filename string, data any) error {
 	path := filepath.Join(dir, filename)
 	content, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		log.Errorf("Failed to marshal %s: %v", filename, err)
-		return
+		return fmt.Errorf("marshal %s: %w", filename, err)
 	}
 	if err := os.WriteFile(path, content, filePermissions); err != nil {
-		log.Errorf("Failed to write %s: %v", path, err)
-		return
+		return fmt.Errorf("write %s: %w", path, err)
 	}
 	log.Infof("Written: %s", path)
+	return nil
 }
 
 func loadJSON(dir, filename string, target any) error {
@@ -1039,7 +1125,21 @@ func loadJSON(dir, filename string, target any) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
-	return json.Unmarshal(data, target)
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+// loadOptionalJSON loads dir/filename into target when the file exists. Absence is fine (the step
+// that writes it is optional), but any other failure — unreadable file or corrupted JSON — is an
+// error rather than being silently treated as absence.
+func loadOptionalJSON(dir, filename string, target any) error {
+	err := loadJSON(dir, filename, target)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 // certificateJSON supports loading a Certificate from the step-d output file.
@@ -1052,18 +1152,23 @@ type certificateJSON struct {
 	ImportedBridges   json.RawMessage `json:"imported_bridge_exits"`
 }
 
-func (c *certificateJSON) toAgglayerCertificate() *agglayertypes.Certificate {
+func (c *certificateJSON) toAgglayerCertificate() (*agglayertypes.Certificate, error) {
 	cert := &agglayertypes.Certificate{
 		NetworkID:         c.NetworkID,
 		Height:            c.Height,
 		PrevLocalExitRoot: c.PrevLocalExitRoot,
 		NewLocalExitRoot:  c.NewLocalExitRoot,
 	}
+	// A corrupted section must not silently load as a certificate with zero exits.
 	if len(c.BridgeExits) > 0 {
-		_ = json.Unmarshal(c.BridgeExits, &cert.BridgeExits)
+		if err := json.Unmarshal(c.BridgeExits, &cert.BridgeExits); err != nil {
+			return nil, fmt.Errorf("parse certificate bridge_exits: %w", err)
+		}
 	}
 	if len(c.ImportedBridges) > 0 {
-		_ = json.Unmarshal(c.ImportedBridges, &cert.ImportedBridgeExits)
+		if err := json.Unmarshal(c.ImportedBridges, &cert.ImportedBridgeExits); err != nil {
+			return nil, fmt.Errorf("parse certificate imported_bridge_exits: %w", err)
+		}
 	}
-	return cert
+	return cert, nil
 }

--- a/tools/exit_certificate/run_extra_test.go
+++ b/tools/exit_certificate/run_extra_test.go
@@ -50,7 +50,7 @@ func TestFileExists(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	require.False(t, fileExists(filepath.Join(dir, "nope.json")))
-	saveJSON(dir, "yes.json", map[string]int{"a": 1})
+	mustSaveJSON(t, dir, "yes.json", map[string]int{"a": 1})
 	require.True(t, fileExists(filepath.Join(dir, "yes.json")))
 }
 
@@ -60,7 +60,7 @@ func TestLoadTargetBlock(t *testing.T) {
 	_, err := loadTargetBlock(dir) // missing → error
 	require.Error(t, err)
 
-	saveJSON(dir, "step-0-l2_target_block.json", uint64(12345))
+	mustSaveJSON(t, dir, "step-0-l2_target_block.json", uint64(12345))
 	n, err := loadTargetBlock(dir)
 	require.NoError(t, err)
 	require.Equal(t, uint64(12345), n)
@@ -72,7 +72,7 @@ func TestLoadWrappedTokensFromLBT(t *testing.T) {
 	_, err := loadWrappedTokensFromLBT(dir) // missing → error
 	require.Error(t, err)
 
-	saveJSON(dir, "step-0-lbt.json", []LBTEntry{
+	mustSaveJSON(t, dir, "step-0-lbt.json", []LBTEntry{
 		{WrappedTokenAddress: common.BytesToAddress([]byte("wrap")), OriginNetwork: 1,
 			OriginTokenAddress: common.BytesToAddress([]byte("orig")), Balance: "1000"},
 	})
@@ -97,13 +97,13 @@ func TestRunSingleCAndD(t *testing.T) {
 	orig := common.BytesToAddress([]byte("orig"))
 
 	// Step 0 + B fixtures: LBT supply 1000, accumulated EOA 100 → SC-locked 900.
-	saveJSON(dir, "step-0-lbt.json", []LBTEntry{
+	mustSaveJSON(t, dir, "step-0-lbt.json", []LBTEntry{
 		{WrappedTokenAddress: tok, OriginNetwork: 1, OriginTokenAddress: orig, Balance: "1000"},
 	})
-	saveJSON(dir, "step-b-accumulated.json", []AccumulatedBalance{
+	mustSaveJSON(t, dir, "step-b-accumulated.json", []AccumulatedBalance{
 		{WrappedTokenAddress: tok, OriginNetwork: 1, OriginTokenAddress: orig, TotalBalance: "100"},
 	})
-	saveJSON(dir, "step-b-eoa-balances.json", []EOABalance{
+	mustSaveJSON(t, dir, "step-b-eoa-balances.json", []EOABalance{
 		{Address: common.BytesToAddress([]byte("eoa")), ETHBalance: "0", Tokens: []EOATokenBalance{
 			{WrappedTokenAddress: tok, OriginNetwork: 1, OriginTokenAddress: orig, Balance: "100"},
 		}},
@@ -134,10 +134,10 @@ func TestRunSingleCMissingInput(t *testing.T) {
 func TestSaveStepEFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	saveStepEFiles(dir, &StepEResult{
+	require.NoError(t, saveStepEFiles(dir, &StepEResult{
 		UnclaimedBridges:  []L1Deposit{{DepositCount: 1}},
 		UnclaimedMessages: []L1Deposit{{DepositCount: 2}},
-	})
+	}))
 	require.True(t, fileExists(filepath.Join(dir, "step-e-unclaimed-bridges.json")))
 	require.True(t, fileExists(filepath.Join(dir, "step-e-unclaimed-messages.json")))
 }

--- a/tools/exit_certificate/run_stepa_test.go
+++ b/tools/exit_certificate/run_stepa_test.go
@@ -30,7 +30,7 @@ func newStepAServer(t *testing.T) string {
 func TestRunSingleA(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	saveJSON(dir, fileStep0TargetBlock, uint64(2))
+	mustSaveJSON(t, dir, fileStep0TargetBlock, uint64(2))
 
 	cfg := &Config{
 		L2RPCURL: newStepAServer(t), L2BridgeAddress: common.BytesToAddress([]byte("bridge")),

--- a/tools/exit_certificate/run_stepb_test.go
+++ b/tools/exit_certificate/run_stepb_test.go
@@ -22,11 +22,11 @@ func TestRunSingleBChain(t *testing.T) {
 	orig := common.BytesToAddress([]byte("orig"))
 
 	// Prerequisites normally produced by Step 0 and Step A.
-	saveJSON(dir, fileStep0TargetBlock, uint64(100))
-	saveJSON(dir, fileStep0LBT, []LBTEntry{
+	mustSaveJSON(t, dir, fileStep0TargetBlock, uint64(100))
+	mustSaveJSON(t, dir, fileStep0LBT, []LBTEntry{
 		{WrappedTokenAddress: tok, OriginNetwork: 1, OriginTokenAddress: orig, Balance: "1000"},
 	})
-	saveJSON(dir, fileStepAAddresses, []common.Address{rich, poor})
+	mustSaveJSON(t, dir, fileStepAAddresses, []common.Address{rich, poor})
 
 	url := newBatchRPCServer(t, func(method string, params []json.RawMessage) any {
 		switch method {

--- a/tools/exit_certificate/run_stepg2_lite_test.go
+++ b/tools/exit_certificate/run_stepg2_lite_test.go
@@ -39,8 +39,8 @@ func TestRunSingleG2LiteNonEmpty(t *testing.T) {
 		"amount":       "1000",
 	}})
 	require.NoError(t, err)
-	saveJSON(dir, fileStepG1ShadowForkBlock, StepG1Result{ShadowForkBlock: 100})
-	saveJSON(dir, fileStepECertificate, &certificateJSON{NetworkID: 1, BridgeExits: bridgeExits})
+	require.NoError(t, saveJSON(dir, fileStepG1ShadowForkBlock, StepG1Result{ShadowForkBlock: 100}))
+	require.NoError(t, saveJSON(dir, fileStepECertificate, &certificateJSON{NetworkID: 1, BridgeExits: bridgeExits}))
 
 	getRootSel := selectorHex(bridgeABI, "getRoot")
 	gasMetaSel := selectorHex(bridgeABI, "gasTokenMetadata")
@@ -62,9 +62,9 @@ func TestRunSingleG2LiteNonEmpty(t *testing.T) {
 		case strings.HasPrefix(data, gasMetaSel):
 			return hexResult(gasMetaOut), nil
 		default:
-			// gasTokenNetwork/gasTokenAddress: an empty result makes fetchGasTokenInfo fall back to the
-			// ETH default (network 0, zero address), which is what this native exit expects.
-			return quoted("0x"), nil
+			// gasTokenNetwork/gasTokenAddress: a zero ABI word decodes as the ETH values (network 0,
+			// zero address), which is what this native exit expects.
+			return hexResult(make([]byte, abiWordBytes)), nil
 		}
 	})
 

--- a/tools/exit_certificate/run_stepg2_lite_test.go
+++ b/tools/exit_certificate/run_stepg2_lite_test.go
@@ -3,6 +3,7 @@ package exit_certificate
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,12 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRunSingleG2LiteNonEmpty drives runSingleG2 in off-chain (no shadow-fork) mode with a single
-// native bridge exit. It builds an empty Step G1 lite DB up front, then serves the bridge getRoot /
-// gasTokenMetadata eth_calls so RunStepG2 builds the lite exit tree and writes its outputs.
-func TestRunSingleG2LiteNonEmpty(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
+// setupLiteG2 prepares everything runSingleG2 needs to run in off-chain (no shadow-fork) mode
+// with a single native bridge exit: an empty Step G1 lite DB, the G1/step-e fixtures, and a stub
+// serving the bridge getRoot / gasTokenMetadata / gas-token eth_calls. Returns the ready Config
+// (its OutputDir is dir).
+func setupLiteG2(t *testing.T, dir string) *Config {
+	t.Helper()
 	ctx := context.Background()
 
 	// Empty Step G1 lite DB (genesis→fork bridges = none → cert exits start at deposit count 0).
@@ -68,14 +69,35 @@ func TestRunSingleG2LiteNonEmpty(t *testing.T) {
 		}
 	})
 
-	cfg := &Config{
+	return &Config{
 		L2RPCURL:        srv.URL,
 		L2BridgeAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
 		L2NetworkID:     1,
 		Options:         Options{OutputDir: dir, VerifyNewLocalExitRootUsingShadowFork: false},
 	}
+}
 
-	require.NoError(t, runSingleG2(ctx, cfg, dir))
+// TestRunSingleG2LiteNonEmpty drives runSingleG2 in off-chain (no shadow-fork) mode with a single
+// native bridge exit: RunStepG2 builds the lite exit tree and writes its outputs.
+func TestRunSingleG2LiteNonEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := setupLiteG2(t, dir)
+
+	require.NoError(t, runSingleG2(context.Background(), cfg, dir))
 	require.True(t, fileExists(filepath.Join(dir, fileStepGNewLocalExitRoot)))
 	require.True(t, fileExists(filepath.Join(dir, fileStepGReorderedCertificate)))
+}
+
+// TestRunSingleG2LiteSaveError covers the AET-39 write-error branch: the step succeeds but its
+// result file cannot be written, which must fail the step instead of leaving a stale file behind.
+func TestRunSingleG2LiteSaveError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := setupLiteG2(t, dir)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, fileStepGNewLocalExitRoot), 0o755))
+
+	err := runSingleG2(context.Background(), cfg, dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fileStepGNewLocalExitRoot)
 }

--- a/tools/exit_certificate/run_steps_success_test.go
+++ b/tools/exit_certificate/run_steps_success_test.go
@@ -40,7 +40,7 @@ func TestRunSingle0Success(t *testing.T) {
 func TestRunSingleFOffline(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	saveJSON(dir, fileStepDCertificate, map[string]any{"network_id": 1})
+	mustSaveJSON(t, dir, fileStepDCertificate, map[string]any{"network_id": 1})
 	cfg := &Config{Options: Options{OutputDir: dir, UseAgglayerAdminToStepFCheck: false}}
 
 	require.NoError(t, runSingleF(context.Background(), cfg, dir))
@@ -50,9 +50,9 @@ func TestRunSingleFOffline(t *testing.T) {
 func TestRunSingleISuccess(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	saveJSON(dir, fileStepGReorderedCertificate, map[string]any{"network_id": 1})
-	saveJSON(dir, fileStepGNewLocalExitRoot, StepGResult{NewLocalExitRoot: common.HexToHash("0xbeef")})
-	saveJSON(dir, fileStepHPreviousLocalExitRoot, StepHResult{PreviousLocalExitRoot: common.HexToHash("0xabcd"), Height: 2})
+	mustSaveJSON(t, dir, fileStepGReorderedCertificate, map[string]any{"network_id": 1})
+	mustSaveJSON(t, dir, fileStepGNewLocalExitRoot, StepGResult{NewLocalExitRoot: common.HexToHash("0xbeef")})
+	mustSaveJSON(t, dir, fileStepHPreviousLocalExitRoot, StepHResult{PreviousLocalExitRoot: common.HexToHash("0xabcd"), Height: 2})
 
 	topic1 := common.BytesToHash([]byte{0x0a})
 	srv := newBatchRPCStub(t, func(method string, _ []any) (json.RawMessage, *jsonRPCError) {

--- a/tools/exit_certificate/run_steps_test.go
+++ b/tools/exit_certificate/run_steps_test.go
@@ -56,7 +56,7 @@ func TestRunSingleSign(t *testing.T) {
 	t.Run("requires signer method", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		saveJSON(dir, fileFinalCertificate, map[string]any{}) // valid empty cert
+		mustSaveJSON(t, dir, fileFinalCertificate, map[string]any{}) // valid empty cert
 		err := runSingleSign(ctx, &Config{Options: Options{OutputDir: dir}}, dir)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "signerConfig.Method")
@@ -107,8 +107,8 @@ func TestRunSingleG2_EmptyCertificate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	saveJSON(dir, fileStepG1ShadowForkBlock, StepG1Result{ShadowForkBlock: 100})
-	saveJSON(dir, fileStepECertificate, map[string]any{}) // empty cert → no bridge exits
+	mustSaveJSON(t, dir, fileStepG1ShadowForkBlock, StepG1Result{ShadowForkBlock: 100})
+	mustSaveJSON(t, dir, fileStepECertificate, map[string]any{}) // empty cert → no bridge exits
 
 	cfg := &Config{
 		L2RPCURL:        srv.URL,

--- a/tools/exit_certificate/run_test.go
+++ b/tools/exit_certificate/run_test.go
@@ -56,13 +56,19 @@ func TestParseStepList(t *testing.T) {
 	}
 }
 
+// mustSaveJSON writes a JSON fixture file, failing the test on error.
+func mustSaveJSON(t *testing.T, dir, filename string, data any) {
+	t.Helper()
+	require.NoError(t, saveJSON(dir, filename, data))
+}
+
 func TestSaveAndLoadJSON(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	testData := []string{"hello", "world"}
 
-	saveJSON(dir, "test.json", testData)
+	mustSaveJSON(t, dir, "test.json", testData)
 
 	var loaded []string
 	err := loadJSON(dir, "test.json", &loaded)
@@ -91,6 +97,35 @@ func TestLoadJSON_InvalidJSON(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSaveJSON_WriteError(t *testing.T) {
+	t.Parallel()
+
+	// A nonexistent directory makes the write fail; saveJSON must report it, not swallow it.
+	err := saveJSON(filepath.Join(t.TempDir(), "missing-subdir"), "out.json", []string{"x"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out.json")
+}
+
+func TestLoadOptionalJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var target []string
+
+	// Absence is fine.
+	require.NoError(t, loadOptionalJSON(dir, "absent.json", &target))
+	require.Empty(t, target)
+
+	// A present, valid file loads normally.
+	mustSaveJSON(t, dir, "present.json", []string{"a"})
+	require.NoError(t, loadOptionalJSON(dir, "present.json", &target))
+	require.Equal(t, []string{"a"}, target)
+
+	// Corruption is an error, not absence.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "corrupt.json"), []byte("{bad}"), 0o600))
+	require.Error(t, loadOptionalJSON(dir, "corrupt.json", &target))
+}
+
 func TestCertificateJSON_ToAgglayerCertificate(t *testing.T) {
 	t.Parallel()
 
@@ -112,7 +147,8 @@ func TestCertificateJSON_ToAgglayerCertificate(t *testing.T) {
 		BridgeExits: bridgeExitsJSON,
 	}
 
-	cert := certJSON.toAgglayerCertificate()
+	cert, err := certJSON.toAgglayerCertificate()
+	require.NoError(t, err)
 	require.Equal(t, uint32(1), cert.NetworkID)
 	require.Len(t, cert.BridgeExits, 1)
 }
@@ -121,9 +157,30 @@ func TestCertificateJSON_EmptyBridgeExits(t *testing.T) {
 	t.Parallel()
 
 	certJSON := &certificateJSON{NetworkID: 1}
-	cert := certJSON.toAgglayerCertificate()
+	cert, err := certJSON.toAgglayerCertificate()
+	require.NoError(t, err)
 	require.Equal(t, uint32(1), cert.NetworkID)
 	require.Empty(t, cert.BridgeExits)
+}
+
+func TestCertificateJSON_CorruptedBridgeExits(t *testing.T) {
+	t.Parallel()
+
+	certJSON := &certificateJSON{
+		NetworkID:   1,
+		BridgeExits: json.RawMessage(`{"not":"an-array"}`),
+	}
+	_, err := certJSON.toAgglayerCertificate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bridge_exits")
+
+	certJSON = &certificateJSON{
+		NetworkID:       1,
+		ImportedBridges: json.RawMessage(`"garbage"`),
+	}
+	_, err = certJSON.toAgglayerCertificate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "imported_bridge_exits")
 }
 
 func TestSaveJSON_ComplexData(t *testing.T) {
@@ -135,7 +192,7 @@ func TestSaveJSON_ComplexData(t *testing.T) {
 		"balance": "1000000",
 	}
 
-	saveJSON(dir, "complex.json", data)
+	mustSaveJSON(t, dir, "complex.json", data)
 
 	content, err := os.ReadFile(filepath.Join(dir, "complex.json"))
 	require.NoError(t, err)

--- a/tools/exit_certificate/silent_data_loss_test.go
+++ b/tools/exit_certificate/silent_data_loss_test.go
@@ -1,0 +1,125 @@
+package exit_certificate
+
+// Tests for issue #1713 (AET-06 and the untracked computeNativeBalance case): scan/decode
+// failures must fail the step instead of warn-and-continue, which silently omitted value
+// (tokens, overrides, the native balance) from the exit certificate. The AET-20 and
+// NewWrappedToken decode paths are covered by TestFetchBridgeEventsInRangeDecodeError and
+// TestRunStep0MalformedNewWrappedTokenEvent.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newJSONRPCErrorServer answers every JSON-RPC request (single or batched) with a
+// JSON-RPC error of the given code. singleRPC propagates it without HTTP-level
+// retries, and batchRPC treats the revert code (3) as permanent, keeping tests fast.
+func newJSONRPCErrorServer(t *testing.T, code int, msg string) string {
+	t.Helper()
+	type rpcReq struct {
+		ID json.RawMessage `json:"id"`
+	}
+	errOf := func(req rpcReq) map[string]any {
+		return map[string]any{
+			"jsonrpc": "2.0", "id": req.ID,
+			"error": map[string]any{"code": code, "message": msg},
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		if len(body) > 0 && body[0] == '[' {
+			var reqs []rpcReq
+			require.NoError(t, json.Unmarshal(body, &reqs))
+			resps := make([]map[string]any, len(reqs))
+			for i, req := range reqs {
+				resps[i] = errOf(req)
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(resps))
+			return
+		}
+		var req rpcReq
+		require.NoError(t, json.Unmarshal(body, &req))
+		require.NoError(t, json.NewEncoder(w).Encode(errOf(req)))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestFetchSetSovereignTokenEventsInRangeCorruptEventAborts(t *testing.T) {
+	t.Parallel()
+	url := newBatchRPCServer(t, func(method string, _ []json.RawMessage) any {
+		require.Equal(t, "eth_getLogs", method)
+		return []map[string]string{{
+			"data":        "0xabcd", // corrupt: too short to decode
+			"blockNumber": "0x10",
+			"logIndex":    "0x0",
+		}}
+	})
+	_, err := fetchSetSovereignTokenEventsInRange(
+		context.Background(), url, common.HexToAddress("0xbridge"), 0, 100)
+	require.ErrorContains(t, err, "decode SetSovereignTokenAddress event")
+}
+
+func TestFetchNewWrappedTokenEventsScanFailureAborts(t *testing.T) {
+	t.Parallel()
+	url := newJSONRPCErrorServer(t, eip1474RevertCode, "scan failed")
+	cfg := &Config{
+		L2RPCURL:        url,
+		L2BridgeAddress: common.HexToAddress("0xbridge"),
+		Options:         Options{BlockRange: 1000, ConcurrencyLimit: 2},
+	}
+	_, err := fetchNewWrappedTokenEvents(context.Background(), cfg, 100)
+	require.ErrorContains(t, err, "scan failed")
+}
+
+func TestRunStep0NativeBalanceFailureAborts(t *testing.T) {
+	t.Parallel()
+	// Log scans (single requests) succeed with no events; the eth_getBalance pair of
+	// computeNativeBalance (a batched request) reverts, so Step 0 must abort instead of
+	// building an LBT without the native entry.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		if len(body) > 0 && body[0] == '[' {
+			var reqs []struct {
+				ID json.RawMessage `json:"id"`
+			}
+			require.NoError(t, json.Unmarshal(body, &reqs))
+			resps := make([]map[string]any, len(reqs))
+			for i, req := range reqs {
+				resps[i] = map[string]any{
+					"jsonrpc": "2.0", "id": req.ID,
+					"error": map[string]any{"code": eip1474RevertCode, "message": "balance unavailable"},
+				}
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(resps))
+			return
+		}
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(body, &req))
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": req.ID, "result": []any{},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &Config{
+		L2RPCURL:        srv.URL,
+		L2BridgeAddress: common.HexToAddress("0xbridge"),
+		TargetBlock:     *aggkittypes.NewBlockNumber(100),
+		Options:         Options{BlockRange: 1000, ConcurrencyLimit: 2, RPCBatchSize: 10},
+	}
+	_, err := RunStep0(context.Background(), cfg)
+	require.ErrorContains(t, err, "compute native balance")
+}

--- a/tools/exit_certificate/silent_failures_test.go
+++ b/tools/exit_certificate/silent_failures_test.go
@@ -200,6 +200,24 @@ func TestDecodeBridgeEventInvalidBlockNumber(t *testing.T) {
 	require.Contains(t, err.Error(), "blockNumber")
 }
 
+func TestFetchBridgeEventsInRangeDecodeError(t *testing.T) {
+	t.Parallel()
+	srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+		out, err := json.Marshal([]map[string]string{{
+			"data":            "0x0000", // too short to be a BridgeEvent payload
+			"blockNumber":     "0x1",
+			"transactionHash": common.HexToHash("0xdead").Hex(),
+		}})
+		require.NoError(t, err)
+		return out, nil
+	})
+	_, err := fetchBridgeEventsInRange(
+		context.Background(), srv.URL, common.HexToAddress("0xbridge"), 1, 0, 10,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode BridgeEvent")
+}
+
 func TestQueryVerifyBatchesInvalidBlockNumber(t *testing.T) {
 	t.Parallel()
 	exitRoot := common.HexToHash("0xabc123")

--- a/tools/exit_certificate/silent_failures_test.go
+++ b/tools/exit_certificate/silent_failures_test.go
@@ -1,0 +1,663 @@
+package exit_certificate
+
+// Tests for the fail-open fixes of issue #1714 (AET-05/07/24/26/36/37/39 + two untracked
+// findings): every branch that used to substitute a silent default now returns an error, and
+// these tests exercise those error paths — corrupted intermediate files, unparseable RPC
+// responses and unwritable output files.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// sabotageOutputFile makes saveJSON(dir, filename, ...) fail by occupying the target
+// path with a directory.
+func sabotageOutputFile(t *testing.T, dir, filename string) {
+	t.Helper()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, filename), 0o755))
+}
+
+// --- AET-39: save helpers propagate write errors ------------------------------------------------
+
+func TestSaveStepFilesWriteErrors(t *testing.T) {
+	t.Parallel()
+
+	stepB := &StepBResult{}
+	stepE := &StepEResult{FinalCertificate: &agglayertypes.Certificate{}}
+
+	cases := []struct {
+		file string
+		call func(dir string) error
+	}{
+		{fileStepBEOABalances, func(dir string) error { return saveStepB1Files(dir, &StepB1Result{}) }},
+		{fileStepBAccumulated, func(dir string) error { return saveStepB1Files(dir, &StepB1Result{}) }},
+		{fileStepBContractAddresses, func(dir string) error { return saveStepB1Files(dir, &StepB1Result{}) }},
+		{fileStepBEOABalances, func(dir string) error { return saveStepBFiles(dir, stepB) }},
+		{fileStepB2DetectedERC20s, func(dir string) error { return saveStepBFiles(dir, stepB) }},
+		{fileStepB2DiscardedERC20s, func(dir string) error { return saveStepBFiles(dir, stepB) }},
+		{fileStepB3ERC20Holders, func(dir string) error { return saveStepBFiles(dir, stepB) }},
+		{fileStepCSCLockedValues, func(dir string) error { return saveStepCFiles(dir, &StepCResult{}) }},
+		{fileStepCHolderBridges, func(dir string) error { return saveStepCFiles(dir, &StepCResult{}) }},
+		{fileStepEUnclaimedBridges, func(dir string) error { return saveStepEFiles(dir, stepE) }},
+		{fileStepEUnclaimedMsgs, func(dir string) error { return saveStepEFiles(dir, stepE) }},
+		{fileStepECertificate, func(dir string) error { return saveStepEFiles(dir, stepE) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			sabotageOutputFile(t, dir, tc.file)
+			err := tc.call(dir)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.file)
+		})
+	}
+}
+
+// --- AET-05/36: corrupted intermediate balances abort steps C and D -----------------------------
+
+func TestRunStepCCorruptedInputs(t *testing.T) {
+	t.Parallel()
+
+	token := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	validLBT := []LBTEntry{{WrappedTokenAddress: token, OriginNetwork: 0, OriginTokenAddress: token, Balance: "100"}}
+
+	t.Run("corrupt accumulated EOA balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepC(validLBT, &StepBResult{
+			Accumulated: []AccumulatedBalance{{WrappedTokenAddress: token, TotalBalance: "not-a-number"}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "accumulated EOA balance")
+	})
+
+	t.Run("corrupt native contract-locked balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepC(validLBT, &StepBResult{NativeContractLocked: "garbage"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "native contract-locked balance")
+	})
+
+	t.Run("corrupt vault token balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepC(validLBT, &StepBResult{
+			ERC20HolderBreakdowns: []ERC20HolderBreakdown{{
+				Address: common.HexToAddress("0xdead"),
+				Detected: &DetectedERC20{
+					WrappedTokenBalances: []WrappedTokenBalance{{
+						Token:   WrappedToken{WrappedTokenAddress: token},
+						Balance: "xx",
+					}},
+				},
+			}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "vault")
+	})
+
+	t.Run("corrupt vault holder balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepC(validLBT, &StepBResult{
+			ERC20HolderBreakdowns: []ERC20HolderBreakdown{{
+				Address: common.HexToAddress("0xdead"),
+				Holders: []ERC20Holder{{Address: common.HexToAddress("0xbeef"), Balance: "??"}},
+				Detected: &DetectedERC20{
+					WrappedTokenBalances: []WrappedTokenBalance{{
+						Token:   WrappedToken{WrappedTokenAddress: token},
+						Balance: "50",
+					}},
+				},
+			}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "holder")
+	})
+
+	t.Run("corrupt LBT balance", func(t *testing.T) {
+		t.Parallel()
+		badLBT := []LBTEntry{{WrappedTokenAddress: token, Balance: "1e18"}}
+		_, err := RunStepC(badLBT, &StepBResult{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "LBT balance")
+	})
+}
+
+func TestRunStepDCorruptedInputs(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{ExitAddress: common.HexToAddress("0xe817"), DestinationNetwork: 0}
+	eoa := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+
+	t.Run("corrupt EOA ETH balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepD(cfg, &StepBResult{
+			EOABalances: []EOABalance{{Address: eoa, ETHBalance: "not-a-number"}},
+		}, &StepCResult{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "ETH balance")
+	})
+
+	t.Run("corrupt EOA token balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepD(cfg, &StepBResult{
+			EOABalances: []EOABalance{{
+				Address:    eoa,
+				ETHBalance: "0",
+				Tokens:     []EOATokenBalance{{Balance: "xx"}},
+			}},
+		}, &StepCResult{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "balance of token")
+	})
+
+	t.Run("corrupt holder bridge amount", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepD(cfg, &StepBResult{}, &StepCResult{
+			HolderBridges: []HolderBridge{{HolderAddress: eoa, Amount: "??"}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "holder bridge amount")
+	})
+
+	t.Run("corrupt pending SC-locked balance", func(t *testing.T) {
+		t.Parallel()
+		_, err := RunStepD(cfg, &StepBResult{}, &StepCResult{
+			SCLockedValues: []SCLockedValue{{PendingSCLockedBalance: "garbage"}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "SC-locked balance")
+	})
+}
+
+// --- AET-26: invalid hex block numbers abort instead of parsing as garbage ----------------------
+
+func TestResolveL1EndBlockInvalidHex(t *testing.T) {
+	t.Parallel()
+	srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+		return quoted("0xzz"), nil
+	})
+	_, err := resolveL1EndBlock(context.Background(), &Config{L1RPCURL: srv.URL})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse L1 latest block")
+}
+
+func TestDecodeBridgeEventInvalidBlockNumber(t *testing.T) {
+	t.Parallel()
+	data := make([]byte, 9*32)
+	new(big.Int).SetInt64(256).FillBytes(data[192:224]) // metadataOffset
+	_, err := decodeBridgeEvent("0x"+common.Bytes2Hex(data), "0xzz", "0x1234")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blockNumber")
+}
+
+func TestQueryVerifyBatchesInvalidBlockNumber(t *testing.T) {
+	t.Parallel()
+	exitRoot := common.HexToHash("0xabc123")
+	srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+		out, err := json.Marshal([]map[string]string{{
+			"blockNumber":     "0xnothex",
+			"transactionHash": common.HexToHash("0xdead").Hex(),
+			"data":            "0x" + common.Bytes2Hex(verifyBatchesData(7, common.Hash{}, exitRoot)),
+		}})
+		require.NoError(t, err)
+		return out, nil
+	})
+	_, _, _, err := queryVerifyBatches( //nolint:dogsled
+		context.Background(), srv.URL, common.HexToAddress("0xabc"), 5, exitRoot, 0, 100)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block number")
+}
+
+func TestReplayedLeafFromReceiptInvalidBlockFields(t *testing.T) {
+	t.Parallel()
+
+	badBlock := bridgeEventReceipt(1, 5, 0)
+	badBlock[0].BlockNumber = "0xzz"
+	_, err := replayedLeafFromReceipt(badBlock, common.HexToHash("0x1"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block number")
+
+	badIndex := bridgeEventReceipt(1, 5, 0)
+	badIndex[0].LogIndex = "0xzz"
+	_, err = replayedLeafFromReceipt(badIndex, common.HexToHash("0x1"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "log index")
+}
+
+// --- AET-05: step F aborts on unparseable agglayer/LBT amounts ----------------------------------
+
+func TestCompareTokenBalancesBadAmounts(t *testing.T) {
+	t.Parallel()
+	addr := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+	_, err := compareTokenBalances(nil, []agglayerTokenEntry{
+		{OriginNetwork: 0, OriginTokenAddress: addr, Amount: "not-a-number"},
+	}, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agglayer amount")
+
+	_, err = compareTokenBalances(nil, nil, []LBTEntry{
+		{OriginNetwork: 0, OriginTokenAddress: addr, Balance: "xx"},
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LBT balance")
+
+	_, err = compareCertificateToLBT(nil, []LBTEntry{
+		{OriginNetwork: 0, OriginTokenAddress: addr, Balance: "xx"},
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LBT balance")
+}
+
+func TestRunStepFBadAgglayerAmountAborts(t *testing.T) {
+	t.Parallel()
+	srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+		return json.RawMessage(`{"balances":[{"originNetwork":0,` +
+			`"originTokenAddress":"0x0000000000000000000000000000000000000000","amount":"garbage"}]}`), nil
+	})
+	cfg := &Config{Options: Options{AgglayerAdminURL: srv.URL, UseAgglayerAdminToStepFCheck: true}}
+	_, err := RunStepF(context.Background(), cfg, &agglayertypes.Certificate{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agglayer amount")
+}
+
+func TestRunStepFOfflineBadLBTAborts(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{Options: Options{UseAgglayerAdminToStepFCheck: false}}
+	_, err := RunStepF(context.Background(), cfg, &agglayertypes.Certificate{}, []LBTEntry{
+		{Balance: "not-a-number"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LBT balance")
+}
+
+func TestRunStepFAgglayerDumpWriteError(t *testing.T) {
+	t.Parallel()
+	srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+		return json.RawMessage(`{"balances":[]}`), nil
+	})
+	dir := t.TempDir()
+	sabotageOutputFile(t, dir, fileStepFAgglayerLBT)
+	cfg := &Config{Options: Options{
+		AgglayerAdminURL: srv.URL, UseAgglayerAdminToStepFCheck: true, OutputDir: dir,
+	}}
+	_, err := RunStepF(context.Background(), cfg, &agglayertypes.Certificate{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fileStepFAgglayerLBT)
+}
+
+// --- untracked: gas token lookup failures propagate (no standard-ETH fallback) ------------------
+
+func TestGasTokenLookupFailurePropagates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cfg := &Config{L2RPCURL: "http://127.0.0.1:1"} // unreachable
+	cert := &agglayertypes.Certificate{BridgeExits: []*agglayertypes.BridgeExit{
+		nativeAssetExit(common.HexToAddress("0x1"), 1),
+	}}
+
+	_, _, err := fetchL2GasTokenInfo(ctx, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gas token info")
+
+	_, err = generateMetadata(ctx, newMockBackend(), cfg, cert, nil)
+	require.ErrorContains(t, err, "gas token info")
+
+	_, _, _, err = runStepG2ShadowFork(ctx, cfg, newMockBackend(), cert, nil) //nolint:dogsled
+	require.ErrorContains(t, err, "gas token info")
+
+	_, _, err = runStepG2BuildLocalExitTree(ctx, cfg, 100, cert, nil)
+	require.ErrorContains(t, err, "gas token info")
+}
+
+func TestSaveFailedExitWriteErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sabotageOutputFile(t, dir, fileStepGFailedExit)
+	job := exitJob{bridge: nativeAssetExit(common.HexToAddress("0x1"), 1)}
+	require.NotPanics(t, func() { saveFailedExit(dir, job, errors.New("replay failed")) })
+}
+
+// --- AET-07/39: single-step runners reject corrupted inputs and report write errors -------------
+
+func TestRunSingleCCorruptOptionalB3(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustSaveJSON(t, dir, fileStepBAccumulated, []AccumulatedBalance{})
+	mustSaveJSON(t, dir, fileStep0LBT, []LBTEntry{{Balance: "1"}})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fileStepB3ERC20Holders), []byte("{bad}"), 0o600))
+
+	err := runSingleC(context.Background(), &Config{}, dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "load step B3 output")
+}
+
+func TestRunSingleDCorruptOptionalHolderBridges(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustSaveJSON(t, dir, fileStepBEOABalances, []EOABalance{})
+	mustSaveJSON(t, dir, fileStepCSCLockedValues, []SCLockedValue{})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fileStepCHolderBridges), []byte("{bad}"), 0o600))
+
+	err := runSingleD(&Config{}, dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "load step C holder bridges")
+}
+
+// corruptCertFixture writes a step certificate whose bridge_exits section is not an array, so
+// toAgglayerCertificate must fail instead of loading a certificate with zero exits (AET-07).
+func corruptCertFixture(t *testing.T, dir, filename string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, filename),
+		[]byte(`{"network_id":1,"bridge_exits":{"bad":1}}`), 0o600))
+}
+
+func TestRunSingleStepsRejectCorruptCertificates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("step E", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		corruptCertFixture(t, dir, fileStepDCertificate)
+		err := runSingleE(ctx, &Config{L1RPCURL: "http://127.0.0.1:1"}, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "load step D certificate")
+	})
+
+	t.Run("step F", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		corruptCertFixture(t, dir, fileStepDCertificate)
+		err := runSingleF(ctx, &Config{}, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "load step D certificate")
+	})
+
+	t.Run("step G2", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		mustSaveJSON(t, dir, fileStepG1ShadowForkBlock, StepG1Result{ShadowForkBlock: 100})
+		corruptCertFixture(t, dir, fileStepECertificate)
+		err := runSingleG2(ctx, &Config{}, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "load certificate for step G2")
+	})
+
+	t.Run("step I", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		corruptCertFixture(t, dir, fileStepGReorderedCertificate)
+		mustSaveJSON(t, dir, fileStepGNewLocalExitRoot, StepGResult{})
+		mustSaveJSON(t, dir, fileStepHPreviousLocalExitRoot, StepHResult{})
+		err := runSingleI(ctx, &Config{}, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "load step G reordered certificate")
+	})
+}
+
+func TestRunSingleFSaveErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("checks file write error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		mustSaveJSON(t, dir, fileStepDCertificate, &certificateJSON{NetworkID: 1})
+		sabotageOutputFile(t, dir, fileStepFChecks)
+		// Offline mode with no LBT file → benign skip result, then the checks write fails.
+		err := runSingleF(ctx, &Config{Options: Options{UseAgglayerAdminToStepFCheck: false}}, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepFChecks)
+	})
+
+	t.Run("token balances write error", func(t *testing.T) {
+		t.Parallel()
+		srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+			return json.RawMessage(`{"balances":[]}`), nil
+		})
+		dir := t.TempDir()
+		mustSaveJSON(t, dir, fileStepDCertificate, &certificateJSON{NetworkID: 1})
+		sabotageOutputFile(t, dir, fileStepFTokenBalances)
+		cfg := &Config{Options: Options{
+			AgglayerAdminURL: srv.URL, UseAgglayerAdminToStepFCheck: true, OutputDir: dir,
+		}}
+		err := runSingleF(ctx, cfg, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepFTokenBalances)
+	})
+}
+
+// --- AET-39: runAll step wrappers propagate write errors ----------------------------------------
+
+func TestRunAllStepWrappersSaveErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	token := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+
+	t.Run("step C sc-locked write error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		sabotageOutputFile(t, dir, fileStepCSCLockedValues)
+		lbt := []LBTEntry{{WrappedTokenAddress: token, Balance: "100"}}
+		_, err := runAllStepC(ctx, &Config{}, dir, lbt, &StepBResult{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepCSCLockedValues)
+	})
+
+	t.Run("step D certificate write error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		sabotageOutputFile(t, dir, fileStepDCertificate)
+		_, err := runAllStepD(&Config{}, dir, &StepBResult{}, &StepCResult{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepDCertificate)
+	})
+
+	t.Run("step F checks write error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		sabotageOutputFile(t, dir, fileStepFChecks)
+		cfg := &Config{Options: Options{UseAgglayerAdminToStepFCheck: false}}
+		cert := &agglayertypes.Certificate{}
+		_, err := runAllStepF(ctx, cfg, dir, nil, cert, cert)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepFChecks)
+	})
+
+	t.Run("step E unclaimed bridges write error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		sabotageOutputFile(t, dir, fileStepEUnclaimedBridges)
+		_, err := runAllStepE(ctx, stepEConfig(emptyStepEStub(t)), dir, emptyCert())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepEUnclaimedBridges)
+	})
+
+	t.Run("step F token balances write error", func(t *testing.T) {
+		t.Parallel()
+		srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+			return json.RawMessage(`{"balances":[]}`), nil
+		})
+		dir := t.TempDir()
+		sabotageOutputFile(t, dir, fileStepFTokenBalances)
+		// The agglayer dump goes to OutputDir (a separate writable dir); the wrapper's
+		// token-balances copy goes to the sabotaged dir.
+		cfg := &Config{Options: Options{
+			AgglayerAdminURL: srv.URL, UseAgglayerAdminToStepFCheck: true, OutputDir: t.TempDir(),
+		}}
+		cert := &agglayertypes.Certificate{}
+		_, err := runAllStepF(ctx, cfg, dir, nil, cert, cert)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepFTokenBalances)
+	})
+
+	t.Run("step F capped final certificate write error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		sabotageOutputFile(t, dir, fileStepFCappedCertificate)
+		cfg := &Config{Options: Options{
+			UseAgglayerAdminToStepFCheck: false,
+			IgnoreBalanceMismatch:        true,
+			CapMode:                      CapModeByAppearance,
+		}}
+		// Certificate sum (1000) exceeds the LBT total (500) → mismatch → capped certificate.
+		cert := &agglayertypes.Certificate{BridgeExits: []*agglayertypes.BridgeExit{
+			MakeBridgeExit(0, token, 0, common.HexToAddress("0x1"), big.NewInt(1000)),
+		}}
+		lbt := []LBTEntry{{WrappedTokenAddress: token, OriginTokenAddress: token, Balance: "500"}}
+		_, err := runAllStepF(ctx, cfg, dir, lbt, cert, cert)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fileStepFCappedCertificate)
+	})
+}
+
+// emptyStepEStub serves the two RPCs a depositless Step E makes: the latest-block probe and the
+// BridgeEvent log scan (always empty).
+func emptyStepEStub(t *testing.T) string {
+	t.Helper()
+	return newBatchRPCServer(t, func(method string, _ []json.RawMessage) any {
+		switch method {
+		case rpcMethodEthBlockNumber:
+			return "0x10"
+		case rpcMethodEthGetLogs:
+			return []map[string]string{}
+		}
+		t.Fatalf("unexpected method %s", method)
+		return nil
+	})
+}
+
+func TestSaveStepEFilesNilResult(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, saveStepEFiles(t.TempDir(), nil))
+}
+
+func TestRunSingleESaveError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustSaveJSON(t, dir, fileStepDCertificate, &certificateJSON{NetworkID: 1})
+	sabotageOutputFile(t, dir, fileStepEUnclaimedBridges)
+
+	err := runSingleE(context.Background(), stepEConfig(emptyStepEStub(t)), dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fileStepEUnclaimedBridges)
+}
+
+func TestRunSingleFCappedCertificateWriteError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	token := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	exits, err := json.Marshal([]map[string]any{{
+		"leaf_type": "Transfer",
+		"token_info": map[string]any{
+			"origin_network":       0,
+			"origin_token_address": token.Hex(),
+		},
+		"dest_network": 0,
+		"dest_address": "0x1111111111111111111111111111111111111111",
+		"amount":       "1000",
+	}})
+	require.NoError(t, err)
+	mustSaveJSON(t, dir, fileStepDCertificate, &certificateJSON{NetworkID: 1, BridgeExits: exits})
+	mustSaveJSON(t, dir, fileStep0LBT,
+		[]LBTEntry{{WrappedTokenAddress: token, OriginTokenAddress: token, Balance: "500"}})
+	sabotageOutputFile(t, dir, fileStepFCappedCertificate)
+
+	cfg := &Config{Options: Options{
+		UseAgglayerAdminToStepFCheck: false,
+		IgnoreBalanceMismatch:        true,
+		CapMode:                      CapModeByAppearance,
+	}}
+	err = runSingleF(context.Background(), cfg, dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fileStepFCappedCertificate)
+}
+
+func TestRunSingle0SaveErrors(t *testing.T) {
+	t.Parallel()
+	for _, file := range []string{fileStep0TargetBlock, fileStep0LBT} {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			sabotageOutputFile(t, dir, file)
+			cfg := step0StubConfig(t)
+			err := runSingle0(context.Background(), cfg, dir)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), file)
+		})
+	}
+}
+
+func TestResolveOrGenerateLBTSaveErrors(t *testing.T) {
+	t.Parallel()
+	for _, file := range []string{fileStep0TargetBlock, fileStep0LBT} {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			sabotageOutputFile(t, dir, file)
+			_, _, _, err := resolveOrGenerateLBT(context.Background(), step0StubConfig(t), dir)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), file)
+		})
+	}
+}
+
+// step0StubConfig wires a Config to a stub serving every RPC RunStep0 makes (see step0Stub).
+func step0StubConfig(t *testing.T) *Config {
+	t.Helper()
+	origin := common.BytesToAddress([]byte("origin"))
+	wrapped := common.BytesToAddress([]byte("wrapped"))
+	return &Config{
+		L2RPCURL:        step0Stub(t, makeWrappedTokenData(1, origin, wrapped)),
+		L2BridgeAddress: common.BytesToAddress([]byte("bridge")),
+		TargetBlock:     *aggkittypes.NewBlockNumber(100),
+		Options:         Options{BlockRange: 50, ConcurrencyLimit: 2, RPCBatchSize: 10},
+	}
+}
+
+func TestRunSingleG1SaveError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustSaveJSON(t, dir, fileStep0TargetBlock, uint64(100))
+	sabotageOutputFile(t, dir, fileStepG1ShadowForkBlock)
+
+	cfg := testConfig(t)
+	cfg.Options.BlockRange = 100
+	cfg.Options.ConcurrencyLimit = 2
+	cfg.L2RPCURL = newEmptyLogsRPCServer(t)
+
+	err := runSingleG1(context.Background(), cfg, dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fileStepG1ShadowForkBlock)
+}
+
+func TestRunSingleB2SaveErrors(t *testing.T) {
+	t.Parallel()
+	for _, file := range []string{fileStepB2DetectedERC20s, fileStepB2DiscardedERC20s} {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			// No contract addresses → RunStepB2 succeeds without any RPC.
+			mustSaveJSON(t, dir, fileStepBContractAddresses, []common.Address{})
+			mustSaveJSON(t, dir, fileStepAAddresses, []common.Address{})
+			mustSaveJSON(t, dir, fileStep0TargetBlock, uint64(100))
+			mustSaveJSON(t, dir, fileStep0LBT, []LBTEntry{{Balance: "1"}})
+			sabotageOutputFile(t, dir, file)
+
+			err := runSingleB2(context.Background(), &Config{}, dir)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), file)
+		})
+	}
+}

--- a/tools/exit_certificate/step_0.go
+++ b/tools/exit_certificate/step_0.go
@@ -55,7 +55,10 @@ func RunStep0(ctx context.Context, cfg *Config) (*Step0Result, error) {
 	log.Infof("Block number:   %d", blockNum)
 
 	// 1. Scan for NewWrappedToken events
-	events := fetchNewWrappedTokenEvents(ctx, cfg, blockNum)
+	events, err := fetchNewWrappedTokenEvents(ctx, cfg, blockNum)
+	if err != nil {
+		return nil, fmt.Errorf("fetch NewWrappedToken events: %w", err)
+	}
 	log.Infof("Found %d NewWrappedToken events", len(events))
 
 	// 2. Apply SetSovereignTokenAddress overrides: if the bridge manager remapped an origin
@@ -108,8 +111,10 @@ type wrappedTokenEvent struct {
 	LegacyAddrs []common.Address
 }
 
-// fetchNewWrappedTokenEvents scans for NewWrappedToken events via a worker pool.
-func fetchNewWrappedTokenEvents(ctx context.Context, cfg *Config, toBlock uint64) []wrappedTokenEvent {
+// fetchNewWrappedTokenEvents scans for NewWrappedToken events via a worker pool. Any range that
+// fails aborts the scan: returning a partial list would silently drop wrapped tokens from the LBT
+// and downstream balance/certificate generation would proceed with incomplete collateral data.
+func fetchNewWrappedTokenEvents(ctx context.Context, cfg *Config, toBlock uint64) ([]wrappedTokenEvent, error) {
 	blockRange := cfg.Options.BlockRange
 	concurrency := cfg.Options.ConcurrencyLimit
 
@@ -136,10 +141,10 @@ func fetchNewWrappedTokenEvents(ctx context.Context, cfg *Config, toBlock uint64
 		"NewWrappedToken",
 	)
 	if err != nil {
-		log.Warnf("Some NewWrappedToken queries failed: %v", err)
+		return nil, err
 	}
 
-	return allEvents
+	return allEvents, nil
 }
 
 // eventLogEntry is a raw eth_getLogs entry: the data hex plus the log's chain position,
@@ -207,8 +212,10 @@ func fetchWrappedTokenEventsInRange(
 	for _, lg := range logData {
 		ev, err := decodeNewWrappedTokenEvent(lg.Data)
 		if err != nil {
-			log.Warnf("Failed to decode NewWrappedToken event: %v", err)
-			continue
+			// A NewWrappedToken event that does not decode must fail the scan: skipping it would
+			// silently drop the token from the LBT and downstream collateral checks.
+			return nil, fmt.Errorf("decode NewWrappedToken event (block %d, log %d): %w",
+				lg.BlockNumber, lg.LogIndex, err)
 		}
 		events = append(events, ev)
 	}

--- a/tools/exit_certificate/step_0.go
+++ b/tools/exit_certificate/step_0.go
@@ -177,10 +177,18 @@ func fetchEventLogsInRange(
 	}
 	entries := make([]eventLogEntry, len(logs))
 	for i, lg := range logs {
+		blockNumber, err := hexToUint64(lg.BlockNumber)
+		if err != nil {
+			return nil, fmt.Errorf("parse log blockNumber %q: %w", lg.BlockNumber, err)
+		}
+		logIndex, err := hexToUint64(lg.LogIndex)
+		if err != nil {
+			return nil, fmt.Errorf("parse log logIndex %q: %w", lg.LogIndex, err)
+		}
 		entries[i] = eventLogEntry{
 			Data:        lg.Data,
-			BlockNumber: hexToUint64(lg.BlockNumber),
-			LogIndex:    hexToUint64(lg.LogIndex),
+			BlockNumber: blockNumber,
+			LogIndex:    logIndex,
 		}
 	}
 	return entries, nil

--- a/tools/exit_certificate/step_0.go
+++ b/tools/exit_certificate/step_0.go
@@ -81,15 +81,14 @@ func RunStep0(ctx context.Context, cfg *Config) (*Step0Result, error) {
 	}
 
 	// 3. Native token unlocked balance
-	var nativeEntry *LBTEntry
-	if nativeEntry, err = computeNativeBalance(ctx, rpcURL, bridgeAddr, blockTag); err != nil {
-		log.Warnf("Failed to compute native balance: %v", err)
-	} else {
-		entries = append(entries, *nativeEntry)
-		log.Infof("Native token unlocked balance: %s", nativeEntry.Balance)
-		log.Infof("Native token info - OriginNetwork: %d, OriginTokenAddress: %s",
-			nativeEntry.OriginNetwork, nativeEntry.OriginTokenAddress.Hex())
+	nativeEntry, err := computeNativeBalance(ctx, rpcURL, bridgeAddr, blockTag)
+	if err != nil {
+		return nil, fmt.Errorf("compute native balance: %w", err)
 	}
+	entries = append(entries, *nativeEntry)
+	log.Infof("Native token unlocked balance: %s", nativeEntry.Balance)
+	log.Infof("Native token info - OriginNetwork: %d, OriginTokenAddress: %s",
+		nativeEntry.OriginNetwork, nativeEntry.OriginTokenAddress.Hex())
 	// 4. WETH token (only on chains with a custom gas token)
 	if wethEntry, err := fetchWETHBalance(ctx, rpcURL, bridgeAddr, blockTag); err != nil {
 		log.Infof("No WETH token on this chain (no custom gas token)")
@@ -378,8 +377,10 @@ func fetchSetSovereignTokenEventsInRange(
 	for _, lg := range logData {
 		ov, err := decodeSetSovereignTokenEvent(lg.Data)
 		if err != nil {
-			log.Warnf("Failed to decode SetSovereignTokenAddress event: %v", err)
-			continue
+			// A skipped override would leave the LBT pointing at the pre-remap wrapped
+			// address, diverging from what getTokenWrappedAddress() returns on-chain.
+			return nil, fmt.Errorf("decode SetSovereignTokenAddress event (block %d, log %d): %w",
+				lg.BlockNumber, lg.LogIndex, err)
 		}
 		ov.BlockNumber = lg.BlockNumber
 		ov.LogIndex = lg.LogIndex

--- a/tools/exit_certificate/step_0_rpc_test.go
+++ b/tools/exit_certificate/step_0_rpc_test.go
@@ -146,6 +146,25 @@ func TestRunStep0(t *testing.T) {
 	require.Equal(t, "90", native.Balance)
 }
 
+// A NewWrappedToken log that fails to decode must abort Step 0 instead of being skipped:
+// a partial scan would silently drop wrapped tokens from the LBT and downstream collateral checks.
+func TestRunStep0MalformedNewWrappedTokenEvent(t *testing.T) {
+	t.Parallel()
+	url := step0Stub(t, "0x1234") // too short to decode as a NewWrappedToken payload
+
+	cfg := &Config{
+		L2RPCURL:        url,
+		L2BridgeAddress: common.BytesToAddress([]byte("bridge")),
+		TargetBlock:     *aggkittypes.NewBlockNumber(100),
+		Options:         Options{BlockRange: 50, ConcurrencyLimit: 2, RPCBatchSize: 10},
+	}
+
+	_, err := RunStep0(context.Background(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fetch NewWrappedToken events")
+	require.Contains(t, err.Error(), "decode NewWrappedToken event")
+}
+
 func TestResolveTargetBlockNumberConstant(t *testing.T) {
 	t.Parallel()
 	// a constant block number resolves with no RPC call.

--- a/tools/exit_certificate/step_0_rpc_test.go
+++ b/tools/exit_certificate/step_0_rpc_test.go
@@ -75,7 +75,7 @@ func step0Stub(t *testing.T, wrappedData string) string {
 			}
 			_ = json.Unmarshal(params[0], &f)
 			if len(f.Topics) > 0 && strings.EqualFold(f.Topics[0], newWrappedTokenTopic.Hex()) {
-				return []map[string]string{{"data": wrappedData}}
+				return []map[string]string{{"data": wrappedData, "blockNumber": "0x1", "logIndex": "0x0"}}
 			}
 			return []map[string]string{} // SetSovereignTokenAddress: none
 		case rpcMethodEthCall:

--- a/tools/exit_certificate/step_0_sovereign_test.go
+++ b/tools/exit_certificate/step_0_sovereign_test.go
@@ -23,7 +23,7 @@ func sovereignStub(t *testing.T, sovereignData string) string {
 		}
 		_ = json.Unmarshal(params[0], &f)
 		if len(f.Topics) > 0 && strings.EqualFold(f.Topics[0], setSovereignTokenTopic.Hex()) {
-			return []map[string]string{{"data": sovereignData}}
+			return []map[string]string{{"data": sovereignData, "blockNumber": "0x1", "logIndex": "0x0"}}
 		}
 		return []map[string]string{}
 	})
@@ -106,7 +106,16 @@ func sovereignRangeStub(t *testing.T, logs []eventLogEntry) string {
 		if len(f.Topics) == 0 || !strings.EqualFold(f.Topics[0], setSovereignTokenTopic.Hex()) {
 			return []map[string]string{}
 		}
-		from, to := hexToUint64(f.FromBlock), hexToUint64(f.ToBlock)
+		from, err := hexToUint64(f.FromBlock)
+		if err != nil {
+			t.Errorf("parse fromBlock %q: %v", f.FromBlock, err)
+			return []map[string]string{}
+		}
+		to, err := hexToUint64(f.ToBlock)
+		if err != nil {
+			t.Errorf("parse toBlock %q: %v", f.ToBlock, err)
+			return []map[string]string{}
+		}
 		out := []map[string]string{}
 		for _, lg := range logs {
 			if lg.BlockNumber >= from && lg.BlockNumber <= to {

--- a/tools/exit_certificate/step_a_test.go
+++ b/tools/exit_certificate/step_a_test.go
@@ -462,7 +462,8 @@ func TestHexToUint64(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := hexToUint64(tt.input)
+			result, err := hexToUint64(tt.input)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/tools/exit_certificate/step_c.go
+++ b/tools/exit_certificate/step_c.go
@@ -31,7 +31,11 @@ func RunStepC(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
 	eoaByToken := make(map[string]*big.Int, len(stepB.Accumulated))
 	for _, entry := range stepB.Accumulated {
 		key := strings.ToLower(entry.WrappedTokenAddress.Hex())
-		eoaByToken[key] = parseDecimalBigInt(entry.TotalBalance)
+		total, err := parseDecimalBigInt(entry.TotalBalance)
+		if err != nil {
+			return nil, fmt.Errorf("accumulated EOA balance for token %s: %w", entry.WrappedTokenAddress.Hex(), err)
+		}
+		eoaByToken[key] = total
 	}
 
 	holderBridges, covered, err := processBreakdowns(stepB.ERC20HolderBreakdowns)
@@ -41,7 +45,10 @@ func RunStepC(lbtEntries []LBTEntry, stepB *StepBResult) (*StepCResult, error) {
 
 	var nativeContractLocked *big.Int
 	if stepB.NativeContractLocked != "" {
-		nativeContractLocked = parseDecimalBigInt(stepB.NativeContractLocked)
+		nativeContractLocked, err = parseDecimalBigInt(stepB.NativeContractLocked)
+		if err != nil {
+			return nil, fmt.Errorf("native contract-locked balance: %w", err)
+		}
 		log.Infof("Native SC-locked will be taken from contract balances: %s wei", nativeContractLocked)
 	}
 
@@ -79,7 +86,11 @@ func processBreakdowns(breakdowns []ERC20HolderBreakdown) ([]HolderBridge, map[s
 		}
 
 		for _, wtb := range bd.Detected.WrappedTokenBalances {
-			contractHolds := parseDecimalBigInt(wtb.Balance)
+			contractHolds, err := parseDecimalBigInt(wtb.Balance)
+			if err != nil {
+				return nil, nil, fmt.Errorf("vault %s balance of token %s: %w",
+					bd.Address.Hex(), wtb.Token.WrappedTokenAddress.Hex(), err)
+			}
 			if contractHolds.Sign() == 0 {
 				continue
 			}
@@ -88,7 +99,11 @@ func processBreakdowns(breakdowns []ERC20HolderBreakdown) ([]HolderBridge, map[s
 
 			distributed := new(big.Int)
 			for _, h := range bd.Holders {
-				amount := parseDecimalBigInt(h.Balance)
+				amount, err := parseDecimalBigInt(h.Balance)
+				if err != nil {
+					return nil, nil, fmt.Errorf("vault %s holder %s balance: %w",
+						bd.Address.Hex(), h.Address.Hex(), err)
+				}
 				if amount.Sign() <= 0 {
 					continue
 				}
@@ -149,7 +164,10 @@ func computeSCLocked(
 
 	for _, tokenKey := range tokenKeys {
 		lbt := lbtByToken[tokenKey]
-		lbtBalance := parseDecimalBigInt(lbt.Balance)
+		lbtBalance, err := parseDecimalBigInt(lbt.Balance)
+		if err != nil {
+			return nil, 0, fmt.Errorf("LBT balance for token %s: %w", lbt.WrappedTokenAddress.Hex(), err)
+		}
 		eoaTotal := new(big.Int)
 		if val, exists := eoaByToken[tokenKey]; exists {
 			eoaTotal.Set(val)

--- a/tools/exit_certificate/step_c_test.go
+++ b/tools/exit_certificate/step_c_test.go
@@ -425,8 +425,8 @@ func TestApplyNativeContractLocked(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		contract := common.HexToAddress("0x00000000000000000000000000000000000000c1")
-		saveJSON(dir, fileStepBContractAddresses, []common.Address{contract})
-		saveJSON(dir, fileStep0TargetBlock, uint64(16))
+		mustSaveJSON(t, dir, fileStepBContractAddresses, []common.Address{contract})
+		mustSaveJSON(t, dir, fileStep0TargetBlock, uint64(16))
 
 		url := newBatchRPCServer(t, func(method string, _ []json.RawMessage) any {
 			require.Equal(t, rpcMethodEthGetBalance, method)

--- a/tools/exit_certificate/step_d.go
+++ b/tools/exit_certificate/step_d.go
@@ -1,6 +1,7 @@
 package exit_certificate
 
 import (
+	"fmt"
 	"math/big"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
@@ -23,13 +24,22 @@ func RunStepD(cfg *Config, stepB *StepBResult, stepC *StepCResult) (*StepDResult
 	destNetwork := cfg.DestinationNetwork
 	exitAddr := cfg.ExitAddress
 
-	eoaExits := buildEOAExits(stepB, destNetwork)
+	eoaExits, err := buildEOAExits(stepB, destNetwork)
+	if err != nil {
+		return nil, err
+	}
 	log.Infof("EOA exits: %d", len(eoaExits))
 
-	holderExits := buildHolderBridgeExits(stepC, destNetwork)
+	holderExits, err := buildHolderBridgeExits(stepC, destNetwork)
+	if err != nil {
+		return nil, err
+	}
 	log.Infof("Holder exits: %d", len(holderExits))
 
-	scExits := buildSCLockedExits(stepC, destNetwork, exitAddr)
+	scExits, err := buildSCLockedExits(stepC, destNetwork, exitAddr)
+	if err != nil {
+		return nil, err
+	}
 	log.Infof("SC-locked exits: %d", len(scExits))
 
 	bridgeExits := make([]*agglayertypes.BridgeExit, 0, len(eoaExits)+len(holderExits)+len(scExits))
@@ -50,7 +60,7 @@ func RunStepD(cfg *Config, stepB *StepBResult, stepC *StepCResult) (*StepDResult
 	return &StepDResult{Certificate: certificate}, nil
 }
 
-func buildEOAExits(stepB *StepBResult, destNetwork uint32) []*agglayertypes.BridgeExit {
+func buildEOAExits(stepB *StepBResult, destNetwork uint32) ([]*agglayertypes.BridgeExit, error) {
 	totalEOAs := len(stepB.EOABalances)
 	log.Infof("Processing %d EOA balance entries...", totalEOAs)
 
@@ -60,52 +70,73 @@ func buildEOAExits(stepB *StepBResult, destNetwork uint32) []*agglayertypes.Brid
 		if totalEOAs > 0 && (i+1)%logInterval == 0 {
 			log.Infof("  EOA progress: %d/%d", i+1, totalEOAs)
 		}
-		exits = append(exits, eoaToExits(eoa, destNetwork)...)
+		eoaExits, err := eoaToExits(eoa, destNetwork)
+		if err != nil {
+			return nil, err
+		}
+		exits = append(exits, eoaExits...)
 	}
-	return exits
+	return exits, nil
 }
 
-func eoaToExits(eoa EOABalance, destNetwork uint32) []*agglayertypes.BridgeExit {
+func eoaToExits(eoa EOABalance, destNetwork uint32) ([]*agglayertypes.BridgeExit, error) {
 	var exits []*agglayertypes.BridgeExit
-	if amount := parseDecimalBigInt(eoa.ETHBalance); amount.Sign() > 0 {
+	amount, err := parseDecimalBigInt(eoa.ETHBalance)
+	if err != nil {
+		return nil, fmt.Errorf("EOA %s ETH balance: %w", eoa.Address.Hex(), err)
+	}
+	if amount.Sign() > 0 {
 		exits = append(exits, makeBridgeExit(0, common.Address{}, destNetwork, eoa.Address, amount))
 	}
 	for _, token := range eoa.Tokens {
-		if amount := parseDecimalBigInt(token.Balance); amount.Sign() > 0 {
+		amount, err := parseDecimalBigInt(token.Balance)
+		if err != nil {
+			return nil, fmt.Errorf("EOA %s balance of token %s: %w",
+				eoa.Address.Hex(), token.WrappedTokenAddress.Hex(), err)
+		}
+		if amount.Sign() > 0 {
 			exits = append(exits, makeBridgeExit(
 				token.OriginNetwork, token.OriginTokenAddress, destNetwork, eoa.Address, amount,
 			))
 		}
 	}
-	return exits
+	return exits, nil
 }
 
-func buildHolderBridgeExits(stepC *StepCResult, destNetwork uint32) []*agglayertypes.BridgeExit {
+func buildHolderBridgeExits(stepC *StepCResult, destNetwork uint32) ([]*agglayertypes.BridgeExit, error) {
 	exits := make([]*agglayertypes.BridgeExit, 0, len(stepC.HolderBridges))
 	for _, hb := range stepC.HolderBridges {
-		amount := parseDecimalBigInt(hb.Amount)
+		amount, err := parseDecimalBigInt(hb.Amount)
+		if err != nil {
+			return nil, fmt.Errorf("holder bridge amount for %s (vault %s): %w",
+				hb.HolderAddress.Hex(), hb.VaultAddress.Hex(), err)
+		}
 		if amount.Sign() <= 0 {
 			continue
 		}
 		exits = append(exits, makeBridgeExit(hb.OriginNetwork, hb.OriginTokenAddress, destNetwork, hb.HolderAddress, amount))
 	}
-	return exits
+	return exits, nil
 }
 
 func buildSCLockedExits(
 	stepC *StepCResult, destNetwork uint32, exitAddr common.Address,
-) []*agglayertypes.BridgeExit {
+) ([]*agglayertypes.BridgeExit, error) {
 	log.Infof("Processing SC-locked values → exit address: %s", exitAddr.Hex())
 
 	exits := make([]*agglayertypes.BridgeExit, 0, len(stepC.SCLockedValues))
 	for _, entry := range stepC.SCLockedValues {
-		amount := parseDecimalBigInt(entry.PendingSCLockedBalance)
+		amount, err := parseDecimalBigInt(entry.PendingSCLockedBalance)
+		if err != nil {
+			return nil, fmt.Errorf("pending SC-locked balance for token %s: %w",
+				entry.WrappedTokenAddress.Hex(), err)
+		}
 		if amount.Sign() <= 0 {
 			continue
 		}
 		exits = append(exits, makeBridgeExit(entry.OriginNetwork, entry.OriginTokenAddress, destNetwork, exitAddr, amount))
 	}
-	return exits
+	return exits, nil
 }
 
 // MakeBridgeExit creates a BridgeExit for an asset transfer. Exported for tests.

--- a/tools/exit_certificate/step_e.go
+++ b/tools/exit_certificate/step_e.go
@@ -130,7 +130,10 @@ func resolveL1EndBlock(ctx context.Context, cfg *Config) (uint64, error) {
 	if err := json.Unmarshal(latestResult, &latestHex); err != nil {
 		return 0, fmt.Errorf("parse L1 latest block: %w", err)
 	}
-	latest := hexToUint64(latestHex)
+	latest, err := hexToUint64(latestHex)
+	if err != nil {
+		return 0, fmt.Errorf("parse L1 latest block: %w", err)
+	}
 
 	if cfg.Options.L1EndBlock > 0 {
 		if cfg.Options.L1EndBlock > latest {
@@ -186,7 +189,7 @@ func checkClaimedBatch(
 		return nil, fmt.Errorf("batch isClaimed: %w", err)
 	}
 
-	return parseClaimedResults(results, deposits), nil
+	return parseClaimedResults(results, deposits)
 }
 
 // encodeIsClaimed ABI-encodes isClaimed(uint32 leafIndex, uint32 sourceBridgeNetwork).
@@ -198,22 +201,31 @@ func encodeIsClaimed(leafIndex, sourceBridgeNetwork uint32) string {
 	return "0x" + common.Bytes2Hex(data)
 }
 
-func parseClaimedResults(results []json.RawMessage, deposits []L1Deposit) map[uint32]struct{} {
+// parseClaimedResults decodes the batched isClaimed responses into the set of claimed deposit
+// counts. A missing or unparseable result is an error: silently classifying it as unclaimed
+// would re-add an already-claimed deposit to the certificate, double-counting its value.
+func parseClaimedResults(results []json.RawMessage, deposits []L1Deposit) (map[uint32]struct{}, error) {
 	claimed := make(map[uint32]struct{})
 	for i, result := range results {
 		if result == nil {
-			continue
+			return nil, fmt.Errorf("missing isClaimed result for deposit count %d", deposits[i].DepositCount)
 		}
-		var hex string
-		if json.Unmarshal(result, &hex) != nil {
-			continue
+		var hexResult string
+		if err := json.Unmarshal(result, &hexResult); err != nil {
+			return nil, fmt.Errorf("parse isClaimed result for deposit count %d: %w",
+				deposits[i].DepositCount, err)
 		}
-		val := hexToBigInt(hex)
+		trimmed := strings.TrimPrefix(strings.TrimPrefix(hexResult, "0x"), "0X")
+		val, ok := new(big.Int).SetString(trimmed, hexBase)
+		if !ok {
+			return nil, fmt.Errorf("invalid isClaimed value %q for deposit count %d",
+				hexResult, deposits[i].DepositCount)
+		}
 		if val.Sign() > 0 {
 			claimed[deposits[i].DepositCount] = struct{}{}
 		}
 	}
-	return claimed
+	return claimed, nil
 }
 
 func filterUnclaimedDeposits(
@@ -813,6 +825,10 @@ func parseBridgeFields(
 	if err != nil {
 		return L1Deposit{}, fmt.Errorf("depositCount: %w", err)
 	}
+	blockNumber, err := hexToUint64(blockNumberHex)
+	if err != nil {
+		return L1Deposit{}, fmt.Errorf("blockNumber: %w", err)
+	}
 
 	return L1Deposit{
 		LeafType:           leafType,
@@ -823,7 +839,7 @@ func parseBridgeFields(
 		Amount:             new(big.Int).SetBytes(data[160:192]),
 		Metadata:           metadata,
 		DepositCount:       depositCount,
-		BlockNumber:        hexToUint64(blockNumberHex),
+		BlockNumber:        blockNumber,
 		TxHash:             common.HexToHash(txHashHex),
 	}, nil
 }

--- a/tools/exit_certificate/step_e.go
+++ b/tools/exit_certificate/step_e.go
@@ -775,7 +775,10 @@ func fetchBridgeEventsInRange(
 	for _, lg := range logs {
 		dep, err := decodeBridgeEvent(lg.Data, lg.BlockNumber, lg.TransactionHash)
 		if err != nil {
-			continue
+			// A BridgeEvent that does not decode must fail the scan: skipping it would silently
+			// drop a potentially unclaimed deposit and produce a false clean Step E result.
+			return nil, fmt.Errorf("decode BridgeEvent (tx %s, block %s): %w",
+				lg.TransactionHash, lg.BlockNumber, err)
 		}
 		if dep.DestinationNetwork == l2NetworkID {
 			deposits = append(deposits, dep)
@@ -811,23 +814,23 @@ func parseBridgeFields(
 ) (L1Deposit, error) {
 	leafType, err := safeUint8(new(big.Int).SetBytes(data[0:32]))
 	if err != nil {
-		return L1Deposit{}, fmt.Errorf("leafType: %w", err)
+		return L1Deposit{}, fmt.Errorf("parse field leafType: %w", err)
 	}
 	originNetwork, err := safeUint32(new(big.Int).SetBytes(data[32:64]))
 	if err != nil {
-		return L1Deposit{}, fmt.Errorf("originNetwork: %w", err)
+		return L1Deposit{}, fmt.Errorf("parse field originNetwork: %w", err)
 	}
 	destNetwork, err := safeUint32(new(big.Int).SetBytes(data[96:128]))
 	if err != nil {
-		return L1Deposit{}, fmt.Errorf("destNetwork: %w", err)
+		return L1Deposit{}, fmt.Errorf("parse field destNetwork: %w", err)
 	}
 	depositCount, err := safeUint32(new(big.Int).SetBytes(data[224:256]))
 	if err != nil {
-		return L1Deposit{}, fmt.Errorf("depositCount: %w", err)
+		return L1Deposit{}, fmt.Errorf("parse field depositCount: %w", err)
 	}
 	blockNumber, err := hexToUint64(blockNumberHex)
 	if err != nil {
-		return L1Deposit{}, fmt.Errorf("blockNumber: %w", err)
+		return L1Deposit{}, fmt.Errorf("parse field blockNumber: %w", err)
 	}
 
 	return L1Deposit{

--- a/tools/exit_certificate/step_e_test.go
+++ b/tools/exit_certificate/step_e_test.go
@@ -114,11 +114,35 @@ func TestParseClaimedResults(t *testing.T) {
 
 	results := []json.RawMessage{trueHex, falseHex, trueHex}
 
-	claimed := parseClaimedResults(results, deposits)
+	claimed, err := parseClaimedResults(results, deposits)
+	require.NoError(t, err)
 
 	require.Contains(t, claimed, uint32(1))
 	require.NotContains(t, claimed, uint32(2))
 	require.Contains(t, claimed, uint32(3))
+}
+
+func TestParseClaimedResults_MissingResult(t *testing.T) {
+	t.Parallel()
+
+	deposits := []L1Deposit{{DepositCount: 7}}
+	_, err := parseClaimedResults([]json.RawMessage{nil}, deposits)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing isClaimed result for deposit count 7")
+}
+
+func TestParseClaimedResults_UnparseableResult(t *testing.T) {
+	t.Parallel()
+
+	deposits := []L1Deposit{{DepositCount: 8}}
+
+	_, err := parseClaimedResults([]json.RawMessage{json.RawMessage(`{"bad":1}`)}, deposits)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deposit count 8")
+
+	_, err = parseClaimedResults([]json.RawMessage{json.RawMessage(`"0xnothex"`)}, deposits)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deposit count 8")
 }
 
 func TestFilterUnclaimedDeposits(t *testing.T) {

--- a/tools/exit_certificate/step_f.go
+++ b/tools/exit_certificate/step_f.go
@@ -64,7 +64,9 @@ func RunStepF(
 		// (e.g. unit tests) — skip the dump there rather than dropping the file in the process's
 		// working directory.
 		if cfg.Options.OutputDir != "" {
-			saveJSON(cfg.Options.OutputDir, fileStepFAgglayerLBT, agglayerRaw)
+			if err := saveJSON(cfg.Options.OutputDir, fileStepFAgglayerLBT, agglayerRaw); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -85,7 +87,10 @@ func RunStepF(
 	}
 
 	groups := groupBridgeExitsByToken(certificate)
-	checks := compareTokenBalances(groups, agglayerResp.Balances, lbtEntries, genesisPrefundWei(cfg))
+	checks, err := compareTokenBalances(groups, agglayerResp.Balances, lbtEntries, genesisPrefundWei(cfg))
+	if err != nil {
+		return nil, err
+	}
 
 	allMatch := true
 	for _, c := range checks {
@@ -216,7 +221,10 @@ func runStepFOfflineLBT(
 
 	log.Info("useAgglayerAdminToStepFCheck=false — comparing LBT (step 0) vs certificate bridge exits (no agglayer query)")
 	groups := groupBridgeExitsByToken(certificate)
-	checks := compareCertificateToLBT(groups, lbtEntries, genesisPrefundWei(cfg))
+	checks, err := compareCertificateToLBT(groups, lbtEntries, genesisPrefundWei(cfg))
+	if err != nil {
+		return nil, err
+	}
 
 	allMatch := true
 	for _, c := range checks {
@@ -335,34 +343,28 @@ func groupBridgeExitsByToken(cert *agglayertypes.Certificate) map[tokenKey][]*ag
 // When lbtEntries is nil, match requires agglayer == certificate sum (two-way fallback).
 // nativePrefund (nil when unset) is discounted from the native-token certificate sum before
 // comparing (see discountGenesisPrefund). CertificateEntries is populated only on mismatch.
+// An unparseable agglayer or LBT amount is an error: skipping the entry would compare — and cap —
+// that token against a silently substituted zero budget.
 func compareTokenBalances(
 	groups map[tokenKey][]*agglayertypes.BridgeExit,
 	agglayerEntries []agglayerTokenEntry,
 	lbtEntries []LBTEntry,
 	nativePrefund *big.Int,
-) []TokenBalanceCheck {
+) ([]TokenBalanceCheck, error) {
 	agglayerMap := make(map[tokenKey]*big.Int, len(agglayerEntries))
 	for _, e := range agglayerEntries {
 		k := tokenKey{e.OriginNetwork, e.OriginTokenAddress}
 		amount, ok := new(big.Int).SetString(e.Amount, decimalBase)
 		if !ok {
-			log.Warnf("Could not parse agglayer amount %q for token (network=%d addr=%s)",
+			return nil, fmt.Errorf("parse agglayer amount %q for token (network=%d addr=%s)",
 				e.Amount, e.OriginNetwork, e.OriginTokenAddress.Hex())
-			continue
 		}
 		agglayerMap[k] = amount
 	}
 
-	lbtMap := make(map[tokenKey]*big.Int, len(lbtEntries))
-	for _, e := range lbtEntries {
-		k := tokenKey{e.OriginNetwork, e.OriginTokenAddress}
-		amount, ok := new(big.Int).SetString(e.Balance, decimalBase)
-		if !ok {
-			log.Warnf("Could not parse LBT balance %q for token (network=%d addr=%s)",
-				e.Balance, e.OriginNetwork, e.OriginTokenAddress.Hex())
-			continue
-		}
-		lbtMap[k] = amount
+	lbtMap, err := lbtBalanceMap(lbtEntries)
+	if err != nil {
+		return nil, err
 	}
 
 	seen := make(map[tokenKey]struct{}, len(groups)+len(agglayerMap)+len(lbtMap))
@@ -435,7 +437,23 @@ func compareTokenBalances(
 		}
 		return checks[i].OriginTokenAddress < checks[j].OriginTokenAddress
 	})
-	return checks
+	return checks, nil
+}
+
+// lbtBalanceMap indexes the LBT entries' balances by token. An unparseable balance is an error:
+// skipping the entry would compare — and cap — that token against a silently substituted zero.
+func lbtBalanceMap(lbtEntries []LBTEntry) (map[tokenKey]*big.Int, error) {
+	lbtMap := make(map[tokenKey]*big.Int, len(lbtEntries))
+	for _, e := range lbtEntries {
+		k := tokenKey{e.OriginNetwork, e.OriginTokenAddress}
+		amount, ok := new(big.Int).SetString(e.Balance, decimalBase)
+		if !ok {
+			return nil, fmt.Errorf("parse LBT balance %q for token (network=%d addr=%s)",
+				e.Balance, e.OriginNetwork, e.OriginTokenAddress.Hex())
+		}
+		lbtMap[k] = amount
+	}
+	return lbtMap, nil
 }
 
 // compareCertificateToLBT builds a per-token comparison of the certificate bridge-exit sums against
@@ -446,17 +464,10 @@ func compareTokenBalances(
 // discountGenesisPrefund). CertificateEntries is populated only on mismatch.
 func compareCertificateToLBT(
 	groups map[tokenKey][]*agglayertypes.BridgeExit, lbtEntries []LBTEntry, nativePrefund *big.Int,
-) []TokenBalanceCheck {
-	lbtMap := make(map[tokenKey]*big.Int, len(lbtEntries))
-	for _, e := range lbtEntries {
-		k := tokenKey{e.OriginNetwork, e.OriginTokenAddress}
-		amount, ok := new(big.Int).SetString(e.Balance, decimalBase)
-		if !ok {
-			log.Warnf("Could not parse LBT balance %q for token (network=%d addr=%s)",
-				e.Balance, e.OriginNetwork, e.OriginTokenAddress.Hex())
-			continue
-		}
-		lbtMap[k] = amount
+) ([]TokenBalanceCheck, error) {
+	lbtMap, err := lbtBalanceMap(lbtEntries)
+	if err != nil {
+		return nil, err
 	}
 
 	seen := make(map[tokenKey]struct{}, len(groups)+len(lbtMap))
@@ -509,7 +520,7 @@ func compareCertificateToLBT(
 		}
 		return checks[i].OriginTokenAddress < checks[j].OriginTokenAddress
 	})
-	return checks
+	return checks, nil
 }
 
 // errCapForbidden is returned by capCertificateExits when at least one bridge exit would have to be

--- a/tools/exit_certificate/step_f_test.go
+++ b/tools/exit_certificate/step_f_test.go
@@ -312,7 +312,8 @@ func TestCompareTokenBalances_AllMatch(t *testing.T) {
 		{OriginNetwork: 0, OriginTokenAddress: addr, Amount: "1000"},
 	}
 
-	checks := compareTokenBalances(groups, agglayerEntries, nil, nil)
+	checks, err := compareTokenBalances(groups, agglayerEntries, nil, nil)
+	require.NoError(t, err)
 	require.Len(t, checks, 1)
 	require.True(t, checks[0].Match)
 	require.Empty(t, checks[0].CertificateEntries)
@@ -334,7 +335,8 @@ func TestCompareTokenBalances_Mismatch(t *testing.T) {
 		{OriginNetwork: 0, OriginTokenAddress: addr, Amount: "999"},
 	}
 
-	checks := compareTokenBalances(groups, agglayerEntries, nil, nil)
+	checks, err := compareTokenBalances(groups, agglayerEntries, nil, nil)
+	require.NoError(t, err)
 	require.Len(t, checks, 1)
 	require.False(t, checks[0].Match)
 	require.Equal(t, "1000", checks[0].CertificateAmount)
@@ -356,7 +358,8 @@ func TestCompareTokenBalances_MissingInAgglayer(t *testing.T) {
 		},
 	}
 
-	checks := compareTokenBalances(groups, nil, nil, nil)
+	checks, err := compareTokenBalances(groups, nil, nil, nil)
+	require.NoError(t, err)
 	require.Len(t, checks, 1)
 	require.False(t, checks[0].Match)
 	require.Equal(t, "500", checks[0].CertificateAmount)
@@ -576,11 +579,12 @@ func TestCapCertificateExits_LBTMinAgglayer(t *testing.T) {
 			{TokenInfo: &agglayertypes.TokenInfo{OriginNetwork: 0, OriginTokenAddress: addr}, Amount: big.NewInt(400)},
 		},
 	}
-	checks := compareTokenBalances(groups, []agglayerTokenEntry{
+	checks, err := compareTokenBalances(groups, []agglayerTokenEntry{
 		{OriginNetwork: 0, OriginTokenAddress: addr, Amount: "800"},
 	}, []LBTEntry{
 		{OriginNetwork: 0, OriginTokenAddress: addr, Balance: "700"},
 	}, nil)
+	require.NoError(t, err)
 	require.Equal(t, big.NewInt(700), checks[0].RemainingBalance)
 
 	exits := []*agglayertypes.BridgeExit{
@@ -734,7 +738,8 @@ func TestCompareTokenBalances_GenesisPrefundDiscount(t *testing.T) {
 		{WrappedTokenAddress: common.Address{}, OriginNetwork: 0, OriginTokenAddress: common.Address{}, Balance: "300"},
 	}
 
-	checks := compareTokenBalances(groups, agglayerEntries, lbt, big.NewInt(700))
+	checks, err := compareTokenBalances(groups, agglayerEntries, lbt, big.NewInt(700))
+	require.NoError(t, err)
 	require.Len(t, checks, 1)
 	require.True(t, checks[0].Match)
 	require.Equal(t, "300", checks[0].CertificateAmount) // discounted sum is what gets compared

--- a/tools/exit_certificate/step_g2.go
+++ b/tools/exit_certificate/step_g2.go
@@ -323,7 +323,10 @@ func runStepG2(
 		if err != nil {
 			return nil, fmt.Errorf("sort exits by replay deposit order: %w", err)
 		}
-		gasTokenNetwork, gasTokenAddress := fetchGasTokenInfoOrDefault(ctx, cfg)
+		gasTokenNetwork, gasTokenAddress, err := fetchL2GasTokenInfo(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
 		replayOrderRoot, _, err := buildLiteTreeFromCertificate(
 			ctx, cfg, &agglayertypes.Certificate{BridgeExits: orderedExits},
 			forkBlock, gasTokenNetwork, gasTokenAddress, orderedMetadata,
@@ -403,7 +406,10 @@ func generateMetadata(
 		return metadatas, nil
 	}
 
-	gasTokenNetwork, gasTokenAddress := fetchGasTokenInfoOrDefault(ctx, cfg)
+	gasTokenNetwork, gasTokenAddress, err := fetchL2GasTokenInfo(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	// Resolve each ERC-20 exit's L2 token address; the bridge's getTokenMetadata is keyed by that
 	// address, exactly as bridgeAsset(token) is.
@@ -486,7 +492,10 @@ func runStepG2ShadowFork(
 	ctx context.Context, cfg *Config, backend forkBackend,
 	certificate *agglayertypes.Certificate, lbtEntries []LBTEntry,
 ) (common.Hash, common.Hash, []bridgesyncerlite.BridgeLeaf, error) {
-	gasTokenNetwork, gasTokenAddress := fetchGasTokenInfoOrDefault(ctx, cfg)
+	gasTokenNetwork, gasTokenAddress, err := fetchL2GasTokenInfo(ctx, cfg)
+	if err != nil {
+		return common.Hash{}, common.Hash{}, nil, err
+	}
 
 	initialLER, err := backend.LocalExitRoot(ctx, "latest")
 	if err != nil {
@@ -562,7 +571,10 @@ func runStepG2BuildLocalExitTree(
 	ctx context.Context, cfg *Config, forkBlock uint64,
 	certificate *agglayertypes.Certificate, generatedMetadata [][]byte,
 ) (common.Hash, [][]byte, error) {
-	gasTokenNetwork, gasTokenAddress := fetchGasTokenInfoOrDefault(ctx, cfg)
+	gasTokenNetwork, gasTokenAddress, err := fetchL2GasTokenInfo(ctx, cfg)
+	if err != nil {
+		return common.Hash{}, nil, err
+	}
 	root, metadatas, err := buildLiteTreeFromCertificate(
 		ctx, cfg, certificate, forkBlock, gasTokenNetwork, gasTokenAddress, generatedMetadata,
 	)
@@ -576,15 +588,16 @@ func runStepG2BuildLocalExitTree(
 	return root, metadatas, nil
 }
 
-// fetchGasTokenInfoOrDefault returns the L2 gas token (network, address), falling back to standard
-// ETH (network 0, zero address) with a warning if the lookup fails.
-func fetchGasTokenInfoOrDefault(ctx context.Context, cfg *Config) (uint32, common.Address) {
+// fetchL2GasTokenInfo returns the L2 gas token (network, address). A lookup failure is propagated
+// instead of assuming standard ETH: on a chain with a custom gas token that default would
+// mis-encode the native exit leaves and produce a wrong NewLocalExitRoot.
+func fetchL2GasTokenInfo(ctx context.Context, cfg *Config) (uint32, common.Address, error) {
 	gasTokenNetwork, gasTokenAddress, err := fetchGasTokenInfo(ctx, cfg.L2RPCURL, cfg.L2BridgeAddress)
 	if err != nil {
-		log.Warnf("Failed to fetch gas token info (assuming standard ETH): %v", err)
-		return 0, common.Address{}
+		return 0, common.Address{}, fmt.Errorf("fetch gas token info from bridge %s: %w",
+			cfg.L2BridgeAddress.Hex(), err)
 	}
-	return gasTokenNetwork, gasTokenAddress
+	return gasTokenNetwork, gasTokenAddress, nil
 }
 
 // forkBackend abstracts every side-effecting interaction Step G2's shadow-fork replay has with the
@@ -962,7 +975,7 @@ func retryDeferredExit(
 
 // saveFailedExit writes the bridge exit whose replay aborted Step G to step-g-failed-exit.json in
 // dir, so the offending exit can be inspected after the run fails. Best-effort: any write error is
-// logged by saveJSON and does not mask the original replay error.
+// logged here and does not mask the original replay error.
 func saveFailedExit(dir string, job exitJob, replayErr error) {
 	fe := FailedBridgeExit{
 		Index:              job.index,
@@ -977,7 +990,9 @@ func saveFailedExit(dir string, job exitJob, replayErr error) {
 		fe.OriginNetwork = job.bridge.TokenInfo.OriginNetwork
 		fe.OriginTokenAddress = job.bridge.TokenInfo.OriginTokenAddress.Hex()
 	}
-	saveJSON(dir, fileStepGFailedExit, fe)
+	if err := saveJSON(dir, fileStepGFailedExit, fe); err != nil {
+		log.Errorf("failed to save %s: %v", fileStepGFailedExit, err)
+	}
 }
 
 // logReplayProgress logs the replay completion percentage, throughput, and ETA. start is the
@@ -1556,9 +1571,17 @@ func replayedLeafFromReceipt(logs []rpcLog, txHash common.Hash) (bridgesyncerlit
 		if !matched {
 			continue
 		}
+		blockNum, err := hexToUint64(l.BlockNumber)
+		if err != nil {
+			return bridgesyncerlite.BridgeLeaf{}, fmt.Errorf("parse BridgeEvent block number: %w", err)
+		}
+		blockPos, err := hexToUint64(l.LogIndex)
+		if err != nil {
+			return bridgesyncerlite.BridgeLeaf{}, fmt.Errorf("parse BridgeEvent log index: %w", err)
+		}
 		return bridgesyncerlite.BridgeLeaf{
-			BlockNum:           hexToUint64(l.BlockNumber),
-			BlockPos:           hexToUint64(l.LogIndex),
+			BlockNum:           blockNum,
+			BlockPos:           blockPos,
 			LeafType:           event.LeafType,
 			OriginNetwork:      event.OriginNetwork,
 			OriginAddress:      event.OriginAddress,

--- a/tools/exit_certificate/step_g2_metadata_test.go
+++ b/tools/exit_certificate/step_g2_metadata_test.go
@@ -65,7 +65,7 @@ func TestGenerateMetadataNativeAndERC20(t *testing.T) {
 	}
 	// LBT maps the external-origin token to its L2 wrapped address (avoids a getTokenWrappedAddress RPC).
 	lbt := []LBTEntry{{OriginNetwork: 99, OriginTokenAddress: origin, WrappedTokenAddress: wrapped}}
-	cfg := &Config{L2NetworkID: 1}
+	cfg := &Config{L2NetworkID: 1, L2RPCURL: gasTokenStubURL(t)}
 
 	metas, err := generateMetadata(context.Background(), backend, cfg, cert, lbt)
 	require.NoError(t, err)

--- a/tools/exit_certificate/step_g2_replay_test.go
+++ b/tools/exit_certificate/step_g2_replay_test.go
@@ -151,11 +151,14 @@ func bridgeEventReceipt(depositCount uint32, blockNum, logIndex uint64) []rpcLog
 
 func replayTestConfig(t *testing.T) *Config {
 	t.Helper()
-	return &Config{Options: Options{
-		OutputDir:                             t.TempDir(),
-		ConcurrencyLimit:                      2,
-		VerifyNewLocalExitRootUsingShadowFork: true, // these tests exercise the shadow-fork orchestration
-	}}
+	return &Config{
+		L2RPCURL: gasTokenStubURL(t),
+		Options: Options{
+			OutputDir:                             t.TempDir(),
+			ConcurrencyLimit:                      2,
+			VerifyNewLocalExitRootUsingShadowFork: true, // these tests exercise the shadow-fork orchestration
+		},
+	}
 }
 
 // nativeAssetExit builds a native (gas-token) exit the way step_d does: a non-nil TokenInfo with a

--- a/tools/exit_certificate/step_g2_rpc_test.go
+++ b/tools/exit_certificate/step_g2_rpc_test.go
@@ -46,6 +46,17 @@ func quoted(s string) json.RawMessage {
 	return json.RawMessage(`"` + s + `"`)
 }
 
+// gasTokenStubURL returns the URL of an RPC stub whose eth_call always returns a zero ABI word,
+// satisfying the bridge gasTokenNetwork()/gasTokenAddress() lookups with the standard-ETH values
+// (fetchL2GasTokenInfo no longer falls back to them on lookup failure).
+func gasTokenStubURL(t *testing.T) string {
+	t.Helper()
+	srv := newRPCStub(t, func(string, []any) (json.RawMessage, *jsonRPCError) {
+		return hexResult(make([]byte, abiWordBytes)), nil
+	})
+	return srv.URL
+}
+
 func TestSetSenderBalance(t *testing.T) {
 	t.Parallel()
 	sender := common.HexToAddress("0x1111111111111111111111111111111111111111")

--- a/tools/exit_certificate/step_i.go
+++ b/tools/exit_certificate/step_i.go
@@ -103,8 +103,12 @@ func fetchL1InfoTreeLeafCount(ctx context.Context, cfg *Config) (uint32, error) 
 
 		leafCount, found, err := queryUpdateL1InfoTreeV2(ctx, cfg.L1RPCURL, cfg.L1GlobalExitRootAddress, start, end)
 		if err != nil {
-			log.Warnf("eth_getLogs [%d-%d] error: %v", start, end, err)
-		} else if found {
+			// Abort instead of moving on to older blocks: if the failed range held the most recent
+			// event, continuing would silently pick an older one and write a stale leaf count into
+			// the final certificate (singleRPC already retried the query internally).
+			return 0, fmt.Errorf("eth_getLogs UpdateL1InfoTreeV2 [%d-%d]: %w", start, end, err)
+		}
+		if found {
 			log.Infof("Found UpdateL1InfoTreeV2 at block range [%d-%d]: leafCount=%d", start, end, leafCount)
 			return leafCount, nil
 		}

--- a/tools/exit_certificate/step_i_test.go
+++ b/tools/exit_certificate/step_i_test.go
@@ -19,6 +19,28 @@ func TestFetchL1InfoTreeLeafCountRequiresConfig(t *testing.T) {
 	require.ErrorContains(t, err, "l1GlobalExitRootAddress")
 }
 
+// TestFetchL1InfoTreeLeafCountAbortsOnGetLogsError covers AET-37: an eth_getLogs failure aborts
+// the backward scan instead of moving on to older blocks — if the failed range held the most
+// recent UpdateL1InfoTreeV2 event, continuing would return a stale leaf count.
+func TestFetchL1InfoTreeLeafCountAbortsOnGetLogsError(t *testing.T) {
+	t.Parallel()
+
+	srv := newRPCStub(t, func(method string, _ []any) (json.RawMessage, *jsonRPCError) {
+		if method == rpcMethodEthBlockNumber {
+			return quoted("0x1a4"), nil
+		}
+		return nil, &jsonRPCError{Code: -32000, Message: "range too large"}
+	})
+	cfg := &Config{
+		L1RPCURL:                srv.URL,
+		L1GlobalExitRootAddress: common.HexToAddress("0x0000000000000000000000000000000000000abc"),
+		Options:                 Options{BlockRange: 100},
+	}
+	_, err := fetchL1InfoTreeLeafCount(context.Background(), cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "eth_getLogs UpdateL1InfoTreeV2")
+}
+
 func TestFetchL1InfoTreeLeafCount(t *testing.T) {
 	t.Parallel()
 

--- a/tools/exit_certificate/step_sign.go
+++ b/tools/exit_certificate/step_sign.go
@@ -76,5 +76,5 @@ func fetchL2ChainID(ctx context.Context, rpcURL string) (uint64, error) {
 	if err := json.Unmarshal(result, &hexStr); err != nil {
 		return 0, fmt.Errorf("parse chain ID: %w", err)
 	}
-	return hexToUint64(hexStr), nil
+	return hexToUint64(hexStr)
 }

--- a/tools/exit_certificate/step_wait.go
+++ b/tools/exit_certificate/step_wait.go
@@ -443,7 +443,11 @@ func queryVerifyBatches(
 		}
 		// data layout: [0:32] numBatch, [32:64] stateRoot, [64:96] exitRoot.
 		if common.BytesToHash(data[64:96]) == exitRoot {
-			return hexToUint64(l.BlockNumber), common.HexToHash(l.TxHash), true, nil
+			block, err := hexToUint64(l.BlockNumber)
+			if err != nil {
+				return 0, common.Hash{}, false, fmt.Errorf("parse VerifyBatchesTrustedAggregator block number: %w", err)
+			}
+			return block, common.HexToHash(l.TxHash), true, nil
 		}
 	}
 	return 0, common.Hash{}, false, nil
@@ -464,5 +468,5 @@ func resolveFinalizedBlock(ctx context.Context, rpcURL string) (uint64, error) {
 	if block.Number == "" {
 		return 0, fmt.Errorf("finalized block not available")
 	}
-	return hexToUint64(block.Number), nil
+	return hexToUint64(block.Number)
 }


### PR DESCRIPTION
## 🔄 Changes Summary

Fixes the remaining silent-data-loss findings from #1713: a scan or decode error was logged as a warning — or dropped entirely — and the pipeline continued, **omitting value from the exit certificate**. Following the AET-04 precedent (#1675), every site now fails fast.

- **AET-06 (SetSovereignTokenAddress)** — a payload that fails to decode aborts the scan (with the log's block/index) instead of warn-and-skip: a skipped override records the pre-remap wrapped address in the LBT, diverging from what `getTokenWrappedAddress()` returns on-chain.
- **Untracked** — a `computeNativeBalance()` failure now aborts Step 0 instead of building the LBT without the native entry (typically the largest one; Step C would compute no native SC-locked value and Step F would have no native LBT row).
- **Already fixed in the base branch (#1716)**: AET-20 (`fetchBridgeEventsInRange` decode errors) and the NewWrappedToken scan/decode part of AET-06 were addressed there directly (`c93fe8dc`, `8d343c91`).
- **AET-38 / AET-40 — obsolete**: `RunStepA2` and `scanBlockHeaders` no longer exist; the Step A state-dump rewrite (AET-02/08, #1701) removed both sites.

## ⚠️ Breaking Changes
- None. Healthy runs behave identically; corrupted scans now fail the step.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `go test ./tools/exit_certificate/...` green; `golangci-lint run` 0 issues. New tests in `silent_data_loss_test.go`: SetSovereignTokenAddress corrupt-event abort, NewWrappedToken worker-pool scan failure, and Step 0 aborting on native-balance failure.

## 🐞 Issues
- Closes #1713

## 🔗 Related PRs
- Built on top of #1716 (AET fail-open series); companion issue #1714.

## 📝 Notes
- The branch is stacked on `fix/exit-certificate-tool-silent_failures` (PR #1716), so this PR's diff against `feature/exit-certificate-tool` includes #1716's commits until that PR merges — review only `e713a125` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
