### PR TITLE
fix(force_ger_update): forget completed tx so repeat sends are not deduped forever

### DIFF
--- a/test/helpers/ethtxmanmock_e2e.go
+++ b/test/helpers/ethtxmanmock_e2e.go
@@ -65,10 +65,12 @@ func NewEthTxManMock(
 					return
 				}
 			}).
-		Return(common.Hash{}, nil)
+		Return(common.Hash{}, nil).
+		Maybe()
 	ethTxMock.EXPECT().
 		Result(mock.Anything, mock.Anything).
-		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil)
+		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil).
+		Maybe()
 	ethTxMock.EXPECT().
 		Remove(mock.Anything, mock.Anything).
 		Return(nil).

--- a/test/helpers/ethtxmanmock_e2e.go
+++ b/test/helpers/ethtxmanmock_e2e.go
@@ -69,6 +69,10 @@ func NewEthTxManMock(
 	ethTxMock.EXPECT().
 		Result(mock.Anything, mock.Anything).
 		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil)
+	ethTxMock.EXPECT().
+		Remove(mock.Anything, mock.Anything).
+		Return(nil).
+		Maybe()
 	ethTxMock.EXPECT().From().Return(auth.From)
 
 	return ethTxMock

--- a/tools/force_ger_update/integration_test.go
+++ b/tools/force_ger_update/integration_test.go
@@ -350,3 +350,49 @@ func testForceGERUpdateScenarios(t *testing.T, useWS bool) {
 	}, integrationQuietWindow, integrationEventuallyTick,
 		"the externally-triggered event must have reset the tool's timer, keeping it quiet")
 }
+
+// TestBootWithRecentEvent_NoUnnecessarySend covers the flip side of TestForceGERUpdate's scenario
+// 1: booting when the GER was genuinely updated (by unrelated bridge activity) moments before the
+// tool started must NOT force a spurious update. This exercises the real Monitor.LastGERUpdate
+// boot scan and the real runLoop end-to-end (nothing here is a hand-injected/synthetic
+// lastGERUpdate) against a simulated L1 that already has one on-chain UpdateL1InfoTree event
+// before the tool ever runs — i.e. a normal restart while the GER is actually fine, as opposed to
+// TestForceGERUpdate's cold-start (never-updated) case.
+func TestBootWithRecentEvent_NoUnnecessarySend(t *testing.T) {
+	env := newIntegrationEnv(t)
+	cfg := env.config(false)
+
+	// Simulate: the GER was genuinely updated (by unrelated bridge activity) moments before this
+	// process starts.
+	env.sendExternalForcedBridgeAsset(t)
+	require.Len(t, env.gerUpdateLogs(t), 1, "expected exactly one pre-existing on-chain event before boot")
+
+	monitor := env.newMonitor(t, cfg)
+	sender := env.newSender(t, cfg)
+
+	// Real boot scan: must find the pre-existing event and NOT report the GER as stale.
+	lastGERUpdate, err := monitor.LastGERUpdate()
+	require.NoError(t, err)
+	require.False(t, lastGERUpdate.IsZero(), "boot scan must find the pre-existing event, not treat the GER as stale")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan error, 1)
+	go func() {
+		loopDone <- runLoop(ctx, monitor, sender, lastGERUpdate,
+			cfg.CheckInterval.Duration, cfg.MaxTimeWithoutGERUpdate.Duration)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-loopDone:
+			require.NoError(t, err)
+		case <-time.After(integrationEventuallyTimeout):
+			t.Fatal("runLoop did not return promptly after ctx cancellation")
+		}
+	}()
+
+	require.Never(t, func() bool {
+		return len(env.gerUpdateLogs(t)) > 1
+	}, integrationQuietWindow, integrationEventuallyTick,
+		"booting with a genuinely fresh GER must not force an unnecessary update")
+}

