### PR TITLE
fix: bridgetracker API.md drift, fail-fast on unset L1GlobalExitRootAddress, unlimited default rate limit (#1781, #1782, #1783)

### DIFF
--- a/bridgesync/migrations/bridgesync0016.sql
+++ b/bridgesync/migrations/bridgesync0016.sql
@@ -1,10 +1,12 @@
 -- +migrate Down
 DROP INDEX IF EXISTS idx_bridge_from_address_upper;
-DROP INDEX IF EXISTS idx_bridge_destination_network;
 
 -- +migrate Up
 -- Backs the "UPPER(from_address) = UPPER($n)" predicate in buildBridgesFilterClause
 -- (bridgesync/processor.go). A plain index on from_address cannot be used through the
 -- UPPER() wrapper, so this is an expression index matching it exactly.
+-- Deliberately NO index on destination_network: aggkit never runs ANALYZE, so SQLite's
+-- default heuristics prefer such an index over idx_bridge_deposit_count_desc (or the
+-- expression index above), replacing early-exit ORDER BY deposit_count plans with full
+-- scans + temp B-tree sorts.
 CREATE INDEX IF NOT EXISTS idx_bridge_from_address_upper ON bridge (UPPER(from_address));
-CREATE INDEX IF NOT EXISTS idx_bridge_destination_network ON bridge (destination_network);

--- a/bridgesync/migrations/migrations_test.go
+++ b/bridgesync/migrations/migrations_test.go
@@ -761,14 +761,19 @@ func TestMigration0016_IndexesExist(t *testing.T) {
 	require.NoError(t, err)
 	defer database.Close()
 
-	for _, indexName := range []string{"idx_bridge_from_address_upper", "idx_bridge_destination_network"} {
-		var name string
-		err := database.QueryRow(
-			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, indexName,
-		).Scan(&name)
-		require.NoError(t, err, "index %s should exist", indexName)
-		require.Equal(t, indexName, name)
-	}
+	var name string
+	err = database.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, "idx_bridge_from_address_upper",
+	).Scan(&name)
+	require.NoError(t, err, "index idx_bridge_from_address_upper should exist")
+	require.Equal(t, "idx_bridge_from_address_upper", name)
+
+	// Without ANALYZE stats, an index on destination_network hijacks the query planner away
+	// from idx_bridge_deposit_count_desc and idx_bridge_from_address_upper, so it must not exist.
+	err = database.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, "idx_bridge_destination_network",
+	).Scan(&name)
+	require.ErrorIs(t, err, sql.ErrNoRows, "index idx_bridge_destination_network must not exist")
 }
 
 func TestMigrationsDown(t *testing.T) {

--- a/bridgetracker/config.go
+++ b/bridgetracker/config.go
@@ -1,6 +1,7 @@
 package bridgetracker
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/agglayer/aggkit/agglayer"
@@ -109,4 +110,13 @@ type Config struct {
 	// adapter (single instance); inject a shared-store implementation so several tracker
 	// instances behind a proxy answer for any registered tx
 	Registry SupervisedRegistry `mapstructure:"-"`
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	if c.L1GlobalExitRootAddress == (common.Address{}) {
+		return fmt.Errorf("[Tracker].L1GlobalExitRootAddress is not set (zero address): " +
+			"the L1 GlobalExitRoot contract address is required for L1->L2 bridge tracking to work")
+	}
+	return nil
 }

--- a/bridgetracker/config_test.go
+++ b/bridgetracker/config_test.go
@@ -1,0 +1,42 @@
+package bridgetracker
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        Config
+		expectedError string
+	}{
+		{
+			name: "valid config",
+			config: Config{
+				L1GlobalExitRootAddress: common.HexToAddress("0x1f7ad7caA53e35b4f0D138dC5CBF91aC108a2674"),
+			},
+			expectedError: "",
+		},
+		{
+			name:          "zero L1GlobalExitRootAddress",
+			config:        Config{},
+			expectedError: "[Tracker].L1GlobalExitRootAddress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}

--- a/common/config.go
+++ b/common/config.go
@@ -23,7 +23,9 @@ type RESTConfig struct {
 	WriteTimeout types.Duration `mapstructure:"WriteTimeout"`
 
 	// MaxRequestsPerIPAndSecond defines how many requests a single IP can
-	// send within a single second
+	// send within a single second. 0 (the default) means unlimited: aggkit
+	// does not enforce request rate limiting in-process. Apply rate limiting
+	// at the fronting reverse proxy / API gateway / ingress if needed.
 	MaxRequestsPerIPAndSecond float64 `mapstructure:"MaxRequestsPerIPAndSecond"`
 }
 

--- a/config/default.go
+++ b/config/default.go
@@ -149,21 +149,21 @@ Host = "0.0.0.0"
 Port = 5576
 ReadTimeout = "2s"
 WriteTimeout = "2s"
-MaxRequestsPerIPAndSecond = 10
+MaxRequestsPerIPAndSecond = 0
 
 [PublicREST]
 Host = "0.0.0.0"
 Port = 5577
 ReadTimeout = "5m"
 WriteTimeout = "5m"
-MaxRequestsPerIPAndSecond = 10
+MaxRequestsPerIPAndSecond = 0
 
 [AdminREST]
 Host = "0.0.0.0"
 Port = 5579
 ReadTimeout = "5m"
 WriteTimeout = "5m"
-MaxRequestsPerIPAndSecond = 10
+MaxRequestsPerIPAndSecond = 0
 
 [BridgeL1Sync]
 DBPath = "{{PathRWData}}/bridgel1sync.sqlite"

--- a/config/default.go
+++ b/config/default.go
@@ -149,7 +149,8 @@ Host = "0.0.0.0"
 Port = 5576
 ReadTimeout = "2s"
 WriteTimeout = "2s"
-MaxRequestsPerIPAndSecond = 0
+# Enforced (tollbooth in cdk-rpc); 0 does NOT mean unlimited here, it means burst-of-1 then 429 forever.
+MaxRequestsPerIPAndSecond = 10
 
 [PublicREST]
 Host = "0.0.0.0"

--- a/docs/bridgetracker/API.md
+++ b/docs/bridgetracker/API.md
@@ -24,9 +24,19 @@ Calling this endpoint **adds the bridge to the list of supervised bridges** (if 
 
 Implemented in `aggkit/bridgetracker/types/` (`status.go`, `tracking.go`, `health.go`, `websocket.go`), except `TrackingData` itself, which lives in `aggkit/bridgetracker/api/tracking_data.go` — it's the only place that constructs it.
 
-All the enums are serialized as numeric values, and each enum field has a companion
-`<field>_string` field with its string representation. The companion fields are regular
-struct fields, auto-populated from the numeric value when the structure is marshaled to JSON.
+Most enum fields are serialized as a **bare string** (`tracking_status`, `bridge_type`,
+`event.leaf_type`, `step_name`, `status`), with the exact value set given per field below. Only
+two fields follow a different, numeric convention: `error_type` (in [ErrorStep](#errorstep)) and
+`status` (in [CertificateData](#certificatedata)) are serialized as their numeric value **plus** a
+companion `<field>_string` field carrying the string representation — that companion is a regular
+struct field, auto-populated from the numeric value when the structure is marshaled to JSON.
+There is no general rule: check the field's type in the tables below.
+
+Optional fields that use Go's `omitempty` tag (e.g. `start_date`, `end_date`, `result`, `error` on
+a step, or `settlement_tx_hash`/`error` on `CertificateData`) are **omitted from the JSON
+altogether** when not applicable, not serialized as `null`. `TrackingData.bridge_status`/
+`step_index`/`all_steps`/`error` are the exception: those are always present in the response,
+explicitly `null` while not applicable, precisely so clients can poll on their presence.
 
 All JSON field names use `snake_case` (they are listed below exactly as they appear on the wire).
 
@@ -36,8 +46,7 @@ Body of every REST response (always `200 OK`) and of every WebSocket `status` me
 
 | field | type | desc |
 | ------|------|------|
-| tracking_status | TrackingStatus (int) | 0->registered (added to the supervised list, `bridge_status`/`step_index`/`all_steps`/`error` still `nil`), 1->running (resolved, alive), 2->error (either a step reached an error on an otherwise-resolved bridge, or the tracker gave up resolving the bridge at all — see `error`), 3->finished (resolved, reached `Claimed`) |
-| tracking_status_string | string | string representation of tracking_status (e.g. "running") |
+| tracking_status | string | bare string, one of `"registered"` (added to the supervised list, `bridge_status`/`step_index`/`all_steps`/`error` still `null`), `"running"` (resolved, alive), `"error"` (either a step reached an error on an otherwise-resolved bridge, or the tracker gave up resolving the bridge at all — see `error`), `"finished"` (resolved, reached `Claimed`) |
 | network_id | uint32 | network of the request |
 | tx_hash | Hash | transaction hash of the request |
 | bridge_status | *BridgeStatus | `null` while tracking_status is `registered`, and forever `null` if the tracker gives up resolving the bridge (`error` is set instead); see [BridgeStatus](#bridgestatus) |
@@ -45,29 +54,151 @@ Body of every REST response (always `200 OK`) and of every WebSocket `status` me
 | all_steps | BridgeStepPath [] | `null` under the same conditions as `bridge_status`; from then on, all expected steps of the bridge's route — GER/LER, certificate and claim data are reported per step in each entry's `result` (see [StepResult](#stepresult)) |
 | error | *ErrorStep | `null` unless the tracker gave up trying to resolve the bridge at all (e.g. the tx does not exist on the network or is not a bridge transaction); see [ErrorStep](#errorstep). Unrelated to per-step errors, which live in `all_steps[i].error` instead |
 
-## BridgeStatus 
+Example (unresolved, just registered):
+
+```json
+{
+  "tracking_status": "registered",
+  "network_id": 1,
+  "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  "bridge_status": null,
+  "step_index": null,
+  "all_steps": null,
+  "error": null
+}
+```
+
+Example (resolved, one step in progress — trimmed to two `all_steps` entries for brevity; a real
+response carries every step of the bridge's route):
+
+```json
+{
+  "tracking_status": "running",
+  "network_id": 1,
+  "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  "bridge_status": {
+    "bridge_type": "L2->L1",
+    "block_number": 1000,
+    "log_index": 2,
+    "block_timestamp": 1700000000,
+    "event": {
+      "leaf_type": "Asset",
+      "origin_network": 1,
+      "origin_address": "0x0000000000000000000000000000000000000020",
+      "destination_network": 0,
+      "destination_address": "0x0000000000000000000000000000000000000030",
+      "amount": "100",
+      "deposit_count": 7
+    }
+  },
+  "step_index": 1,
+  "all_steps": [
+    {
+      "step_index": 0,
+      "step_name": "WaitingLERUpdate",
+      "status": "done",
+      "start_date": "2026-08-10T10:00:00Z",
+      "end_date": "2026-08-10T10:00:05Z",
+      "result": {
+        "network_id": 1,
+        "ler": "0x000000000000000000000000000000000000000000000000000000000000000b",
+        "block_number": 998
+      }
+    },
+    {
+      "step_index": 1,
+      "step_name": "PendingInclusion",
+      "status": "inProgress",
+      "start_date": "2026-08-10T10:00:05Z"
+    }
+  ],
+  "error": null
+}
+```
+
+## BridgeStatus
+
+`BridgeStatus` is not flat: the facts taken directly off the on-chain `BridgeEvent` log
+(leaf type, origin/destination, amount, deposit count) nest under an `event` object
+([BridgeEventData](#bridgeeventdata)); `bridge_status` itself only carries the direction and the
+block-level context (block number/index/timestamp) around that event.
 
 | field | type | desc |
 | ------|------|------|
-| bridge_type | BridgeType (int) | 0-> L1->L2, 1->L2->L1, 2->L2->L2 |
-| bridge_type_string | string | string representation of bridge_type (e.g. "L2->L2") |
-| bridge_leaf_type | BridgeLeafType (int) | 0->Asset (bridgeAsset), 1->Message (bridgeMessage) |
-| bridge_leaf_type_string | string | string representation of bridge_leaf_type (e.g. "Asset") |
+| bridge_type | string | bare string, one of `"L1->L2"`, `"L2->L1"`, `"L2->L2"` |
 | block_number | uint64 | block, on the origin network, where the `BridgeEvent` (`bridgeAsset`/`bridgeMessage`) was emitted |
 | log_index | uint32 | position of the `BridgeEvent` log within `block_number` |
+| block_timestamp | uint64 | timestamp of the block, on the origin network, where the `BridgeEvent` was emitted |
+| event | BridgeEventData | facts unpacked directly from the on-chain `BridgeEvent` log, see [BridgeEventData](#bridgeeventdata) |
+
+### BridgeEventData
+
+| field | type | desc |
+| ------|------|------|
+| leaf_type | string | bare string, one of `"Asset"` (`bridgeAsset`), `"Message"` (`bridgeMessage`) |
+| origin_network | uint32 | network where the bridged asset originates from |
+| origin_address | Address | address of the asset on the origin network |
+| destination_network | uint32 | network the bridge exits to (0 -> Mainnet) |
+| destination_address | Address | address that receives the asset on the destination network |
+| amount | string | amount of the asset being bridged, as a **decimal string** (not a JSON number) — avoids precision loss on wei-scale amounts in clients that decode numbers as `float64` (e.g. JavaScript) |
+| deposit_count | uint32 | index of the bridge leaf in the origin exit tree |
+
+Example (`TrackingData.bridge_status` once resolved):
+
+```json
+{
+  "bridge_type": "L2->L1",
+  "block_number": 1000,
+  "log_index": 2,
+  "block_timestamp": 1700000000,
+  "event": {
+    "leaf_type": "Asset",
+    "origin_network": 1,
+    "origin_address": "0x0000000000000000000000000000000000000020",
+    "destination_network": 0,
+    "destination_address": "0x0000000000000000000000000000000000000030",
+    "amount": "100",
+    "deposit_count": 7
+  }
+}
+```
 
 ## BridgeStepPath
 | field | type | desc |
 | ------|------|------|
-| step | BridgeStep (int) | 0->WaitingGERUpdate, 1->WaitingLERUpdate, 2->PendingInclusion, 3->CertificatePending, 4->WaitL1SettledGER, 5->WaitingGERInjection, 6->WaitingClaim, 7->Claimed |
-| step_string | string | string representation of step (e.g. "WaitingGERUpdate") |
-| status | StepStatus (int) | 0->pending, 1->inProgress, 2->done, 3->error
-| status_string | string | string representation of status (e.g. "inProgress") |
-| start_date | *time.Time | can be nil
-| end_date | *time.Time | can be nil
-| expected_duration | *Duration | serialized as human-readable string (e.g. "5m0s")
-| result | *StepResult | data produced by the step once it completes; its shape depends on `step` (see [StepResult](#stepresult)). `nil` until the step produces it, and for steps without a result |
-| error | *ErrorStep | error details, only set when `status` is `error` (see [ErrorStep](#errorstep)) |
+| step_index | int | this step's position within the parent `TrackingData.all_steps` list |
+| step_name | string | bare string, one of `"WaitingGERUpdate"`, `"WaitingLERUpdate"`, `"PendingInclusion"`, `"CertificatePending"`, `"WaitL1SettledGER"`, `"WaitingGERInjection"`, `"WaitingClaim"`, `"Claimed"` |
+| status | string | bare string, one of `"pending"`, `"inProgress"`, `"done"`, `"error"` |
+| start_date | *time.Time | **omitted** (no key) while `nil`, not serialized as `null` |
+| end_date | *time.Time | **omitted** (no key) while `nil`, not serialized as `null` |
+| expected_duration | *Duration | reserved for a future per-step protocol duration estimate; serializes as a human-readable string (e.g. `"5m0s"`) when set, **omitted** otherwise — no resolver currently populates it, so it never appears on the wire today; do not rely on it |
+| result | *StepResult | data produced by the step once it completes; its shape depends on `step_name` (see [StepResult](#stepresult)). **Omitted** (no key) until the step produces it, and for steps without a result |
+| error | *ErrorStep | error details, only set when `status` is `"error"` (see [ErrorStep](#errorstep)). **Omitted** (no key) otherwise |
+
+Example (an in-progress step, and a completed one with a result):
+
+```json
+{
+  "step_index": 0,
+  "step_name": "WaitingGERUpdate",
+  "status": "inProgress",
+  "start_date": "2026-08-10T10:00:00Z"
+}
+```
+
+```json
+{
+  "step_index": 2,
+  "step_name": "PendingInclusion",
+  "status": "done",
+  "start_date": "2026-08-10T10:00:05Z",
+  "end_date": "2026-08-10T10:02:00Z",
+  "result": {
+    "certificate_id": "0x000000000000000000000000000000000000000000000000000000000000000f",
+    "new_ler": "0x0000000000000000000000000000000000000000000000000000000000000010"
+  }
+}
+```
 
 ## StepResult
 
@@ -88,7 +219,7 @@ Carried in the `result` field of a [BridgeStepPath](#bridgesteppath). Its shape 
 
 The same structure carries two different kinds of error, depending on where it appears:
 
-- in the `error` field of a [BridgeStepPath](#bridgesteppath), when that step's `status` is `error` (3) — a step of an otherwise-resolved bridge failed;
+- in the `error` field of a [BridgeStepPath](#bridgesteppath), when that step's `status` is `"error"` — a step of an otherwise-resolved bridge failed;
 - in the `error` field of [TrackingData](#trackingdata) — the tracker gave up trying to resolve the bridge at all (e.g. `bridgeAsset`/`bridgeMessage` tx not found, or the tx exists but emitted no `BridgeEvent`). In that case `retry_count` counts the not-found polls before giving up.
 
 | field | type | desc |
@@ -99,6 +230,13 @@ The same structure carries two different kinds of error, depending on where it a
 | description | string [] | human-readable description(s) of the error, one entry per occurrence |
 
 ## GERData
+
+**Not part of any tracker response.** `GERData` (`bridgetracker/types/status.go`) is the domain
+layer's internal currency to decide GER coverage (`GERSource.OriginGER`/`InjectedGER`); it is
+never embedded in `TrackingData`, `BridgeStatus` or `BridgeStepPath`. It has JSON tags and its own
+`MarshalJSON` (documented here for completeness in case it is ever exposed or logged), but no
+tracker endpoint or WebSocket message currently serializes it.
+
 | field | type | desc |
 | ------|------|------|
 | network_id | uint32 | Network (0->Mainnet)
@@ -110,13 +248,29 @@ The same structure carries two different kinds of error, depending on where it a
 | ler_type_string | string | string representation of ler_type (e.g. "Mainnet")
 
 ## CertificateData
+
+This is one of the two response fields that **does** follow the numeric+`_string` convention
+(the other is [ErrorStep.error_type](#errorstep)) — everything else in the tracker response is a
+bare string, see the note at the top of [Response types](#response-types).
+
 | field | type | desc |
 | ------|------|------|
 | certificate_id | Hash |
 | status | CertificateStatus (int) | Mapped from proto in [agglayer_grpc_client.go:559](aggkit/agglayer/grpc/agglayer_grpc_client.go#L559): 0->`Pending`, 1->`Proven`, 2->`Candidate`, 3->`InError`, 4->`Settled`
 | status_string | string | string representation of status (e.g. "Settled")
-| error | string | Only set if the proto carries `Error.Message` (relevant for `InError` certs)
-| settlement_tx_hash | *Hash |
+| error | string | Only set if the proto carries `Error.Message` (relevant for `InError` certs); **omitted** (no key) otherwise |
+| settlement_tx_hash | *Hash | Set once the certificate has a settlement tx (normally only from `Settled` onward); **omitted** (no key), not `null`, before that |
+
+Example (settled certificate, as it appears in `all_steps[i].result` for `CertificatePending`):
+
+```json
+{
+  "certificate_id": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  "status": 4,
+  "status_string": "Settled",
+  "settlement_tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002"
+}
+```
 
 ## ErrorData
 
@@ -197,7 +351,7 @@ All messages are JSON text frames with an envelope:
 - Connecting adds the bridge to the list of supervised bridges, same as the REST endpoint.
 - On connect, the server immediately sends a `status` message with the current [TrackingData](#trackingdata) — `bridge_status`/`step_index`/`all_steps` are `null` if the tracker has no information yet, or populated if it does.
 - After that, a new `status` message is pushed every time something changes: `tracking_status` moves, `bridge_status`/`step_index`/`all_steps` go from `null` to populated, `step_index` moves, a step status/date in `all_steps` changes, or the certificate status changes. Each message carries the full `TrackingData`, not a delta.
-- When the bridge reaches a terminal state — `Claimed` (`tracking_status_string == "finished"`), or the tracker giving up trying to resolve it at all (`tracking_status_string == "error"` with `bridge_status: null` and `error` set) — the server sends the final `status` message and closes the connection with code `1000` (normal closure). A step-level error on an otherwise-resolved bridge (`tracking_status_string == "error"` with `bridge_status` populated) is **not** terminal: the connection stays open and the engine keeps polling in case it clears.
+- When the bridge reaches a terminal state — `Claimed` (`tracking_status == "finished"`), or the tracker giving up trying to resolve it at all (`tracking_status == "error"` with `bridge_status: null` and `error` set) — the server sends the final `status` message and closes the connection with code `1000` (normal closure). A step-level error on an otherwise-resolved bridge (`tracking_status == "error"` with `bridge_status` populated) is **not** terminal: the connection stays open and the engine keeps polling in case it clears.
 
 ### Errors
 

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -134,6 +134,24 @@ Example:
 
 When rate limiting is enabled, if the number of requests exceeds `NumRequests` within the specified `Interval`, the system will wait until the next interval before allowing more requests. This helps prevent overwhelming the system with too many requests in a short period.
 
+## RESTConfig
+
+`RESTConfig` configures a shared Gin-based HTTP server. It backs every REST section in the config, such as `[RPC]`,
+`[PublicREST]`, `[AdminREST]`, and the proxy's `[REST]`.
+
+| Field Name | Type | Description |
+| --- | --- | --- |
+| Host | string | Hostname or IP address the REST service listens on |
+| Port | int | Port number the REST service is accessible on |
+| ReadTimeout | types.Duration | HTTP server read timeout |
+| WriteTimeout | types.Duration | HTTP server write timeout |
+| MaxRequestsPerIPAndSecond | float64 | Unused; kept for config compatibility. See below |
+
+`MaxRequestsPerIPAndSecond` is not enforced: aggkit does not rate-limit requests in-process. Its default is `0`
+(unlimited). If you need per-IP request throttling, apply it at the fronting reverse proxy / API gateway / ingress —
+that is also where it is most effective, since a service sitting behind a proxy typically sees every client as the
+proxy's single IP, making in-process per-IP limiting ineffective anyway.
+
 ## RPCClientConfig
 
 `RPCClientConfig` configures the JSON-RPC client used to connect to Ethereum nodes. It is used in multiple places, notably `[L1NetworkConfig.RPC]` (L1 node) and `[Common.L2RPC]` (L2 node).

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -136,8 +136,8 @@ When rate limiting is enabled, if the number of requests exceeds `NumRequests` w
 
 ## RESTConfig
 
-`RESTConfig` configures a shared Gin-based HTTP server. It backs every REST section in the config, such as `[RPC]`,
-`[PublicREST]`, `[AdminREST]`, and the proxy's `[REST]`.
+`RESTConfig` configures a shared Gin-based HTTP server. It backs the REST sections in the config: `[PublicREST]`,
+`[AdminREST]`, and the proxy's `[REST]`.
 
 | Field Name | Type | Description |
 | --- | --- | --- |
@@ -151,6 +151,11 @@ When rate limiting is enabled, if the number of requests exceeds `NumRequests` w
 (unlimited). If you need per-IP request throttling, apply it at the fronting reverse proxy / API gateway / ingress —
 that is also where it is most effective, since a service sitting behind a proxy typically sees every client as the
 proxy's single IP, making in-process per-IP limiting ineffective anyway.
+
+Note that the `[RPC]` section is **not** a `RESTConfig`: it is the JSON-RPC server config from
+`github.com/0xPolygon/cdk-rpc`, whose `MaxRequestsPerIPAndSecond` **is** enforced (via tollbooth). There, `0` does
+not mean unlimited — `tollbooth.NewLimiter(0, ...)` produces a limiter with a burst of 1 and no refill, i.e. one
+request per IP ever. Its default stays `10`.
 
 ## RPCClientConfig
 

--- a/proxy/cmd/run.go
+++ b/proxy/cmd/run.go
@@ -155,6 +155,9 @@ func runTracker(
 	restServer *proxy.RESTServer,
 ) {
 	trackerCfg := cfg.Tracker
+	if err := trackerCfg.Validate(); err != nil {
+		log.Fatalf("invalid tracker config: %v", err)
+	}
 	registry := bridgetracker.NewMemoryRegistry(trackerCfg.MaxTrackedBridges)
 	trackerCfg.Logger = log.WithFields("module", "bridgetracker")
 	trackerCfg.ConfigSHA1 = configSHA1

--- a/proxy/config/default.go
+++ b/proxy/config/default.go
@@ -27,7 +27,7 @@ Host = "0.0.0.0"
 Port = 8080
 ReadTimeout = "5m"
 WriteTimeout = "5m"
-MaxRequestsPerIPAndSecond = 10
+MaxRequestsPerIPAndSecond = 0
 
 [Tracker]
 # RetentionPeriod: how long a terminal bridge (finished, or failed to ever resolve) stays

--- a/proxy/scripts/configuration_based_on_kurtosis.sh
+++ b/proxy/scripts/configuration_based_on_kurtosis.sh
@@ -20,8 +20,9 @@ Usage: $0 [OPTIONS]
 Creates tmp/proxy-kurtosis.toml based on a running Kurtosis enclave.
 
 The generated config points [L1RPC] at the enclave's L1 node, sets
-[BridgeServiceFinder].RollupManagerAddr from the aggkit config artifact, and
-fills static [BridgeServiceFinder.BridgeURLs] / [BridgeServiceFinder.RPCURLs]
+[BridgeServiceFinder].RollupManagerAddr and [Tracker].L1GlobalExitRootAddress
+from the aggkit config artifact, and fills static
+[BridgeServiceFinder.BridgeURLs] / [BridgeServiceFinder.RPCURLs]
 overrides for every L2 network found in the enclave, plus network 0 (L1):
 its RPC is the enclave's L1 node and its bridge service is the first aggkit
 instance (all of them sync the L1 side). The static overrides are required
@@ -185,6 +186,17 @@ get_rollup_manager_addr() {
     echo "$addr"
 }
 
+get_l1_ger_addr() {
+    local addr
+    addr=$(grep -E '^\s*polygonZkEVMGlobalExitRootAddress\s*=' "$AGGKIT_CONFIG_DIR/config.toml" \
+        | head -1 | tr -d '[:space:]' | cut -f2 -d'=' | tr -d '"')
+    if [[ -z "$addr" ]]; then
+        log_error "polygonZkEVMGlobalExitRootAddress not found in config.toml"
+        exit 1
+    fi
+    echo "$addr"
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -212,6 +224,12 @@ trap cleanup_aggkit_config EXIT
 log_info "Getting RollupManager address from aggkit config artifact..."
 ROLLUP_MANAGER_ADDR=$(get_rollup_manager_addr)
 log_info "RollupManagerAddr: $ROLLUP_MANAGER_ADDR"
+
+# L1GlobalExitRootAddress: same source as RollupManagerAddr, read from the aggkit config
+# artifact (the GlobalExitRoot contract is shared by every network in the enclave)
+log_info "Getting L1 GlobalExitRoot address from aggkit config artifact..."
+L1_GER_ADDR=$(get_l1_ger_addr)
+log_info "L1GlobalExitRootAddress: $L1_GER_ADDR"
 
 # ---------------------------------------------------------------------------
 # Per-network static overrides (BridgeURLs / RPCURLs)
@@ -293,6 +311,9 @@ BlockChunkSize = 10000
 HealthCheckPath = "$HEALTH_CHECK_PATH"
 HealthCheckTimeout = "5s"
 RequireAllHealthyOnStart = false
+
+[Tracker]
+L1GlobalExitRootAddress = "$L1_GER_ADDR"
 EOF
 
 if [[ -n "$BRIDGE_URLS_BLOCK" ]]; then


### PR DESCRIPTION
## 🔄 Changes Summary
- **#1781 — bridgetracker API.md wire-format drift**: rewrote `docs/bridgetracker/API.md` to match the actual serializer. Most enums are bare strings (`tracking_status`, `bridge_type`, `event.leaf_type`, `step_name`, step `status`); only `ErrorStep.error_type` and `CertificateData.status` use the numeric+`_string` convention. Documented the `event` nesting inside `BridgeStatus`, `block_timestamp`, `step_index`, and omitempty optionals (omitted from the JSON, not `null`). Flagged `GERData` as domain-internal (never on the wire) and `expected_duration` as wired-but-never-populated. Refreshed every example payload to the real shapes.
- **#1782 — silent stall on unset `[Tracker].L1GlobalExitRootAddress`**: added `bridgetracker.Config.Validate()` (zero address → error) called from `runTracker` in `proxy/cmd/run.go`, so the proxy now fails fast at startup with an actionable message instead of silently stalling every L1→L2 route at `WaitingGERUpdate`. `proxy/scripts/configuration_based_on_kurtosis.sh` now emits `[Tracker].L1GlobalExitRootAddress`, read from `polygonZkEVMGlobalExitRootAddress` in the same aggkit config artifact it already uses for `RollupManagerAddr` (the e2e script already set it).
- **#1783 — dead `MaxRequestsPerIPAndSecond` config**: defaulted it to `0` in the sections where it is genuinely dead (`[PublicREST]`, `[AdminREST]` in `config/default.go`, `[REST]` in `proxy/config/default.go` — all `common.RESTConfig`, which has no rate-limit middleware), documented `0` as unlimited there, and documented (field comment + new `RESTConfig` section in `docs/common_config.md`) that aggkit's REST servers do not rate-limit in-process and rate limiting belongs at the reverse proxy / gateway / ingress layer. **`[RPC]` keeps its default of `10`**: it maps to `jRPC.Config` from `github.com/0xPolygon/cdk-rpc`, whose server enforces the field via tollbooth — and `tollbooth.NewLimiter(0, nil)` is *not* unlimited, it is burst-of-1-then-429-forever (an earlier iteration of this PR set it to `0` and broke every e2e job that queries the RPC port more than once; caught by CI and reverted here).
- **Follow-up to #1780 review ([discussion](https://github.com/agglayer/aggkit/pull/1780#discussion_r3748368773)) — drop `idx_bridge_destination_network`**: the index added in migration 0016 hijacks SQLite's query planner (aggkit never runs `ANALYZE`, so an indexed equality is assumed highly selective) and steals the plan from `idx_bridge_deposit_count_desc` / `idx_bridge_from_address_upper`. Reproduced on a 1M-row fixture: network-filtered bridge paging regressed ~0.5ms → ~600ms, network+`from_address` combo ~0.1ms → ~230ms, claim-candidate range queries ~0.5ms → ~180ms. The `UPPER(from_address)` expression index alone fixes the bug 0016 targeted, so the index is deleted in place (migration 0016 has not shipped in any release) and the migration test now asserts it does **not** exist.

## ⚠️ Breaking Changes
- 🛠️ **Config**: running the proxy with the `tracker` component now **fails at startup** if `[Tracker].L1GlobalExitRootAddress` is unset/zero (previously it started and silently never resolved any L1→L2 bridge). Deployments that run the tracker must set the address — the only in-repo config that runs it (`test/e2e/envs/op-pp-2chains`) already does.
- 🔌 **API/CLI**: none (doc-only for the tracker wire format; the serializer is unchanged).
- 🗑️ **Deprecated Features**: none. `MaxRequestsPerIPAndSecond` is kept (removing it would hard-fail existing configs); only its default and documentation changed.

## 📋 Config Updates
- 🧾 **Diff/Config snippet**:
```toml
# was 10 in [PublicREST], [AdminREST] (aggkit) and [REST] (proxy); 0 = unlimited (the limit was never enforced there anyway)
# [RPC].MaxRequestsPerIPAndSecond stays 10 — it IS enforced (tollbooth via cdk-rpc) and 0 would mean "1 request per IP, ever"
MaxRequestsPerIPAndSecond = 0

# now required when running the proxy with the tracker component (generated automatically by
# proxy/scripts/configuration_based_on_kurtosis.sh and configuration_based_on_e2e.sh)
[Tracker]
L1GlobalExitRootAddress = "0x..."
```

## ✅ Testing
- 🤖 **Automatic**: new unit test `TestConfig_Validate` (bridgetracker) covering zero-address → error and valid address → nil. `make build`, `make lint` (0 issues), and `go test ./bridgetracker/... ./proxy/... ./config/... ./common/...` all green. The op-pp-2chains e2e env already sets the GER address, so the new validation does not affect CI.
- 🤖 **Planner regression check**: `TestMigration0016_IndexesExist` red/greened — with the index present the new `must not exist` assertion fails; with the fix it passes. Benchmarks above measured via EXPLAIN QUERY PLAN + timed queries on a migrated 1M-row fixture using the production connection pragmas.
- 🖱️ **Manual**: doc corrections in API.md were cross-checked field-by-field against the JSON struct tags in `bridgetracker/api/` and `bridgetracker/types/` (they also match the live rc4 captures reported in #1781).

## 🐞 Issues
- Closes #1781
- Closes #1782
- Closes #1783

## 🔗 Related PRs
- N/A

## 📝 Notes
- Two of #1781's claims were corrected against the code rather than copied: the leaf-type key under `event` is `leaf_type` (not `bridge_leaf_type`), and `expected_duration` *is* wired in the serializer (`omitempty`) but no resolver populates it — it's documented as reserved/never-emitted rather than deleted.
- #1782's longer-term suggestion (signature-based fallback in `GERSource` so the address becomes truly optional, like `BridgeAddrs`) is intentionally **not** included — fail-fast + fixed reference recipe covers the operational gap; the fallback can be a follow-up if wanted.
- #1783: if in-process rate limiting is ever implemented deliberately, keep `0`/unlimited as the default and make the limiter proxy-aware (trusted proxies + forwarded headers), per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


