### PR TITLE
fix(force_ger_update): reset timer from our own confirmed send, not only the monitor

### DIFF
--- a/tools/force_ger_update/integration_test.go
+++ b/tools/force_ger_update/integration_test.go
@@ -37,21 +37,14 @@ const (
 	// long enough that the negative ("stays quiet") assertions below have comfortable margin
 	// against the monitor's own detection latency (at most one EventPollInterval in polling mode).
 	//
-	// The tool has an inherent, PLAN.md-acknowledged race in polling mode: the in-flight guard is
-	// released when the send is *confirmed mined*, and if that happens before the monitor's poll
-	// loop has observed the resulting UpdateL1InfoTree event and reset lastGERUpdate, the next
-	// CheckInterval tick still sees the stale (pre-reset) timestamp and legitimately fires a second,
-	// "redundant (harmless)" send. Real deployments never hit this because a transaction takes far
-	// longer to *mine* than the monitor takes to *detect* an event. This test must encode that same
-	// invariant, and robustly (CI runners starve goroutines unpredictably), so what matters is the
-	// RATIO, not absolute values:
-	//   - integrationSenderPoll (how long the send stays "in flight" — the mock mines instantly, so
-	//     the send is confirmed only on the sender's first Result poll, i.e. after one senderPoll) is
-	//     kept MUCH larger than integrationEventPollInterval (how often the monitor re-scans). With a
-	//     ~30x ratio, the monitor observes the event and resets the timer many poll cycles before the
-	//     guard releases, even under heavy, proportional scheduler starvation — so no second send.
-	//   - integrationEventPollInterval is also < integrationCheckInterval so detection generally beats
-	//     the next elapsed-time evaluation regardless.
+	// runLoop's own confirmed send resets lastGERUpdate the moment SendForcedGERUpdate reports a
+	// genuine on-chain confirmation — it does not wait for (or depend on) the monitor independently
+	// observing the resulting UpdateL1InfoTree event, precisely to avoid a redundant second send in
+	// the gap between "ethtxmanager reports Mined" and "the monitor's poll/watch cycle has scanned
+	// that block" (see runLoop's doc comment). This suite still keeps integrationSenderPoll much
+	// larger than integrationEventPollInterval, and integrationEventPollInterval below
+	// integrationCheckInterval, purely as generous scheduling margin for a constrained/starved CI
+	// runner — not because a race would otherwise cause a spurious second send.
 	// (The two subtests also run sequentially rather than in parallel — see TestForceGERUpdate — so a
 	// constrained CI runner isn't driving two simulated backends + monitor/sender loops at once.)
 	integrationMaxTimeWithoutGER = 2 * time.Second

--- a/tools/force_ger_update/run.go
+++ b/tools/force_ger_update/run.go
@@ -111,25 +111,40 @@ func dialL1(ctx context.Context, url string) (aggkittypes.BaseEthereumClienter, 
 // ethtxmanager, or clients involved).
 //
 // It starts monitor.Start(ctx) to observe UpdateL1InfoTree events (each one resets lastGERUpdate to
-// the event's block timestamp — the single source of truth for "when was the GER last updated");
-// every checkInterval it computes elapsed = time.Now() - lastGERUpdate and, when elapsed is at
-// least maxTimeWithoutGERUpdate and no forced update is currently in flight, triggers
-// sender.SendForcedGERUpdate in a background goroutine. Because lastGERUpdate starts at the
-// zero time.Time when the boot scan found nothing (see GERMonitor.LastGERUpdate), elapsed is
-// enormous in that case, so the very first tick fires a send without any special-casing.
+// the event's block timestamp — one of the two ways "when was the GER last updated" gets reset, the
+// other being our own confirmed send, see below); every checkInterval it computes
+// elapsed = time.Now() - lastGERUpdate and, when elapsed is at least maxTimeWithoutGERUpdate and no
+// forced update is currently in flight, triggers sender.SendForcedGERUpdate in a background
+// goroutine. Because lastGERUpdate starts at the zero time.Time when the boot scan found nothing
+// (see GERMonitor.LastGERUpdate), elapsed is enormous in that case, so the very first tick fires a
+// send without any special-casing.
 //
 // SendForcedGERUpdate blocks until the transaction reaches a terminal status (or ctx is
-// cancelled), so the in-flight guard here is what prevents a second send from being started while
-// one is still pending; the timer itself is only ever reset by an observed monitor event, never by
-// the send completing.
+// cancelled); the goroutine reports its outcome on sendDone rather than clearing the in-flight
+// guard itself. The main select loop below is the only place that ever clears it — and it always
+// does so in the same iteration where it applies a genuine confirmation's confirmedAt to
+// lastGERUpdate, never before. That ordering (reset timer, THEN clear the guard, both in one
+// single-threaded step) is what makes this race-free: a later ticker tick can only ever observe
+// inFlight == false after lastGERUpdate has already been advanced, so it can never fire a
+// redundant second send off a stale timer. This replaced an earlier version where the goroutine
+// cleared the guard itself immediately after SendForcedGERUpdate returned, relying solely on the
+// GERMonitor to independently observe the resulting UpdateL1InfoTree event to reset the timer:
+// the guard could drop as soon as the ethtxmanager reported Mined, which can happen before the
+// monitor's own poll/watch cycle has scanned the block containing that event, so a checkInterval
+// tick landing in that gap still saw the old (pre-reset) lastGERUpdate and legitimately fired a
+// second, redundant send — observed in production as occasional back-to-back bridgeMessage
+// transactions. A later monitor event for the same tx is still consumed as usual; it just
+// re-confirms a lastGERUpdate that was already reset (neither reset path below ever moves the
+// timer backwards).
 //
-// Timer semantics / clock skew: lastGERUpdate is an L1 *block* timestamp (chain clock) while
-// elapsed is measured against the tool's local wall clock (time.Since). In practice L1 block
-// timestamps track real time closely, so the small skew between the two clocks is immaterial next
-// to a MaxTimeWithoutGERUpdate that is realistically minutes-to-hours. The skew is also safe in
-// both directions: if a block timestamp is slightly ahead of the local clock, time.Since is
-// negative, elapsed stays below the threshold, and the tool simply waits a little longer before
-// forcing an update (it never over-fires from skew, and a negative duration never panics).
+// Timer semantics / clock skew: lastGERUpdate is either an L1 *block* timestamp (chain clock, from a
+// monitor event) or a local wall-clock time (from a confirmed send), while elapsed is always
+// measured against the tool's local wall clock (time.Since). In practice L1 block timestamps track
+// real time closely, so the small skew between the two clocks is immaterial next to a
+// MaxTimeWithoutGERUpdate that is realistically minutes-to-hours. The skew is also safe in both
+// directions: if a block timestamp is slightly ahead of the local clock, time.Since is negative,
+// elapsed stays below the threshold, and the tool simply waits a little longer before forcing an
+// update (it never over-fires from skew, and a negative duration never panics).
 //
 // runLoop returns nil once ctx is cancelled, after every goroutine it started has finished.
 func runLoop(
@@ -154,9 +169,15 @@ func runLoop(
 	)
 	defer wg.Wait()
 
+	// sendDone carries the outcome of our own sends to the select loop below. Buffered 1: the
+	// in-flight guard ensures at most one send is ever outstanding, so the goroutine can never
+	// block trying to deliver here.
+	sendDone := make(chan sendOutcome, 1)
+
 	triggerSend := func() {
 		// CompareAndSwap(false, true) atomically checks-and-sets: exactly one caller can win this
 		// race per in-flight window, so concurrent/rapid ticks can never launch two sends at once.
+		// Only the main loop's sendDone case (below) ever clears inFlight back to false.
 		if !inFlight.CompareAndSwap(false, true) {
 			log.Debugf("force_ger_update: forced update already in flight, skipping")
 			return
@@ -165,12 +186,13 @@ func runLoop(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			defer inFlight.Store(false)
 
 			log.Infof("force_ger_update: elapsed time since last GER update exceeded threshold, " +
 				"sending forced GER update")
-			if err := sender.SendForcedGERUpdate(ctx); err != nil {
-				log.Errorf("force_ger_update: forced GER update failed: %v", err)
+			confirmedAt, err := sender.SendForcedGERUpdate(ctx)
+			select {
+			case sendDone <- sendOutcome{confirmedAt: confirmedAt, err: err}:
+			case <-ctx.Done():
 			}
 		}()
 	}
@@ -190,7 +212,22 @@ func runLoop(
 			}
 			log.Infof("force_ger_update: observed UpdateL1InfoTree at block %d (timestamp %s), "+
 				"resetting timer", ev.BlockNumber, ev.BlockTimestamp)
-			lastGERUpdate = ev.BlockTimestamp
+			if ev.BlockTimestamp.After(lastGERUpdate) {
+				lastGERUpdate = ev.BlockTimestamp
+			}
+
+		case res := <-sendDone:
+			if res.err != nil {
+				log.Errorf("force_ger_update: forced GER update failed: %v", res.err)
+			} else if !res.confirmedAt.IsZero() {
+				log.Infof("force_ger_update: forced GER update confirmed at %s, resetting timer", res.confirmedAt)
+				if res.confirmedAt.After(lastGERUpdate) {
+					lastGERUpdate = res.confirmedAt
+				}
+			}
+			// Clearing the guard here, after the (possible) reset above, is what closes the race:
+			// see this function's doc comment.
+			inFlight.Store(false)
 
 		case <-ticker.C:
 			elapsed := time.Since(lastGERUpdate)
@@ -199,6 +236,13 @@ func runLoop(
 			}
 		}
 	}
+}
+
+// sendOutcome carries a completed SendForcedGERUpdate call's result from the goroutine that ran it
+// back to runLoop's single-threaded select loop.
+type sendOutcome struct {
+	confirmedAt time.Time
+	err         error
 }
 
 // logStartupSummary logs a config summary (no secrets), the sender address, and the boot-derived

--- a/tools/force_ger_update/run_test.go
+++ b/tools/force_ger_update/run_test.go
@@ -33,10 +33,10 @@ var _ GERMonitor = (*fakeMonitor)(nil)
 // SendForcedGERUpdate call.
 type fakeSender struct {
 	calls atomic.Int32
-	send  func(ctx context.Context) error
+	send  func(ctx context.Context) (time.Time, error)
 }
 
-func (s *fakeSender) SendForcedGERUpdate(ctx context.Context) error {
+func (s *fakeSender) SendForcedGERUpdate(ctx context.Context) (time.Time, error) {
 	s.calls.Add(1)
 	return s.send(ctx)
 }
@@ -44,19 +44,32 @@ func (s *fakeSender) SendForcedGERUpdate(ctx context.Context) error {
 var _ ForcedUpdateSender = (*fakeSender)(nil)
 
 // blockingSender returns a fakeSender whose SendForcedGERUpdate blocks on block (or ctx.Done(),
-// per the real Sender's documented contract) before returning nil — simulating a send that stays
-// "in flight" until the test releases it. A nil block returns immediately.
+// per the real Sender's documented contract) before returning a zero confirmedAt — simulating a
+// send that stays "in flight" until the test releases it, without itself ever resetting the timer
+// (deliberately: these tests are about the in-flight guard, not the confirmed-send reset path — see
+// confirmingSender for that). A nil block returns immediately.
 func blockingSender(block <-chan struct{}) *fakeSender {
 	return &fakeSender{
-		send: func(ctx context.Context) error {
+		send: func(ctx context.Context) (time.Time, error) {
 			if block == nil {
-				return nil
+				return time.Time{}, nil
 			}
 			select {
 			case <-block:
 			case <-ctx.Done():
 			}
-			return nil
+			return time.Time{}, nil
+		},
+	}
+}
+
+// confirmingSender returns a fakeSender whose SendForcedGERUpdate returns immediately with
+// confirmedAt = time.Now() and no error — simulating a send that ethtxmanager has just confirmed
+// Mined, without blocking (unlike blockingSender).
+func confirmingSender() *fakeSender {
+	return &fakeSender{
+		send: func(context.Context) (time.Time, error) {
+			return time.Now(), nil
 		},
 	}
 }
@@ -171,6 +184,57 @@ func TestRunLoop_InFlightGuard_NoDoubleSend(t *testing.T) {
 	err := runLoop(ctx, monitor, sender, time.Time{}, 5*time.Millisecond, 500*time.Millisecond)
 	require.NoError(t, err)
 	require.Equal(t, int32(1), sender.calls.Load(), "expected exactly one send across the whole in-flight window")
+}
+
+// TestRunLoop_ConfirmedSendResetsTimer_NoRedundantSecondSend is the regression test for a
+// production bug: two forced-update transactions were occasionally observed back to back. The
+// in-flight guard used to be released by the sending goroutine itself immediately after
+// SendForcedGERUpdate returned, and the timer was reset only when the GERMonitor independently
+// observed the resulting UpdateL1InfoTree event. Those two things can race: the guard can drop as
+// soon as ethtxmanager reports Mined, which is often before the monitor's own poll/watch cycle has
+// scanned the block containing that event, so a checkInterval tick landing in that gap still saw
+// the stale timer and fired a legitimate-looking but redundant second send.
+//
+// This test isolates that scenario at the extreme: the monitor never delivers an event at all
+// (worst case for the old design), while the sender confirms every send immediately. Many
+// checkInterval ticks fire in the following window — under the old design every single one would
+// have re-triggered a send, since nothing but the (never-arriving) monitor event reset the timer.
+func TestRunLoop_ConfirmedSendResetsTimer_NoRedundantSecondSend(t *testing.T) {
+	t.Parallel()
+
+	const (
+		checkInterval = 2 * time.Millisecond
+		maxWithoutGER = 200 * time.Millisecond
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	monitor := &fakeMonitor{events: make(chan GERUpdateEvent)} // never written to: the monitor never observes anything
+	sender := confirmingSender()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runLoop(ctx, monitor, sender, time.Time{}, checkInterval, maxWithoutGER)
+	}()
+
+	// Booting stale fires exactly one send almost immediately.
+	require.Eventually(t, func() bool { return sender.calls.Load() == 1 }, time.Second, time.Millisecond,
+		"stale boot must trigger the first forced-update send")
+
+	// Many checkInterval ticks (every 2ms) fire over the next window, far sooner than maxWithoutGER
+	// (200ms) could legitimately trip again from the reset the confirmed send itself must have
+	// applied.
+	require.Never(t, func() bool { return sender.calls.Load() > 1 }, 100*time.Millisecond, time.Millisecond,
+		"a confirmed send must reset the timer itself, without depending on the monitor observing the resulting event")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runLoop did not return promptly after ctx cancellation")
+	}
 }
 
 // TestRunLoop_ContextCancelled_ReturnsPromptly proves the loop, and any in-flight send, unwind

--- a/tools/force_ger_update/sender.go
+++ b/tools/force_ger_update/sender.go
@@ -84,8 +84,9 @@ func NewSender(cfg ForceGERUpdateConfig, ethTxManager EthTxManager, opts ...Opti
 }
 
 // SendForcedGERUpdate submits (or, in DryRun mode, only logs) a bridgeMessage transaction with
-// forceUpdateGlobalExitRoot = true, and waits for it to be mined before returning.
-func (s *Sender) SendForcedGERUpdate(ctx context.Context) error {
+// forceUpdateGlobalExitRoot = true, and waits for it to reach a terminal status before returning.
+// See ForcedUpdateSender for what confirmedAt means in each case.
+func (s *Sender) SendForcedGERUpdate(ctx context.Context) (time.Time, error) {
 	data, err := s.bridgeAbi.Pack(
 		bridgeMessageFuncName,
 		s.destinationNetwork,
@@ -94,20 +95,20 @@ func (s *Sender) SendForcedGERUpdate(ctx context.Context) error {
 		[]byte{},
 	)
 	if err != nil {
-		return fmt.Errorf("pack %s call: %w", bridgeMessageFuncName, err)
+		return time.Time{}, fmt.Errorf("pack %s call: %w", bridgeMessageFuncName, err)
 	}
 
 	if s.dryRun {
 		log.Infof("force_ger_update dry-run: would send bridgeMessage tx to %s, calldata=0x%x",
 			s.bridgeAddr, data)
-		return nil
+		return time.Time{}, nil
 	}
 
 	id, err := s.ethTxManager.Add(ctx, &s.bridgeAddr, common.Big0, data, 0, nil)
 	if err == nil {
 		log.Infof("forced GER update transaction submitted with ID: %s", id.Hex())
 	} else if !errors.Is(err, ethtxmanager.ErrAlreadyExists) {
-		return fmt.Errorf("add forced GER update transaction: %w", err)
+		return time.Time{}, fmt.Errorf("add forced GER update transaction: %w", err)
 	}
 	if err != nil {
 		log.Infof("forced GER update transaction already exists in monitoring DB with ID: %s", id.Hex())
@@ -117,12 +118,13 @@ func (s *Sender) SendForcedGERUpdate(ctx context.Context) error {
 }
 
 // waitForResult polls the ethtxmanager for id's status until a terminal state is reached:
-// Mined/Safe/Finalized succeed, Failed returns an error, and Evicted is logged and returns nil
-// (mirrors aggoracle/chaingersender/evm.go's submitTransaction monitoring loop). Every terminal
-// state also forgets id (see forgetTerminalTx) so the next SendForcedGERUpdate call — which packs
+// Mined/Safe/Finalized succeed (returning the local time the confirmation was observed), Failed
+// returns an error, and Evicted is logged and returns a zero confirmedAt with no error (mirrors
+// aggoracle/chaingersender/evm.go's submitTransaction monitoring loop). Every terminal state also
+// forgets id (see forgetTerminalTx) so the next SendForcedGERUpdate call — which packs
 // byte-for-byte identical calldata — is free to submit a genuinely new transaction instead of
 // perpetually re-observing this one.
-func (s *Sender) waitForResult(ctx context.Context, id common.Hash) error {
+func (s *Sender) waitForResult(ctx context.Context, id common.Hash) (time.Time, error) {
 	ticker := time.NewTicker(s.pollInterval)
 	defer ticker.Stop()
 
@@ -130,12 +132,12 @@ func (s *Sender) waitForResult(ctx context.Context, id common.Hash) error {
 		select {
 		case <-ctx.Done():
 			log.Infof("context cancelled while waiting for forced GER update tx %s", id.Hex())
-			return nil
+			return time.Time{}, nil
 
 		case <-ticker.C:
 			res, err := s.ethTxManager.Result(ctx, id)
 			if err != nil {
-				return fmt.Errorf("check forced GER update transaction %s status: %w", id.Hex(), err)
+				return time.Time{}, fmt.Errorf("check forced GER update transaction %s status: %w", id.Hex(), err)
 			}
 
 			switch res.Status {
@@ -144,17 +146,17 @@ func (s *Sender) waitForResult(ctx context.Context, id common.Hash) error {
 				continue
 			case ethtxtypes.MonitoredTxStatusFailed:
 				s.forgetTerminalTx(ctx, id)
-				return fmt.Errorf("forced GER update tx %s failed", id.Hex())
+				return time.Time{}, fmt.Errorf("forced GER update tx %s failed", id.Hex())
 			case ethtxtypes.MonitoredTxStatusEvicted:
 				log.Infof("forced GER update tx %s was evicted", id.Hex())
 				s.forgetTerminalTx(ctx, id)
-				return nil
+				return time.Time{}, nil
 			case ethtxtypes.MonitoredTxStatusMined,
 				ethtxtypes.MonitoredTxStatusSafe,
 				ethtxtypes.MonitoredTxStatusFinalized:
 				log.Infof("forced GER update tx %s was successfully mined at block %d", id.Hex(), res.MinedAtBlockNumber)
 				s.forgetTerminalTx(ctx, id)
-				return nil
+				return time.Now(), nil
 			default:
 				log.Errorf("unexpected forced GER update tx status: %s", res.Status)
 			}

--- a/tools/force_ger_update/sender_test.go
+++ b/tools/force_ger_update/sender_test.go
@@ -96,7 +96,9 @@ func TestSendForcedGERUpdate_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+	confirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.False(t, confirmedAt.IsZero(), "a genuinely mined tx must report a non-zero confirmation time")
 
 	require.NotNil(t, capturedData)
 	require.Equal(t, "240ff378", common.Bytes2Hex(capturedData[:4]))
@@ -135,9 +137,10 @@ func TestSendForcedGERUpdate_Failed(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err = sender.SendForcedGERUpdate(ctx)
+	confirmedAt, err := sender.SendForcedGERUpdate(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), txID.Hex())
+	require.True(t, confirmedAt.IsZero())
 }
 
 func TestSendForcedGERUpdate_Evicted(t *testing.T) {
@@ -167,7 +170,9 @@ func TestSendForcedGERUpdate_Evicted(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+	confirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.True(t, confirmedAt.IsZero(), "an evicted tx never actually updated the GER, so it must not reset the caller's timer")
 }
 
 func TestSendForcedGERUpdate_AlreadyExists(t *testing.T) {
@@ -197,7 +202,9 @@ func TestSendForcedGERUpdate_AlreadyExists(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+	confirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.False(t, confirmedAt.IsZero())
 }
 
 // TestSendForcedGERUpdate_RepeatedCallsResubmitAfterCompletion is the regression test for the
@@ -248,8 +255,13 @@ func TestSendForcedGERUpdate_RepeatedCallsResubmitAfterCompletion(t *testing.T) 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+	firstConfirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.False(t, firstConfirmedAt.IsZero())
+
+	secondConfirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.False(t, secondConfirmedAt.IsZero())
 }
 
 func TestSendForcedGERUpdate_DryRun(t *testing.T) {
@@ -263,7 +275,9 @@ func TestSendForcedGERUpdate_DryRun(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+	confirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.True(t, confirmedAt.IsZero(), "dry-run never actually sends anything, so it must not reset the caller's timer")
 
 	ethTxMan.AssertNotCalled(t, "Add",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -295,7 +309,9 @@ func TestSendForcedGERUpdate_RemoveFailureDoesNotFailSend(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	require.NoError(t, sender.SendForcedGERUpdate(ctx))
+	confirmedAt, err := sender.SendForcedGERUpdate(ctx)
+	require.NoError(t, err)
+	require.False(t, confirmedAt.IsZero(), "a Remove failure is best-effort and must not suppress the mined confirmation")
 }
 
 func TestNewSender_DefaultsDestinationAddressToSenderFrom(t *testing.T) {

--- a/tools/force_ger_update/types.go
+++ b/tools/force_ger_update/types.go
@@ -37,8 +37,13 @@ type GERMonitor interface {
 // (forceUpdateGlobalExitRoot = true) through the ethtxmanager.
 type ForcedUpdateSender interface {
 	// SendForcedGERUpdate submits (or, in DryRun mode, only logs) a bridgeMessage transaction with
-	// forceUpdateGlobalExitRoot = true, and waits for it to be mined before returning.
-	SendForcedGERUpdate(ctx context.Context) error
+	// forceUpdateGlobalExitRoot = true, and waits for it to reach a terminal status before
+	// returning. When the tx is genuinely confirmed on L1 (Mined/Safe/Finalized), confirmedAt is the
+	// (local wall-clock) time that was observed and err is nil; the caller uses confirmedAt to reset
+	// its own "time since last GER update" timer immediately, without waiting for the GERMonitor to
+	// independently detect the resulting event — see runLoop's doc comment for why that matters.
+	// confirmedAt is the zero time.Time in every other case (DryRun, Evicted, or an error).
+	SendForcedGERUpdate(ctx context.Context) (confirmedAt time.Time, err error)
 }
 
 // EthTxManager is the narrow ethtxmanager interface (Add/Result/From/...) used to submit and track


### PR DESCRIPTION
## 🔄 Changes Summary
- Production observed `force_ger_update` occasionally sending two `bridgeMessage` transactions back to back (reported against `0x4b0c1C64e8cd233EBF947C3De4daE57C2548B061` on `0x2A3dD3EB832af982EC71669E178424b10DcA2Ede`), despite `#1769`'s dedup fix already shipped.
- Root cause: the in-flight guard was released by the sending goroutine itself immediately after `SendForcedGERUpdate` returned, while `lastGERUpdate` was reset **only** when the `GERMonitor` independently observed the resulting `UpdateL1InfoTree` event. Those two things can race — the guard can drop as soon as `ethtxmanager` reports the tx `Mined`, which can happen before the monitor's own poll/watch cycle has scanned the block containing that event. A `CheckInterval` tick landing in that gap still saw the stale (pre-reset) timer and legitimately fired a second, redundant send.
- Fix: `SendForcedGERUpdate` now returns a `confirmedAt` timestamp whenever the tx is genuinely confirmed on L1 (Mined/Safe/Finalized — zero in every other case: DryRun, Evicted, error). The in-flight guard is now cleared **exclusively** by `runLoop`'s own single-threaded select loop, in the same step where it applies that confirmation to `lastGERUpdate` — a later tick can only ever observe the guard cleared after the timer has already been advanced, closing the race entirely rather than just narrowing it. A later monitor event for the same tx is still consumed as usual (it just re-confirms an already-reset timer; neither reset path ever moves the timer backwards).

## ⚠️ Breaking Changes
- None (internal `ForcedUpdateSender` interface signature change only — no config/API/CLI impact).

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `go test -race ./tools/force_ger_update/...` — updated all `sender_test.go` call sites for the new `(confirmedAt time.Time, err error)` return, added assertions on `confirmedAt` per status (non-zero for Mined, zero for Evicted/DryRun/Failed). Added `TestRunLoop_ConfirmedSendResetsTimer_NoRedundantSecondSend`, the regression test for this bug: a monitor that never delivers an event, paired with a sender that confirms immediately, asserts exactly one send happens across many rapid `CheckInterval` ticks — verified this fails against the pre-fix logic (reverted locally, confirmed red, then restored) before finalizing.
- Updated `integration_test.go`'s stale comment describing the "inherent, PLAN.md-acknowledged race" — the race is now closed by design; the timing-ratio margins it also described are kept as generous CI scheduling headroom, not as the thing preventing a spurious second send.
- 🖱️ **Manual**: N/A

## 🐞 Issues
- N/A — reported via production observation on Etherscan (no logs available), root-caused by code inspection.

## 🔗 Related PRs
- #1769 (previous fix in this tool — closed the tx-dedup-forever bug; this PR fixes a separate, subsequent issue observed after that shipped)

## 📝 Notes
- `Evicted` still deliberately returns a zero `confirmedAt` (no error): an evicted tx never actually updated the GER on-chain, so it must not reset the timer, unlike a real Mined/Safe/Finalized confirmation.