--- a/tools/force_ger_update/sender.go
+++ b/tools/force_ger_update/sender.go
@@ -118,7 +118,10 @@ func (s *Sender) SendForcedGERUpdate(ctx context.Context) error {
 
 // waitForResult polls the ethtxmanager for id's status until a terminal state is reached:
 // Mined/Safe/Finalized succeed, Failed returns an error, and Evicted is logged and returns nil
-// (mirrors aggoracle/chaingersender/evm.go's submitTransaction monitoring loop).
+// (mirrors aggoracle/chaingersender/evm.go's submitTransaction monitoring loop). Every terminal
+// state also forgets id (see forgetTerminalTx) so the next SendForcedGERUpdate call — which packs
+// byte-for-byte identical calldata — is free to submit a genuinely new transaction instead of
+// perpetually re-observing this one.
 func (s *Sender) waitForResult(ctx context.Context, id common.Hash) error {
 	ticker := time.NewTicker(s.pollInterval)
 	defer ticker.Stop()
@@ -140,18 +143,41 @@ func (s *Sender) waitForResult(ctx context.Context, id common.Hash) error {
 				ethtxtypes.MonitoredTxStatusSent:
 				continue
 			case ethtxtypes.MonitoredTxStatusFailed:
+				s.forgetTerminalTx(ctx, id)
 				return fmt.Errorf("forced GER update tx %s failed", id.Hex())
 			case ethtxtypes.MonitoredTxStatusEvicted:
 				log.Infof("forced GER update tx %s was evicted", id.Hex())
+				s.forgetTerminalTx(ctx, id)
 				return nil
 			case ethtxtypes.MonitoredTxStatusMined,
 				ethtxtypes.MonitoredTxStatusSafe,
 				ethtxtypes.MonitoredTxStatusFinalized:
 				log.Infof("forced GER update tx %s was successfully mined at block %d", id.Hex(), res.MinedAtBlockNumber)
+				s.forgetTerminalTx(ctx, id)
 				return nil
 			default:
 				log.Errorf("unexpected forced GER update tx status: %s", res.Status)
 			}
 		}
+	}
+}
+
+// forgetTerminalTx removes id from the ethtxmanager's monitoring DB once it has reached a
+// terminal status (Mined/Safe/Finalized/Failed/Evicted).
+//
+// ethtxmanager.Add derives id deterministically from (to, value, data) alone — it never looks at
+// nonce or gas price — and every SendForcedGERUpdate call packs the exact same calldata (same
+// destination network/address, forceUpdateGlobalExitRoot=true, empty metadata). Without this
+// cleanup the very first forced-update tx would occupy that id forever: every later call, whether
+// triggered by the next elapsed-time tick or by a fresh process after a restart, would collide on
+// Add with ErrAlreadyExists and just re-observe that same (already-terminal) tx instead of ever
+// broadcasting a new one — the GER would stay stale and every restart would appear to "retrigger"
+// a send that is really a no-op.
+//
+// Best-effort: a failure to remove only risks repeating that same no-op on the next call, so it is
+// logged rather than propagated as an error of the (already terminal) send itself.
+func (s *Sender) forgetTerminalTx(ctx context.Context, id common.Hash) {
+	if err := s.ethTxManager.Remove(ctx, id); err != nil {
+		log.Warnf("force_ger_update: remove completed tx %s from monitoring DB: %v", id.Hex(), err)
 	}
 }

--- a/tools/force_ger_update/sender_test.go
+++ b/tools/force_ger_update/sender_test.go
@@ -2,6 +2,7 @@ package force_ger_update
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -84,6 +85,11 @@ func TestSendForcedGERUpdate_Success(t *testing.T) {
 		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined, MinedAtBlockNumber: nil}, nil).
 		Once()
 
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, txID).
+		Return(nil).
+		Once()
+
 	sender, err := NewSender(cfg, ethTxMan, WithPollInterval(testPollInterval))
 	require.NoError(t, err)
 
