### PR TITLE
fix(l1infotreesync): self-heal committed-state divergence by escalating reorg to last verified checkpoint

### DIFF
--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -419,13 +419,17 @@ func (b BridgeSyncRuntimeData) IsCompatible(storage BridgeSyncRuntimeData) (*Bri
 }
 
 type processor struct {
-	syncerID         string
-	db               *sql.DB
-	exitTree         types.FullTreer
-	log              *log.Logger
-	mu               mutex.RWMutex
-	halted           bool
-	haltedReason     string
+	syncerID     string
+	db           *sql.DB
+	exitTree     types.FullTreer
+	log          *log.Logger
+	mu           mutex.RWMutex
+	halted       bool
+	haltedReason string
+	// haltGuardHits counts consecutive isHalted() short-circuits in ProcessBlock, so the
+	// "processor is halted" log can be throttled instead of firing on every call. Reset on
+	// unhalt.
+	haltGuardHits    int
 	dbQueryTimeout   time.Duration
 	bridgeSubscriber aggkitcommon.PubSub[uint64]
 	initialLER       common.Hash
@@ -1015,7 +1019,7 @@ func loadReorgedDepositCounts(tx dbtypes.Txer, fromBlock uint64) (map[uint32]str
 // and updates the last processed block (can be called without events for that purpose)
 func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	if p.isHalted() {
-		p.log.Errorf("processor is halted due to: %s", p.haltedReason)
+		p.logHaltGuardHit()
 		return sync.ErrInconsistentState
 	}
 
@@ -1780,7 +1784,24 @@ func (p *processor) halt(reason string) {
 
 	p.halted = true
 	p.haltedReason = reason
+	p.haltGuardHits = 0
 	p.log.Errorf("processor is halted due to the following reason: %s", reason)
+}
+
+// logHaltGuardHit logs (at a throttled rate) that a call was rejected because the processor is
+// halted. See aggkitcommon.ShouldLogRetryAtError.
+func (p *processor) logHaltGuardHit() {
+	p.mu.Lock()
+	p.haltGuardHits++
+	hits := p.haltGuardHits
+	reason := p.haltedReason
+	p.mu.Unlock()
+
+	if aggkitcommon.ShouldLogRetryAtError(hits) {
+		p.log.Errorf("processor is halted due to: %s (rejected call #%d while halted)", reason, hits)
+	} else {
+		p.log.Debugf("processor is halted due to: %s (rejected call #%d while halted)", reason, hits)
+	}
 }
 
 // unhalt sets the processor to a non-halted state, allowing it to process blocks again
@@ -1790,6 +1811,7 @@ func (p *processor) unhalt() {
 
 	p.halted = false
 	p.haltedReason = ""
+	p.haltGuardHits = 0
 	p.log.Info("processor unhalted")
 }
 

--- a/common/retry_log.go
+++ b/common/retry_log.go
@@ -1,0 +1,21 @@
+package common
+
+// Bounded-retry-logging policy: loops that can retry indefinitely (e.g. a driver retrying a
+// halted processor, or a halted-processor guard that keeps rejecting calls) must not log at
+// error level on every single attempt, since that can produce millions of log lines during a
+// prolonged incident. Instead: log at error level for the first RetryErrorLogBurst attempts,
+// then only every RetryErrorLogInterval-th attempt afterwards; log at debug level otherwise.
+const (
+	RetryErrorLogBurst    = 5
+	RetryErrorLogInterval = 100
+)
+
+// ShouldLogRetryAtError reports whether the given (1-based) attempt/hit count should be logged
+// at error level under the bounded-retry-logging policy described above. Callers should log at
+// debug level when this returns false.
+func ShouldLogRetryAtError(attempt int) bool {
+	if attempt <= 0 {
+		return false
+	}
+	return attempt <= RetryErrorLogBurst || attempt%RetryErrorLogInterval == 0
+}

--- a/common/retry_log_test.go
+++ b/common/retry_log_test.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldLogRetryAtError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		attempt int
+		want    bool
+	}{
+		{name: "attempt 0 is not logged at error", attempt: 0, want: false},
+		{name: "negative attempt is not logged at error", attempt: -1, want: false},
+		{name: "attempt 1 is within the initial burst", attempt: 1, want: true},
+		{name: "attempt 5 is the last of the initial burst", attempt: 5, want: true},
+		{name: "attempt 6 is past the initial burst", attempt: 6, want: false},
+		{name: "attempt 99 is not a multiple of the interval", attempt: 99, want: false},
+		{name: "attempt 100 matches the interval", attempt: 100, want: true},
+		{name: "attempt 199 is not a multiple of the interval", attempt: 199, want: false},
+		{name: "attempt 200 matches the interval", attempt: 200, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, ShouldLogRetryAtError(tt.attempt))
+		})
+	}
+}

--- a/etherman/batch_requests.go
+++ b/etherman/batch_requests.go
@@ -8,6 +8,7 @@ import (
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	aggkittypes "github.com/agglayer/aggkit/types"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"golang.org/x/sync/errgroup"
 )
