### PR TITLE
feat(agglayer): make per-method cache policy configurable on the client

### DIFF
--- a/agglayer/agglayer_client_cache.go
+++ b/agglayer/agglayer_client_cache.go
@@ -2,8 +2,9 @@ package agglayer
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"time"
+	"strings"
 
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/config/types"
@@ -11,12 +12,77 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 )
 
+// MethodPolicy is the access policy applied to one AgglayerClientInterface method by
+// AgglayerClientCache: whether calls to it are served from cache, passed straight through to the
+// underlying client, or refused outright
+type MethodPolicy string
+
+const (
+	// MethodPolicyCached routes the call through the response cache, keyed by its arguments (see
+	// AgglayerClientCache); a cache miss falls through to the underlying client and stores the
+	// result. Rejected by CacheConfig.Validate for SendCertificate: caching a mutating call would
+	// silently skip submitting a certificate on a hit
+	MethodPolicyCached MethodPolicy = "cached"
+	// MethodPolicyPassthrough calls the underlying agglayer client directly, uncached. This is
+	// the effective policy for any method left unset (the zero value) in configuration
+	MethodPolicyPassthrough MethodPolicy = "passthrough"
+	// MethodPolicyForbidden refuses the call immediately with ErrMethodForbidden, without ever
+	// reaching the underlying agglayer client -- e.g. a read-only client that must never be able
+	// to SendCertificate
+	MethodPolicyForbidden MethodPolicy = "forbidden"
+)
+
+// ErrMethodForbidden is the error a forbidden method call fails with (see MethodPolicyForbidden)
+var ErrMethodForbidden = errors.New("method forbidden by client policy")
+
+// effective returns the policy to apply: p itself, or MethodPolicyPassthrough if p is the zero
+// value -- a method left unset in configuration
+func (p MethodPolicy) effective() MethodPolicy {
+	if p == "" {
+		return MethodPolicyPassthrough
+	}
+	return p
+}
+
+// Validate reports whether p is a recognized policy; the zero value is valid (see effective)
+func (p MethodPolicy) Validate() error {
+	switch p {
+	case "", MethodPolicyCached, MethodPolicyPassthrough, MethodPolicyForbidden:
+		return nil
+	default:
+		return fmt.Errorf("invalid method policy %q: must be one of %q, %q, %q",
+			p, MethodPolicyCached, MethodPolicyPassthrough, MethodPolicyForbidden)
+	}
+}
+
+// CacheConfig configures AgglayerClientCache: the shared TTL/capacity its per-method caches are
+// built with, and the policy applied to each AgglayerClientInterface method. A method left unset
+// (the zero value) behaves as MethodPolicyPassthrough
 type CacheConfig struct {
 	// TTL that an item is valid in the cache before it is considered stale.
 	TTL types.Duration
-	// Capacity is the maximum number of items that can be stored in the cache.
-	// If the cache exceeds this capacity, it will evict the least recently used items.
+	// Capacity is the maximum number of items that can be stored in each per-method cache.
+	// If a cache exceeds this capacity, it evicts the least recently used items.
 	Capacity uint64
+
+	// SendCertificate is the policy for AgglayerClientInterface.SendCertificate. MethodPolicyCached
+	// is rejected by Validate (see its doc)
+	SendCertificate MethodPolicy `mapstructure:"SendCertificate"`
+	// GetCertificateHeader is the policy for AgglayerClientInterface.GetCertificateHeader, cached
+	// (if enabled) by certificate hash -- an immutable lookup key, safe to cache
+	GetCertificateHeader MethodPolicy `mapstructure:"GetCertificateHeader"`
+	// GetEpochConfiguration is the policy for AgglayerClientInterface.GetEpochConfiguration; it
+	// takes no network id, so its cache -- if enabled -- holds a single global entry
+	GetEpochConfiguration MethodPolicy `mapstructure:"GetEpochConfiguration"`
+	// GetLatestSettledCertificateHeader is the policy for
+	// AgglayerClientInterface.GetLatestSettledCertificateHeader, cached (if enabled) by network id
+	GetLatestSettledCertificateHeader MethodPolicy `mapstructure:"GetLatestSettledCertificateHeader"`
+	// GetLatestPendingCertificateHeader is the policy for
+	// AgglayerClientInterface.GetLatestPendingCertificateHeader, cached (if enabled) by network id
+	GetLatestPendingCertificateHeader MethodPolicy `mapstructure:"GetLatestPendingCertificateHeader"`
+	// GetNetworkInfo is the policy for AgglayerClientInterface.GetNetworkInfo, cached (if enabled)
+	// by network id
+	GetNetworkInfo MethodPolicy `mapstructure:"GetNetworkInfo"`
 }
 
 // Validate checks if the configuration cache settings are valid.
@@ -30,105 +96,222 @@ func (c *CacheConfig) Validate() error {
 	if c.Capacity == 0 {
 		return fmt.Errorf("invalid Capacity %d. Must be >0", c.Capacity)
 	}
+	for _, mp := range c.methodPolicies() {
+		if err := mp.policy.Validate(); err != nil {
+			return fmt.Errorf("%s: %w", mp.name, err)
+		}
+	}
+	if c.SendCertificate.effective() == MethodPolicyCached {
+		return fmt.Errorf(
+			"SendCertificate cannot use the %q policy: it is a mutating call, "+
+				"caching it would silently skip submitting a certificate", MethodPolicyCached)
+	}
 	return nil
+}
+
+// methodPolicies lists every configured method policy keyed by method name, in the fixed order
+// String prints them in
+func (c *CacheConfig) methodPolicies() []struct {
+	name   string
+	policy MethodPolicy
+} {
+	return []struct {
+		name   string
+		policy MethodPolicy
+	}{
+		{"SendCertificate", c.SendCertificate},
+		{"GetCertificateHeader", c.GetCertificateHeader},
+		{"GetEpochConfiguration", c.GetEpochConfiguration},
+		{"GetLatestSettledCertificateHeader", c.GetLatestSettledCertificateHeader},
+		{"GetLatestPendingCertificateHeader", c.GetLatestPendingCertificateHeader},
+		{"GetNetworkInfo", c.GetNetworkInfo},
+	}
 }
 
 func (c *CacheConfig) String() string {
 	if c == nil {
 		return "CacheConfig is nil"
 	}
-	return fmt.Sprintf("TTL: %s, Capacity: %d", c.TTL.String(), c.Capacity)
+	var s strings.Builder
+	fmt.Fprintf(&s, "TTL: %s, Capacity: %d", c.TTL.String(), c.Capacity)
+	for _, mp := range c.methodPolicies() {
+		fmt.Fprintf(&s, ", %s: %s", mp.name, mp.policy.effective())
+	}
+	return s.String()
 }
 