@@ -118,6 +124,11 @@ func TestSendForcedGERUpdate_Failed(t *testing.T) {
 		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusFailed}, nil).
 		Once()
 
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, txID).
+		Return(nil).
+		Once()
+
 	sender, err := NewSender(cfg, ethTxMan, WithPollInterval(testPollInterval))
 	require.NoError(t, err)
 
@@ -127,6 +138,36 @@ func TestSendForcedGERUpdate_Failed(t *testing.T) {
 	err = sender.SendForcedGERUpdate(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), txID.Hex())
+}
+
+func TestSendForcedGERUpdate_Evicted(t *testing.T) {
+	ethTxMan := aggoraclemocks.NewEthTxManager(t)
+	cfg := testConfig()
+
+	txID := common.HexToHash("0xdddd")
+
+	ethTxMan.EXPECT().
+		Add(mock.Anything, &testBridgeAddr, common.Big0, mock.Anything, uint64(0), (*types.BlobTxSidecar)(nil)).
+		Return(txID, nil).
+		Once()
+
+	ethTxMan.EXPECT().
+		Result(mock.Anything, txID).
+		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusEvicted}, nil).
+		Once()
+
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, txID).
+		Return(nil).
+		Once()
+
+	sender, err := NewSender(cfg, ethTxMan, WithPollInterval(testPollInterval))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, sender.SendForcedGERUpdate(ctx))
 }
 
 func TestSendForcedGERUpdate_AlreadyExists(t *testing.T) {
@@ -145,12 +186,69 @@ func TestSendForcedGERUpdate_AlreadyExists(t *testing.T) {
 		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil).
 		Once()
 
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, txID).
+		Return(nil).
+		Once()
+
 	sender, err := NewSender(cfg, ethTxMan, WithPollInterval(testPollInterval))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+}
+
+// TestSendForcedGERUpdate_RepeatedCallsResubmitAfterCompletion is the regression test for the
+// bug this fix addresses: every SendForcedGERUpdate call packs byte-for-byte identical calldata,
+// so ethtxmanager.Add would deterministically derive the same id every time. Before this fix, a
+// completed tx's record lingered forever in the ethtxmanager's monitoring DB, so every later call
+// collided on Add with ErrAlreadyExists and just re-observed the first (already-terminal) tx
+// forever — no new transaction was ever actually broadcast again, which looked like the tool
+// "hanging" between sends and re-triggering a no-op send on every restart. This test drives two
+// full SendForcedGERUpdate calls back-to-back and asserts the second one gets a fresh Add (no
+// ErrAlreadyExists) with its own distinct id, proving the first tx's record was forgotten.
+func TestSendForcedGERUpdate_RepeatedCallsResubmitAfterCompletion(t *testing.T) {
+	ethTxMan := aggoraclemocks.NewEthTxManager(t)
+	cfg := testConfig()
+
+	firstID := common.HexToHash("0xeeee")
+	secondID := common.HexToHash("0xffff")
+
+	ethTxMan.EXPECT().
+		Add(mock.Anything, &testBridgeAddr, common.Big0, mock.Anything, uint64(0), (*types.BlobTxSidecar)(nil)).
+		Return(firstID, nil).
+		Once()
+	ethTxMan.EXPECT().
+		Result(mock.Anything, firstID).
+		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil).
+		Once()
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, firstID).
+		Return(nil).
+		Once()
+
+	ethTxMan.EXPECT().
+		Add(mock.Anything, &testBridgeAddr, common.Big0, mock.Anything, uint64(0), (*types.BlobTxSidecar)(nil)).
+		Return(secondID, nil).
+		Once()
+	ethTxMan.EXPECT().
+		Result(mock.Anything, secondID).
+		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil).
+		Once()
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, secondID).
+		Return(nil).
+		Once()
+
+	sender, err := NewSender(cfg, ethTxMan, WithPollInterval(testPollInterval))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, sender.SendForcedGERUpdate(ctx))
 	require.NoError(t, sender.SendForcedGERUpdate(ctx))
 }
 