@@ -18,11 +19,12 @@ type blockRawEth struct {
 	Hash       string `json:"hash"`
 	Timestamp  string `json:"timestamp"` // hex string
 	ParentHash string `json:"parentHash"`
+	LogsBloom  string `json:"logsBloom"` // hex string, empty if not provided
 }
 
 func (b *blockRawEth) String() string {
-	return fmt.Sprintf("{Number=%s, Hash=%s, Timestamp=%s, ParentHash=%s}",
-		b.Number, b.Hash, b.Timestamp, b.ParentHash)
+	return fmt.Sprintf("{Number=%s, Hash=%s, Timestamp=%s, ParentHash=%s, LogsBloom=%s}",
+		b.Number, b.Hash, b.Timestamp, b.ParentHash, b.LogsBloom)
 }
 
 func (b *blockRawEth) ToBlockHeader() (*aggkittypes.BlockHeader, error) {
@@ -40,11 +42,18 @@ func (b *blockRawEth) ToBlockHeader() (*aggkittypes.BlockHeader, error) {
 	hash := common.HexToHash(b.Hash)
 	parentHash := common.HexToHash(b.ParentHash)
 
+	var logsBloom *ethtypes.Bloom
+	if b.LogsBloom != "" {
+		bloom := ethtypes.BytesToBloom(common.FromHex(b.LogsBloom))
+		logsBloom = &bloom
+	}
+
 	return &aggkittypes.BlockHeader{
 		Number:     number,
 		Hash:       hash,
 		Time:       timeStamp,
 		ParentHash: &parentHash,
+		LogsBloom:  logsBloom,
 	}, nil
 }
 

--- a/etherman/batch_requests_test.go
+++ b/etherman/batch_requests_test.go
@@ -10,12 +10,47 @@ import (
 	aggkittypes "github.com/agglayer/aggkit/types"
 	mockaggkittypes "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBlockRawEth_ToBlockHeader(t *testing.T) {
+	t.Run("populates logs bloom when present", func(t *testing.T) {
+		var bloom ethtypes.Bloom
+		bloom.Add(common.HexToAddress("0xaaaa").Bytes())
+		raw := &blockRawEth{
+			Number:     "0x1",
+			Hash:       "0xabc",
+			Timestamp:  "0x123",
+			ParentHash: "0xdef",
+			LogsBloom:  "0x" + common.Bytes2Hex(bloom.Bytes()),
+		}
+
+		header, err := raw.ToBlockHeader()
+
+		require.NoError(t, err)
+		require.NotNil(t, header.LogsBloom)
+		require.Equal(t, bloom, *header.LogsBloom)
+	})
+
+	t.Run("leaves logs bloom nil when absent", func(t *testing.T) {
+		raw := &blockRawEth{
+			Number:     "0x1",
+			Hash:       "0xabc",
+			Timestamp:  "0x123",
+			ParentHash: "0xdef",
+		}
+
+		header, err := raw.ToBlockHeader()
+
+		require.NoError(t, err)
+		require.Nil(t, header.LogsBloom)
+	})
+}
 
 func TestRetrieveBlockHeadersBatchExploratory(t *testing.T) {
 	t.Skip("This test is for exploratory purposes to check the behavior of batch requests" +

--- a/l1infotreesync/e2e_committed_state_selfheal_test.go
+++ b/l1infotreesync/e2e_committed_state_selfheal_test.go
@@ -1,0 +1,237 @@
+package l1infotreesync
+
+import (
+	"context"
+	"path"
+	gosync "sync"
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/log"
+	mdrsync "github.com/agglayer/aggkit/multidownloader/sync"
+	mdrsynctypes "github.com/agglayer/aggkit/multidownloader/sync/types"
+	aggkitsync "github.com/agglayer/aggkit/sync"
+	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedPoisonDownloader is a hand-written mdrsynctypes.DownloaderInterface that plays back a
+// fixed script of blocks, simulating a flaky RPC that silently omitted the UpdateL1InfoTree/V2
+// logs for one specific block exactly once (the bokuto incident, 2026-08-05). It is a deliberate
+// simplification of a full multidownloader+simulated-chain e2e test (as in
+// e2e_reorg_halt_test.go): driving the real multidownloader stack showed that its own
+// unsafe/safe block cache replays an already-fetched (poisoned) response on retry rather than
+// re-querying the RPC, which defeats a literal "RPC glitches once" simulation at the ethclient
+// level. Scripting DownloaderInterface directly -- the same seam l1infotreesync.go wires the real
+// downloader into -- lets the test drive the real processor + real multidownloader/sync.EVMDriver
+// (including its withRetry/RetryHandler machinery) through the exact self-healing path while
+// keeping the "RPC" behavior deterministic and inspectable. Every response is counted so the test
+// can assert on the *sequence* of what was served instead of trying to catch transient
+// halted/unhalted states via polling: since there is no real network latency here, a full
+// halt -> shallow-recover -> halt-again -> escalate -> heal cycle can complete in well under a
+// millisecond, faster than any polling interval could reliably observe.
+type scriptedPoisonDownloader struct {
+	mu             gosync.Mutex
+	poisonConsumed bool
+
+	checkpointServed int
+	poisonedServed   int
+	healedServed     int
+	failingServed    int
+
+	checkpointBlock aggkitsync.Block // block 1: leaf0 + a matching checkpoint
+	poisonedBlock   aggkitsync.Block // block 2 as first fetched: 0 events (the dropped logs)
+	healedBlock     aggkitsync.Block // block 2 once re-fetched: leaf1 + a matching checkpoint
+	failingBlock    aggkitsync.Block // block 3: leaf2 + a checkpoint against the REAL (3-leaf) root
+}
+
+func (d *scriptedPoisonDownloader) ChainID(ctx context.Context) (uint64, error) {
+	return 1, nil
+}
+
+func (d *scriptedPoisonDownloader) DownloadNextBlocks(
+	ctx context.Context, fromBlockHeader *aggkittypes.BlockHeader, maxBlocks uint64,
+	syncerConfig aggkittypes.SyncerConfig,
+) (*mdrsynctypes.DownloadResult, error) {
+	var lastProcessed uint64
+	if fromBlockHeader != nil {
+		lastProcessed = fromBlockHeader.Number
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var block aggkitsync.Block
+	switch lastProcessed {
+	case 0:
+		d.checkpointServed++
+		block = d.checkpointBlock
+	case 1:
+		if !d.poisonConsumed {
+			d.poisonConsumed = true
+			d.poisonedServed++
+			block = d.poisonedBlock
+		} else {
+			d.healedServed++
+			block = d.healedBlock
+		}
+	case 2:
+		d.failingServed++
+		block = d.failingBlock
+	default:
+		// Caught up: nothing more to serve.
+		return &mdrsynctypes.DownloadResult{}, nil
+	}
+
+	return &mdrsynctypes.DownloadResult{
+		Data: aggkitsync.EVMBlocks{
+			&aggkitsync.EVMBlock{
+				EVMBlockHeader: aggkitsync.EVMBlockHeader{Num: block.Num, Hash: block.Hash},
+				Events:         block.Events,
+			},
+		},
+		CompletionPercentage: 100,
+	}, nil
+}
+
+func (d *scriptedPoisonDownloader) counts() (checkpoint, poisoned, healed, failing int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.checkpointServed, d.poisonedServed, d.healedServed, d.failingServed
+}
+
+// TestE2E_CommittedStateSelfHeal is a regression test for the bokuto outage (aggkit v0.11.0-rc2,
+// 2026-08-05): a flaky RPC silently drops the UpdateL1InfoTree/V2 logs for one block, so that
+// block commits with a leaf missing and no immediate error -- the divergence is now permanently
+// in already-committed data. Only much later, when a subsequent legitimate UpdateL1InfoTreeV2
+// checkpoint no longer matches the (now short) local tree, does the processor halt, at a block
+// that is *not* where the real divergence lives. Recovering by purging just the failing batch
+// (the pre-fix rc2 behavior, PR #1738) can never reach the divergence and loops forever (observed
+// on bokuto: ~90s per attempt, 13+ hours straight). This test asserts the desired self-healing
+// behavior: the second consecutive halt at the same block escalates the purge back to the last
+// verified checkpoint, which reaches (and re-downloads, now correctly) the block with the missing
+// leaf, and the syncer fully recovers.
+func TestE2E_CommittedStateSelfHeal(t *testing.T) {
+	ctx := context.Background()
+
+	leaf0 := &UpdateL1InfoTree{
+		MainnetExitRoot: common.HexToHash("0xaa"), RollupExitRoot: common.Hash{},
+		ParentHash: common.HexToHash("0x01"), Timestamp: 1,
+	}
+	leaf1 := &UpdateL1InfoTree{
+		MainnetExitRoot: common.HexToHash("0xbb"), RollupExitRoot: common.Hash{},
+		ParentHash: common.HexToHash("0x02"), Timestamp: 2,
+	}
+	leaf2 := &UpdateL1InfoTree{
+		MainnetExitRoot: common.HexToHash("0xcc"), RollupExitRoot: common.Hash{},
+		ParentHash: common.HexToHash("0x03"), Timestamp: 3,
+	}
+
+	// Ground truth: what the real L1 chain's tree looks like after each leaf, computed with a
+	// throwaway processor so the scripted UpdateL1InfoTreeV2 checkpoints stay internally
+	// consistent -- exactly what real events derived from the real chain would contain.
+	realProcessor, err := newProcessor(path.Join(t.TempDir(), "real-chain.sqlite"))
+	require.NoError(t, err)
+	rootAfter := func(blockNum uint64, leaf *UpdateL1InfoTree) (common.Hash, uint32) {
+		require.NoError(t, realProcessor.ProcessBlock(ctx, aggkitsync.Block{
+			Num:    blockNum,
+			Events: []any{Event{UpdateL1InfoTree: leaf}},
+		}))
+		root, err := realProcessor.l1InfoTree.GetLastRoot(realProcessor.db)
+		require.NoError(t, err)
+		return root.Hash, root.Index + 1
+	}
+	root0, leafCount0 := rootAfter(1, leaf0)
+	root1, leafCount1 := rootAfter(2, leaf1)
+	root2, leafCount2 := rootAfter(3, leaf2)
+
+	downloader := &scriptedPoisonDownloader{
+		checkpointBlock: aggkitsync.Block{
+			Num: 1,
+			Events: []any{
+				Event{UpdateL1InfoTree: leaf0},
+				Event{UpdateL1InfoTreeV2: &UpdateL1InfoTreeV2{CurrentL1InfoRoot: root0, LeafCount: leafCount0}},
+			},
+		},
+		poisonedBlock: aggkitsync.Block{Num: 2}, // 0 events: the dropped-log block
+		healedBlock: aggkitsync.Block{
+			Num: 2,
+			Events: []any{
+				Event{UpdateL1InfoTree: leaf1},
+				Event{UpdateL1InfoTreeV2: &UpdateL1InfoTreeV2{CurrentL1InfoRoot: root1, LeafCount: leafCount1}},
+			},
+		},
+		failingBlock: aggkitsync.Block{
+			Num: 3,
+			Events: []any{
+				Event{UpdateL1InfoTree: leaf2},
+				Event{UpdateL1InfoTreeV2: &UpdateL1InfoTreeV2{CurrentL1InfoRoot: root2, LeafCount: leafCount2}},
+			},
+		},
+	}
+
+	p, err := newProcessor(path.Join(t.TempDir(), "syncer.sqlite"))
+	require.NoError(t, err)
+
+	rh := &aggkitsync.RetryHandler{RetryAfterErrorPeriod: 5 * time.Millisecond, MaxRetryAttemptsAfterError: -1}
+	syncerConfig := aggkittypes.SyncerConfig{FromBlock: 0}
+	driver := mdrsync.NewEVMDriver(log.WithFields("test", "committed-poison"), p, downloader, syncerConfig, 1, rh, nil)
+
+	driverCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go driver.Sync(driverCtx, &syncerConfig.FromBlock)
+
+	// --- Recovery (the red/green assertion). Desired post-fix behavior: the syncer processes the
+	// checkpoint block, then silently commits the poisoned block with a leaf missing (no error);
+	// the failing checkpoint at block 3 then halts the processor. The first Reorg only purges
+	// block 3, which can never reach the real, earlier, committed divergence at block 2, so the
+	// processor halts again at the exact same block. That second consecutive halt must escalate
+	// the purge back to the last verified checkpoint (block 1), re-downloading block 2 -- now
+	// correctly, since the one-shot poison was already consumed -- and the syncer must fully
+	// recover. Pre-fix, this never happens: the shallow purge repeats forever and the processor
+	// stays halted (the bokuto incident behavior) -- observable here as failingServed growing
+	// without bound and lastProcessed never reaching 3.
+	require.Eventually(t, func() bool {
+		lastProcessed, found, lastErr := p.GetLastProcessedBlock(ctx)
+		return lastErr == nil && found && !p.isHalted() && lastProcessed >= 3
+	}, 10*time.Second, 2*time.Millisecond,
+		"syncer did not self-heal from the committed-state divergence: the driver keeps retrying the same "+
+			"shallow purge and the processor stays halted")
+
+	// The sequence of what the (fake) RPC actually served proves the desired recovery path was
+	// taken, not just that the final state happens to look right:
+	//  - the poisoned block-2 response was served (and consumed) exactly once: a real flaky-RPC
+	//    glitch is transient, not a permanent malfunction.
+	//  - the failing block-3 checkpoint was served (and failed) at least twice: once triggering
+	//    the first, shallow (no-progress) recovery, and once more triggering the escalation.
+	//  - the checkpoint block was re-served after the escalation purged back to it.
+	//  - the healed block-2 response (with the real, previously-missing leaf) was served during
+	//    the escalated recovery.
+	checkpointServed, poisonedServed, healedServed, failingServed := downloader.counts()
+	require.Equal(t, 1, poisonedServed, "the poisoned response must be consumed exactly once (one-shot glitch)")
+	require.GreaterOrEqual(t, failingServed, 2,
+		"the failing checkpoint must have been retried at least once before escalating")
+	require.GreaterOrEqual(t, checkpointServed, 2,
+		"the checkpoint block must have been re-downloaded after the escalated purge reached it")
+	require.GreaterOrEqual(t, healedServed, 1,
+		"the healed (previously poisoned) block must have been re-downloaded during the escalated recovery")
+
+	// Strengthening: the previously missing leaf must now be present with its real content (the
+	// range was re-downloaded, this time without the RPC glitch), the later leaf must be at its
+	// correct index, and the checkpoint must have advanced past the whole recovered range.
+	info1, err := p.GetInfoByIndex(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), info1.BlockNumber)
+	require.Equal(t, common.HexToHash("0xbb"), info1.MainnetExitRoot)
+
+	info2, err := p.GetInfoByIndex(ctx, 2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), info2.BlockNumber)
+	require.Equal(t, common.HexToHash("0xcc"), info2.MainnetExitRoot)
+
+	checkpointBlockNum, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(3), checkpointBlockNum, "the checkpoint must have advanced past the recovered range")
+}

--- a/l1infotreesync/l1infotreesync.go
+++ b/l1infotreesync/l1infotreesync.go
@@ -81,6 +81,9 @@ func NewMultidownloadBased(
 	if err != nil {
 		return nil, err
 	}
+	// Fallback target for an escalated reorg recovery (see processor.Reorg) when no verified
+	// checkpoint has ever been recorded.
+	processor.initialBlock = cfg.InitialBlock
 	rh := &sync.RetryHandler{
 		RetryAfterErrorPeriod:      cfg.RetryAfterErrorPeriod.Duration,
 		MaxRetryAttemptsAfterError: cfg.MaxRetryAttemptsAfterError,
@@ -158,6 +161,9 @@ func NewLegacy(
 	if err != nil {
 		return nil, err
 	}
+	// Fallback target for an escalated reorg recovery (see processor.Reorg) when no verified
+	// checkpoint has ever been recorded.
+	processor.initialBlock = cfg.InitialBlock
 
 	rh := &sync.RetryHandler{
 		RetryAfterErrorPeriod:      cfg.RetryAfterErrorPeriod.Duration,

--- a/l1infotreesync/migrations/l1infotreesync0005.sql
+++ b/l1infotreesync/migrations/l1infotreesync0005.sql
@@ -1,0 +1,12 @@
+-- +migrate Down
+DROP TABLE IF EXISTS l1info_checkpoint;
+
+-- +migrate Up
+CREATE TABLE l1info_checkpoint (
+    -- single_row_id prevents having more than 1 row in this table
+    single_row_id INTEGER check(single_row_id=1) NOT NULL DEFAULT 1,
+    -- block_num is the last block whose UpdateL1InfoTreeV2 sanity check passed, proving the
+    -- local L1 info tree was consistent with L1 as of that event.
+    block_num     INTEGER NOT NULL,
+    PRIMARY KEY (single_row_id)
+);

--- a/l1infotreesync/migrations/migrations.go
+++ b/l1infotreesync/migrations/migrations.go
@@ -25,13 +25,17 @@ var mig003 string
 //go:embed l1infotreesync0004.sql
 var mig004 string
 
+//go:embed l1infotreesync0005.sql
+var mig005 string
+
 func RunMigrations(dbPath string) error {
-	migrations := make([]types.Migration, 0, 4+2*len(treeMigrations.Migrations)) //nolint:mnd
+	migrations := make([]types.Migration, 0, 5+2*len(treeMigrations.Migrations)) //nolint:mnd
 	migrations = append(migrations,
 		types.Migration{ID: "l1infotreesync0001", SQL: mig001},
 		types.Migration{ID: "l1infotreesync0002", SQL: mig002},
 		types.Migration{ID: "l1infotreesync0003", SQL: mig003},
 		types.Migration{ID: "l1infotreesync0004", SQL: mig004},
+		types.Migration{ID: "l1infotreesync0005", SQL: mig005},
 	)
 	for _, tm := range treeMigrations.Migrations {
 		migrations = append(migrations, types.Migration{

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -34,7 +34,26 @@ type processor struct {
 	mu             mutex.RWMutex
 	halted         bool
 	haltedReason   string
-	log            *log.Logger
+	// haltedBlock is the block number that caused the current halt, when known (set by
+	// haltAtBlock). It's used to detect that a Reorg recovery attempt is being retried at the
+	// same block with no progress, so it can be escalated. nil for halts raised through the
+	// legacy halt(reason) entry point, which carry no block context.
+	haltedBlock *uint64
+	// lastReorgRecoveryBlock remembers the haltedBlock of the most recent Reorg call that was
+	// invoked while the processor was halted. It intentionally survives unhalt/halt cycles: if
+	// the next halt happens at the very same block, the corresponding Reorg call is the second
+	// consecutive recovery attempt for that block, meaning the previous purge made no progress,
+	// and the reorg must be escalated (see Reorg).
+	lastReorgRecoveryBlock *uint64
+	// haltGuardHits counts consecutive isHalted() short-circuits in ProcessBlocks/ProcessBlock,
+	// so the "processor is halted" log can be throttled instead of firing on every call. Reset
+	// on unhalt.
+	haltGuardHits int
+	// initialBlock is the syncer's configured starting block (Config.InitialBlock). It's used as
+	// the fallback escalation target when a Reorg recovery must deepen but no verified checkpoint
+	// has ever been recorded (e.g. a fresh or pre-upgrade DB).
+	initialBlock uint64
+	log          *log.Logger
 }
 
 // UpdateL1InfoTree representation of the UpdateL1InfoTree event
@@ -319,9 +338,25 @@ func (p *processor) GetProcessedBlockUntil(ctx context.Context, blockNum uint64)
 }
 
 // Reorg triggers a purge and reset process on the processor to leaf it on a state
-// as if the last block processed was firstReorgedBlock-1
+// as if the last block processed was firstReorgedBlock-1.
+//
+// Escalation: if this call is recovering from a halt (the processor is currently halted) and the
+// previous Reorg-based recovery attempt was also triggered by a halt at the very same block, then
+// the previous purge made no progress (the processor halted again at the exact same place). This
+// means the actual divergence lies in already-committed data, at or before that block, and
+// firstReorgedBlock (typically the start of the in-memory batch that just failed) can never reach
+// it. In that case the purge is deepened to the last verified checkpoint block (the most recent
+// block whose UpdateL1InfoTreeV2 sanity check passed), or to the syncer's configured initial block
+// if no checkpoint has ever been recorded. This converts a permanent stuck-halt loop into an
+// automatic (if occasionally expensive) self-heal. See haltAtBlock/lastReorgRecoveryBlock.
 func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
-	p.log.Infof("reorging to block %d", firstReorgedBlock)
+	p.mu.Lock()
+	wasHalted := p.halted
+	haltedBlock := p.haltedBlock
+	lastRecoveryBlock := p.lastReorgRecoveryBlock
+	p.mu.Unlock()
+
+	escalate := wasHalted && haltedBlock != nil && lastRecoveryBlock != nil && *lastRecoveryBlock == *haltedBlock
 
 	tx, err := db.NewTx(ctx, p.db)
 	if err != nil {
@@ -337,17 +372,35 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 		}
 	}()
 
-	res, err := tx.Exec(`DELETE FROM block WHERE num >= $1;`, firstReorgedBlock)
+	targetBlock := firstReorgedBlock
+	if escalate {
+		targetBlock, err = p.escalatedReorgTarget(tx, firstReorgedBlock, *haltedBlock)
+		if err != nil {
+			return fmt.Errorf("computing escalated reorg target: %w", err)
+		}
+	}
+
+	p.log.Infof("reorging to block %d", targetBlock)
+
+	res, err := tx.Exec(`DELETE FROM block WHERE num >= $1;`, targetBlock)
 	if err != nil {
 		return err
 	}
 
-	if err = p.l1InfoTree.Reorg(tx, firstReorgedBlock); err != nil {
+	if err = p.l1InfoTree.Reorg(tx, targetBlock); err != nil {
 		return err
 	}
 
-	if err = p.rollupExitTree.Reorg(tx, firstReorgedBlock); err != nil {
+	if err = p.rollupExitTree.Reorg(tx, targetBlock); err != nil {
 		return err
+	}
+
+	// The checkpoint vouches for the data at (and before) its own block: if that block is being
+	// purged, the checkpoint no longer holds and must be cleared, so a future escalation falls
+	// back to an earlier (or, absent any other checkpoint, the initial) block instead of trusting
+	// a checkpoint whose block no longer exists.
+	if err := clearCheckpointBlockAtOrAfterWithTx(tx, targetBlock); err != nil {
+		return fmt.Errorf("clearing stale checkpoint: %w", err)
 	}
 
 	rowsAffected, err := res.RowsAffected()
@@ -359,9 +412,15 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 		return err
 	}
 
-	p.log.Infof("reorged to block %d, %d rows affected", firstReorgedBlock, rowsAffected)
+	p.log.Infof("reorged to block %d, %d rows affected", targetBlock, rowsAffected)
 
 	shouldRollback = false
+
+	if wasHalted && haltedBlock != nil {
+		p.mu.Lock()
+		p.lastReorgRecoveryBlock = haltedBlock
+		p.mu.Unlock()
+	}
 
 	// Unhalt unconditionally: a successfully committed purge leaves the DB at a valid
 	// consolidation point even when it deleted nothing (rowsAffected == 0), because a halt
@@ -370,12 +429,38 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 	p.unhalt()
 	return nil
 }
+
+// escalatedReorgTarget computes the deepened purge target for an escalated Reorg: the last
+// verified checkpoint block, or the syncer's initial block if no checkpoint has ever been
+// recorded. It never purges shallower than firstReorgedBlock (see Reorg).
+func (p *processor) escalatedReorgTarget(tx dbtypes.Querier, firstReorgedBlock, haltedBlock uint64) (uint64, error) {
+	checkpointBlock, hasCheckpoint, err := getCheckpointBlockWithTx(tx)
+	if err != nil {
+		return 0, fmt.Errorf("reading last verified checkpoint: %w", err)
+	}
+
+	if hasCheckpoint {
+		target := min(firstReorgedBlock, checkpointBlock)
+		p.log.Warnf("escalating reorg recovery: processor halted again at block %d after a previous "+
+			"recovery attempt made no progress; deepening purge from %d to the last verified checkpoint "+
+			"block %d (the most recent block known to be consistent with L1)",
+			haltedBlock, firstReorgedBlock, target)
+		return target, nil
+	}
+
+	target := min(firstReorgedBlock, p.initialBlock)
+	p.log.Warnf("escalating reorg recovery: processor halted again at block %d after a previous "+
+		"recovery attempt made no progress, and no verified checkpoint has ever been recorded; "+
+		"deepening purge from %d to the syncer's initial block %d — this forces a full resync of l1infotreesync",
+		haltedBlock, firstReorgedBlock, target)
+	return target, nil
+}
 func (p *processor) ProcessBlocks(ctx context.Context, blocks *mdrsynctypes.DownloadResult) error {
 	if blocks == nil || len(blocks.Data) == 0 {
 		return nil
 	}
 	if p.isHalted() {
-		p.log.Errorf("processor is halted due to: %s", p.haltedReason)
+		p.logHaltGuardHit()
 		return sync.ErrInconsistentState
 	}
 	return p.processBlocksSameTx(ctx, blocks)
@@ -428,7 +513,7 @@ func (p *processor) processBlocksSameTx(ctx context.Context, blocks *mdrsynctype
 // and updates the last processed block (can be called without events for that purpose)
 func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	if p.isHalted() {
-		p.log.Errorf("processor is halted due to: %s", p.haltedReason)
+		p.logHaltGuardHit()
 		return sync.ErrInconsistentState
 	}
 
@@ -538,8 +623,15 @@ func (p *processor) processBlock(tx dbtypes.Txer, block sync.Block) error {
 					root.Index, event.UpdateL1InfoTreeV2.LeafCount,
 					block.Num,
 				)
-				p.halt(errStr)
+				blockNum := block.Num
+				p.haltAtBlock(errStr, &blockNum)
 				return sync.ErrInconsistentState
+			}
+			// The sanity check passed: the local l1-info-tree root matches L1 as of this event, so
+			// block.Num is a verified checkpoint. Persist it in the same tx as the batch so a later
+			// escalated Reorg can safely purge back to (and re-verify) this exact block. See Reorg.
+			if err := setCheckpointBlockWithTx(tx, block.Num); err != nil {
+				return fmt.Errorf("persisting last verified checkpoint at block %d: %w", block.Num, err)
 			}
 		}
 		if event.VerifyBatches != nil {
@@ -573,6 +665,41 @@ func (p *processor) getLastIndex(tx dbtypes.Querier) (uint32, error) {
 		return 0, db.ErrNotFound
 	}
 	return lastProcessedIndex, err
+}
+
+// getCheckpointBlockWithTx returns the last verified checkpoint block (the most recent block
+// whose UpdateL1InfoTreeV2 sanity check passed). found is false if no checkpoint has been
+// recorded yet.
+func getCheckpointBlockWithTx(tx dbtypes.Querier) (blockNum uint64, found bool, err error) {
+	row := tx.QueryRow("SELECT block_num FROM l1info_checkpoint WHERE single_row_id = 1;")
+	err = row.Scan(&blockNum)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return blockNum, true, nil
+}
+
+// setCheckpointBlockWithTx records blockNum as the last verified checkpoint. It must be called
+// within the same tx that commits the batch containing the passing UpdateL1InfoTreeV2 event, so
+// the checkpoint is atomic with the data it vouches for.
+func setCheckpointBlockWithTx(tx dbtypes.Txer, blockNum uint64) error {
+	_, err := tx.Exec(`
+		INSERT INTO l1info_checkpoint (single_row_id, block_num) VALUES (1, $1)
+		ON CONFLICT(single_row_id) DO UPDATE SET block_num = $1;
+	`, blockNum)
+	return err
+}
+
+// clearCheckpointBlockAtOrAfterWithTx deletes the stored checkpoint if its block is being purged
+// by a Reorg down to purgeFromBlock (i.e. the checkpoint's own block is >= purgeFromBlock), since
+// the checkpoint no longer vouches for data that no longer exists. It's a no-op if there is no
+// checkpoint, or if the checkpoint predates purgeFromBlock.
+func clearCheckpointBlockAtOrAfterWithTx(tx dbtypes.Txer, purgeFromBlock uint64) error {
+	_, err := tx.Exec(`DELETE FROM l1info_checkpoint WHERE block_num >= $1;`, purgeFromBlock)
+	return err
 }
 
 func (p *processor) GetFirstL1InfoWithRollupExitRoot(rollupExitRoot common.Hash) (*L1InfoTreeLeaf, error) {
@@ -651,6 +778,13 @@ func (p *processor) isHalted() bool {
 
 // halt sets the processor to a halted state with a reason
 func (p *processor) halt(reason string) {
+	p.haltAtBlock(reason, nil)
+}
+
+// haltAtBlock is like halt, but additionally records the block number that caused the halt, so
+// Reorg can detect that a recovery attempt is being retried at the same block with no progress
+// and escalate accordingly (see Reorg).
+func (p *processor) haltAtBlock(reason string, blockNum *uint64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -660,7 +794,27 @@ func (p *processor) halt(reason string) {
 
 	p.halted = true
 	p.haltedReason = reason
+	p.haltedBlock = blockNum
+	p.haltGuardHits = 0
 	p.log.Errorf("processor is halted, due to the following reason: %s", reason)
+}
+
+// logHaltGuardHit logs (at a throttled rate) that a call was rejected because the processor is
+// halted. Production incidents have shown this guard can be hit tens of thousands of times while
+// a halt is being (unsuccessfully) recovered from, so logging it at error level unconditionally
+// floods the logs; see aggkitcommon.ShouldLogRetryAtError.
+func (p *processor) logHaltGuardHit() {
+	p.mu.Lock()
+	p.haltGuardHits++
+	hits := p.haltGuardHits
+	reason := p.haltedReason
+	p.mu.Unlock()
+
+	if aggkitcommon.ShouldLogRetryAtError(hits) {
+		p.log.Errorf("processor is halted due to: %s (rejected call #%d while halted)", reason, hits)
+	} else {
+		p.log.Debugf("processor is halted due to: %s (rejected call #%d while halted)", reason, hits)
+	}
 }
 
 // unhalt sets the processor to an unhalted state
@@ -675,5 +829,7 @@ func (p *processor) unhalt() {
 
 	p.halted = false
 	p.haltedReason = ""
+	p.haltedBlock = nil
+	p.haltGuardHits = 0
 	p.log.Info("processor is unhalted")
 }

--- a/l1infotreesync/processor_test.go
+++ b/l1infotreesync/processor_test.go
@@ -688,3 +688,260 @@ func TestProcessBlocksWorksAfterUnhaltingReorg(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), info.BlockNumber)
 }
+
+// commitPassingCheckpoint processes a leaf-adding block at leafBlock, fills every block in
+// between with an empty block (so block numbers stay contiguous for callers that also process
+// surrounding blocks), and finally a block at checkpointBlock whose UpdateL1InfoTreeV2 event
+// matches the resulting root exactly. The V2 sanity check therefore passes and checkpointBlock is
+// persisted as the last verified checkpoint.
+func commitPassingCheckpoint(t *testing.T, p *processor, leafBlock, checkpointBlock uint64) {
+	t.Helper()
+	ctx := context.Background()
+
+	err := p.ProcessBlock(ctx, aggkitsync.Block{
+		Num: leafBlock,
+		Events: []any{
+			Event{UpdateL1InfoTree: &UpdateL1InfoTree{
+				MainnetExitRoot: common.HexToHash(fmt.Sprintf("%x", leafBlock)),
+				RollupExitRoot:  common.HexToHash("5ca1e"),
+				ParentHash:      common.HexToHash("1010101"),
+				Timestamp:       420,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	for n := leafBlock + 1; n < checkpointBlock; n++ {
+		require.NoError(t, p.ProcessBlock(ctx, aggkitsync.Block{Num: n}))
+	}
+
+	root, err := p.l1InfoTree.GetLastRoot(p.db)
+	require.NoError(t, err)
+
+	err = p.ProcessBlock(ctx, aggkitsync.Block{
+		Num: checkpointBlock,
+		Events: []any{
+			Event{UpdateL1InfoTreeV2: &UpdateL1InfoTreeV2{
+				CurrentL1InfoRoot: root.Hash,
+				LeafCount:         root.Index + 1,
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, p.isHalted())
+}
+
+// TestProcessorPersistsCheckpointOnPassingV2Check covers the write side of the self-healing fix:
+// when the UpdateL1InfoTreeV2 sanity check passes, the block that carried it must be recorded as
+// the last verified checkpoint.
+func TestProcessorPersistsCheckpointOnPassingV2Check(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestProcessorPersistsCheckpointOnPassingV2Check.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+
+	checkpointBlock, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.False(t, found, "no checkpoint should exist before any block is processed")
+	require.Zero(t, checkpointBlock)
+
+	commitPassingCheckpoint(t, p, 1, 2)
+
+	checkpointBlock, found, err = getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(2), checkpointBlock)
+}
+
+// TestProcessorCheckpointAtomicWithBatch verifies that persisting the checkpoint is atomic with
+// the rest of the batch: if the same block's tx later fails and rolls back (here, via a
+// verify_batches primary-key collision), the checkpoint set earlier in that same tx must not be
+// persisted either.
+func TestProcessorCheckpointAtomicWithBatch(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestProcessorCheckpointAtomicWithBatch.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	err = p.ProcessBlock(ctx, aggkitsync.Block{
+		Num: 1,
+		Events: []any{
+			Event{UpdateL1InfoTree: &UpdateL1InfoTree{
+				MainnetExitRoot: common.HexToHash("beef"),
+				RollupExitRoot:  common.HexToHash("5ca1e"),
+				ParentHash:      common.HexToHash("1010101"),
+				Timestamp:       420,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	root, err := p.l1InfoTree.GetLastRoot(p.db)
+	require.NoError(t, err)
+
+	// Block 2: the V2 checkpoint passes first, then two VerifyBatches events collide on the same
+	// (block_num, block_pos) primary key, forcing the whole block's tx to roll back.
+	err = p.ProcessBlock(ctx, aggkitsync.Block{
+		Num: 2,
+		Events: []any{
+			Event{UpdateL1InfoTreeV2: &UpdateL1InfoTreeV2{
+				CurrentL1InfoRoot: root.Hash,
+				LeafCount:         root.Index + 1,
+			}},
+			Event{VerifyBatches: &VerifyBatches{
+				BlockPosition: 0,
+				RollupID:      1,
+				NumBatch:      1,
+				StateRoot:     common.HexToHash("aaaa"),
+				ExitRoot:      common.HexToHash("bbbb"),
+			}},
+			Event{VerifyBatches: &VerifyBatches{
+				BlockPosition: 0, // duplicate block_pos -> PRIMARY KEY collision on insert
+				RollupID:      2,
+				NumBatch:      1,
+				StateRoot:     common.HexToHash("cccc"),
+				ExitRoot:      common.HexToHash("dddd"),
+			}},
+		},
+	})
+	require.Error(t, err)
+
+	_, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.False(t, found, "checkpoint must not survive a rolled-back batch")
+}
+
+// TestReorgClearsCheckpointWhenPurgingAtOrPastIt verifies that a Reorg purging blocks at or after
+// the checkpoint's own block clears the stored checkpoint, since it no longer vouches for data
+// that no longer exists.
+func TestReorgClearsCheckpointWhenPurgingAtOrPastIt(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestReorgClearsCheckpointWhenPurgingAtOrPastIt.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	commitPassingCheckpoint(t, p, 1, 5)
+
+	require.NoError(t, p.Reorg(ctx, 3))
+
+	_, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.False(t, found, "checkpoint at block 5 must be cleared by a reorg purging from block 3")
+}
+
+// TestReorgKeepsCheckpointWhenPurgingAfterIt verifies that a Reorg purging blocks strictly after
+// the checkpoint's own block leaves the checkpoint untouched.
+func TestReorgKeepsCheckpointWhenPurgingAfterIt(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestReorgKeepsCheckpointWhenPurgingAfterIt.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	commitPassingCheckpoint(t, p, 1, 5)
+
+	require.NoError(t, p.Reorg(ctx, 10))
+
+	checkpointBlock, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(5), checkpointBlock)
+}
+
+// TestReorgFirstAttemptDoesNotEscalate verifies that the first Reorg recovering from a halt at
+// block B purges exactly at the requested block, with no escalation.
+func TestReorgFirstAttemptDoesNotEscalate(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestReorgFirstAttemptDoesNotEscalate.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	for n := uint64(1); n <= 10; n++ {
+		require.NoError(t, p.ProcessBlock(ctx, aggkitsync.Block{Num: n}))
+	}
+
+	haltedBlock := uint64(50)
+	p.haltAtBlock("test: first halt at block 50", &haltedBlock)
+	require.True(t, p.isHalted())
+
+	require.NoError(t, p.Reorg(ctx, 8))
+	require.False(t, p.isHalted())
+
+	lastProcessed, _, err := p.GetLastProcessedBlock(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), lastProcessed, "first recovery attempt must purge exactly from the requested block")
+
+	require.NotNil(t, p.lastReorgRecoveryBlock)
+	require.Equal(t, haltedBlock, *p.lastReorgRecoveryBlock)
+}
+
+// TestReorgEscalatesOnSecondConsecutiveHaltAtSameBlock is the core regression test for the
+// bokuto incident (2026-08-05): a v0.11.0-rc2 processor kept halting at the exact same block
+// because the true divergence was in already-committed data. The second consecutive Reorg
+// recovery for that same halted block must escalate the purge back to the last verified
+// checkpoint, deep enough to actually reach the divergence.
+func TestReorgEscalatesOnSecondConsecutiveHaltAtSameBlock(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestReorgEscalatesOnSecondConsecutiveHaltAtSameBlock.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// A verified checkpoint at block 5 (the divergence, by construction, is at or before it).
+	commitPassingCheckpoint(t, p, 1, 5)
+	for n := uint64(6); n <= 10; n++ {
+		require.NoError(t, p.ProcessBlock(ctx, aggkitsync.Block{Num: n}))
+	}
+
+	haltedBlock := uint64(50)
+
+	// First halt+recovery attempt at block 50: shallow purge, no progress made (the driver
+	// re-downloads and hits the exact same failure at block 50 again).
+	p.haltAtBlock("test: halt #1 at block 50", &haltedBlock)
+	require.NoError(t, p.Reorg(ctx, 50))
+	require.False(t, p.isHalted())
+
+	// Second consecutive halt at the very same block: escalate.
+	p.haltAtBlock("test: halt #2 at block 50 (no progress)", &haltedBlock)
+	require.NoError(t, p.Reorg(ctx, 50))
+	require.False(t, p.isHalted())
+
+	lastProcessed, _, err := p.GetLastProcessedBlock(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), lastProcessed,
+		"escalated recovery must purge back to (and including) the checkpoint block, so it is re-verified")
+
+	_, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.False(t, found, "the checkpoint's own block was purged, so the checkpoint must be cleared")
+}
+
+// TestReorgEscalationFallsBackToInitialBlockWhenNoCheckpoint verifies that, absent any verified
+// checkpoint (fresh DB, or one created before this upgrade), escalation falls back to the
+// syncer's configured initial block, i.e. a full resync.
+func TestReorgEscalationFallsBackToInitialBlockWhenNoCheckpoint(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestReorgEscalationFallsBackToInitialBlockWhenNoCheckpoint.sqlite")
+	p, err := newProcessor(dbPath)
+	require.NoError(t, err)
+	p.initialBlock = 3
+	ctx := context.Background()
+
+	for n := uint64(1); n <= 10; n++ {
+		require.NoError(t, p.ProcessBlock(ctx, aggkitsync.Block{Num: n}))
+	}
+
+	_, found, err := getCheckpointBlockWithTx(p.db)
+	require.NoError(t, err)
+	require.False(t, found, "fixture broken: no checkpoint should have been recorded")
+
+	haltedBlock := uint64(100)
+	p.haltAtBlock("test: halt #1 at block 100", &haltedBlock)
+	require.NoError(t, p.Reorg(ctx, 100))
+	require.False(t, p.isHalted())
+
+	p.haltAtBlock("test: halt #2 at block 100 (no progress)", &haltedBlock)
+	require.NoError(t, p.Reorg(ctx, 100))
+	require.False(t, p.isHalted())
+
+	lastProcessed, _, err := p.GetLastProcessedBlock(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), lastProcessed,
+		"escalation without a checkpoint must fall back to the syncer's initial block")
+}

--- a/multidownloader/evm_multidownloader.go
+++ b/multidownloader/evm_multidownloader.go
@@ -595,6 +595,25 @@ func getContracts(logQueries []mdrtypes.LogQuery) []common.Address {
 	return addresses
 }
 
+// subsetBlockHeadersResult builds a BlockHeadersResult restricted to blockNumbers out of a wider
+// result. Block numbers with neither a header nor a recorded error in full are reported as missing.
+func subsetBlockHeadersResult(
+	full *aggkittypes.BlockHeadersResult, blockNumbers []uint64) *aggkittypes.BlockHeadersResult {
+	subset := aggkittypes.NewBlockHeadersResult()
+	for _, bn := range blockNumbers {
+		if hdr, ok := full.Headers[bn]; ok {
+			subset.AddHeader(bn, hdr)
+			continue
+		}
+		if blockErr, ok := full.Errors[bn]; ok {
+			subset.AddError(bn, blockErr)
+			continue
+		}
+		subset.AddError(bn, fmt.Errorf("block header not present in retrieval result"))
+	}
+	return subset
+}
+
 func (dh *EVMMultidownloader) checkIntegrityNewLogsBlockHeaders(logs []types.Log,
 	blockHeaders aggkittypes.ListBlockHeaders) error {
 	blockMap := blockHeaders.ToMap()
@@ -649,6 +668,15 @@ func (dh *EVMMultidownloader) StepUnsafe(ctx context.Context) (bool, error) {
 	if err = dh.checkIntegrityNewLogsBlockHeaders(logs, blockHeaders); err != nil {
 		return false, err
 	}
+	// Verify that the logs response is not missing any log for a block whose bloom is positive for
+	// its queried addresses (see logs_completeness.go). Suspicions are arbitrated before ever
+	// producing an error, so a bloom false positive never wedges the syncer in a retry loop.
+	addrsByBlock := dh.getAddrsForBlockNumbers(blocks)
+	if err = dh.verifyLogsCompleteness(ctx, blockHeaders, logs, func(bn uint64) []common.Address {
+		return addrsByBlock[bn]
+	}); err != nil {
+		return false, fmt.Errorf("Unsafe/Step: %w", err)
+	}
 	newState, err := dh.newStateAftersLogQueries(logQueries)
 	if err != nil {
 		return false, fmt.Errorf("Unsafe/Step: failed to create new state: %w", err)
@@ -696,25 +724,70 @@ func (dh *EVMMultidownloader) StepSafe(ctx context.Context) (bool, error) {
 	dh.log.Debugf("Safe/Step: logs (%d) for blockRange=%s, addrs=%v", len(logs),
 		logQueryData.BlockRange.String(), logQueryData.Addrs)
 	blocks := getBlockNumbers(logs)
-	dh.log.Debugf("Safe/Step: querying blockHeaders for %d blocks", len(blocks))
+
+	// Headers are fetched for every block number in the queried range, not only the ones that have
+	// logs: the eth_getLogs completeness check below needs the bloom of every block in range to
+	// detect a silently omitted log. Storage volume is intentionally unchanged -- blockHeaders
+	// (used by storeData) is still derived below from only the blocks that have logs.
+	allBlockNumbers := logQueryData.BlockRange.ListBlockNumbers()
+	dh.log.Debugf("Safe/Step: querying blockHeaders for %d blocks in range (verification) / %d blocks with logs (storage)",
+		len(allBlockNumbers), len(blocks))
+	fullRangeHeaders := aggkittypes.NewBlockHeadersResult()
+	if len(allBlockNumbers) > 0 {
+		fullRangeHeaders, err = dh.ethClient.RetrieveBlockHeaders(
+			ctx, allBlockNumbers, dh.cfg.MaxParallelBlockHeaderRetrieval)
+		if err != nil {
+			return false, fmt.Errorf("Safe/Step: failed to retrieve %d block headers: %w", len(allBlockNumbers), err)
+		}
+	}
+
+	// blockHeaders (persisted to storage) only needs the headers of blocks that have logs; the
+	// retrieval-success requirements below apply to those blocks only so that a failure to fetch a
+	// verification-only header (one with no logs) never regresses availability.
 	var blockHeaders []*aggkittypes.BlockHeader
 	if len(blocks) > 0 {
-		blockHeadersResult, err := dh.ethClient.RetrieveBlockHeaders(ctx, blocks, dh.cfg.MaxParallelBlockHeaderRetrieval)
-		if err != nil {
-			return false, fmt.Errorf("Safe/Step: failed to retrieve %d block headers: %w", len(blocks), err)
-		}
+		eventBlocksResult := subsetBlockHeadersResult(fullRangeHeaders, blocks)
 		// Check for partial failures
-		if !blockHeadersResult.Success() {
-			for blockNum, blockErr := range blockHeadersResult.Errors {
+		if !eventBlocksResult.Success() {
+			for blockNum, blockErr := range eventBlocksResult.Errors {
 				dh.log.Errorf("Safe/Step: failed to retrieve block %d: %v", blockNum, blockErr)
 			}
-			if !blockHeadersResult.PartialSuccess() {
+			if !eventBlocksResult.PartialSuccess() {
 				return false, fmt.Errorf("Safe/Step: failed to retrieve any block headers")
 			}
 			dh.log.Warnf("Safe/Step: partial success retrieving block headers: %d/%d succeeded",
-				len(blockHeadersResult.Headers), len(blocks))
+				len(eventBlocksResult.Headers), len(blocks))
 		}
-		blockHeaders = blockHeadersResult.GetOrderedHeaders(blocks)
+		blockHeaders = eventBlocksResult.GetOrderedHeaders(blocks)
+	}
+
+	// Blocks in the queried range whose header could not be retrieved are simply excluded from the
+	// completeness check below (nothing to verify without a header); log how many were skipped.
+	eventBlockSet := make(map[uint64]struct{}, len(blocks))
+	for _, bn := range blocks {
+		eventBlockSet[bn] = struct{}{}
+	}
+	missingVerificationHeaders := 0
+	for _, bn := range allBlockNumbers {
+		if _, ok := fullRangeHeaders.Headers[bn]; ok {
+			continue
+		}
+		if _, isEventBlock := eventBlockSet[bn]; isEventBlock {
+			continue // already logged above via eventBlocksResult
+		}
+		missingVerificationHeaders++
+	}
+	if missingVerificationHeaders > 0 {
+		dh.log.Warnf("Safe/Step: skipping eth_getLogs completeness check for %d block(s) in range %s: "+
+			"header retrieval failed", missingVerificationHeaders, logQueryData.BlockRange.String())
+	}
+
+	// Verify that the logs response is not missing any log for a block whose bloom is positive for
+	// the queried addresses (see logs_completeness.go). Suspicions are arbitrated before ever
+	// producing an error, so a bloom false positive never wedges the syncer in a retry loop.
+	if err = dh.verifyLogsCompleteness(ctx, fullRangeHeaders.GetOrderedHeaders(allBlockNumbers), logs,
+		uniformAddrsForBlock(logQueryData.Addrs)); err != nil {
+		return false, fmt.Errorf("Safe/Step: %w", err)
 	}
 
 	// Calculate new state (not set in memory until commit is successful)

--- a/multidownloader/evm_multidownloader_test.go
+++ b/multidownloader/evm_multidownloader_test.go
@@ -351,6 +351,10 @@ func TestEVMMultidownloader_StepSafe(t *testing.T) {
 	testData.mockBlockNotifierManager.EXPECT().GetCurrentBlockNumber(mock.Anything, aggkittypes.FinalizedBlock).
 		Return(uint64(150), nil).Maybe()
 	testData.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.Anything).Return([]ethtypes.Log{}, nil).Maybe()
+	// StepSafe fetches headers for the whole queried range (not only blocks with logs) to run the
+	// eth_getLogs completeness check; an empty result means no bloom is positive, so no suspicion.
+	testData.mockEthClient.EXPECT().RetrieveBlockHeaders(mock.Anything, mock.Anything, mock.Anything).
+		Return(aggkittypes.NewBlockHeadersResult(), nil).Maybe()
 	err = testData.mdr.Initialize(t.Context())
 	require.NoError(t, err)
 
@@ -384,11 +388,14 @@ func TestEVMMultidownloader_StepSafe_TotalHeaderFailure(t *testing.T) {
 	data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.Anything).
 		Return([]ethtypes.Log{testLog}, nil).Once()
 
-	// All headers fail — no partial success
+	// Headers are now fetched for the whole queried range, not just the blocks with logs, to run
+	// the eth_getLogs completeness check. Block 120 (the only block with a log) fails to retrieve
+	// — no partial success for the event blocks — while the rest of the range is absent from the
+	// result too, which is treated as skipped verification, not an error.
 	rpcResult := aggkittypes.NewBlockHeadersResult()
 	rpcResult.AddError(120, fmt.Errorf("rpc error"))
 	data.mockEthClient.EXPECT().
-		RetrieveBlockHeaders(mock.Anything, []uint64{120}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).
+		RetrieveBlockHeaders(mock.Anything, mock.Anything, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).
 		Return(rpcResult, nil).Once()
 
 	_, err = data.mdr.StepSafe(t.Context())

--- a/multidownloader/logs_completeness.go
+++ b/multidownloader/logs_completeness.go
@@ -1,0 +1,146 @@
+package multidownloader
+
+import (
+	"context"
+	"fmt"
+
+	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// maxArbitrationAttempts bounds the number of by-hash re-queries used to arbitrate a suspicious
+// block. It must stay small: arbitration runs synchronously inside a syncer step.
+const maxArbitrationAttempts = 2
+
+// findSuspiciousBlockNumbers scans headers for eth_getLogs completeness suspicion: a header whose
+// logs bloom is positive for the addresses queried for that block, but for which logs contains no
+// entry with that block number. Blooms have no false negatives, so a bloom-positive header with no
+// matching log is a signal of a possible silent eth_getLogs omission. Bloom false positives are
+// also possible and are deterministic per (block, address), so this function only flags suspicion
+// -- callers MUST arbitrate (see arbitrateSuspiciousBlock) before ever treating it as an error.
+// Headers with LogsBloom == nil are always skipped: the bloom is unavailable, so there is nothing
+// to verify for that block (graceful degradation for RPCs/mocks that don't provide blooms).
+func findSuspiciousBlockNumbers(headers []*aggkittypes.BlockHeader, logs []types.Log,
+	addrsForBlock func(blockNumber uint64) []common.Address) []uint64 {
+	blockNumbersWithLogs := make(map[uint64]struct{}, len(logs))
+	for _, lg := range logs {
+		blockNumbersWithLogs[lg.BlockNumber] = struct{}{}
+	}
+	suspicious := make([]uint64, 0, len(headers))
+	for _, h := range headers {
+		if h == nil || h.LogsBloom == nil {
+			continue
+		}
+		if !h.BloomMightContainAddresses(addrsForBlock(h.Number)) {
+			continue
+		}
+		if _, hasLog := blockNumbersWithLogs[h.Number]; hasLog {
+			continue
+		}
+		suspicious = append(suspicious, h.Number)
+	}
+	return suspicious
+}
+
+// uniformAddrsForBlock adapts a single, range-wide address list (as used by the safe-step LogQuery)
+// to the per-block addrsForBlock signature required by findSuspiciousBlockNumbers/verifyLogsCompleteness.
+func uniformAddrsForBlock(addrs []common.Address) func(uint64) []common.Address {
+	return func(uint64) []common.Address { return addrs }
+}
+
+// getAddrsForBlockNumbers returns, for each given block number, the addresses currently pending to
+// sync for that block. It mirrors the mutex pattern used by getUnsafeLogQueries since it reads
+// dh.state.
+func (dh *EVMMultidownloader) getAddrsForBlockNumbers(blockNumbers []uint64) map[uint64][]common.Address {
+	dh.mutex.Lock()
+	defer dh.mutex.Unlock()
+	result := make(map[uint64][]common.Address, len(blockNumbers))
+	for _, bn := range blockNumbers {
+		result[bn] = dh.state.GetAddressesToSyncForBlockNumber(bn)
+	}
+	return result
+}
+
+// verifyLogsCompleteness runs the eth_getLogs completeness check over headers and arbitrates every
+// suspicious block it finds (see findSuspiciousBlockNumbers and arbitrateSuspiciousBlock). It
+// returns an error as soon as arbitration confirms a genuine eth_getLogs omission.
+func (dh *EVMMultidownloader) verifyLogsCompleteness(ctx context.Context, headers []*aggkittypes.BlockHeader,
+	logs []types.Log, addrsForBlock func(blockNumber uint64) []common.Address) error {
+	suspiciousNumbers := findSuspiciousBlockNumbers(headers, logs, addrsForBlock)
+	if len(suspiciousNumbers) == 0 {
+		return nil
+	}
+	headersByNumber := make(map[uint64]*aggkittypes.BlockHeader, len(headers))
+	for _, h := range headers {
+		if h != nil {
+			headersByNumber[h.Number] = h
+		}
+	}
+	for _, bn := range suspiciousNumbers {
+		if err := dh.arbitrateSuspiciousBlock(ctx, headersByNumber[bn], addrsForBlock(bn)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// arbitrateSuspiciousBlock decides whether a bloom-suspicious block is a genuine eth_getLogs
+// omission or a bloom false positive. Bloom false positives are deterministic per (block, address):
+// a naive "suspicious -> error" would wedge the syncer in an infinite retry loop on one, so every
+// suspicion must be arbitrated here before it is ever allowed to produce an error.
+//
+// It re-queries logs for the single block by block hash, up to maxArbitrationAttempts times (a
+// retry may land on a healthy node behind a load balancer/proxy). Only logs whose BlockHash matches
+// hdr.Hash are counted, guarding against a misbehaving RPC returning logs for the wrong block.
+//
+//   - If any attempt returns >=1 matching log, this is a genuine omission: it logs at Warn (block
+//     number, addresses, how many logs the original response missed) and returns an error so the
+//     whole step retries -- a healthy/round-robin RPC heals it, while a persistently-broken RPC
+//     produces a loud, bounded retry loop instead of silently corrupting the DB.
+//   - If every attempt succeeds and returns no matching logs, this is treated as a bloom false
+//     positive (or an omission pinned to this specific block hash, which is indistinguishable from
+//     here): it logs at Debug and the block is accepted as empty.
+//   - If every attempt fails to execute (RPC/transport error), no verdict can be reached; this is
+//     treated conservatively as an error rather than silently accepting the block, since silently
+//     accepting an unverifiable suspicious block is exactly the failure mode this check exists to
+//     prevent.
+func (dh *EVMMultidownloader) arbitrateSuspiciousBlock(ctx context.Context, hdr *aggkittypes.BlockHeader,
+	addrs []common.Address) error {
+	reachedVerdict := false
+	for attempt := 1; attempt <= maxArbitrationAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		query := ethereum.FilterQuery{BlockHash: &hdr.Hash, Addresses: addrs}
+		logs, err := dh.ethClient.FilterLogs(ctx, query)
+		if err != nil {
+			dh.log.Warnf("arbitrateSuspiciousBlock: attempt %d/%d: failed to re-query logs for block %d (hash %s): %s",
+				attempt, maxArbitrationAttempts, hdr.Number, hdr.Hash.String(), err.Error())
+			continue
+		}
+		matching := 0
+		for _, lg := range logs {
+			if lg.BlockHash == hdr.Hash {
+				matching++
+			}
+		}
+		if matching > 0 {
+			dh.log.Warnf("arbitrateSuspiciousBlock: genuine eth_getLogs omission detected at block %d (hash %s) "+
+				"for addrs %v: original response missed %d log(s)",
+				hdr.Number, hdr.Hash.String(), addrs, matching)
+			return fmt.Errorf("arbitrateSuspiciousBlock: eth_getLogs omitted %d log(s) for block %d (hash %s)",
+				matching, hdr.Number, hdr.Hash.String())
+		}
+		reachedVerdict = true
+	}
+	if !reachedVerdict {
+		return fmt.Errorf("arbitrateSuspiciousBlock: could not arbitrate suspicious block %d (hash %s): "+
+			"all %d re-query attempts failed", hdr.Number, hdr.Hash.String(), maxArbitrationAttempts)
+	}
+	dh.log.Debugf("arbitrateSuspiciousBlock: block %d (hash %s) bloom-positive for addrs %v but no logs found "+
+		"after %d arbitration attempt(s); treating as bloom false positive",
+		hdr.Number, hdr.Hash.String(), addrs, maxArbitrationAttempts)
+	return nil
+}

--- a/multidownloader/logs_completeness_test.go
+++ b/multidownloader/logs_completeness_test.go
@@ -1,0 +1,178 @@
+package multidownloader
+
+import (
+	"errors"
+	"testing"
+
+	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var errRPCUnavailable = errors.New("rpc unavailable")
+
+func bloomForAddress(addr common.Address) *ethtypes.Bloom {
+	var bloom ethtypes.Bloom
+	bloom.Add(addr.Bytes())
+	return &bloom
+}
+
+func TestFindSuspiciousBlockNumbers(t *testing.T) {
+	addr := common.HexToAddress("0x1")
+	other := common.HexToAddress("0x2")
+
+	t.Run("bloom-positive and empty logs is flagged", func(t *testing.T) {
+		headers := []*aggkittypes.BlockHeader{
+			{Number: 100, Hash: common.HexToHash("0xa"), LogsBloom: bloomForAddress(addr)},
+		}
+		suspicious := findSuspiciousBlockNumbers(headers, nil, uniformAddrsForBlock([]common.Address{addr}))
+		require.Equal(t, []uint64{100}, suspicious)
+	})
+
+	t.Run("bloom-negative and empty logs is not flagged", func(t *testing.T) {
+		headers := []*aggkittypes.BlockHeader{
+			{Number: 100, Hash: common.HexToHash("0xa"), LogsBloom: bloomForAddress(other)},
+		}
+		suspicious := findSuspiciousBlockNumbers(headers, nil, uniformAddrsForBlock([]common.Address{addr}))
+		require.Empty(t, suspicious)
+	})
+
+	t.Run("bloom-positive with a matching log is not flagged", func(t *testing.T) {
+		headers := []*aggkittypes.BlockHeader{
+			{Number: 100, Hash: common.HexToHash("0xa"), LogsBloom: bloomForAddress(addr)},
+		}
+		logs := []ethtypes.Log{{BlockNumber: 100, Address: addr}}
+		suspicious := findSuspiciousBlockNumbers(headers, logs, uniformAddrsForBlock([]common.Address{addr}))
+		require.Empty(t, suspicious)
+	})
+
+	t.Run("nil bloom is always skipped", func(t *testing.T) {
+		headers := []*aggkittypes.BlockHeader{
+			{Number: 100, Hash: common.HexToHash("0xa"), LogsBloom: nil},
+		}
+		suspicious := findSuspiciousBlockNumbers(headers, nil, uniformAddrsForBlock([]common.Address{addr}))
+		require.Empty(t, suspicious)
+	})
+
+	t.Run("nil header is skipped", func(t *testing.T) {
+		headers := []*aggkittypes.BlockHeader{nil}
+		suspicious := findSuspiciousBlockNumbers(headers, nil, uniformAddrsForBlock([]common.Address{addr}))
+		require.Empty(t, suspicious)
+	})
+}
+
+func TestEVMMultidownloader_ArbitrateSuspiciousBlock(t *testing.T) {
+	addrs := []common.Address{common.HexToAddress("0x1")}
+	blockHash := common.HexToHash("0xabc")
+	hdr := &aggkittypes.BlockHeader{Number: 100, Hash: blockHash}
+
+	byHashQuery := func(q ethereum.FilterQuery) bool {
+		return q.BlockHash != nil && *q.BlockHash == blockHash
+	}
+
+	t.Run("refetch returns a matching log -> genuine omission error", func(t *testing.T) {
+		data := newEVMMultidownloaderTestData(t, true)
+		omittedLog := ethtypes.Log{BlockHash: blockHash, BlockNumber: 100}
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(byHashQuery)).
+			Return([]ethtypes.Log{omittedLog}, nil).Once()
+
+		err := data.mdr.arbitrateSuspiciousBlock(t.Context(), hdr, addrs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "omitted 1 log")
+	})
+
+	t.Run("refetch returns no logs twice -> accepted as bloom false positive", func(t *testing.T) {
+		data := newEVMMultidownloaderTestData(t, true)
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(byHashQuery)).
+			Return([]ethtypes.Log{}, nil).Twice()
+
+		err := data.mdr.arbitrateSuspiciousBlock(t.Context(), hdr, addrs)
+		require.NoError(t, err)
+	})
+
+	t.Run("refetch returns a log for a different block hash -> not counted, accepted", func(t *testing.T) {
+		data := newEVMMultidownloaderTestData(t, true)
+		wrongHashLog := ethtypes.Log{BlockHash: common.HexToHash("0xdead"), BlockNumber: 100}
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(byHashQuery)).
+			Return([]ethtypes.Log{wrongHashLog}, nil).Twice()
+
+		err := data.mdr.arbitrateSuspiciousBlock(t.Context(), hdr, addrs)
+		require.NoError(t, err)
+	})
+
+	t.Run("all attempts fail to execute -> conservative error, not silent accept", func(t *testing.T) {
+		data := newEVMMultidownloaderTestData(t, true)
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(byHashQuery)).
+			Return(nil, errRPCUnavailable).Twice()
+
+		err := data.mdr.arbitrateSuspiciousBlock(t.Context(), hdr, addrs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not arbitrate")
+	})
+}
+
+func TestEVMMultidownloader_StepSafe_LogsCompleteness(t *testing.T) {
+	addr := common.HexToAddress("0x1")
+	hashBlock100 := common.HexToHash("0xaaa100")
+
+	setup := func(t *testing.T) *testDataEVMMultidownloader {
+		t.Helper()
+		data := newEVMMultidownloaderTestData(t, false)
+		data.mockEthClient.EXPECT().ChainID(mock.Anything).Return(common.Big1, nil)
+		err := data.mdr.RegisterSyncer(aggkittypes.SyncerConfig{
+			SyncerID:          "syncer1",
+			ContractAddresses: []common.Address{addr},
+			FromBlock:         100,
+			ToBlock:           aggkittypes.FinalizedBlock,
+		})
+		require.NoError(t, err)
+		data.mockBlockNotifierManager.EXPECT().GetCurrentBlockNumber(mock.Anything, aggkittypes.FinalizedBlock).
+			Return(uint64(101), nil).Maybe()
+		err = data.mdr.Initialize(t.Context())
+		require.NoError(t, err)
+
+		// The range-wide eth_getLogs response silently omits the log for block 100.
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
+			return q.BlockHash == nil
+		})).Return([]ethtypes.Log{}, nil).Once()
+
+		rpcResult := aggkittypes.NewBlockHeadersResult()
+		rpcResult.AddHeader(100, &aggkittypes.BlockHeader{Number: 100, Hash: hashBlock100, LogsBloom: bloomForAddress(addr)})
+		rpcResult.AddHeader(101, &aggkittypes.BlockHeader{Number: 101, Hash: common.HexToHash("0xaaa101")})
+		data.mockEthClient.EXPECT().
+			RetrieveBlockHeaders(mock.Anything, []uint64{100, 101}, data.mdr.cfg.MaxParallelBlockHeaderRetrieval).
+			Return(rpcResult, nil).Once()
+
+		return data
+	}
+
+	byHashQuery := func(hash common.Hash) func(q ethereum.FilterQuery) bool {
+		return func(q ethereum.FilterQuery) bool {
+			return q.BlockHash != nil && *q.BlockHash == hash
+		}
+	}
+
+	t.Run("genuine omission detected -> step returns error", func(t *testing.T) {
+		data := setup(t)
+		omittedLog := ethtypes.Log{BlockHash: hashBlock100, BlockNumber: 100, Address: addr}
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(byHashQuery(hashBlock100))).
+			Return([]ethtypes.Log{omittedLog}, nil).Once()
+
+		_, err := data.mdr.StepSafe(t.Context())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "omitted 1 log")
+	})
+
+	t.Run("bloom false positive -> step succeeds", func(t *testing.T) {
+		data := setup(t)
+		data.mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.MatchedBy(byHashQuery(hashBlock100))).
+			Return([]ethtypes.Log{}, nil).Twice()
+
+		finished, err := data.mdr.StepSafe(t.Context())
+		require.NoError(t, err)
+		require.True(t, finished)
+	})
+}

--- a/multidownloader/sync/evmdownloader.go
+++ b/multidownloader/sync/evmdownloader.go
@@ -286,7 +286,11 @@ func (d *EVMDownloader) appendLog(ctx context.Context, block *sync.EVMBlock, log
 		err := appenderFn(block, log)
 		if err != nil {
 			attempts++
-			d.logger.Errorf("error trying to append log (attempt %d): %v", attempts, err)
+			if aggkitcommon.ShouldLogRetryAtError(attempts) {
+				d.logger.Errorf("error trying to append log (attempt %d): %v", attempts, err)
+			} else {
+				d.logger.Debugf("error trying to append log (attempt %d): %v", attempts, err)
+			}
 			d.rh.Handle(ctx, "appendLogs", attempts)
 			continue
 		}

--- a/multidownloader/sync/evmdriver.go
+++ b/multidownloader/sync/evmdriver.go
@@ -30,6 +30,11 @@ type EVMDriver struct {
 	// can be nil is there are no information yet
 	// 0 -> 0%, 100, -> 100%
 	completionPercentage *float64
+	// recoveryFirstBlock/recoveryAttempts track consecutive processBlocks poisoned-batch recovery
+	// attempts (see processBlocks) for the same in-memory batch, so the recovery log can be
+	// throttled instead of firing on every retry of an unrecoverable batch.
+	recoveryFirstBlock *uint64
+	recoveryAttempts   int
 }
 
 func NewEVMDriver(
@@ -143,9 +148,21 @@ func (d *EVMDriver) processBlocks(ctx context.Context, data *mdrsynctypes.Downlo
 		// last committed block (a zero-row purge that unhalts it), then propagate the error so the
 		// Sync loop backs off and re-downloads the range from the last committed block.
 		firstBlock := data.Data[0].Num
-		d.logger.Errorf("processor halted while processing in-memory batch [%d..%d], most likely built from "+
-			"an undetected L1 tip reorg: %v. Discarding the batch and resetting the processor to its last "+
-			"committed block; the range will be re-downloaded", firstBlock, data.Data.LastBlock().Num, err)
+		if d.recoveryFirstBlock != nil && *d.recoveryFirstBlock == firstBlock {
+			d.recoveryAttempts++
+		} else {
+			d.recoveryFirstBlock = &firstBlock
+			d.recoveryAttempts = 1
+		}
+		msg := fmt.Sprintf("processor halted while processing in-memory batch [%d..%d] (consecutive recovery "+
+			"attempt %d for this batch), most likely built from an undetected L1 tip reorg: %v. Discarding the "+
+			"batch and resetting the processor to its last committed block; the range will be re-downloaded",
+			firstBlock, data.Data.LastBlock().Num, d.recoveryAttempts, err)
+		if aggkitcommon.ShouldLogRetryAtError(d.recoveryAttempts) {
+			d.logger.Error(msg)
+		} else {
+			d.logger.Debug(msg)
+		}
 		if reorgErr := d.processor.Reorg(ctx, firstBlock); reorgErr != nil {
 			return fmt.Errorf("recovering from inconsistent state: processor.Reorg(%d) failed: %w "+
 				"(original error: %v)", firstBlock, reorgErr, err)
@@ -184,7 +201,11 @@ func (d *EVMDriver) withRetry(ctx context.Context, opName string, fn func() erro
 					return err
 				}
 				attempts++
-				d.logger.Errorf("error during %s (attempt %d): %v", opName, attempts, err)
+				if aggkitcommon.ShouldLogRetryAtError(attempts) {
+					d.logger.Errorf("error during %s (attempt %d): %v", opName, attempts, err)
+				} else {
+					d.logger.Debugf("error during %s (attempt %d): %v", opName, attempts, err)
+				}
 				d.rh.Handle(ctx, opName, attempts)
 			} else {
 				return nil

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -541,7 +541,11 @@ func (d *EVMDownloaderImplementation) getEventsByBlockRangeWithRetry(
 					break
 				}
 				attempts++
-				d.log.Error("error trying to append log: ", err)
+				if aggkitcommon.ShouldLogRetryAtError(attempts) {
+					d.log.Errorf("error trying to append log (attempt %d): %v", attempts, err)
+				} else {
+					d.log.Debugf("error trying to append log (attempt %d): %v", attempts, err)
+				}
 				d.rh.Handle(ctx, "appendLogs", attempts)
 			}
 		}

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -470,7 +470,31 @@ func (d *EVMDownloaderImplementation) WaitForNewBlocks(
 }
 
 func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context, fromBlock, toBlock uint64) EVMBlocks {
-	return d.getEventsByBlockRangeWithRetry(ctx, fromBlock, toBlock, 0)
+	select {
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+
+	// lastFinalizedBlock scopes the eth_getLogs completeness check (see checkLogsCompleteness) to
+	// blocks strictly above it, i.e. the unfinalized zone near the chain tip where a flaky/mixed
+	// RPC view can silently omit a log while header hashes stay canonical -- invisible to
+	// header-hash reorg detection by construction. Verifying a block costs one HeaderByNumber call
+	// (this package has no batch machinery), which is prohibitive across large finalized catch-up
+	// ranges, so the finalized zone is intentionally left unchecked here. Completeness of the
+	// finalized zone for legacy syncers (bridgesync, claimsync, l2gersync) is therefore a known
+	// gap; their long-term fix is migrating to the multidownloader, which verifies both zones.
+	// It is fetched once per invocation (not per retry below) to keep that cost bounded.
+	lastFinalizedBlock, err := d.GetLastFinalizedBlock(ctx)
+	if err != nil {
+		d.log.Warnf(
+			"logs completeness check: error getting last finalized block, skipping check for range [%d,%d]: %v",
+			fromBlock, toBlock, err,
+		)
+		lastFinalizedBlock = toBlock
+	}
+
+	return d.getEventsByBlockRangeWithRetry(ctx, fromBlock, toBlock, 0, lastFinalizedBlock)
 }
 
 func (d *EVMDownloaderImplementation) GetLogs(ctx context.Context, fromBlock, toBlock uint64) []types.Log {
@@ -480,13 +504,24 @@ func (d *EVMDownloaderImplementation) GetLogs(ctx context.Context, fromBlock, to
 
 func (d *EVMDownloaderImplementation) getEventsByBlockRangeWithRetry(
 	ctx context.Context,
-	fromBlock, toBlock uint64, retryCount int,
+	fromBlock, toBlock uint64, hashRetryCount int, lastFinalizedBlock uint64,
 ) EVMBlocks {
-	select {
-	case <-ctx.Done():
-		return nil
-	default:
-		logs := d.GetLogs(ctx, fromBlock, toBlock)
+	omissionAttempts := 0
+retry:
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		// getUnfilteredLogs/filterLogs are used directly here (instead of GetLogs) so the
+		// unfiltered, address-only-filtered logs are available to checkLogsCompleteness below:
+		// bloom-positive for an address only asserts that *some* unfiltered log exists for that
+		// block, not that a log matching the queried topics exists (a contract emitting only a
+		// non-queried event would otherwise be flagged as a false omission).
+		unfilteredLogs := d.getUnfilteredLogs(ctx, fromBlock, toBlock)
+		logs := d.filterLogs(unfilteredLogs)
 		if d.logsHook != nil {
 			originalCount := len(logs)
 			logs = d.logsHook(ctx, fromBlock, toBlock, logs)
@@ -508,9 +543,9 @@ func (d *EVMDownloaderImplementation) getEventsByBlockRangeWithRetry(
 					d.log.Infof(
 						"there has been a block hash change between the event query and the block query "+
 							"for block %d: %s vs (logs)%s. Retrying attempt %d/%d.",
-						l.BlockNumber, b.Hash, l.BlockHash, retryCount, MaxRetryCountBlockHashMismatch,
+						l.BlockNumber, b.Hash, l.BlockHash, hashRetryCount, MaxRetryCountBlockHashMismatch,
 					)
-					if retryCount >= MaxRetryCountBlockHashMismatch {
+					if hashRetryCount >= MaxRetryCountBlockHashMismatch {
 						// Log an error and return nil if the maximum retry count is reached.
 						d.log.Errorf(
 							"max retry attempts %d reached for block hash mismatch on block %d, returning nil",
@@ -518,8 +553,11 @@ func (d *EVMDownloaderImplementation) getEventsByBlockRangeWithRetry(
 						)
 						return nil
 					}
-					// Retry the operation with an incremented retry count.
-					return d.getEventsByBlockRangeWithRetry(ctx, fromBlock, toBlock, retryCount+1)
+					// Retry with an incremented retry count. hashRetryCount is kept separate from
+					// omissionAttempts below: a hash mismatch is a distinct, already-bounded
+					// failure mode and must not share (or reset) the omission-retry budget.
+					hashRetryCount++
+					continue retry
 				}
 				latestBlock = &EVMBlock{
 					EVMBlockHeader: EVMBlockHeader{
@@ -548,6 +586,34 @@ func (d *EVMDownloaderImplementation) getEventsByBlockRangeWithRetry(
 				}
 				d.rh.Handle(ctx, "appendLogs", attempts)
 			}
+		}
+
+		// Block header logs blooms have no false negatives, so a bloom-positive, zero-log block is
+		// only ever *suspicious* -- never a direct failure -- because a bloom false positive is
+		// deterministic per (block, address) and would otherwise wedge the syncer forever.
+		// checkLogsCompleteness arbitrates every suspicion with a single-block re-query before
+		// reporting a confirmed omission.
+		if d.checkLogsCompleteness(ctx, fromBlock, toBlock, lastFinalizedBlock, unfilteredLogs) {
+			omissionAttempts++
+			// A confirmed omission must NOT be treated like an exhausted hash-mismatch retry
+			// (which returns nil above): returning nil here would make the Download loop treat the
+			// range as legitimately empty and advance past it, permanently losing the omitted log
+			// (a missing deposit / wrong exit tree, with no error surfaced anywhere). Retry
+			// indefinitely instead, with bounded/throttled logging, so a persistently-omitting RPC
+			// produces a loud but bounded log stream rather than silent data loss.
+			if aggkitcommon.ShouldLogRetryAtError(omissionAttempts) {
+				d.log.Errorf(
+					"confirmed eth_getLogs omission for range [%d,%d] (attempt %d), retrying range download",
+					fromBlock, toBlock, omissionAttempts,
+				)
+			} else {
+				d.log.Debugf(
+					"confirmed eth_getLogs omission for range [%d,%d] (attempt %d), retrying range download",
+					fromBlock, toBlock, omissionAttempts,
+				)
+			}
+			d.rh.Handle(ctx, "logsCompletenessOmission", omissionAttempts)
+			continue retry
 		}
 
 		return blocks

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -318,6 +318,11 @@ func TestGetEventsByBlockRange(t *testing.T) {
 				clientMock.EXPECT().FilterLogs(cancelledCtx, query).Return(tc.inputLogs, nil)
 			} else {
 				clientMock.EXPECT().FilterLogs(mock.Anything, query).Return(tc.inputLogs, nil)
+				// GetEventsByBlockRange now fetches the last finalized block once, up front, to
+				// scope the eth_getLogs completeness check to the unfinalized zone. Report the
+				// whole range as finalized so the check's verify window is empty and no extra
+				// HeaderByNumber/FilterLogs calls are needed for these pre-existing test cases.
+				clientMock.EXPECT().BlockNumber(mock.Anything, mock.Anything).Return(tc.toBlock, nil)
 			}
 
 			// Setup custom mocks if provided
@@ -1041,6 +1046,9 @@ func TestEVMDownloaderImplementation_SetLogsHook_HookInvokedInGetEventsByBlockRa
 	rawLog := types.Log{BlockNumber: 10, Topics: []common.Hash{eventSignature}, Address: contractAddr}
 	// FilterLogs returns one log; the hook filters it out.
 	mockEthClient.EXPECT().FilterLogs(mock.Anything, mock.Anything).Return([]types.Log{rawLog}, nil).Once()
+	// GetEventsByBlockRange fetches the last finalized block up front for the completeness check;
+	// report the whole range as finalized so its verify window is empty here.
+	mockEthClient.EXPECT().BlockNumber(mock.Anything, mock.Anything).Return(uint64(20), nil).Once()
 
 	var hookCalledFrom, hookCalledTo uint64
 	sut.SetLogsHook(func(_ context.Context, from, to uint64, logs []types.Log) []types.Log {

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -336,7 +336,11 @@ func (d *EVMDriver) withRetry(ctx context.Context, opName string, fn func() erro
 			err := fn()
 			if err != nil {
 				attempts++
-				d.log.Errorf("error during %s (attempt %d): %v", opName, attempts, err)
+				if aggkitcommon.ShouldLogRetryAtError(attempts) {
+					d.log.Errorf("error during %s (attempt %d): %v", opName, attempts, err)
+				} else {
+					d.log.Debugf("error during %s (attempt %d): %v", opName, attempts, err)
+				}
 
 				// Stop retrying on permanent errors
 				if isStopRetryError(err) {

--- a/sync/logs_completeness.go
+++ b/sync/logs_completeness.go
@@ -1,0 +1,187 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	aggkittypes "github.com/agglayer/aggkit/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// maxArbitrationAttempts bounds the single-block re-query used to arbitrate a bloom-positive,
+// zero-log block (see checkLogsCompleteness). Kept small: arbitration exists to distinguish a
+// genuine eth_getLogs omission from a deterministic bloom false positive, not to compensate for a
+// generally unhealthy RPC.
+const maxArbitrationAttempts = 2
+
+// checkLogsCompleteness defends against a silent eth_getLogs omission: during an L1 reorg a
+// flaky/mixed RPC view can make eth_getLogs skip a log for a block while that block's header hash
+// stays canonical, which is invisible to header-hash-based reorg detection by construction (this
+// is exactly what happened in the bokuto 2026-08-05 incident). Block header logs blooms have no
+// false negatives, so a block whose bloom is positive for one of d.addressesToQuery but for which
+// unfilteredLogs contains no entry is *suspicious*.
+//
+// A bloom false positive is deterministic per (block, address): suspicion alone must never fail
+// the range -- that would wedge the syncer forever on a false positive -- so every suspicion is
+// arbitrated with a single-block re-query (arbitrateSuspectedOmission) before being trusted.
+//
+// The check only covers blocks strictly above lastFinalizedBlock. Verifying a block costs one
+// HeaderByNumber call (this package has no batch machinery), which is prohibitive across large
+// finalized catch-up ranges, while the mixed-view/reorg omission class this defends against lives
+// near the chain tip; during steady tailing this window is small. Completeness of the finalized
+// zone for legacy syncers (bridgesync, claimsync, l2gersync) is therefore a known gap -- their
+// long-term fix is migrating to the multidownloader, which verifies both zones.
+//
+// It returns true when at least one suspected omission was arbitrated and confirmed genuine, in
+// which case the caller must retry the whole range rather than accept it (see the comment at the
+// call site in getEventsByBlockRangeWithRetry for why treating it like an ordinary empty range
+// would be unsafe).
+func (d *EVMDownloaderImplementation) checkLogsCompleteness(
+	ctx context.Context, fromBlock, toBlock, lastFinalizedBlock uint64, unfilteredLogs []types.Log,
+) bool {
+	verifyFrom := fromBlock
+	if lastFinalizedBlock >= verifyFrom {
+		verifyFrom = lastFinalizedBlock + 1
+	}
+	if verifyFrom > toBlock {
+		// Whole range is at or below the last finalized block: outside the verified window.
+		return false
+	}
+
+	blocksWithLogs := make(map[uint64]struct{}, len(unfilteredLogs))
+	for _, l := range unfilteredLogs {
+		blocksWithLogs[l.BlockNumber] = struct{}{}
+	}
+
+	for blockNum := verifyFrom; blockNum <= toBlock; blockNum++ {
+		if _, ok := blocksWithLogs[blockNum]; ok {
+			// At least one unfiltered log already accounts for this block; nothing to check.
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+		}
+
+		header, canceled := d.getHeaderForCompletenessCheck(ctx, blockNum)
+		if canceled {
+			return false
+		}
+
+		// Nil bloom (retrieval path didn't provide it) or bloom negative: no assertion can be
+		// made, or the bloom itself guarantees no queried address logged in this block. Either
+		// way, not suspicious -- graceful degradation to "skip the check" for that block.
+		if !header.BloomMightContainAddresses(d.addressesToQuery) {
+			continue
+		}
+
+		if d.arbitrateSuspectedOmission(ctx, blockNum, header.Hash) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getHeaderForCompletenessCheck fetches the header for blockNum, retrying on the same transient
+// errors as GetBlockHeader (block temporarily not found during a reorg, other transient RPC
+// errors), but returning the raw *aggkittypes.BlockHeader so its LogsBloom is available.
+func (d *EVMDownloaderImplementation) getHeaderForCompletenessCheck(
+	ctx context.Context, blockNum uint64,
+) (*aggkittypes.BlockHeader, bool) {
+	attempts := 0
+	for {
+		header, err := d.ethClient.HeaderByNumber(ctx, aggkittypes.NewBlockNumber(blockNum))
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil, true
+			}
+			if errors.Is(err, ethereum.NotFound) {
+				// Block num can temporarily disappear from the execution client due to a reorg;
+				// wait and retry rather than treating it as an error.
+				d.log.Warnf("logs completeness check: block %d not found on the ethereum client: %v", blockNum, err)
+				if d.rh.RetryAfterErrorPeriod != 0 {
+					time.Sleep(d.rh.RetryAfterErrorPeriod)
+				} else {
+					time.Sleep(DefaultWaitPeriodBlockNotFound)
+				}
+				continue
+			}
+
+			attempts++
+			d.log.Errorf("logs completeness check: error getting header for block %d, err: %v", blockNum, err)
+			d.rh.Handle(ctx, "logsCompletenessGetHeader", attempts)
+			continue
+		}
+
+		return header, false
+	}
+}
+
+// arbitrateSuspectedOmission re-queries logs for a single block by hash to distinguish a genuine
+// eth_getLogs omission from a deterministic bloom false positive. It returns true when a log
+// matching blockHash is found (omission confirmed genuine) and also, conservatively, when every
+// arbitration attempt fails to execute: an unverifiable suspicious block must trigger a range
+// retry rather than be silently accepted, since silent acceptance is exactly the failure mode this
+// check exists to prevent (same semantics as the multidownloader's arbitrateSuspiciousBlock). A
+// successfully executed query with no matching logs is a bloom-false-positive verdict.
+func (d *EVMDownloaderImplementation) arbitrateSuspectedOmission(
+	ctx context.Context, blockNum uint64, blockHash common.Hash,
+) bool {
+	query := ethereum.FilterQuery{
+		BlockHash: &blockHash,
+		Addresses: d.addressesToQuery,
+	}
+
+	reachedVerdict := false
+	for attempt := 1; attempt <= maxArbitrationAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+		}
+
+		logs, err := d.ethClient.FilterLogs(ctx, query)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return false
+			}
+			d.log.Warnf("logs completeness check: arbitration query failed for block %d (attempt %d/%d): %v",
+				blockNum, attempt, maxArbitrationAttempts, err)
+			continue
+		}
+
+		for _, l := range logs {
+			if l.BlockHash == blockHash {
+				d.log.Warnf(
+					"logs completeness check: confirmed eth_getLogs omission for block %d (hash %s): "+
+						"bloom-positive block had 0 logs in the range query but arbitration found %d log(s)",
+					blockNum, blockHash.Hex(), len(logs),
+				)
+				return true
+			}
+		}
+		reachedVerdict = true
+	}
+
+	if !reachedVerdict {
+		d.log.Warnf(
+			"logs completeness check: could not arbitrate suspicious block %d (hash %s): all %d re-query "+
+				"attempts failed; conservatively retrying the range",
+			blockNum, blockHash.Hex(), maxArbitrationAttempts,
+		)
+		return true
+	}
+
+	d.log.Debugf(
+		"logs completeness check: block %d (hash %s) was bloom-positive but arbitration found no matching logs "+
+			"after %d attempt(s); treating as a deterministic bloom false positive",
+		blockNum, blockHash.Hex(), maxArbitrationAttempts,
+	)
+	return false
+}

--- a/sync/logs_completeness_test.go
+++ b/sync/logs_completeness_test.go
@@ -1,0 +1,242 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/agglayer/aggkit/log"
+	aggkittypes "github.com/agglayer/aggkit/types"
+	aggkittypesmocks "github.com/agglayer/aggkit/types/mocks"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// newLogsCompletenessSUT builds a bare EVMDownloaderImplementation for unit-testing
+// checkLogsCompleteness directly, without going through GetEventsByBlockRange.
+func newLogsCompletenessSUT(t *testing.T, mockEthClient *aggkittypesmocks.MultiDownloader) *EVMDownloaderImplementation {
+	t.Helper()
+	return &EVMDownloaderImplementation{
+		ethClient:        mockEthClient,
+		addressesToQuery: []common.Address{contractAddr},
+		log:              log.WithFields("test", "logsCompleteness"),
+		rh: &RetryHandler{
+			RetryAfterErrorPeriod:      time.Millisecond,
+			MaxRetryAttemptsAfterError: 5,
+		},
+	}
+}
+
+// TestGetEventsByBlockRange_LogsOmissionHealedOnRetry covers the end-to-end healing path: the
+// first eth_getLogs range query silently omits a log for a bloom-positive block, arbitration
+// confirms the omission (finds the log by BlockHash), the range is retried, and the second
+// attempt returns the log.
+func TestGetEventsByBlockRange_LogsOmissionHealedOnRetry(t *testing.T) {
+	ctx := context.Background()
+	d, clientMock := NewTestDownloader(t, time.Millisecond)
+
+	blockNum := uint64(10)
+	logC, updateC := generateEvent(uint32(blockNum))
+
+	header := types.Header{Number: big.NewInt(int64(blockNum)), ParentHash: common.HexToHash("foo")}
+	blockHash := header.Hash() // matches logC.BlockHash produced by generateEvent
+	parentHash := common.HexToHash("foo")
+
+	var bloom types.Bloom
+	bloom.Add(contractAddr.Bytes())
+
+	// lastFinalizedBlock (5) < blockNum (10): the block is in the verified, unfinalized zone.
+	clientMock.EXPECT().BlockNumber(mock.Anything, mock.Anything).Return(uint64(5), nil).Once()
+
+	addressQuery := ethereum.FilterQuery{
+		Addresses: []common.Address{contractAddr},
+		FromBlock: new(big.Int).SetUint64(blockNum),
+		ToBlock:   new(big.Int).SetUint64(blockNum),
+	}
+	// First attempt: eth_getLogs silently omits the log even though the block is bloom-positive.
+	clientMock.EXPECT().FilterLogs(mock.Anything, addressQuery).Return([]types.Log{}, nil).Once()
+
+	// checkLogsCompleteness fetches the header for the (apparently) empty block and finds a
+	// positive bloom for the queried address.
+	clientMock.EXPECT().HeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(blockNum)).
+		Return(&aggkittypes.BlockHeader{
+			Number:     blockNum,
+			Hash:       blockHash,
+			ParentHash: &parentHash,
+			LogsBloom:  &bloom,
+		}, nil)
+
+	// Arbitration re-query by block hash finds the log: the omission is confirmed genuine.
+	arbitrationQuery := ethereum.FilterQuery{
+		BlockHash: &blockHash,
+		Addresses: []common.Address{contractAddr},
+	}
+	clientMock.EXPECT().FilterLogs(mock.Anything, arbitrationQuery).Return([]types.Log{*logC}, nil).Once()
+
+	// Second attempt (range retried indefinitely on confirmed omission): the log now comes back.
+	clientMock.EXPECT().FilterLogs(mock.Anything, addressQuery).Return([]types.Log{*logC}, nil).Once()
+
+	blocks := d.GetEventsByBlockRange(ctx, blockNum, blockNum)
+
+	require.Len(t, blocks, 1)
+	require.Equal(t, blockNum, blocks[0].Num)
+	require.Equal(t, []interface{}{updateC}, blocks[0].Events)
+	clientMock.AssertExpectations(t)
+}
+
+// TestGetEventsByBlockRange_LogsBloomFalsePositive covers the deterministic-false-positive path:
+// the block is bloom-positive but genuinely has no log for the queried address, so arbitration
+// consistently returns empty. The range must be accepted as-is, with no unbounded retry loop.
+func TestGetEventsByBlockRange_LogsBloomFalsePositive(t *testing.T) {
+	ctx := context.Background()
+	d, clientMock := NewTestDownloader(t, time.Millisecond)
+
+	blockNum := uint64(10)
+	header := types.Header{Number: big.NewInt(int64(blockNum)), ParentHash: common.HexToHash("foo")}
+	blockHash := header.Hash()
+	parentHash := common.HexToHash("foo")
+
+	var bloom types.Bloom
+	bloom.Add(contractAddr.Bytes())
+
+	clientMock.EXPECT().BlockNumber(mock.Anything, mock.Anything).Return(uint64(5), nil).Once()
+
+	addressQuery := ethereum.FilterQuery{
+		Addresses: []common.Address{contractAddr},
+		FromBlock: new(big.Int).SetUint64(blockNum),
+		ToBlock:   new(big.Int).SetUint64(blockNum),
+	}
+	// Only ONE call expected: no retry loop must be triggered by a bloom false positive.
+	clientMock.EXPECT().FilterLogs(mock.Anything, addressQuery).Return([]types.Log{}, nil).Once()
+
+	clientMock.EXPECT().HeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(blockNum)).
+		Return(&aggkittypes.BlockHeader{
+			Number:     blockNum,
+			Hash:       blockHash,
+			ParentHash: &parentHash,
+			LogsBloom:  &bloom,
+		}, nil).Once()
+
+	arbitrationQuery := ethereum.FilterQuery{
+		BlockHash: &blockHash,
+		Addresses: []common.Address{contractAddr},
+	}
+	// Arbitration consistently empty (bounded at maxArbitrationAttempts = 2).
+	clientMock.EXPECT().FilterLogs(mock.Anything, arbitrationQuery).Return([]types.Log{}, nil).Twice()
+
+	blocks := d.GetEventsByBlockRange(ctx, blockNum, blockNum)
+
+	require.Empty(t, blocks)
+	clientMock.AssertExpectations(t)
+}
+
+// TestCheckLogsCompleteness_FinalizedZoneSkipped verifies that a block at or below
+// lastFinalizedBlock is never checked: no header is fetched and no arbitration query is issued,
+// regardless of what its bloom would have said.
+func TestCheckLogsCompleteness_FinalizedZoneSkipped(t *testing.T) {
+	ctx := context.Background()
+	mockEthClient := aggkittypesmocks.NewMultiDownloader(t)
+	sut := newLogsCompletenessSUT(t, mockEthClient)
+
+	// fromBlock == toBlock == lastFinalizedBlock: entirely within the finalized zone.
+	confirmed := sut.checkLogsCompleteness(ctx, 10, 10, 10, nil)
+
+	require.False(t, confirmed)
+	mockEthClient.AssertExpectations(t) // no HeaderByNumber/FilterLogs calls expected or made
+}
+
+// TestCheckLogsCompleteness_NilBloomSkipped verifies graceful degradation: when the header's bloom
+// is nil (not provided by the retrieval path), the block is never treated as suspicious and no
+// arbitration query is issued.
+func TestCheckLogsCompleteness_NilBloomSkipped(t *testing.T) {
+	ctx := context.Background()
+	mockEthClient := aggkittypesmocks.NewMultiDownloader(t)
+	sut := newLogsCompletenessSUT(t, mockEthClient)
+
+	blockNum := uint64(10)
+	header := types.Header{Number: big.NewInt(int64(blockNum)), ParentHash: common.HexToHash("foo")}
+	blockHash := header.Hash()
+	parentHash := common.HexToHash("foo")
+
+	mockEthClient.EXPECT().HeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(blockNum)).
+		Return(&aggkittypes.BlockHeader{
+			Number:     blockNum,
+			Hash:       blockHash,
+			ParentHash: &parentHash,
+			LogsBloom:  nil,
+		}, nil).Once()
+
+	// lastFinalizedBlock = blockNum-1 puts blockNum inside the verify window; unfilteredLogs is
+	// empty for it, so the header is fetched, but its nil bloom must skip the check.
+	confirmed := sut.checkLogsCompleteness(ctx, blockNum, blockNum, blockNum-1, nil)
+
+	require.False(t, confirmed)
+	mockEthClient.AssertExpectations(t) // header fetched once; no arbitration FilterLogs call
+}
+
+// TestCheckLogsCompleteness_NonQueriedTopicNotSuspicious verifies the topic subtlety: a block
+// whose contract emitted only a non-queried event has an unfiltered log (address matched) even
+// though filterLogs would later drop it on topic. Since checkLogsCompleteness is given the
+// unfiltered logs, that block must never be flagged as suspicious.
+func TestCheckLogsCompleteness_NonQueriedTopicNotSuspicious(t *testing.T) {
+	ctx := context.Background()
+	mockEthClient := aggkittypesmocks.NewMultiDownloader(t)
+	sut := newLogsCompletenessSUT(t, mockEthClient)
+
+	blockNum := uint64(10)
+	nonQueriedLog := types.Log{
+		Address:     contractAddr,
+		BlockNumber: blockNum,
+		Topics:      []common.Hash{common.HexToHash("0xabc123")}, // not eventSignature
+	}
+
+	confirmed := sut.checkLogsCompleteness(ctx, blockNum, blockNum, blockNum-1, []types.Log{nonQueriedLog})
+
+	require.False(t, confirmed)
+	// No HeaderByNumber/FilterLogs calls: the block is already accounted for by the unfiltered log.
+	mockEthClient.AssertExpectations(t)
+}
+
+// TestCheckLogsCompleteness_UnverifiableSuspicionRetriesRange verifies the conservative verdict:
+// when a block is bloom-positive with no logs and every arbitration re-query fails to execute, no
+// verdict can be reached, and the range must be retried rather than the suspicious block being
+// silently accepted (silent acceptance is exactly the failure mode this check exists to prevent).
+func TestCheckLogsCompleteness_UnverifiableSuspicionRetriesRange(t *testing.T) {
+	ctx := context.Background()
+	mockEthClient := aggkittypesmocks.NewMultiDownloader(t)
+	sut := newLogsCompletenessSUT(t, mockEthClient)
+
+	blockNum := uint64(10)
+	header := types.Header{Number: big.NewInt(int64(blockNum)), ParentHash: common.HexToHash("foo")}
+	blockHash := header.Hash()
+	parentHash := common.HexToHash("foo")
+
+	var bloom types.Bloom
+	bloom.Add(contractAddr.Bytes())
+
+	mockEthClient.EXPECT().HeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(blockNum)).
+		Return(&aggkittypes.BlockHeader{
+			Number:     blockNum,
+			Hash:       blockHash,
+			ParentHash: &parentHash,
+			LogsBloom:  &bloom,
+		}, nil).Once()
+
+	// Every arbitration attempt fails to execute (RPC/transport error, not an empty result).
+	arbitrationQuery := ethereum.FilterQuery{
+		BlockHash: &blockHash,
+		Addresses: []common.Address{contractAddr},
+	}
+	mockEthClient.EXPECT().FilterLogs(mock.Anything, arbitrationQuery).
+		Return(nil, errors.New("blockHash filter not supported")).Times(maxArbitrationAttempts)
+
+	confirmed := sut.checkLogsCompleteness(ctx, blockNum, blockNum, blockNum-1, nil)
+
+	require.True(t, confirmed)
+	mockEthClient.AssertExpectations(t)
+}

--- a/types/block_header.go
+++ b/types/block_header.go
@@ -14,6 +14,9 @@ type BlockHeader struct {
 	ParentHash *common.Hash `json:"parentHash"`
 	// the RequestedBlock is the original Block requested
 	RequestedBlock *BlockNumberFinality
+	// LogsBloom is the block header's logs bloom filter. Nil means the bloom was not provided by
+	// the retrieval path, in which case completeness verification is skipped for that block.
+	LogsBloom *types.Bloom
 }
 
 func (gb *BlockHeader) Brief() string {
@@ -36,13 +39,32 @@ func NewBlockHeaderFromEthHeader(ethHeader *types.Header) *BlockHeader {
 	if ethHeader == nil {
 		return nil
 	}
-	return NewBlockHeader(ethHeader.Number.Uint64(),
+	bh := NewBlockHeader(ethHeader.Number.Uint64(),
 		ethHeader.Hash(),
 		ethHeader.Time,
 		&ethHeader.ParentHash)
+	bh.LogsBloom = &ethHeader.Bloom
+	return bh
 }
 func (gb *BlockHeader) Empty() bool {
 	return gb == nil
+}
+
+// BloomMightContainAddresses reports whether the header's logs bloom indicates that at least
+// one of the given addresses may have emitted a log in this block. It returns false when the
+// bloom is not available (nil), since no assertion can be made in that case. Blooms have no
+// false negatives: a false result with a non-nil bloom is a guarantee that none of the
+// addresses logged in this block.
+func (bh *BlockHeader) BloomMightContainAddresses(addrs []common.Address) bool {
+	if bh == nil || bh.LogsBloom == nil {
+		return false
+	}
+	for _, addr := range addrs {
+		if types.BloomLookup(*bh.LogsBloom, addr) {
+			return true
+		}
+	}
+	return false
 }
 
 func (gb *BlockHeader) String() string {

--- a/types/block_header_test.go
+++ b/types/block_header_test.go
@@ -44,6 +44,23 @@ func TestNewBlockHeaderFromEthHeader(t *testing.T) {
 		header := NewBlockHeaderFromEthHeader(nil)
 		require.Nil(t, header)
 	})
+
+	t.Run("copies the logs bloom", func(t *testing.T) {
+		var bloom types.Bloom
+		bloom.Add(common.HexToAddress("0xaaaa").Bytes())
+		ethHeader := &types.Header{
+			Number:     big.NewInt(456),
+			Time:       1640995300,
+			ParentHash: common.HexToHash("0xfedcba0987654321"),
+			Bloom:      bloom,
+		}
+
+		header := NewBlockHeaderFromEthHeader(ethHeader)
+
+		require.NotNil(t, header)
+		require.NotNil(t, header.LogsBloom)
+		require.Equal(t, bloom, *header.LogsBloom)
+	})
 }
 
 func TestBlockHeader_String(t *testing.T) {
@@ -123,5 +140,46 @@ func TestBlockHeader_Empty(t *testing.T) {
 
 		result := header.Empty()
 		require.False(t, result)
+	})
+}
+
+func TestBlockHeader_BloomMightContainAddresses(t *testing.T) {
+	addrA := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	addrB := common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	t.Run("nil bloom returns false", func(t *testing.T) {
+		header := &BlockHeader{}
+
+		require.False(t, header.BloomMightContainAddresses([]common.Address{addrA}))
+	})
+
+	t.Run("bloom containing address A matches [A] and [B, A]", func(t *testing.T) {
+		var bloom types.Bloom
+		bloom.Add(addrA.Bytes())
+		header := &BlockHeader{LogsBloom: &bloom}
+
+		require.True(t, header.BloomMightContainAddresses([]common.Address{addrA}))
+		require.True(t, header.BloomMightContainAddresses([]common.Address{addrB, addrA}))
+	})
+
+	t.Run("bloom containing address A does not match [B]", func(t *testing.T) {
+		var bloom types.Bloom
+		bloom.Add(addrA.Bytes())
+		header := &BlockHeader{LogsBloom: &bloom}
+
+		require.False(t, header.BloomMightContainAddresses([]common.Address{addrB}))
+	})
+
+	t.Run("empty (zero) bloom returns false", func(t *testing.T) {
+		var bloom types.Bloom
+		header := &BlockHeader{LogsBloom: &bloom}
+
+		require.False(t, header.BloomMightContainAddresses([]common.Address{addrA}))
+	})
+
+	t.Run("nil receiver returns false", func(t *testing.T) {
+		var header *BlockHeader
+
+		require.False(t, header.BloomMightContainAddresses([]common.Address{addrA}))
 	})
 }


### PR DESCRIPTION
## 🔄 Changes Summary
- **`eth_getLogs` completeness verification (logsBloom check) — root-cause defense, all syncers**: the corruption class behind the bokuto incident is an `eth_getLogs` response that silently omits a log while every observed header hash stays canonical (flaky/mixed RPC view during an L1 reorg) — invisible to header-hash reorg detection *by construction*. Header logs blooms are part of the hash-committed header and have **no false negatives**, so a block whose bloom is positive for a queried contract address but for which the logs response contains no entry is a *suspected omission*. Because bloom **false positives are deterministic** per (block, address), suspicion alone never fails a range (that would wedge the syncer forever); every suspicion is **arbitrated** with a single-block re-query by block hash (≤2 attempts): logs found → genuine omission → the range/step errors and retries loudly (a healthy/round-robin RPC heals it; a persistently-broken RPC produces a loud, log-throttled retry loop instead of silent corruption); consistently empty → bloom false positive → accepted at debug. Wired into:
  - `aggkittypes.BlockHeader` gains `LogsBloom` (+ `BloomMightContainAddresses`), populated by both header retrieval paths (`etherman` batch JSON and `HeaderByNumber`); `nil` bloom ⇒ check skipped (graceful degradation for RPCs/mocks without blooms).
  - **multidownloader** (`l1infotreesync`): `StepUnsafe` (headers for the whole pending range already in hand — near-free) and `StepSafe` (now fetches headers for the **entire** queried range via the existing parallel batch machinery; **storage volume unchanged** — only event-block headers are persisted, the rest are verification-only).
  - **legacy `sync` downloader** (`bridgesync`, `claimsync`, `l2gersync` — syncers with *no* content-integrity oracle, where an omitted log = a silently missing deposit / wrong exit tree): verification of the **unfinalized zone** (`(lastFinalized, toBlock]`), where the mixed-view omission class lives; a confirmed omission retries the range indefinitely with throttled logging — never returning `nil`, which would advance past the omitted log and commit the corruption.
- **Self-healing escalated reorg in `l1infotreesync`** (follow-up to #1738 / v0.11.0-rc2): every `UpdateL1InfoTreeV2` sanity check that passes now persists its block as a *last verified checkpoint* (new single-row `l1info_checkpoint` table, migration `l1infotreesync0005`), atomically in the same tx as the batch it vouches for. When a `Reorg` recovery is attempted a second consecutive time for the same halted block — i.e. the #1738 batch-start purge made no progress because the divergence lives in already-COMMITTED data — the purge escalates to the last verified checkpoint block, or to the syncer's configured `InitialBlock` if no checkpoint has ever been recorded (full l1infotreesync resync). This converts a permanent stuck-halt loop into an automatic self-heal.
- **Bounded error logging in indefinite retry loops**: new `common.ShouldLogRetryAtError` policy (error level for the first 5 attempts, then every 100th; debug otherwise) applied to `multidownloader/sync/evmdriver.go` (`withRetry` + the poisoned-batch recovery log), the legacy `sync/evmdriver.go` `withRetry`, both `evmdownloader.go` append-log retry loops, and the halted-processor guards in `l1infotreesync`/`bridgesync` (hit counter, reset on unhalt). No change to retry semantics or timing — log volume/level only.

**Production evidence (bokuto, 2026-08-05)**: a v0.11.0-rc2 pod looped for 13+ hours on the same block, ~once per 90s:

    reorging to block 11414610
    reorged to block 11414610, 0 rows affected
    processor is unhalted
    processor is halted, due to: failed to check UpdateL1InfoTreeV2.
      Index: 220309 vs event.LeafCount: 220310. Happened on block 11414610

The local tree was missing a leaf committed *before* the failing batch's first block (flaky RPC omitting a log during a Sepolia reorg), permanently out of reach of the batch-start purge — and neither reorg detector can see it, since the stored headers are canonical; only the event content is orphaned. Meanwhile the bokuto fleet emitted >1.3M `state is inconsistent` error lines in 24h. **The logsBloom check would have caught the omission at download time** (the missing leaf's block bloom was positive for the GER contract); the checkpoint escalation remains as the recovery of last resort for divergence that still reaches the DB.

## ⚠️ Breaking Changes
- 🛠️ **Config**: none
- 🔌 **API/CLI**: none
- 🗑️ **Deprecated Features**: none
- **Behavioral notes**:
  - on a DB that is already corrupted (divergence committed before this upgrade, so no checkpoint recorded yet), the first escalation purges back to `InitialBlock`, i.e. l1infotreesync re-syncs from scratch automatically — replacing today's "halted forever until manual DB wipe".
  - multidownloader `StepSafe` now performs one batched header retrieval covering every block of each queried range (previously only blocks with logs). RPC load increases accordingly during initial sync/catch-up; steady-state tailing ranges are small. Persisted data is unchanged.
  - legacy-downloader syncers perform up to one `HeaderByNumber` per zero-log block above the finalized mark per queried range (bounded by the queried chunk; one-time cost when catching up through the unfinalized zone).

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: none — new DB migration `l1infotreesync0005` (single-row `l1info_checkpoint` table) applies automatically on startup.

## ✅ Testing
- 🤖 **Automatic**:
  - `l1infotreesync/e2e_committed_state_selfheal_test.go` drives the real processor + multidownloader `EVMDriver` + `RetryHandler` through the full halt → shallow-recover → halt-again → escalate → heal cycle with committed poison (one `UpdateL1InfoTree` leaf dropped from a downloaded batch); 7 processor unit tests (checkpoint persistence/atomicity/clearing on purge, escalation trigger, initial-block fallback); `common/retry_log_test.go` covers the throttling cadence.
  - logsBloom verification: `types/block_header_test.go` (bloom lookup semantics, nil-bloom degradation, RPC→header conversions), `etherman/batch_requests_test.go` (raw JSON `logsBloom` parsing), `multidownloader/logs_completeness_test.go` (suspicion detection, arbitration verdicts incl. wrong-BlockHash guard and all-attempts-failed conservative error, `StepSafe` omission vs. false-positive step-level paths), `sync/logs_completeness_test.go` (end-to-end omission healed on retry, deterministic bloom false positive accepted without a retry loop, finalized-zone and nil-bloom skips, non-queried-topic subtlety against unfiltered logs, unverifiable suspicion conservatively retried).
- 🖱️ **Manual**: deploy to `bokuto-bridge-aggkit` (dev, `infra-common-development`), currently stuck looping on block 11414610 — expect one escalated reorg (full resync, since no checkpoint exists on the corrupted DB), then normal sync with no further `failed to check UpdateL1InfoTreeV2` halts; while any retry loop is stuck, error-log rate should drop to ~1 line per 100 attempts. Any future RPC omission should now surface at download time as `confirmed eth_getLogs omission` / `arbitrateSuspiciousBlock: genuine eth_getLogs omission` warnings.

## 🐞 Issues
- N/A — reported via [Slack](https://0xpolygon.slack.com/archives/C07J2T5QBM4/p1785942517949789?thread_ts=1785419164.348709&cid=C07J2T5QBM4)

## 🔗 Related PRs
- #1738 (v0.11.0-rc2 tip-reorg halt fix — this PR covers the committed-state case its notes explicitly left out)

## 📝 Notes
- **Defense in depth, three layers**: (1) the logsBloom completeness check catches omissions at download time for *all* syncers; (2) for l1infotreesync, the `UpdateL1InfoTreeV2` sanity check catches anything that still reaches the DB; (3) the checkpoint-escalated reorg self-heals instead of halting forever. Layers 2–3 exist only for l1infotreesync (only syncer with an on-chain content commitment), which is why layer 1 is downloader-level and generic.
- **Arbitration semantics**: a block whose bloom is positive but whose by-hash re-query is also consistently empty is indistinguishable from a bloom false positive and is accepted (debug-logged). A node whose per-hash log index is *persistently* broken for a canonical hash therefore still slips through layer 1 — for l1infotreesync layers 2–3 cover it; for the other syncers this is a documented residual risk (the observed production failure mode was transient/mixed-view, which layer 1 catches). If every arbitration attempt fails to *execute*, the range errs conservatively rather than accepting an unverifiable block.
- **Known gap (legacy downloader)**: the finalized zone is not completeness-checked there (one sequential `HeaderByNumber` per block is prohibitive across large catch-up ranges; the package has no batch machinery). The multidownloader verifies both zones — migrating the remaining syncers to it closes the gap.
- Escalation lives entirely inside the processor (`Reorg`/`haltAtBlock`), so the driver–processor interface and its mocks are untouched. A genuine reorg notification arriving while halted at the same block would also escalate — deeper than strictly needed, but always safe (the range is simply re-downloaded).
- Soundness: a passed `UpdateL1InfoTreeV2` checkpoint at block C proves the local tree matched L1 as of that event, so any later divergence is strictly after it — purging `>= C` and re-downloading is always sufficient. The checkpoint is cleared (same tx) whenever a purge reaches its own block.
- `bridgesync` halt semantics are intentionally untouched (no equivalent on-chain checkpoint event); it now gets the downloader-level logsBloom protection plus the throttled guard logging.
- **Ops follow-up (recommended, separate PR)**: emit metrics/monitors on `escalating reorg recovery` and `confirmed eth_getLogs omission` events — both self-heal conditions that indicate the underlying RPC served inconsistent data and should be visible, not silently absorbed.
- Known follow-up (separate PR): aggsender resubmits `InError` certificates with a stale L1 info root after an L1 reorg (`L1InfoRootNotFound` on agglayer-node); it should rebuild the certificate against the current L1 info tree on retry.