-// AgglayerClientCache provides a caching layer for agglayer client using a TTL (time-to-live) cache.
-// It interacts with an AgglayerClientInterface to fetch certificate headers as needed and stores them
-// in a cache keyed by common.Hash. This helps reduce redundant network calls and improves performance
-// by serving frequently accessed certificate headers from the cache.
+// AgglayerClientCache decorates an AgglayerClientInterface, applying the per-method policy
+// configured in CacheConfig: a method call is served from its own TTL cache
+// (MethodPolicyCached), passed straight through to agglayerClient (MethodPolicyPassthrough, the
+// default for an unset method), or refused with ErrMethodForbidden without ever reaching
+// agglayerClient (MethodPolicyForbidden). Every per-method cache is keyed by that method's own
+// arguments (e.g. certificate hash, network id) and is safe for concurrent use -- the
+// underlying ttlcache.Cache handles its own locking, and policy is read-only after construction
 type AgglayerClientCache struct {
 	agglayerClient AgglayerClientInterface
-	cache          *ttlcache.Cache[common.Hash, agglayertypes.CertificateHeader]
+	policy         CacheConfig
+
+	certificateHeaderCache       *ttlcache.Cache[common.Hash, agglayertypes.CertificateHeader]
+	epochConfigurationCache      *ttlcache.Cache[struct{}, agglayertypes.ClockConfiguration]
+	latestSettledCertHeaderCache *ttlcache.Cache[uint32, agglayertypes.CertificateHeader]
+	latestPendingCertHeaderCache *ttlcache.Cache[uint32, agglayertypes.CertificateHeader]
+	networkInfoCache             *ttlcache.Cache[uint32, agglayertypes.NetworkInfo]
 }
 