@@ -170,6 +268,34 @@ func TestSendForcedGERUpdate_DryRun(t *testing.T) {
 	ethTxMan.AssertNotCalled(t, "Add",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	ethTxMan.AssertNotCalled(t, "Result", mock.Anything, mock.Anything)
+}
+
+func TestSendForcedGERUpdate_RemoveFailureDoesNotFailSend(t *testing.T) {
+	ethTxMan := aggoraclemocks.NewEthTxManager(t)
+	cfg := testConfig()
+
+	txID := common.HexToHash("0x1234")
+
+	ethTxMan.EXPECT().
+		Add(mock.Anything, &testBridgeAddr, common.Big0, mock.Anything, uint64(0), (*types.BlobTxSidecar)(nil)).
+		Return(txID, nil).
+		Once()
+	ethTxMan.EXPECT().
+		Result(mock.Anything, txID).
+		Return(ethtxtypes.MonitoredTxResult{Status: ethtxtypes.MonitoredTxStatusMined}, nil).
+		Once()
+	ethTxMan.EXPECT().
+		Remove(mock.Anything, txID).
+		Return(errors.New("db locked")).
+		Once()
+
+	sender, err := NewSender(cfg, ethTxMan, WithPollInterval(testPollInterval))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, sender.SendForcedGERUpdate(ctx))
 }
 
 func TestNewSender_DefaultsDestinationAddressToSenderFrom(t *testing.T) {


### PR DESCRIPTION
## 🔄 Changes Summary
- `SendForcedGERUpdate` packs byte-for-byte identical `bridgeMessage` calldata on every call (same destination network/address, `forceUpdateGlobalExitRoot=true`, empty metadata). `ethtxmanager.Add` derives its monitored-tx id deterministically from `(to, value, data)` only, so every call after the very first one collided with `ErrAlreadyExists` and just re-observed that first (already-terminal) tx forever — no new transaction was ever actually broadcast again.
- In practice this meant the GER never got updated again after the first forced send: every later trigger (including on every process restart, since the boot scan would always find the GER still genuinely stale) looked like it was sending a tx but was really polling a stuck/old no-op.
- Fix: once the tx reaches a terminal status (Mined/Safe/Finalized/Failed/Evicted), remove it from the ethtxmanager's monitoring DB so the next call is free to submit a genuinely new transaction.

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `go test ./tools/force_ger_update/...` — updated `TestSendForcedGERUpdate_Success`/`_Failed`/`_AlreadyExists` to assert the new `Remove` call, added `TestSendForcedGERUpdate_Evicted`, `TestSendForcedGERUpdate_RemoveFailureDoesNotFailSend` (best-effort cleanup doesn't fail the send), and `TestSendForcedGERUpdate_RepeatedCallsResubmitAfterCompletion` — the regression test for this bug, which drives two full send cycles back-to-back and asserts the second gets a fresh `Add` (no `ErrAlreadyExists`) with its own id.
  Also added `TestBootWithRecentEvent_NoUnnecessarySend`: the existing `TestForceGERUpdate` integration test only covered the cold-start case (no prior `UpdateL1InfoTree` event -> the tool must force one); this covers the flip side that a normal restart should not (a genuinely fresh GER, updated moments earlier by unrelated bridge activity, must not trigger a spurious send), driving the real `Monitor.LastGERUpdate` boot scan and the real `runLoop` end-to-end against a simulated L1 seeded with one on-chain event before the tool starts.
- 🖱️ **Manual**: N/A

## 🐞 Issues
- N/A — reported via internal feedback (no logs available), root-caused by code inspection.

## 🔗 Related PRs
- N/A

## 📝 Notes
- This bug is invisible in the `TestSendForcedGERUpdate_AlreadyExists` test as it stood before this PR: that test only exercises a single send and already asserted success on `ErrAlreadyExists`, which is the correct behavior for a genuinely still-in-flight tx but was silently masking the fact that a *completed* tx's id was never freed for reuse.