### PR TITLE
ci(test-unit): report coverage in job summary and PR comment

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -37,3 +37,35 @@ jobs:
 
       - name: Test
         run: make test-unit
+
+      - name: Coverage summary
+        run: |
+          {
+            echo "## Coverage"
+            echo ""
+            echo '```'
+            go tool cover -func=coverage.out | tail -n 1
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  code-coverage-report:
+    name: code-coverage-report
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: test-unit
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Post coverage report on the PR
+        uses: fgrosse/go-coverage-report@v1.3.0
+        with:
+          coverage-artifact-name: coverage
+          coverage-file-name: coverage.out


### PR DESCRIPTION
## 🔄 Changes Summary
- Restore coverage visibility lost with the SonarQube/SonarCloud removal (#1719), consuming the `coverage.out` that `make test-unit` already generates:
  - **Coverage summary**: print the total from `go tool cover -func` to the workflow run's job summary
  - **Coverage artifact**: upload `coverage.out` as the `coverage` artifact (downloadable for `go tool cover -html` inspection; also serves as the diff baseline on pushes to `develop`/`main`/`release/**`)
  - **PR comment**: new `code-coverage-report` job (PRs only) posts a sticky comment with the total coverage delta vs the base branch and per-file coverage of changed packages, via `fgrosse/go-coverage-report@v1.3.0`
- The report job declares its own scoped permissions (`pull-requests: write` to comment, `actions: read` to download the base-branch artifact); the `test-unit` job is unchanged

## ⚠️ Breaking Changes
- None (CI-only change)

## 📋 Config Updates
- None

## ✅ Testing
- 🤖 **Automatic**: `test-unit` runs unchanged on this PR; the new summary step and artifact upload execute in this PR's run
- 🖱️ **Manual**: the coverage summary command was verified locally against a real `coverage.out` profile

## 🔗 Related PRs
- Follow-up to #1719 (SonarQube/SonarCloud removal)

## 📝 Notes
- **First-run caveat**: the `code-coverage-report` job will fail on PRs with "artifact not found" until this change lands on `develop` and a push run uploads the first baseline `coverage` artifact. It is a separate job, so `test-unit` itself is unaffected.
- PRs from forks won't get the comment (no `pull-requests: write` on forked PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
