### PR TITLE
fix(bridgesync): index UPPER(from_address) and destination_network on bridge table

### DIFF
--- a/bridgesync/migrations/bridgesync0016.sql
+++ b/bridgesync/migrations/bridgesync0016.sql
@@ -1,0 +1,10 @@
+-- +migrate Down
+DROP INDEX IF EXISTS idx_bridge_from_address_upper;
+DROP INDEX IF EXISTS idx_bridge_destination_network;
+
+-- +migrate Up
+-- Backs the "UPPER(from_address) = UPPER($n)" predicate in buildBridgesFilterClause
+-- (bridgesync/processor.go). A plain index on from_address cannot be used through the
+-- UPPER() wrapper, so this is an expression index matching it exactly.
+CREATE INDEX IF NOT EXISTS idx_bridge_from_address_upper ON bridge (UPPER(from_address));
+CREATE INDEX IF NOT EXISTS idx_bridge_destination_network ON bridge (destination_network);

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -752,6 +752,25 @@ func TestMigration0015(t *testing.T) {
 	require.False(t, tableExists("unset_claim"), "unset_claim table should be dropped by migration 0015")
 }
 
+func TestMigration0016_IndexesExist(t *testing.T) {
+	dbPath := path.Join(t.TempDir(), "bridgesyncTest0016.sqlite")
+	err := RunMigrations(dbPath)
+	require.NoError(t, err)
+
+	database, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer database.Close()
+
+	for _, indexName := range []string{"idx_bridge_from_address_upper", "idx_bridge_destination_network"} {
+		var name string
+		err := database.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, indexName,
+		).Scan(&name)
+		require.NoError(t, err, "index %s should exist", indexName)
+		require.Equal(t, indexName, name)
+	}
+}
+
 func TestMigrationsDown(t *testing.T) {
 	dbPath := path.Join(t.TempDir(), "bridgesyncTestDown.sqlite")
 	err := RunMigrations(dbPath)


### PR DESCRIPTION
## 🔄 Changes Summary
- Fixes `GET /bridge/v1/bridges` full-scanning the `bridge` table (~1.1M rows) whenever `from_address` is supplied, timing out regardless of `page_size` or how many rows actually match.
- Root cause: `buildBridgesFilterClause` (`bridgesync/processor.go:586`) filters via `UPPER(from_address) = UPPER($n)`, and there is no index — plain or expression — usable through the `UPPER()` wrapper. `GetTotalNumberOfRecordsWithParams` (`bridgesync/processor.go:1476`) runs the same predicate as an unconditional `COUNT(*)` on every paged request, so both the count and the page query degrade to a full table scan.
- Fix: new `bridgesync0016` migration adding `idx_bridge_from_address_upper` (expression index on `UPPER(from_address)`, matching the query predicate exactly) and `idx_bridge_destination_network` (backing the `network_ids` filter, which also had no index).

## ⚠️ Breaking Changes
- 🛠️ **Config**: None
- 🔌 **API/CLI**: None (endpoint behavior/response semantics unchanged)
- 🗑️ **Deprecated Features**: None

## 📋 Config Updates
- 🧾 **Diff/Config snippet**: None — new DB migration `bridgesync0016` applies automatically on startup

## ✅ Testing
- 🤖 **Automatic**: New `TestMigration0016_IndexesExist` asserts both indexes exist after running migrations. Existing `bridgesync`/`bridgesync/migrations` suites pass unchanged.
- 🖱️ **Manual**: `go build ./...`, `go test ./bridgesync/...` (all green), `make lint` on `bridgesync/migrations/...` (0 issues). Verified with `EXPLAIN QUERY PLAN` against an in-memory SQLite DB that both `SELECT ... WHERE UPPER(from_address) = UPPER(?)` and `SELECT COUNT(*) ... WHERE UPPER(from_address) = UPPER(?)` switch from a table scan to `SEARCH bridge USING INDEX idx_bridge_from_address_upper`.

## 🐞 Issues
- Closes #1779

## 🔗 Related PRs
- Same pattern as #1774 (`fix(claimsync): prevent GetClaimsPaged timeout on large claim tables`)

## 📝 Notes
- Scoped to the index fix the issue's "Suggested fix" section calls out as the core problem. The issue also lists follow-on ideas (avoiding `COUNT(*)` on `sync-status`, keyset pagination, timeout layering, `GetBridgesInDepositRange`/`GetBridgesByContent`, `bridge_archive` indexes) as separate, lower-priority work worth tracking independently rather than bundling into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)