### PR TITLE
feat(bridgetracker): add idle timeout eviction to bound registry memory

### DIFF
--- a/bridgetracker/config.go
+++ b/bridgetracker/config.go
@@ -36,6 +36,10 @@ var DefaultL2BlockFinality = aggkittypes.LatestBlock
 // the in-memory registry accepts before refusing new ones (see registry.go's memoryRegistry).
 const DefaultMaxTrackedBridges = 100_000
 
+// DefaultIdleTimeout is the default Config.IdleTimeout (see DefaultEngineIdleTimeout for the
+// semantics; both must stay in sync with the [Tracker] section of the proxy's default config)
+var DefaultIdleTimeout = types.Duration{Duration: DefaultEngineIdleTimeout}
+
 // Config holds the configuration of the bridge tracker service. Only the mapstructure-tagged
 // fields come from the configuration file; the rest are wired programmatically by the binary
 // (see proxy/cmd)
@@ -46,6 +50,13 @@ type Config struct {
 	// same tx re-registers it and tracking restarts from scratch — the retry path for a tx
 	// the tracker gave up on
 	RetentionPeriod types.Duration `mapstructure:"RetentionPeriod"`
+
+	// IdleTimeout is how long a bridge — terminal or still active — stays in the registry once
+	// nobody has read it (no Get/GetAndAwait) and it has no active WebSocket subscriber. Unlike
+	// RetentionPeriod, this applies regardless of TrackingStatus: a bridge that never resolves
+	// and that nobody is polling or subscribed to would otherwise stay supervised (and in
+	// memory) forever. A value <= 0 falls back to DefaultIdleTimeout
+	IdleTimeout types.Duration `mapstructure:"IdleTimeout"`
 
 	// RegisterResolveTimeout is how long the GetTxStatus endpoint waits, the first time a tx is
 	// registered, for the tracking engine's immediate resolution attempt (triggered right away
@@ -76,9 +87,11 @@ type Config struct {
 	L1GlobalExitRootAddress common.Address `mapstructure:"L1GlobalExitRootAddress"`
 
 	// MaxTrackedBridges bounds how many distinct bridges the in-memory registry (see Registry)
-	// accepts at once; a request that would exceed it fails instead of registering the bridge.
-	// A value <= 0 falls back to DefaultMaxTrackedBridges. Only applies to the default in-memory
-	// adapter — ignored when Registry is set to a custom implementation.
+	// accepts at once; a request that would exceed it fails instead of registering the bridge —
+	// reaching the cap never evicts an existing entry to make room, so RetentionPeriod and
+	// IdleTimeout are what keep the registry under it during normal operation. A value <= 0
+	// falls back to DefaultMaxTrackedBridges. Only applies to the default in-memory adapter —
+	// ignored when Registry is set to a custom implementation.
 	MaxTrackedBridges int `mapstructure:"MaxTrackedBridges"`
 
 	// AgglayerClient configures the client used to query the agglayer for a bridge's covering

--- a/bridgetracker/domain/ports.go
+++ b/bridgetracker/domain/ports.go
@@ -74,6 +74,16 @@ type SupervisedStore interface {
 	// until they are pruned, so clients observe the final TrackingStatus during the whole
 	// retention window
 	PruneTerminal(olderThan time.Time) (int, error)
+
+	// PruneIdle forgets the supervised bridges — terminal or still active — that have neither
+	// been accessed (Get/GetAndAwait) nor had an active WebSocket subscription since before
+	// olderThan, returning how many were forgotten. A bridge with at least one active
+	// subscription is never pruned this way, no matter how stale olderThan is: an open
+	// WebSocket connection is itself ongoing interest in the bridge. This bounds the memory an
+	// abandoned-but-still-active tracker (nobody polling, no subscriber, but not yet resolved)
+	// would otherwise hold onto indefinitely, complementing PruneTerminal's grace period for
+	// bridges that did resolve
+	PruneIdle(olderThan time.Time) (int, error)
 }
 
 // StatusNotifier is the driven port push consumers (the WebSocket handler) use to follow a

--- a/bridgetracker/engine.go
+++ b/bridgetracker/engine.go
@@ -26,6 +26,13 @@ const (
 	// for the same tx re-registers it and tracking restarts from scratch — the retry path for
 	// a tx the tracker gave up on
 	DefaultEngineRetentionPeriod = 10 * time.Minute
+	// DefaultEngineIdleTimeout is the default time a bridge — terminal or still active — is
+	// kept once nobody has read it (no Get/GetAndAwait) and it has no active WebSocket
+	// subscriber. It bounds the memory an abandoned tracker holds onto regardless of whether it
+	// ever resolves, on top of RetentionPeriod's grace period for the ones that do. Set well
+	// above PollInterval and a plausible client poll cadence so a caller polling at a normal
+	// pace never sees its bridge evicted between two of its own requests
+	DefaultEngineIdleTimeout = 30 * time.Minute
 )
 
 // EngineConfig holds the tracking engine tunables. Zero values take the defaults above
@@ -41,6 +48,9 @@ type EngineConfig struct {
 	// RetentionPeriod is how long a terminal bridge stays queryable before being forgotten
 	// (see DefaultEngineRetentionPeriod)
 	RetentionPeriod time.Duration
+	// IdleTimeout is how long an unaccessed, unsubscribed bridge — terminal or still active —
+	// is kept before being forgotten (see DefaultEngineIdleTimeout)
+	IdleTimeout time.Duration
 }
 
 // withDefaults returns cfg with every zero-value tunable replaced by its default
@@ -56,6 +66,9 @@ func (cfg EngineConfig) withDefaults() EngineConfig {
 	}
 	if cfg.RetentionPeriod <= 0 {
 		cfg.RetentionPeriod = DefaultEngineRetentionPeriod
+	}
+	if cfg.IdleTimeout <= 0 {
+		cfg.IdleTimeout = DefaultEngineIdleTimeout
 	}
 	return cfg
 }
@@ -177,8 +190,9 @@ func (e *Engine) resolveTriggered(ctx context.Context, id domain.TrackingID) {
 	_ = e.resolveBridgeStep(ctx, tracking)
 }
 
-// tick runs one resolution round over the supervised list, then forgets the terminal
-// entries whose retention has elapsed (see EngineConfig.RetentionPeriod)
+// tick runs one resolution round over the supervised list, then forgets the terminal entries
+// whose retention has elapsed (see EngineConfig.RetentionPeriod) and the unaccessed,
+// unsubscribed entries whose idle timeout has elapsed (see EngineConfig.IdleTimeout)
 func (e *Engine) tick(ctx context.Context) {
 	active, err := e.store.GetTrackerActives(nil)
 	if err != nil {
@@ -203,6 +217,15 @@ func (e *Engine) tick(ctx context.Context) {
 	}
 	if pruned > 0 {
 		e.logger.Infof("forgot %d terminal bridges past the %s retention", pruned, e.cfg.RetentionPeriod)
+	}
+
+	prunedIdle, err := e.store.PruneIdle(e.now().Add(-e.cfg.IdleTimeout))
+	if err != nil {
+		e.logger.Warnf("failed to prune idle bridges: %v", err)
+		return
+	}
+	if prunedIdle > 0 {
+		e.logger.Infof("forgot %d idle bridges past the %s idle timeout", prunedIdle, e.cfg.IdleTimeout)
 	}
 }
 

--- a/bridgetracker/engine_test.go
+++ b/bridgetracker/engine_test.go
@@ -314,6 +314,54 @@ func TestEngineRetentionAndRetry(t *testing.T) {
 	require.Equal(t, types.StepWaitingLERUpdate, currentStep(t, store))
 }
 
+// TestEngineIdleTimeout pins that the tick janitor forgets a bridge nobody has accessed since
+// registration, even if it never reaches a terminal state: RetentionPeriod alone would keep an
+// active-but-abandoned bridge supervised forever, since it is never Failed nor Finished
+func TestEngineIdleTimeout(t *testing.T) {
+	f := &fakeSources{bridge: l2ToL2Bridge()}
+	engine, store, clock := newTestEngine(t, f)
+	engine.cfg.IdleTimeout = 5 * time.Minute
+	id := TrackingID{NetworkID: 1, TxHash: testHash}
+
+	mustRegister(t, store, id)
+	engine.tick(t.Context())
+	require.Equal(t, 1, store.GetNumTracker())
+
+	// within the idle window (lastAccess still the registration above), the bridge stays
+	// supervised however many ticks run — it never resolves to a terminal state on its own
+	*clock = clock.Add(engine.cfg.IdleTimeout / 2)
+	engine.tick(t.Context())
+	require.Equal(t, 1, store.GetNumTracker())
+
+	// past the window, with nobody having read it since registration, the tick janitor forgets
+	// it — even though it never reached a terminal state
+	*clock = clock.Add(engine.cfg.IdleTimeout)
+	engine.tick(t.Context())
+	require.Zero(t, store.GetNumTracker())
+}
+
+// TestEngineIdleTimeoutExtendedByAccess pins that reading the bridge resets the idle window, so
+// a client that keeps polling never sees its own bridge idle-evicted out from under it
+func TestEngineIdleTimeoutExtendedByAccess(t *testing.T) {
+	f := &fakeSources{bridge: l2ToL2Bridge()}
+	engine, store, clock := newTestEngine(t, f)
+	engine.cfg.IdleTimeout = 5 * time.Minute
+	id := TrackingID{NetworkID: 1, TxHash: testHash}
+
+	mustRegister(t, store, id)
+	engine.tick(t.Context())
+
+	*clock = clock.Add(engine.cfg.IdleTimeout / 2)
+	mustGet(t, store, id) // the client polls: this bumps lastAccess to the current clock
+	engine.tick(t.Context())
+	require.Equal(t, 1, store.GetNumTracker())
+
+	// another half window elapses: still short of a full IdleTimeout since the poll above
+	*clock = clock.Add(engine.cfg.IdleTimeout / 2)
+	engine.tick(t.Context())
+	require.Equal(t, 1, store.GetNumTracker(), "the poll above should have reset the idle window")
+}
+
 // TestEngineNotABridge pins that a tx which exists but is not a bridge transaction (reverted,
 // or emitted no BridgeEvent) is marked as terminally failed immediately, with no retries: the
 // receipt is already final, so waiting cannot change the outcome

--- a/bridgetracker/mocks/mock_supervised_registry.go
+++ b/bridgetracker/mocks/mock_supervised_registry.go
@@ -303,6 +303,62 @@ func (_c *SupervisedRegistry_GetTrackerActives_Call) RunAndReturn(run func(*uint
 	return _c
 }
 
+// PruneIdle provides a mock function with given fields: olderThan
+func (_m *SupervisedRegistry) PruneIdle(olderThan time.Time) (int, error) {
+	ret := _m.Called(olderThan)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PruneIdle")
+	}
+
+	var r0 int
+	var r1 error
+	if rf, ok := ret.Get(0).(func(time.Time) (int, error)); ok {
+		return rf(olderThan)
+	}
+	if rf, ok := ret.Get(0).(func(time.Time) int); ok {
+		r0 = rf(olderThan)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	if rf, ok := ret.Get(1).(func(time.Time) error); ok {
+		r1 = rf(olderThan)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SupervisedRegistry_PruneIdle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PruneIdle'
+type SupervisedRegistry_PruneIdle_Call struct {
+	*mock.Call
+}
+
+// PruneIdle is a helper method to define mock.On call
+//   - olderThan time.Time
+func (_e *SupervisedRegistry_Expecter) PruneIdle(olderThan interface{}) *SupervisedRegistry_PruneIdle_Call {
+	return &SupervisedRegistry_PruneIdle_Call{Call: _e.mock.On("PruneIdle", olderThan)}
+}
+
+func (_c *SupervisedRegistry_PruneIdle_Call) Run(run func(olderThan time.Time)) *SupervisedRegistry_PruneIdle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Time))
+	})
+	return _c
+}
+
+func (_c *SupervisedRegistry_PruneIdle_Call) Return(_a0 int, _a1 error) *SupervisedRegistry_PruneIdle_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SupervisedRegistry_PruneIdle_Call) RunAndReturn(run func(time.Time) (int, error)) *SupervisedRegistry_PruneIdle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PruneTerminal provides a mock function with given fields: olderThan
 func (_m *SupervisedRegistry) PruneTerminal(olderThan time.Time) (int, error) {
 	ret := _m.Called(olderThan)

--- a/bridgetracker/mocks/mock_supervised_store.go
+++ b/bridgetracker/mocks/mock_supervised_store.go
@@ -303,6 +303,62 @@ func (_c *SupervisedStore_GetTrackerActives_Call) RunAndReturn(run func(*uint32)
 	return _c
 }
 
+// PruneIdle provides a mock function with given fields: olderThan
+func (_m *SupervisedStore) PruneIdle(olderThan time.Time) (int, error) {
+	ret := _m.Called(olderThan)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PruneIdle")
+	}
+
+	var r0 int
+	var r1 error
+	if rf, ok := ret.Get(0).(func(time.Time) (int, error)); ok {
+		return rf(olderThan)
+	}
+	if rf, ok := ret.Get(0).(func(time.Time) int); ok {
+		r0 = rf(olderThan)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	if rf, ok := ret.Get(1).(func(time.Time) error); ok {
+		r1 = rf(olderThan)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SupervisedStore_PruneIdle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PruneIdle'
+type SupervisedStore_PruneIdle_Call struct {
+	*mock.Call
+}
+
+// PruneIdle is a helper method to define mock.On call
+//   - olderThan time.Time
+func (_e *SupervisedStore_Expecter) PruneIdle(olderThan interface{}) *SupervisedStore_PruneIdle_Call {
+	return &SupervisedStore_PruneIdle_Call{Call: _e.mock.On("PruneIdle", olderThan)}
+}
+
+func (_c *SupervisedStore_PruneIdle_Call) Run(run func(olderThan time.Time)) *SupervisedStore_PruneIdle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Time))
+	})
+	return _c
+}
+
+func (_c *SupervisedStore_PruneIdle_Call) Return(_a0 int, _a1 error) *SupervisedStore_PruneIdle_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SupervisedStore_PruneIdle_Call) RunAndReturn(run func(time.Time) (int, error)) *SupervisedStore_PruneIdle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PruneTerminal provides a mock function with given fields: olderThan
 func (_m *SupervisedStore) PruneTerminal(olderThan time.Time) (int, error) {
 	ret := _m.Called(olderThan)

--- a/bridgetracker/registry.go
+++ b/bridgetracker/registry.go
@@ -19,6 +19,9 @@ type bridgeEntry struct {
 	// terminalSince is when the snapshot first became terminal (see isTerminal); zero while
 	// it is not. It anchors the retention window PruneTerminal evicts by
 	terminalSince time.Time
+	// lastAccess is when this entry was last read (Get/GetAndAwait) or gained a new
+	// subscriber; it anchors the idle window PruneIdle evicts by
+	lastAccess time.Time
 }
 
 // triggerBufferSize bounds the backlog of newly registered ids awaiting the engine's
@@ -33,7 +36,7 @@ const triggerBufferSize = 256
 type memoryRegistry struct {
 	mu      sync.RWMutex
 	bridges map[TrackingID]*bridgeEntry
-	// now is the clock terminalSince is stamped with, injectable for tests
+	// now is the clock terminalSince and lastAccess are stamped with, injectable for tests
 	now func() time.Time
 	// maxEntries bounds how many distinct bridges can be registered at once (see create): an
 	// unauthenticated caller registering an unbounded number of distinct (network, tx hash)
@@ -104,6 +107,7 @@ func (r *memoryRegistry) Get(id TrackingID, createIfNotExists bool) (*domain.Tra
 			return nil, err
 		}
 	}
+	entry.lastAccess = r.now()
 	return entry.tracking, nil
 }
 