-// NewCertificateCache creates and returns a new AgglayerClientCache instance with the specified
-// Agglayer client, time-to-live (TTL) duration for cache entries, and maximum cache capacity.
-// The cache stores certificate headers indexed by their hash and automatically evicts entries
-// based on the provided TTL and capacity constraints.
-func NewCertificateCache(
-	agglayerClient AgglayerClientInterface,
-	ttl time.Duration,
-	capacity uint64) *AgglayerClientCache {
-	c := ttlcache.New(
-		ttlcache.WithTTL[common.Hash, agglayertypes.CertificateHeader](ttl),
-		ttlcache.WithCapacity[common.Hash, agglayertypes.CertificateHeader](capacity),
-		// disable extension of the TTL on cache hits
-		ttlcache.WithDisableTouchOnHit[common.Hash, agglayertypes.CertificateHeader](),
-	)
+// NewAgglayerClientCache returns an AgglayerClientCache decorating agglayerClient per cfg (see
+// its doc); cfg is assumed already validated (see CacheConfig.Validate, run by
+// ClientConfig.Validate before NewAgglayerClient ever reaches this constructor). Every
+// per-method cache is built with the same cfg.TTL/cfg.Capacity, even for a method whose policy
+// is not MethodPolicyCached -- unused caches cost one empty ttlcache.Cache each, a fixed and
+// negligible allocation
+func NewAgglayerClientCache(agglayerClient AgglayerClientInterface, cfg CacheConfig) *AgglayerClientCache {
 	return &AgglayerClientCache{
-		cache:          c,
-		agglayerClient: agglayerClient,
+		agglayerClient:               agglayerClient,
+		policy:                       cfg,
+		certificateHeaderCache:       newTTLCache[common.Hash, agglayertypes.CertificateHeader](cfg),
+		epochConfigurationCache:      newTTLCache[struct{}, agglayertypes.ClockConfiguration](cfg),
+		latestSettledCertHeaderCache: newTTLCache[uint32, agglayertypes.CertificateHeader](cfg),
+		latestPendingCertHeaderCache: newTTLCache[uint32, agglayertypes.CertificateHeader](cfg),
+		networkInfoCache:             newTTLCache[uint32, agglayertypes.NetworkInfo](cfg),
 	}
 }
 
-// GetCertificateHeader retrieves the certificate header associated with the given certificateID.
-// It first attempts to fetch the certificate header from the local cache. If the header is not
-// present in the cache, it fetches it from the agglayer client, stores it in the cache with the
-// default TTL, and then returns it. Returns an error if the certificate header cannot be retrieved
-// from the agglayer client.
-//
-// Parameters:
-//   - ctx: The context for controlling cancellation and deadlines.
-//   - certificateID: The unique identifier (hash) of the certificate.
-//
-// Returns:
-//   - *agglayertypes.CertificateHeader: The retrieved certificate header.
-//   - error: An error if the certificate header could not be retrieved.
-func (c *AgglayerClientCache) GetCertificateHeader(
-	ctx context.Context, certificateID common.Hash) (*agglayertypes.CertificateHeader, error) {
-	c.cache.DeleteExpired()
+// newTTLCache builds a cache with cfg's TTL/Capacity and hit semantics shared by every
+// per-method cache: a hit never extends the entry's TTL, so a value is forgotten TTL after it
+// was first stored, no matter how often it is read in between
+func newTTLCache[K comparable, V any](cfg CacheConfig) *ttlcache.Cache[K, V] {
+	return ttlcache.New(
+		ttlcache.WithTTL[K, V](cfg.TTL.Duration),
+		ttlcache.WithCapacity[K, V](cfg.Capacity),
+		ttlcache.WithDisableTouchOnHit[K, V](),
+	)
+}
 
-	if c.cache.Has(certificateID) {
-		tmp := c.cache.Get(certificateID).Value()
-		return &tmp, nil
+// forbiddenErr wraps ErrMethodForbidden with the refused method's name
+func forbiddenErr(method string) error {
+	return fmt.Errorf("%s: %w", method, ErrMethodForbidden)
+}
+
+// cachedPtr resolves a *V through cache keyed by key: a hit returns a copy of the cached value,
+// a miss calls fetch, stores its dereferenced result (propagating a fetch error as-is, without
+// caching it) and returns it. Shared by every AgglayerClientCache method returning a pointer
+func cachedPtr[K comparable, V any](cache *ttlcache.Cache[K, V], key K, fetch func() (*V, error)) (*V, error) {
+	cache.DeleteExpired()
+	if item := cache.Get(key); item != nil {
+		v := item.Value()
+		return &v, nil
 	}
 
-	certificateHeader, err := c.agglayerClient.GetCertificateHeader(ctx, certificateID)
+	v, err := fetch()
 	if err != nil {
 		return nil, err
 	}
-
-	// if DefaultTTL is set, the cache will use the TTL from the cache configuration
-	// defined in the NewCertificateCache function
-	c.cache.Set(certificateID, *certificateHeader, ttlcache.DefaultTTL)
-
-	return certificateHeader, nil
+	cache.Set(key, *v, ttlcache.DefaultTTL)
+	return v, nil
 }
 
-// SendCertificate sends a certificate to the Agglayer client. (no cache)
+// cachedVal is cachedPtr's counterpart for a method returning V by value instead of *V (see
+// GetNetworkInfo)
+func cachedVal[K comparable, V any](cache *ttlcache.Cache[K, V], key K, fetch func() (V, error)) (V, error) {
+	cache.DeleteExpired()
+	if item := cache.Get(key); item != nil {
+		return item.Value(), nil
+	}
+
+	v, err := fetch()
+	if err != nil {
+		var zero V
+		return zero, err
+	}
+	cache.Set(key, v, ttlcache.DefaultTTL)
+	return v, nil
+}
+
+// SendCertificate sends a certificate to the Agglayer client, per c.policy.SendCertificate
+// (MethodPolicyCached is never a possible value here, see CacheConfig.Validate)
 func (c *AgglayerClientCache) SendCertificate(
 	ctx context.Context,
 	certificate *agglayertypes.Certificate) (common.Hash, error) {
+	if c.policy.SendCertificate.effective() == MethodPolicyForbidden {
+		return common.Hash{}, forbiddenErr("SendCertificate")
+	}
 	return c.agglayerClient.SendCertificate(ctx, certificate)
 }
 
-// GetEpochConfiguration retrieves the current epoch configuration from the Agglayer client. (no cache)
-func (c *AgglayerClientCache) GetEpochConfiguration(ctx context.Context) (*agglayertypes.ClockConfiguration, error) {
-	return c.agglayerClient.GetEpochConfiguration(ctx)
+// GetCertificateHeader retrieves the certificate header for certificateID, per
+// c.policy.GetCertificateHeader
+func (c *AgglayerClientCache) GetCertificateHeader(
+	ctx context.Context, certificateID common.Hash) (*agglayertypes.CertificateHeader, error) {
+	switch c.policy.GetCertificateHeader.effective() {
+	case MethodPolicyForbidden:
+		return nil, forbiddenErr("GetCertificateHeader")
+	case MethodPolicyCached:
+		return cachedPtr(c.certificateHeaderCache, certificateID, func() (*agglayertypes.CertificateHeader, error) {
+			return c.agglayerClient.GetCertificateHeader(ctx, certificateID)
+		})
+	default: // MethodPolicyPassthrough
+		return c.agglayerClient.GetCertificateHeader(ctx, certificateID)
+	}
 }
 
-// GetLatestSettledCertificateHeader retrieves the latest settled certificate header for a given network ID. (no cache)
+// GetEpochConfiguration retrieves the current epoch configuration, per
+// c.policy.GetEpochConfiguration
+func (c *AgglayerClientCache) GetEpochConfiguration(ctx context.Context) (*agglayertypes.ClockConfiguration, error) {
+	switch c.policy.GetEpochConfiguration.effective() {
+	case MethodPolicyForbidden:
+		return nil, forbiddenErr("GetEpochConfiguration")
+	case MethodPolicyCached:
+		return cachedPtr(c.epochConfigurationCache, struct{}{}, func() (*agglayertypes.ClockConfiguration, error) {
+			return c.agglayerClient.GetEpochConfiguration(ctx)
+		})
+	default: // MethodPolicyPassthrough
+		return c.agglayerClient.GetEpochConfiguration(ctx)
+	}
+}
+
+// GetLatestSettledCertificateHeader retrieves the latest settled certificate header for
+// networkID, per c.policy.GetLatestSettledCertificateHeader
 func (c *AgglayerClientCache) GetLatestSettledCertificateHeader(ctx context.Context,
 	networkID uint32) (*agglayertypes.CertificateHeader, error) {
-	return c.agglayerClient.GetLatestSettledCertificateHeader(ctx, networkID)
+	switch c.policy.GetLatestSettledCertificateHeader.effective() {
+	case MethodPolicyForbidden:
+		return nil, forbiddenErr("GetLatestSettledCertificateHeader")
+	case MethodPolicyCached:
+		return cachedPtr(c.latestSettledCertHeaderCache, networkID, func() (*agglayertypes.CertificateHeader, error) {
+			return c.agglayerClient.GetLatestSettledCertificateHeader(ctx, networkID)
+		})
+	default: // MethodPolicyPassthrough
+		return c.agglayerClient.GetLatestSettledCertificateHeader(ctx, networkID)
+	}
 }
 
-// GetLatestPendingCertificateHeader retrieves the latest pending certificate header for a given network ID. (no cache)
+// GetLatestPendingCertificateHeader retrieves the latest pending certificate header for
+// networkID, per c.policy.GetLatestPendingCertificateHeader
 func (c *AgglayerClientCache) GetLatestPendingCertificateHeader(ctx context.Context,
 	networkID uint32) (*agglayertypes.CertificateHeader, error) {
-	return c.agglayerClient.GetLatestPendingCertificateHeader(ctx, networkID)
+	switch c.policy.GetLatestPendingCertificateHeader.effective() {
+	case MethodPolicyForbidden:
+		return nil, forbiddenErr("GetLatestPendingCertificateHeader")
+	case MethodPolicyCached:
+		return cachedPtr(c.latestPendingCertHeaderCache, networkID, func() (*agglayertypes.CertificateHeader, error) {
+			return c.agglayerClient.GetLatestPendingCertificateHeader(ctx, networkID)
+		})
+	default: // MethodPolicyPassthrough
+		return c.agglayerClient.GetLatestPendingCertificateHeader(ctx, networkID)
+	}
 }
 
-// GetNetworkInfo retrieves the network state for a given network ID from the Agglayer client. (no cache)
+// GetNetworkInfo retrieves the network state for networkID, per c.policy.GetNetworkInfo
 func (c *AgglayerClientCache) GetNetworkInfo(
 	ctx context.Context, networkID uint32) (agglayertypes.NetworkInfo, error) {
-	return c.agglayerClient.GetNetworkInfo(ctx, networkID)
+	switch c.policy.GetNetworkInfo.effective() {
+	case MethodPolicyForbidden:
+		return agglayertypes.NetworkInfo{}, forbiddenErr("GetNetworkInfo")
+	case MethodPolicyCached:
+		return cachedVal(c.networkInfoCache, networkID, func() (agglayertypes.NetworkInfo, error) {
+			return c.agglayerClient.GetNetworkInfo(ctx, networkID)
+		})
+	default: // MethodPolicyPassthrough
+		return c.agglayerClient.GetNetworkInfo(ctx, networkID)
+	}
 }

--- a/agglayer/agglayer_client_cache.go
+++ b/agglayer/agglayer_client_cache.go
@@ -194,7 +194,12 @@ func forbiddenErr(method string) error {
 
 // cachedPtr resolves a *V through cache keyed by key: a hit returns a copy of the cached value,
 // a miss calls fetch, stores its dereferenced result (propagating a fetch error as-is, without
-// caching it) and returns it. Shared by every AgglayerClientCache method returning a pointer
+// caching it) and returns it. Shared by every AgglayerClientCache method returning a pointer.
+// A (nil, nil) result -- a legitimate "nothing to report" answer for e.g.
+// GetLatestPendingCertificateHeader when there is no pending certificate, not an error -- is
+// passed through as-is and never cached: caching it would need a sentinel to tell "no result" apart
+// from V's own zero value, and every miss just falls through to fetch again, exactly as if this
+// method were MethodPolicyPassthrough for that key until a real result appears
 func cachedPtr[K comparable, V any](cache *ttlcache.Cache[K, V], key K, fetch func() (*V, error)) (*V, error) {
 	cache.DeleteExpired()
 	if item := cache.Get(key); item != nil {
@@ -203,8 +208,8 @@ func cachedPtr[K comparable, V any](cache *ttlcache.Cache[K, V], key K, fetch fu
 	}
 
 	v, err := fetch()
-	if err != nil {
-		return nil, err
+	if err != nil || v == nil {
+		return v, err
 	}
 	cache.Set(key, *v, ttlcache.DefaultTTL)
 	return v, nil

--- a/agglayer/agglayer_client_cache_test.go
+++ b/agglayer/agglayer_client_cache_test.go
@@ -231,3 +231,43 @@ func TestGetEpochConfigurationCachedGlobally(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, clockCfg, got)
 }
+
+// TestCachedPtrNilResultIsNeverCached pins that a (nil, nil) result -- the legitimate
+// "nothing to report" answer GetLatestPendingCertificateHeader gives when there is no pending
+// certificate for the network, not an error -- is passed through as-is without panicking, and
+// is never cached: every subsequent call for that key reaches the underlying client again
+// until a real, non-nil result appears
+func TestCachedPtrNilResultIsNeverCached(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
+	cfg := cachedConfig(time.Minute, 10)
+	cfg.GetLatestPendingCertificateHeader = MethodPolicyCached
+	cache := NewAgglayerClientCache(mockAgglayerClient, cfg)
+
+	// no pending certificate for this network: the real client behavior being regression-tested
+	mockAgglayerClient.EXPECT().GetLatestPendingCertificateHeader(ctx, uint32(1)).Return(nil, nil).Twice()
+
+	got, err := cache.GetLatestPendingCertificateHeader(ctx, 1)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// a second call is NOT a cache hit (the .Twice() above would fail otherwise): nil is never
+	// cached, so this reaches the underlying client again instead of dereferencing a nil pointer
+	got, err = cache.GetLatestPendingCertificateHeader(ctx, 1)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// once a real pending certificate shows up, it is cached normally
+	header := &agglayertypes.CertificateHeader{NetworkID: 1}
+	mockAgglayerClient.EXPECT().GetLatestPendingCertificateHeader(ctx, uint32(1)).Return(header, nil).Once()
+
+	got, err = cache.GetLatestPendingCertificateHeader(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, header, got)
+
+	got, err = cache.GetLatestPendingCertificateHeader(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, header, got)
+}

--- a/agglayer/agglayer_client_cache_test.go
+++ b/agglayer/agglayer_client_cache_test.go
@@ -8,10 +8,17 @@ import (
 
 	"github.com/agglayer/aggkit/agglayer/mocks"
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
+	configtypes "github.com/agglayer/aggkit/config/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/require"
 )
+
+// cachedConfig returns a CacheConfig with the given TTL/capacity and every method left unset
+// (MethodPolicyPassthrough), for tests that only care about one method's policy
+func cachedConfig(ttl time.Duration, capacity uint64) CacheConfig {
+	return CacheConfig{TTL: configtypes.Duration{Duration: ttl}, Capacity: capacity}
+}
 
 func TestGetCertificateHeader(t *testing.T) {
 	t.Parallel()
@@ -21,14 +28,14 @@ func TestGetCertificateHeader(t *testing.T) {
 	checkHasCertFn := func(certCache *AgglayerClientCache, expectedCert *agglayertypes.CertificateHeader, certID common.Hash) {
 		certificateHeader, err := certCache.GetCertificateHeader(ctx, certID)
 		require.NoError(t, err)
-		require.True(t, certCache.cache.Has(certID)) // Ensure the cache has the certificate
+		require.True(t, certCache.certificateHeaderCache.Has(certID)) // Ensure the cache has the certificate
 		require.Equal(t, expectedCert, certificateHeader)
 	}
 
 	checkCacheIsEmptyFn := func(certCache *AgglayerClientCache, certID common.Hash, ttl time.Duration) {
 		time.Sleep(ttl)
-		require.False(t, certCache.cache.Has(certID)) // Ensure the cache is empty after TTL
-		require.Zero(t, certCache.cache.Len())
+		require.False(t, certCache.certificateHeaderCache.Has(certID)) // Ensure the cache is empty after TTL
+		require.Zero(t, certCache.certificateHeaderCache.Len())
 	}
 
 	ttl := 500 * time.Millisecond
@@ -42,7 +49,9 @@ func TestGetCertificateHeader(t *testing.T) {
 	}
 
 	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
-	certCache := NewCertificateCache(mockAgglayerClient, ttl, capacity)
+	cfg := cachedConfig(ttl, capacity)
+	cfg.GetCertificateHeader = MethodPolicyCached
+	certCache := NewAgglayerClientCache(mockAgglayerClient, cfg)
 
 	// Test cache doesn't have the certificate header initially
 	mockAgglayerClient.EXPECT().GetCertificateHeader(ctx, certificateID).Return(certificateHeader, nil).Once()
@@ -50,7 +59,7 @@ func TestGetCertificateHeader(t *testing.T) {
 	checkCacheIsEmptyFn(certCache, certificateID, ttl)
 
 	// Test cache has the certificate header after it was fetched
-	certCache.cache.Set(certificateID, *certificateHeader, ttlcache.DefaultTTL)
+	certCache.certificateHeaderCache.Set(certificateID, *certificateHeader, ttlcache.DefaultTTL)
 	checkHasCertFn(certCache, certificateHeader, certificateID)
 	checkCacheIsEmptyFn(certCache, certificateID, ttl)
 
@@ -67,14 +76,14 @@ func TestGetCertificateHeader(t *testing.T) {
 	}
 	mockAgglayerClient.EXPECT().GetCertificateHeader(ctx, newCertID).Return(newCert, nil).Once()
 	checkHasCertFn(certCache, newCert, newCertID)
-	require.False(t, certCache.cache.Has(certificateID)) // Ensure the old certificate is evicted from the cache
+	require.False(t, certCache.certificateHeaderCache.Has(certificateID)) // Ensure the old certificate is evicted
 	checkCacheIsEmptyFn(certCache, certificateID, ttl)
 
 	// Test client returns an error
 	mockAgglayerClient.EXPECT().GetCertificateHeader(ctx, certificateID).Return(nil, errors.New("some error")).Once()
 	_, err := certCache.GetCertificateHeader(ctx, certificateID)
 	require.ErrorContains(t, err, "some error")
-	require.Zero(t, certCache.cache.Len()) // Ensure the cache is empty after
+	require.Zero(t, certCache.certificateHeaderCache.Len()) // Ensure the cache is empty after
 }
 
 func TestExpiration(t *testing.T) {
@@ -90,7 +99,9 @@ func TestExpiration(t *testing.T) {
 	}
 
 	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
-	certCache := NewCertificateCache(mockAgglayerClient, ttl, capacity)
+	cfg := cachedConfig(ttl, capacity)
+	cfg.GetCertificateHeader = MethodPolicyCached
+	certCache := NewAgglayerClientCache(mockAgglayerClient, cfg)
 
 	mockAgglayerClient.EXPECT().GetCertificateHeader(t.Context(), certificateID).Return(certificateHeader, nil).Times(2)
 	// Insert item on cache
@@ -103,4 +114,120 @@ func TestExpiration(t *testing.T) {
 	// Cache is expire and request again the Certificate
 	_, err = certCache.GetCertificateHeader(t.Context(), certificateID)
 	require.NoError(t, err)
+}
+
+// TestMethodPolicyPassthroughIsTheDefault pins that a method left unset in CacheConfig behaves
+// as MethodPolicyPassthrough: every call reaches the underlying client, none are served from
+// cache
+func TestMethodPolicyPassthroughIsTheDefault(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
+	cache := NewAgglayerClientCache(mockAgglayerClient, cachedConfig(time.Minute, 10))
+
+	header := &agglayertypes.CertificateHeader{NetworkID: 1}
+	mockAgglayerClient.EXPECT().GetLatestSettledCertificateHeader(ctx, uint32(1)).Return(header, nil).Twice()
+
+	_, err := cache.GetLatestSettledCertificateHeader(ctx, 1)
+	require.NoError(t, err)
+	_, err = cache.GetLatestSettledCertificateHeader(ctx, 1)
+	require.NoError(t, err)
+	// mockery enforces the exact .Twice() call count via t.Cleanup: a cache hit on the second
+	// call would leave one expected call unfulfilled and fail the test
+}
+
+// TestMethodPolicyForbidden pins that every AgglayerClientInterface method configured as
+// MethodPolicyForbidden fails with ErrMethodForbidden without ever reaching the underlying
+// client: mockAgglayerClient has no expectations set up at all, so an accidental pass-through
+// would panic the test instead of silently succeeding
+func TestMethodPolicyForbidden(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
+	cache := NewAgglayerClientCache(mockAgglayerClient, CacheConfig{
+		TTL:                               configtypes.Duration{Duration: time.Minute},
+		Capacity:                          10,
+		SendCertificate:                   MethodPolicyForbidden,
+		GetCertificateHeader:              MethodPolicyForbidden,
+		GetEpochConfiguration:             MethodPolicyForbidden,
+		GetLatestSettledCertificateHeader: MethodPolicyForbidden,
+		GetLatestPendingCertificateHeader: MethodPolicyForbidden,
+		GetNetworkInfo:                    MethodPolicyForbidden,
+	})
+
+	_, err := cache.SendCertificate(ctx, &agglayertypes.Certificate{})
+	require.ErrorIs(t, err, ErrMethodForbidden)
+
+	_, err = cache.GetCertificateHeader(ctx, common.Hash{})
+	require.ErrorIs(t, err, ErrMethodForbidden)
+
+	_, err = cache.GetEpochConfiguration(ctx)
+	require.ErrorIs(t, err, ErrMethodForbidden)
+
+	_, err = cache.GetLatestSettledCertificateHeader(ctx, 1)
+	require.ErrorIs(t, err, ErrMethodForbidden)
+
+	_, err = cache.GetLatestPendingCertificateHeader(ctx, 1)
+	require.ErrorIs(t, err, ErrMethodForbidden)
+
+	_, err = cache.GetNetworkInfo(ctx, 1)
+	require.ErrorIs(t, err, ErrMethodForbidden)
+}
+
+// TestGetNetworkInfoCachedByNetworkID pins that a cached GetNetworkInfo (a value, not a
+// pointer, unlike every other cached method) is keyed by network id: repeating a call for the
+// same network is a hit, a different network id is its own entry
+func TestGetNetworkInfoCachedByNetworkID(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
+	cfg := cachedConfig(time.Minute, 10)
+	cfg.GetNetworkInfo = MethodPolicyCached
+	cache := NewAgglayerClientCache(mockAgglayerClient, cfg)
+
+	info1 := agglayertypes.NetworkInfo{NetworkID: 1, Status: "active"}
+	info2 := agglayertypes.NetworkInfo{NetworkID: 2, Status: "syncing"}
+	mockAgglayerClient.EXPECT().GetNetworkInfo(ctx, uint32(1)).Return(info1, nil).Once()
+	mockAgglayerClient.EXPECT().GetNetworkInfo(ctx, uint32(2)).Return(info2, nil).Once()
+
+	got, err := cache.GetNetworkInfo(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, info1, got)
+
+	// repeated call for the same network: served from cache (the .Once() above still holds)
+	got, err = cache.GetNetworkInfo(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, info1, got)
+
+	// a different network id is a separate cache entry
+	got, err = cache.GetNetworkInfo(ctx, 2)
+	require.NoError(t, err)
+	require.Equal(t, info2, got)
+}
+
+// TestGetEpochConfigurationCachedGlobally pins that GetEpochConfiguration -- the only cached
+// method with no network id or hash argument -- caches a single global entry shared by every
+// call
+func TestGetEpochConfigurationCachedGlobally(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockAgglayerClient := mocks.NewAgglayerClientMock(t)
+	cfg := cachedConfig(time.Minute, 10)
+	cfg.GetEpochConfiguration = MethodPolicyCached
+	cache := NewAgglayerClientCache(mockAgglayerClient, cfg)
+
+	clockCfg := &agglayertypes.ClockConfiguration{EpochDuration: 10, GenesisBlock: 100}
+	mockAgglayerClient.EXPECT().GetEpochConfiguration(ctx).Return(clockCfg, nil).Once()
+
+	got, err := cache.GetEpochConfiguration(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clockCfg, got)
+
+	got, err = cache.GetEpochConfiguration(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clockCfg, got)
 }

--- a/agglayer/client.go
+++ b/agglayer/client.go
@@ -42,8 +42,7 @@ func NewAgglayerClient(cfg ClientConfig, logger aggkitcommon.Logger) (AgglayerCl
 		return nil, err
 	}
 	if cfg.Cached {
-		client = NewCertificateCache(
-			client, cfg.ConfigurationCache.TTL.Duration, cfg.ConfigurationCache.Capacity)
+		client = NewAgglayerClientCache(client, *cfg.ConfigurationCache)
 	}
 
 	// Apply rate limiting wrapper if any rate limits are configured

--- a/agglayer/config.go
+++ b/agglayer/config.go
@@ -21,7 +21,10 @@ func (a APIRateLimitConfig) String() string {
 }
 
 type ClientConfig struct {
-	GRPC               *aggkitgrpc.ClientConfig
+	GRPC *aggkitgrpc.ClientConfig
+	// Cached is the master switch for the response cache/policy wrapper (see CacheConfig):
+	// false ignores every per-method policy in ConfigurationCache and calls the underlying
+	// agglayer client directly for all methods, exactly as if none were configured.
 	Cached             bool
 	ConfigurationCache *CacheConfig
 	// APIRateLimits defines rate limiting configuration for specific API methods

--- a/agglayer/config_test.go
+++ b/agglayer/config_test.go
@@ -26,8 +26,9 @@ var (
 		},
 		Cached: true,
 		ConfigurationCache: &CacheConfig{
-			TTL:      types.Duration{Duration: time.Second},
-			Capacity: 100,
+			TTL:                  types.Duration{Duration: time.Second},
+			Capacity:             100,
+			GetCertificateHeader: MethodPolicyCached,
 		},
 	}
 	testValidConfigWithRateLimits = ClientConfig{
@@ -88,6 +89,45 @@ func TestClientConfigValidate(t *testing.T) {
 			config:      &testValidConfigWithRateLimits,
 			expectedErr: "",
 		},
+		{
+			name: "invalid config - unknown method policy",
+			config: &ClientConfig{
+				GRPC:   testValidConfigExampleNoCache.GRPC,
+				Cached: true,
+				ConfigurationCache: &CacheConfig{
+					TTL:                  types.Duration{Duration: time.Second},
+					Capacity:             100,
+					GetCertificateHeader: MethodPolicy("bogus"),
+				},
+			},
+			expectedErr: "invalid method policy",
+		},
+		{
+			name: "invalid config - SendCertificate cannot be cached",
+			config: &ClientConfig{
+				GRPC:   testValidConfigExampleNoCache.GRPC,
+				Cached: true,
+				ConfigurationCache: &CacheConfig{
+					TTL:             types.Duration{Duration: time.Second},
+					Capacity:        100,
+					SendCertificate: MethodPolicyCached,
+				},
+			},
+			expectedErr: "SendCertificate cannot use",
+		},
+		{
+			name: "valid config - SendCertificate forbidden, unlisted methods default to passthrough",
+			config: &ClientConfig{
+				GRPC:   testValidConfigExampleNoCache.GRPC,
+				Cached: true,
+				ConfigurationCache: &CacheConfig{
+					TTL:             types.Duration{Duration: time.Second},
+					Capacity:        100,
+					SendCertificate: MethodPolicyForbidden,
+				},
+			},
+			expectedErr: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -101,4 +141,17 @@ func TestClientConfigValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMethodPolicyEffectiveDefaultsUnsetToPassthrough pins that the zero value MethodPolicy ("")
+// is valid and resolves to MethodPolicyPassthrough -- a method simply left out of configuration
+func TestMethodPolicyEffectiveDefaultsUnsetToPassthrough(t *testing.T) {
+	var unset MethodPolicy
+	require.NoError(t, unset.Validate())
+	require.Equal(t, MethodPolicyPassthrough, unset.effective())
+
+	require.NoError(t, MethodPolicyCached.Validate())
+	require.NoError(t, MethodPolicyPassthrough.Validate())
+	require.NoError(t, MethodPolicyForbidden.Validate())
+	require.ErrorContains(t, MethodPolicy("bogus").Validate(), "invalid method policy")
 }

--- a/config/default.go
+++ b/config/default.go
@@ -289,6 +289,12 @@ TriggerCertMode = "Auto"
 		[AggSender.AgglayerClient.ConfigurationCache]
 			TTL = "5m"
 			Capacity = 100
+			SendCertificate = "passthrough"
+			GetCertificateHeader = "cached"
+			GetEpochConfiguration = "passthrough"
+			GetLatestSettledCertificateHeader = "passthrough"
+			GetLatestPendingCertificateHeader = "passthrough"
+			GetNetworkInfo = "passthrough"
 		[AggSender.AgglayerClient.GRPC]
 			URL = "{{AggLayerURL}}"
 			MinConnectTimeout = "5s"
@@ -379,6 +385,7 @@ BlockFinalityForL1InfoTree = "{{AggSender.BlockFinalityForL1InfoTree}}"
 	[Validator.AgglayerClient.ConfigurationCache]
 		TTL = "5m"
 		Capacity = 100
+		GetCertificateHeader = "cached"
 	[Validator.AgglayerClient.GRPC]
 		URL = "{{AggSender.AgglayerClient.GRPC.URL}}"
 		MinConnectTimeout = "{{AggSender.AgglayerClient.GRPC.MinConnectTimeout}}"

--- a/config/default.go
+++ b/config/default.go
@@ -385,7 +385,12 @@ BlockFinalityForL1InfoTree = "{{AggSender.BlockFinalityForL1InfoTree}}"
 	[Validator.AgglayerClient.ConfigurationCache]
 		TTL = "5m"
 		Capacity = 100
+		SendCertificate = "passthrough"
 		GetCertificateHeader = "cached"
+		GetEpochConfiguration = "passthrough"
+		GetLatestSettledCertificateHeader = "passthrough"
+		GetLatestPendingCertificateHeader = "passthrough"
+		GetNetworkInfo = "passthrough"
 	[Validator.AgglayerClient.GRPC]
 		URL = "{{AggSender.AgglayerClient.GRPC.URL}}"
 		MinConnectTimeout = "{{AggSender.AgglayerClient.GRPC.MinConnectTimeout}}"

--- a/docs/bridgetracker.md
+++ b/docs/bridgetracker.md
@@ -78,6 +78,11 @@ Cached = true
 [Tracker.AgglayerClient.ConfigurationCache]
 TTL = "1s"
 Capacity = 100
+SendCertificate = "forbidden"
+GetCertificateHeader = "cached"
+GetEpochConfiguration = "cached"
+GetLatestPendingCertificateHeader = "cached"
+GetNetworkInfo = "cached"
 [Tracker.AgglayerClient.GRPC]
 URL = "https://agglayer-dev.polygon.technology"
 UseTLS = false
@@ -94,7 +99,13 @@ UseTLS = false
 - `MaxTrackedBridges`: caps the in-memory supervised list; a request beyond it fails instead of
   registering the bridge.
 - `AgglayerClient`: the client used to resolve an L2-originated bridge's covering certificate and
-  its status (`PendingInclusion`/`CertificatePending`/`WaitL1SettledGER`).
+  its status (`PendingInclusion`/`CertificatePending`/`WaitL1SettledGER`). `Cached` is the master
+  switch for `ConfigurationCache`'s per-method policy (`false` ignores it entirely). Each method
+  is `cached` (served from its own TTL cache), `passthrough` (always calls the agglayer directly,
+  the default for a method left unset), or `forbidden` (refused without ever reaching the
+  agglayer — the tracker only ever reads agglayer state, so `SendCertificate` is forbidden here).
+  `GetLatestSettledCertificateHeader` is intentionally left unset (passthrough): its "latest"
+  answer must always be fresh.
 
 ## API Documentation
 

--- a/proxy/config/default.go
+++ b/proxy/config/default.go
@@ -41,6 +41,12 @@ Cached = true
 [Tracker.AgglayerClient.ConfigurationCache]
 TTL = "1s"
 Capacity = 100
+# The tracker only ever reads agglayer state -- it must never be able to submit a certificate.
+SendCertificate = "forbidden"
+GetCertificateHeader = "cached"
+GetEpochConfiguration = "cached"
+GetLatestPendingCertificateHeader = "cached"
+GetNetworkInfo = "cached"
 [Tracker.AgglayerClient.GRPC]
 #URL = "https://agglayer-dev.polygon.technology"
 UseTLS = false


### PR DESCRIPTION
## 🔄 Changes Summary
- Replace the hardcoded "only `GetCertificateHeader` is cached" behavior with a per-method
  policy on `CacheConfig`: each `AgglayerClientInterface` method (`SendCertificate`,
  `GetCertificateHeader`, `GetEpochConfiguration`, `GetLatestSettledCertificateHeader`,
  `GetLatestPendingCertificateHeader`, `GetNetworkInfo`) can be set to `cached`, `passthrough`
  (the default for a method left unset) or `forbidden` (refused immediately with
  `ErrMethodForbidden`, without ever reaching the underlying client).
- Lets the bridge tracker collapse repeated per-bridge agglayer calls (e.g. several tracked
  L2->Lx bridges on the same origin network asking for the same certificate) into one cached
  call per network instead of one per tracked bridge.
- `agglayer_client_cache.go`: the cache decorator now builds one typed `ttlcache` per cacheable
  method (keyed by the method's own arguments — hash, network id, or a single global entry for
  `GetEpochConfiguration`) and dispatches per the configured policy. Every per-method
  `ttlcache.Cache` is safe for concurrent use on its own, and policy is read-only after
  construction, so the decorator needs no additional locking.
- `ClientConfig.Cached` stays the master switch: `false` ignores every per-method policy (all
  passthrough), matching prior behavior.
- `CacheConfig.Validate` rejects an unknown policy string and rejects `cached` for
  `SendCertificate` (a mutating call — caching it would silently skip submitting a certificate).

## ⚠️ Breaking Changes
- 🛠️ **Config**: `CacheConfig` gains 6 new per-method fields. `Cached=true` alone no longer
  implies `GetCertificateHeader` caching — each client config now explicitly opts individual
  methods into `cached` (see Config Updates below for what each existing deployment gets).

## 📋 Config Updates
- 🧾 **Tracker (proxy)** — `SendCertificate=forbidden` (the tracker only ever reads agglayer
  state), `GetCertificateHeader`/`GetEpochConfiguration`/`GetLatestPendingCertificateHeader=cached`;
  `GetLatestSettledCertificateHeader` left as `passthrough` (must always be fresh):
  ```toml
  [Tracker.AgglayerClient.ConfigurationCache]
  TTL = "1s"
  Capacity = 100
  SendCertificate = "forbidden"
  GetCertificateHeader = "cached"
  GetEpochConfiguration = "cached"
  GetLatestPendingCertificateHeader = "cached"
  GetNetworkInfo = "cached"
  ```
- 🧾 **AggSender** — `GetCertificateHeader=cached`, everything else `passthrough`; `Cached`
  stays `false` by default, unchanged:
  ```toml
  [AggSender.AgglayerClient.ConfigurationCache]
  TTL = "5m"
  Capacity = 100
  SendCertificate = "passthrough"
  GetCertificateHeader = "cached"
  GetEpochConfiguration = "passthrough"
  GetLatestSettledCertificateHeader = "passthrough"
  GetLatestPendingCertificateHeader = "passthrough"
  GetNetworkInfo = "passthrough"
  ```
- 🧾 **Validator** — explicit `GetCertificateHeader=cached` added to preserve its previous
  implicit caching behavior (it already had `Cached=true`, which no longer caches anything by
  itself under the new per-method model).

## ✅ Testing
- 🤖 **Automatic**: `go test ./agglayer/... ./config/... ./proxy/...` (new tests:
  `TestMethodPolicyForbidden`, `TestMethodPolicyPassthroughIsTheDefault`,
  `TestGetNetworkInfoCachedByNetworkID`, `TestGetEpochConfigurationCachedGlobally`, plus
  validation tests for unknown policies and `SendCertificate=cached` rejection);
  `golangci-lint run` on all touched packages — 0 issues; `go build ./...` — clean.
- 🖱️ **Manual**: none required — behavior verified via unit tests with mocked calls.

## 🐞 Issues
- Closes #1755

## 📝 Notes
- `Cached` (bool) is kept as the master on/off switch per explicit design decision: `false`
  ignores every per-method policy, matching the pre-existing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)