@@ -123,6 +127,7 @@ func (r *memoryRegistry) GetAndAwait(id TrackingID, timeout time.Duration) (*dom
 			return nil, err
 		}
 	}
+	entry.lastAccess = r.now()
 
 	if existed || timeout <= 0 {
 		tracking := entry.tracking
@@ -166,6 +171,7 @@ func (r *memoryRegistry) Subscribe(id TrackingID) (<-chan *domain.TrackingData, 
 			return nil, nil, err
 		}
 	}
+	entry.lastAccess = r.now()
 	ch := make(chan *domain.TrackingData, 1)
 	entry.subscribers[ch] = struct{}{}
 
@@ -270,6 +276,26 @@ func (r *memoryRegistry) PruneTerminal(olderThan time.Time) (int, error) {
 	return pruned, nil
 }
 
+// PruneIdle implements SupervisedStore: it forgets every entry — terminal or still active —
+// that has no active subscriber and was last accessed (Get/GetAndAwait, or gaining a
+// subscriber) before olderThan. An entry with at least one active subscriber is never a
+// candidate, regardless of how stale olderThan is: an open WebSocket connection is itself
+// ongoing interest in the bridge, distinct from — and not extended by — plain polling. A
+// pruned entry is gone as if never requested, same as PruneTerminal
+func (r *memoryRegistry) PruneIdle(olderThan time.Time) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pruned := 0
+	for id, entry := range r.bridges {
+		if len(entry.subscribers) == 0 && entry.lastAccess.Before(olderThan) {
+			delete(r.bridges, id)
+			pruned++
+		}
+	}
+	return pruned, nil
+}
+
 // GetNetworks implements SupervisedStore: the networks with at least one supervised bridge,
 // optionally filtered to those with at least one bridge in the given TrackingStatus
 func (r *memoryRegistry) GetNetworks(status *types.TrackingStatus) ([]uint32, error) {
@@ -301,8 +327,12 @@ func (r *memoryRegistry) GetNumTracker() int {
 }
 
 // create adds a fresh (Registered, nil BridgeStatus) entry for id, or domain.ErrRegistryFull if
-// the registry is already at maxEntries. It also wakes the tracking engine to resolve id right
-// away (see signalTrigger) instead of leaving it for the next poll tick. Callers must hold r.mu
+// the registry is already at maxEntries. Reaching the cap never evicts an existing entry to make
+// room, whether that entry is idle or actively watched: PruneTerminal and PruneIdle are what keep
+// the registry under the cap during normal operation (see their docs), and a request that would
+// exceed it is simply rejected — this is a deliberate, unconditional safety net, not a policy
+// gap. It also wakes the tracking engine to resolve id right away (see signalTrigger) instead of
+// leaving it for the next poll tick. Callers must hold r.mu
 func (r *memoryRegistry) create(id TrackingID) (*bridgeEntry, error) {
 	if len(r.bridges) >= r.maxEntries {
 		return nil, domain.ErrRegistryFull
@@ -311,6 +341,7 @@ func (r *memoryRegistry) create(id TrackingID) (*bridgeEntry, error) {
 	entry := &bridgeEntry{
 		tracking:    domain.NewTrackingData(id, domain.TrackingBridgeTx{}, nil),
 		subscribers: make(map[chan *domain.TrackingData]struct{}),
+		lastAccess:  r.now(),
 	}
 	r.bridges[id] = entry
 	r.signalTrigger(id)

--- a/bridgetracker/registry_test.go
+++ b/bridgetracker/registry_test.go
@@ -145,6 +145,70 @@ func TestRegistryPruneTerminal(t *testing.T) {
 	require.Nil(t, tracking.Error())
 }
 
+// TestRegistryPruneIdle pins the idle-eviction semantics: an entry with no active subscriber
+// last accessed before the deadline is forgotten regardless of its tracking status (terminal or
+// still active), while a subscribed entry is never a candidate however stale its lastAccess is
+func TestRegistryPruneIdle(t *testing.T) {
+	r := newMemoryRegistry(0)
+	clock := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	r.now = func() time.Time { return clock }
+
+	idleActive := TrackingID{NetworkID: 1, TxHash: testHash}
+	idleFinished := TrackingID{NetworkID: 1, TxHash: common.HexToHash("0x05")}
+	subscribed := TrackingID{NetworkID: 1, TxHash: common.HexToHash("0x06")}
+	for _, id := range []TrackingID{idleActive, idleFinished, subscribed} {
+		_, err := r.Get(id, true)
+		require.NoError(t, err)
+	}
+	require.NoError(t, publishStatus(r, idleFinished, testBridgeInfo(), testAllSteps(true)))
+	_, unsubscribe, err := r.Subscribe(subscribed)
+	require.NoError(t, err)
+	defer unsubscribe()
+
+	// nothing was accessed before the deadline yet: everything is kept
+	pruned, err := r.PruneIdle(clock.Add(-time.Minute))
+	require.NoError(t, err)
+	require.Zero(t, pruned)
+	require.Equal(t, 3, r.GetNumTracker())
+
+	// past the deadline, both unsubscribed entries are forgotten — active or terminal makes no
+	// difference — but the subscribed one survives regardless of how stale its lastAccess is
+	pruned, err = r.PruneIdle(clock.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, 2, pruned)
+	require.Equal(t, 1, r.GetNumTracker())
+	_, err = r.Get(idleActive, false)
+	require.ErrorIs(t, err, domain.ErrTrackingNotFound)
+	_, err = r.Get(idleFinished, false)
+	require.ErrorIs(t, err, domain.ErrTrackingNotFound)
+	_, err = r.Get(subscribed, false)
+	require.NoError(t, err)
+}
+
+// TestRegistryPruneIdleSkipsRecentlyAccessedEntry pins that a plain Get (no subscription) counts
+// as access and extends the idle window: a bridge a client keeps polling is never idle-evicted
+// out from under it
+func TestRegistryPruneIdleSkipsRecentlyAccessedEntry(t *testing.T) {
+	r := newMemoryRegistry(0)
+	clock := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	r.now = func() time.Time { return clock }
+	id := TrackingID{NetworkID: 1, TxHash: testHash}
+
+	_, err := r.Get(id, true)
+	require.NoError(t, err)
+
+	// a later read at T+1min bumps lastAccess, so a deadline that would otherwise have caught
+	// the original (T+0) access no longer does
+	clock = clock.Add(time.Minute)
+	_, err = r.Get(id, false)
+	require.NoError(t, err)
+
+	pruned, err := r.PruneIdle(clock.Add(-30 * time.Second))
+	require.NoError(t, err)
+	require.Zero(t, pruned)
+	require.Equal(t, 1, r.GetNumTracker())
+}
+
 // TestRegistryUpdateTrackingBridgeTxUnregisteredReturnsNotFound pins that, unlike Get,
 // UpdateTrackingBridgeTx never creates the entry on its own: the bridge must already be in
 // the supervised list (via Get(id, true) or Subscribe)
@@ -424,6 +488,28 @@ func TestRegistryGetRefusesNewEntryPastCapacity(t *testing.T) {
 	require.NoError(t, err)
 	_, err = r.Get(TrackingID{NetworkID: 1, TxHash: common.HexToHash("0x01")}, false)
 	require.NoError(t, err)
+}
+
+// TestRegistryGetAndAwaitBumpsLastAccess pins that GetAndAwait counts as access too, on both
+// the newly-created and the already-registered path — not just plain Get
+func TestRegistryGetAndAwaitBumpsLastAccess(t *testing.T) {
+	r := newMemoryRegistry(0)
+	clock := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	r.now = func() time.Time { return clock }
+	id := TrackingID{NetworkID: 1, TxHash: testHash}
+
+	_, err := r.GetAndAwait(id, 0)
+	require.NoError(t, err)
+
+	clock = clock.Add(time.Minute)
+	_, err = r.GetAndAwait(id, 0)
+	require.NoError(t, err)
+
+	// a deadline that would have caught the original (T+0) access no longer does: the second
+	// GetAndAwait call bumped lastAccess to T+1min
+	pruned, err := r.PruneIdle(clock.Add(-30 * time.Second))
+	require.NoError(t, err)
+	require.Zero(t, pruned)
 }
 
 // TestRegistryGetAndAwaitExistingEntryReturnsImmediately pins that GetAndAwait on an

--- a/docs/bridgetracker.md
+++ b/docs/bridgetracker.md
@@ -68,6 +68,7 @@ section:
 ```toml
 [Tracker]
 RetentionPeriod = "10m"
+IdleTimeout = "30m"
 RegisterResolveTimeout = "3s"
 L1BlockFinality = "LatestBlock"
 L2BlockFinality = "LatestBlock"
@@ -85,6 +86,10 @@ UseTLS = false
 
 - `RetentionPeriod`: how long a terminal bridge (finished, or failed to ever resolve) stays
   queryable before the tracker forgets it and a later request re-registers it from scratch.
+- `IdleTimeout`: how long a bridge — terminal or still active — stays supervised once nobody has
+  read it (REST poll) and it has no active WebSocket subscriber. Unlike `RetentionPeriod`, this
+  applies regardless of status: a bridge that never resolves and that nobody is watching would
+  otherwise stay in memory forever.
 - `RegisterResolveTimeout`: how long the first request for a freshly registered tx waits for the
   engine's immediate resolution attempt before answering, so it has a shot at real progress
   instead of the bare `registered` state; a lookup of an already-registered tx never waits.
@@ -92,7 +97,8 @@ UseTLS = false
   before the tracker accepts it, so a later reorg cannot leave it permanently following an
   orphaned deposit (a resolved bridge is never re-checked).
 - `MaxTrackedBridges`: caps the in-memory supervised list; a request beyond it fails instead of
-  registering the bridge.
+  registering the bridge — reaching the cap never evicts an existing entry to make room, so
+  `RetentionPeriod` and `IdleTimeout` are what keep the registry under it during normal operation.
 - `AgglayerClient`: the client used to resolve an L2-originated bridge's covering certificate and
   its status (`PendingInclusion`/`CertificatePending`/`WaitL1SettledGER`).
 

--- a/proxy/cmd/run.go
+++ b/proxy/cmd/run.go
@@ -183,7 +183,10 @@ func runTracker(
 		trackerCfg.L1BlockFinality, log.WithFields("module", "bridgetracker-gersource"))
 
 	engine, err := bridgetracker.NewEngine(
-		bridgetracker.EngineConfig{RetentionPeriod: trackerCfg.RetentionPeriod.Duration},
+		bridgetracker.EngineConfig{
+			RetentionPeriod: trackerCfg.RetentionPeriod.Duration,
+			IdleTimeout:     trackerCfg.IdleTimeout.Duration,
+		},
 		log.WithFields("module", "bridgetracker-engine"),
 		registry,
 		bridgetracker.EngineSources{

--- a/proxy/config/default.go
+++ b/proxy/config/default.go
@@ -30,10 +30,27 @@ WriteTimeout = "5m"
 MaxRequestsPerIPAndSecond = 10
 
 [Tracker]
+# RetentionPeriod: how long a terminal bridge (finished, or failed to ever resolve) stays
+# queryable before the tracker forgets it; a later request for the same tx re-registers it and
+# tracking restarts from scratch.
 RetentionPeriod = "10m"
+# IdleTimeout: how long a bridge -- terminal or still active -- stays supervised once nobody has
+# read it (REST poll) and it has no active WebSocket subscriber. Unlike RetentionPeriod, this
+# applies regardless of status, so a bridge that never resolves and that nobody is watching does
+# not stay in memory forever.
+IdleTimeout = "30m"
+# RegisterResolveTimeout: how long the first request for a freshly registered tx waits for the
+# engine's immediate resolution attempt before answering, so it has a shot at real progress
+# instead of the bare "registered" state; a lookup of an already-registered tx never waits.
 RegisterResolveTimeout = "3s"
+# L1BlockFinality / L2BlockFinality: the finality a bridge's creating tx receipt must reach on
+# L1/L2 before the tracker accepts it, so a later reorg cannot leave it permanently following an
+# orphaned deposit (a resolved bridge is never re-checked).
 L1BlockFinality = "LatestBlock"
 L2BlockFinality = "LatestBlock"
+# MaxTrackedBridges: caps the in-memory supervised list; a request beyond it fails instead of
+# registering the bridge -- reaching the cap never evicts an existing entry to make room, so
+# RetentionPeriod and IdleTimeout are what keep the registry under it during normal operation.
 MaxTrackedBridges = 100000
 
 [Tracker.AgglayerClient]

--- a/proxy/config/default.go
+++ b/proxy/config/default.go
@@ -34,20 +34,24 @@ MaxRequestsPerIPAndSecond = 10
 # queryable before the tracker forgets it; a later request for the same tx re-registers it and
 # tracking restarts from scratch.
 RetentionPeriod = "10m"
+
 # IdleTimeout: how long a bridge -- terminal or still active -- stays supervised once nobody has
 # read it (REST poll) and it has no active WebSocket subscriber. Unlike RetentionPeriod, this
 # applies regardless of status, so a bridge that never resolves and that nobody is watching does
 # not stay in memory forever.
 IdleTimeout = "30m"
+
 # RegisterResolveTimeout: how long the first request for a freshly registered tx waits for the
 # engine's immediate resolution attempt before answering, so it has a shot at real progress
 # instead of the bare "registered" state; a lookup of an already-registered tx never waits.
 RegisterResolveTimeout = "3s"
+
 # L1BlockFinality / L2BlockFinality: the finality a bridge's creating tx receipt must reach on
 # L1/L2 before the tracker accepts it, so a later reorg cannot leave it permanently following an
 # orphaned deposit (a resolved bridge is never re-checked).
 L1BlockFinality = "LatestBlock"
 L2BlockFinality = "LatestBlock"
+
 # MaxTrackedBridges: caps the in-memory supervised list; a request beyond it fails instead of
 # registering the bridge -- reaching the cap never evicts an existing entry to make room, so
 # RetentionPeriod and IdleTimeout are what keep the registry under it during normal operation.


### PR DESCRIPTION
## 🔄 Changes Summary
- Add `IdleTimeout` config: a supervised bridge — terminal or still active — is forgotten once
  nobody has read it (REST poll) and it has no active WebSocket subscriber for that long,
  regardless of `TrackingStatus`. Complements the existing `RetentionPeriod` (grace period for
  terminal bridges only), bounding the memory a bridge that never resolves and that nobody is
  watching would otherwise hold onto forever.
- `registry.go`: track `lastAccess` per entry (bumped on `Get`/`GetAndAwait`/`Subscribe`); new
  `PruneIdle` forgets unsubscribed entries idle past a deadline.
- `engine.go`: new `IdleTimeout` tunable (default 30m); `tick()` calls `PruneIdle` alongside the
  existing `PruneTerminal`.
- `MaxTrackedBridges` keeps rejecting registration once at capacity instead of evicting an
  existing entry to make room — `RetentionPeriod` and `IdleTimeout` are what keep the registry
  under the cap during normal operation.
- Wired `IdleTimeout` through `bridgetracker.Config`, the proxy's default config (with
  explanatory comments for every `[Tracker]` field) and `proxy/cmd/run.go`.
- Docs updated in `docs/bridgetracker.md`.

## ⚠️ Breaking Changes
- None.

## 📋 Config Updates
- 🧾 Only `IdleTimeout` is new; the rest of `[Tracker]` is shown below for context (also gained
  explanatory comments, no behavior change):
  ```toml
  [Tracker]
  RetentionPeriod = "10m"
  IdleTimeout = "30m"                # <- new field, default 30m
  RegisterResolveTimeout = "3s"
  L1BlockFinality = "LatestBlock"
  L2BlockFinality = "LatestBlock"
  MaxTrackedBridges = 100000
  ```
  - `RetentionPeriod` *(existing)*: grace period a terminal bridge (finished/failed) stays
    queryable before being forgotten.
  - `IdleTimeout` **(new)**: how long a bridge — terminal or still active — stays supervised
    once nobody has read it (REST poll) and it has no active WebSocket subscriber. Unlike
    `RetentionPeriod`, applies regardless of status.
  - `RegisterResolveTimeout` *(existing)*: how long the first request for a freshly registered
    tx waits for the engine's immediate resolution attempt before answering.
  - `L1BlockFinality` / `L2BlockFinality` *(existing)*: finality a bridge's creating tx receipt
    must reach before the tracker accepts it.
  - `MaxTrackedBridges` *(existing)*: caps the in-memory supervised list; unchanged behavior
    (still a hard reject on cap, never an eviction) but now documented alongside
    `RetentionPeriod`/`IdleTimeout` as what keeps the registry under it in practice.

## ✅ Testing
- 🤖 **Automatic**: `go test ./bridgetracker/... ./proxy/...` (new: `TestRegistryPruneIdle`,
  `TestRegistryPruneIdleSkipsRecentlyAccessedEntry`, `TestRegistryGetAndAwaitBumpsLastAccess`,
  `TestEngineIdleTimeout`, `TestEngineIdleTimeoutExtendedByAccess`); `golangci-lint run` on both
  packages — 0 issues.
- 🖱️ **Manual**: none required — behavior verified via unit tests with an injectable clock.

## 🐞 Issues
- Closes #1748

## 📝 Notes
- Eviction-on-cap (bullet 3 of the issue) was deliberately kept as a hard reject
  (`ErrRegistryFull`), never forcing out an existing entry — whether idle or WS-subscribed — to
  make room for a new one; `RetentionPeriod`/`IdleTimeout` are the mechanisms that keep the
  registry under `MaxTrackedBridges` in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)