### PR TITLE
fix(bridgeservice): correct l1-info-tree-index fallback and cross-syncer error codes

### DIFF
--- a/autoclaim/proof/preparer.go
+++ b/autoclaim/proof/preparer.go
@@ -28,6 +28,7 @@ type L1BridgeSyncer interface {
 // L1InfoTreeSyncer exposes the L1 info tree methods needed to prepare L1-origin claim proofs.
 type L1InfoTreeSyncer interface {
 	GetInfoByIndex(ctx context.Context, index uint32) (*l1infotreesync.L1InfoTreeLeaf, error)
+	GetLatestL1InfoLeafUntilBlock(ctx context.Context, blockNum uint64) (*l1infotreesync.L1InfoTreeLeaf, error)
 	GetRollupExitTreeMerkleProof(ctx context.Context, networkID uint32, root common.Hash) (treetypes.Proof, error)
 	GetLastInfo() (*l1infotreesync.L1InfoTreeLeaf, error)
 	GetFirstInfo() (*l1infotreesync.L1InfoTreeLeaf, error)
@@ -228,14 +229,17 @@ func (p *Preparer) firstL1InfoTreeIndexForL1Bridge(
 		if root == nil {
 			return 0, fmt.Errorf("failed to get last root for L1: empty result")
 		}
-		// TODO(#1795): root.Index is a position in the L1 bridge exit tree (a deposit count),
-		// but GetInfoByIndex expects an L1 info tree index. The two counters are unrelated, so
-		// this lookup fails whenever the L1 bridge syncer trails the L1 info tree syncer. The
-		// same bug was fixed in bridgeservice/bridge.go by clamping on root.BlockNum via
-		// GetLatestL1InfoLeafUntilBlock; this call site still needs the equivalent fix.
-		lastInfo, err = p.l1InfoTree.GetInfoByIndex(ctx, root.Index)
+		if root.BlockNum == 0 {
+			return 0, fmt.Errorf("bridgesync L1 has not indexed any block yet: %w", bridgeservice.ErrNotOnL1Info)
+		}
+		// root.Index is a position in the L1 bridge exit tree (i.e. a deposit count), not an L1 info
+		// tree index, so it must never be fed into an l1infotreesync leaf lookup. Clamp by the last
+		// L1 block indexed by bridgesync L1 instead, which is the same index space for both syncers.
+		lastInfo, err = p.l1InfoTree.GetLatestL1InfoLeafUntilBlock(ctx, root.BlockNum)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get last info for L1: %w", err)
+			return 0, fmt.Errorf(
+				"l1infotreesync has no L1 info tree leaf at or before L1 block %d "+
+					"(last block indexed by bridgesync L1): %w", root.BlockNum, err)
 		}
 		if lastInfo == nil {
 			return 0, fmt.Errorf("failed to get last info for L1: empty result")

--- a/autoclaim/proof/preparer.go
+++ b/autoclaim/proof/preparer.go
@@ -228,6 +228,11 @@ func (p *Preparer) firstL1InfoTreeIndexForL1Bridge(
 		if root == nil {
 			return 0, fmt.Errorf("failed to get last root for L1: empty result")
 		}
+		// TODO(#1795): root.Index is a position in the L1 bridge exit tree (a deposit count),
+		// but GetInfoByIndex expects an L1 info tree index. The two counters are unrelated, so
+		// this lookup fails whenever the L1 bridge syncer trails the L1 info tree syncer. The
+		// same bug was fixed in bridgeservice/bridge.go by clamping on root.BlockNum via
+		// GetLatestL1InfoLeafUntilBlock; this call site still needs the equivalent fix.
 		lastInfo, err = p.l1InfoTree.GetInfoByIndex(ctx, root.Index)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get last info for L1: %w", err)

--- a/autoclaim/proof/preparer_test.go
+++ b/autoclaim/proof/preparer_test.go
@@ -564,14 +564,17 @@ func (f *fakeL1BridgeSyncer) GetLastRoot(_ context.Context) (*treetypes.Root, er
 }
 
 type fakeL1InfoTreeSyncer struct {
-	infoByIndex      map[uint32]*l1infotreesync.L1InfoTreeLeaf
-	infoByIndexErr   error
-	rollupProof      treetypes.Proof
-	rollupProofErr   error
-	lastInfo         *l1infotreesync.L1InfoTreeLeaf
-	firstInfo        *l1infotreesync.L1InfoTreeLeaf
-	infoAfterBlock   map[uint64]*l1infotreesync.L1InfoTreeLeaf
-	rollupProofCalls []rollupProofCall
+	infoByIndex          map[uint32]*l1infotreesync.L1InfoTreeLeaf
+	infoByIndexErr       error
+	latestInfoUntilBlock *l1infotreesync.L1InfoTreeLeaf
+	latestInfoUntilErr   error
+	latestInfoUntilCalls []uint64
+	rollupProof          treetypes.Proof
+	rollupProofErr       error
+	lastInfo             *l1infotreesync.L1InfoTreeLeaf
+	firstInfo            *l1infotreesync.L1InfoTreeLeaf
+	infoAfterBlock       map[uint64]*l1infotreesync.L1InfoTreeLeaf
+	rollupProofCalls     []rollupProofCall
 }
 
 func (f *fakeL1InfoTreeSyncer) GetInfoByIndex(
@@ -586,6 +589,17 @@ func (f *fakeL1InfoTreeSyncer) GetInfoByIndex(
 		return nil, errors.New("info not found")
 	}
 	return info, nil
+}
+
+func (f *fakeL1InfoTreeSyncer) GetLatestL1InfoLeafUntilBlock(
+	_ context.Context,
+	blockNum uint64,
+) (*l1infotreesync.L1InfoTreeLeaf, error) {
+	f.latestInfoUntilCalls = append(f.latestInfoUntilCalls, blockNum)
+	if f.latestInfoUntilErr != nil {
+		return nil, f.latestInfoUntilErr
+	}
+	return f.latestInfoUntilBlock, nil
 }
 
 func (f *fakeL1InfoTreeSyncer) GetRollupExitTreeMerkleProof(
@@ -615,6 +629,12 @@ func (f *fakeL1InfoTreeSyncer) GetFirstInfoAfterBlock(blockNum uint64) (*l1infot
 	}
 	return info, nil
 }
+
+// Compile-time assertion: fakeL1InfoTreeSyncer implements L1InfoTreeSyncer.
+var _ L1InfoTreeSyncer = (*fakeL1InfoTreeSyncer)(nil)
+
+// Compile-time assertion: fakeL1BridgeSyncer implements L1BridgeSyncer.
+var _ L1BridgeSyncer = (*fakeL1BridgeSyncer)(nil)
 
 type getProofCall struct {
 	depositCount  uint32
@@ -738,4 +758,128 @@ func TestBinarySearchLowerAndUpperLimitBranches(t *testing.T) {
 	require.NotNil(t, result)
 	require.True(t, result.Ready)
 	require.Equal(t, uint32(50), result.Proof.L1InfoTreeIndex)
+}
+
+// INC-129 regression fixtures shared by the skew tests below. bridgesync L1 trails l1infotreesync,
+// so GetRootByLER cannot resolve the MER of the newest info tree leaf and the fallback fires. The
+// old fallback fed GetLastRoot's Index -- a position in the L1 bridge exit tree, i.e. a deposit
+// count of ~1.1M -- into l1InfoTree.GetInfoByIndex, which expects an L1 info tree index. No such
+// row could exist, so the preparer failed with "sql: no rows in result set".
+const (
+	// the deposit count the caller asks about, and the deposit count bridgesync L1 has settled
+	skewDepositCount     = uint32(1_146_000)
+	skewLastRootIndex    = uint32(1_146_035)
+	skewLastRootBlockNum = uint64(8_412)
+	// the L1 info tree syncer is ahead: its newest leaf sits at a later L1 block
+	skewTipInfoBlockNum     = uint64(8_501)
+	skewClampedInfoBlockNum = uint64(8_400)
+	skewFirstInfoBlockNum   = uint64(4_000)
+	// midpoint of [skewFirstInfoBlockNum, skewClampedInfoBlockNum]; with the unclamped tip block as
+	// the upper limit the binary search would probe 6_250 instead and find no fixture
+	skewProbedBlock   = uint64(6_200)
+	skewExpectedIndex = uint32(74_099)
+)
+
+// newSkewedFakes builds a bridgesync-L1-trails-l1infotreesync pair of fakes. lastRootBlockNum is
+// the BlockNum carried by the root returned from the GetLastRoot fallback.
+func newSkewedFakes(lastRootBlockNum uint64) (*fakeL1BridgeSyncer, *fakeL1InfoTreeSyncer) {
+	tipInfo := testL1InfoTreeLeaf(skewTipInfoBlockNum, 74_390, "0xdead")
+	clampedInfo := testL1InfoTreeLeaf(skewClampedInfoBlockNum, 74_301, "0xcafe")
+	firstInfo := testL1InfoTreeLeaf(skewFirstInfoBlockNum, 1, "0xfeed")
+	targetInfo := testL1InfoTreeLeaf(6_250, skewExpectedIndex, "0xbeef")
+
+	bridge := &fakeL1BridgeSyncer{
+		// tipInfo.MainnetExitRoot is deliberately absent: bridgesync L1 has never seen that MER,
+		// which is what pushes the code into the GetLastRoot fallback.
+		rootsByLER: map[common.Hash]*treetypes.Root{
+			targetInfo.MainnetExitRoot: {Index: skewDepositCount, BlockNum: 6_260},
+		},
+		lastRoot: &treetypes.Root{Index: skewLastRootIndex, BlockNum: lastRootBlockNum},
+		proof:    testProof("0xaa"),
+	}
+	l1InfoTree := &fakeL1InfoTreeSyncer{
+		lastInfo:  tipInfo,
+		firstInfo: firstInfo,
+		// the clamp must be by L1 block number, never by the deposit count
+		latestInfoUntilBlock: clampedInfo,
+		infoAfterBlock: map[uint64]*l1infotreesync.L1InfoTreeLeaf{
+			skewProbedBlock: targetInfo,
+		},
+		infoByIndex: map[uint32]*l1infotreesync.L1InfoTreeLeaf{
+			skewExpectedIndex: targetInfo,
+		},
+		rollupProof: testProof("0xbb"),
+	}
+	return bridge, l1InfoTree
+}
+
+func TestFirstL1InfoTreeIndexForL1BridgeIndexSpaceSkew(t *testing.T) {
+	// guard the fixture itself: if the two index spaces ever converge, this test stops proving
+	// anything, because a block number would also be a plausible L1 info tree index
+	require.Greater(t, uint64(skewLastRootIndex), skewLastRootBlockNum*100,
+		"the deposit count and the L1 block number must stay orders of magnitude apart")
+
+	ctx := context.Background()
+
+	t.Run("returns a valid l1 info tree index instead of an error", func(t *testing.T) {
+		bridge, l1InfoTree := newSkewedFakes(skewLastRootBlockNum)
+		preparer := NewPreparer(bridge, l1InfoTree, nil)
+
+		index, err := preparer.firstL1InfoTreeIndexForL1Bridge(ctx, skewDepositCount, 20)
+		require.NoError(t, err)
+		require.Equal(t, skewExpectedIndex, index)
+		// the fallback clamped on the bridge syncer's block, not on its deposit count
+		require.Equal(t, []uint64{skewLastRootBlockNum}, l1InfoTree.latestInfoUntilCalls)
+	})
+
+	t.Run("prepares a proof while the L1 bridge syncer trails", func(t *testing.T) {
+		bridge, l1InfoTree := newSkewedFakes(skewLastRootBlockNum)
+		preparer := NewPreparer(bridge, l1InfoTree, nil)
+
+		result, err := preparer.Prepare(ctx, testRequest(skewDepositCount))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.Ready)
+		require.Equal(t, skewExpectedIndex, result.Proof.L1InfoTreeIndex)
+		require.Equal(t, []uint64{skewLastRootBlockNum}, l1InfoTree.latestInfoUntilCalls)
+	})
+}
+
+func TestFirstL1InfoTreeIndexForL1BridgeLastRootBlockZero(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reports not-on-l1-info instead of clamping by block 0", func(t *testing.T) {
+		bridge, l1InfoTree := newSkewedFakes(0)
+		preparer := NewPreparer(bridge, l1InfoTree, nil)
+
+		_, err := preparer.firstL1InfoTreeIndexForL1Bridge(ctx, skewDepositCount, 20)
+		require.ErrorIs(t, err, bridgeservice.ErrNotOnL1Info)
+		require.ErrorContains(t, err, "bridgesync L1 has not indexed any block yet")
+		require.Empty(t, l1InfoTree.latestInfoUntilCalls)
+	})
+
+	t.Run("keeps the request pending", func(t *testing.T) {
+		bridge, l1InfoTree := newSkewedFakes(0)
+		preparer := NewPreparer(bridge, l1InfoTree, nil)
+
+		result, err := preparer.Prepare(ctx, testRequest(skewDepositCount))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.Ready)
+		require.Nil(t, result.Proof)
+		require.Empty(t, l1InfoTree.latestInfoUntilCalls)
+	})
+}
+
+func TestFirstL1InfoTreeIndexForL1BridgeClampLookupError(t *testing.T) {
+	ctx := context.Background()
+	clampErr := errors.New("sql: no rows in result set")
+
+	bridge, l1InfoTree := newSkewedFakes(skewLastRootBlockNum)
+	l1InfoTree.latestInfoUntilErr = clampErr
+	preparer := NewPreparer(bridge, l1InfoTree, nil)
+
+	_, err := preparer.firstL1InfoTreeIndexForL1Bridge(ctx, skewDepositCount, 20)
+	require.ErrorIs(t, err, clampErr)
+	require.ErrorContains(t, err, "l1infotreesync has no L1 info tree leaf at or before L1 block 8412")
 }

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -34,6 +34,7 @@ import (
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
+	aggkitsync "github.com/agglayer/aggkit/sync"
 	tree "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
@@ -75,6 +76,8 @@ const (
 	errSetupRequest      = "failed to setup request: %v"
 	errDepositCountParam = "invalid deposit count parameter: %v"
 	errInvalidParam      = "invalid %s parameter"
+	// errSyncerInconsistent is the response body used when a syncer is halted resolving a reorg
+	errSyncerInconsistent = "a syncer is temporarily inconsistent (reorg being resolved), retry later: %s"
 
 	// etrogVersionID is the version ID of AgglayerManager after Etrog upgrade
 	etrogVersionID = 2
@@ -778,7 +781,9 @@ func (b *BridgeService) GetLegacyTokenMigrationsHandler(c *gin.Context) {
 // @Produce json
 // @Success 200 {object} uint32
 // @Failure 400 {object} types.ErrorResponse "Bad Request"
+// @Failure 404 {object} types.ErrorResponse "Not Found - not indexed by the syncers yet, retry later"
 // @Failure 500 {object} types.ErrorResponse "Internal Server Error"
+// @Failure 503 {object} types.ErrorResponse "Service Unavailable - a syncer is resolving a reorg, retry later"
 // @Router /l1-info-tree-index [get]
 func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 	b.logger.Debugf("L1InfoTreeIndexForBridge request received (network id=%s, deposit count=%s)",
@@ -823,16 +828,11 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 	}
 
 	if err != nil {
-		b.logger.Debugf(
-			"failed to get L1 info tree index (network id=%d, deposit count=%d): %v",
-			networkID,
-			depositCount,
-			err,
-		)
-		statusCode = http.StatusInternalServerError
-		c.JSON(statusCode,
-			gin.H{"error": fmt.Sprintf("failed to get l1 info tree index for network id %d and deposit count %d, error: %s",
-				networkID, depositCount, err)})
+		statusCode = b.respondSyncerError(c, err,
+			fmt.Sprintf("l1 info tree index for network id %d and deposit count %d is not available yet, retry later: %s",
+				networkID, depositCount, err),
+			fmt.Sprintf("failed to get l1 info tree index for network id %d and deposit count %d, error: %s",
+				networkID, depositCount, err))
 		return
 	}
 
@@ -848,8 +848,9 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 // @Produce json
 // @Success 200 {object} types.L1InfoTreeLeafResponse
 // @Failure 400 {object} types.ErrorResponse "Bad Request"
-// @Failure 404 {object} types.ErrorResponse "Not Found - global exit root not injected yet"
+// @Failure 404 {object} types.ErrorResponse "Not Found - global exit root not injected or leaf not indexed yet"
 // @Failure 500 {object} types.ErrorResponse "Internal Server Error"
+// @Failure 503 {object} types.ErrorResponse "Service Unavailable - a syncer is resolving a reorg, retry later"
 // @Router /injected-l1-info-leaf [get]
 func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 	b.logger.Debugf("InjectedInfoAfterIndex request received (network id=%s, leaf index=%s)",
@@ -906,11 +907,11 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 
 		l1InfoLeaf, err = b.l1InfoTree.GetInfoByIndex(ctx, e.L1InfoTreeIndex)
 		if err != nil {
-			b.logger.Errorf("failed to get L1 info tree leaf (leaf index=%d): %v", e.L1InfoTreeIndex, err)
-			statusCode = http.StatusInternalServerError
-			c.JSON(statusCode,
-				gin.H{"error": fmt.Sprintf("failed to get L1 info tree leaf (leaf index=%d), error: %s",
-					e.L1InfoTreeIndex, err)})
+			statusCode = b.respondSyncerError(c, err,
+				fmt.Sprintf("l1infotreesync has not indexed l1 info tree leaf index %d yet "+
+					"(already injected on L2 per l2gersync), retry later", e.L1InfoTreeIndex),
+				fmt.Sprintf("failed to get L1 info tree leaf (leaf index=%d), error: %s",
+					e.L1InfoTreeIndex, err))
 			return
 		}
 	default:
@@ -921,11 +922,10 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 	}
 
 	if err != nil {
-		b.logger.Debugf("failed to get L1 info tree leaf (network id=%d, leaf index=%d): %v", networkID, l1InfoTreeIndex, err)
-		statusCode = http.StatusInternalServerError
-		c.JSON(statusCode,
-			gin.H{"error": fmt.Sprintf("failed to get L1 info tree leaf (network id=%d, leaf index=%d), error: %s",
-				networkID, l1InfoTreeIndex, err)})
+		statusCode = b.respondSyncerError(c, err,
+			fmt.Sprintf("l1infotreesync has not indexed l1 info tree leaf index %d yet, retry later", l1InfoTreeIndex),
+			fmt.Sprintf("failed to get L1 info tree leaf (network id=%d, leaf index=%d), error: %s",
+				networkID, l1InfoTreeIndex, err))
 		return
 	}
 
@@ -1011,7 +1011,9 @@ func (b *BridgeService) L1InfoTreeLeafByGERHandler(c *gin.Context) {
 // @Produce json
 // @Success 200 {object} types.ClaimProof "Merkle proofs and L1 info tree leaf"
 // @Failure 400 {object} types.ErrorResponse "Bad Request"
+// @Failure 404 {object} types.ErrorResponse "Not Found - not indexed by the syncers yet, retry later"
 // @Failure 500 {object} types.ErrorResponse "Internal Server Error"
+// @Failure 503 {object} types.ErrorResponse "Service Unavailable - syncer not available or resolving a reorg"
 // @Router /claim-proof [get]
 func (b *BridgeService) ClaimProofHandler(c *gin.Context) {
 	b.logger.Debugf("ClaimProof request received (network id=%s, l1 info tree index=%s, deposit count=%s)",
@@ -1029,29 +1031,32 @@ func (b *BridgeService) ClaimProofHandler(c *gin.Context) {
 	networkID, err := parseUintQuery(c, networkIDParam, true, uint32(0))
 	if err != nil {
 		b.logger.Warnf(errNetworkID, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		statusCode = http.StatusBadRequest
+		c.JSON(statusCode, gin.H{"error": err.Error()})
 		return
 	}
 
 	l1InfoTreeIndex, err := parseUintQuery(c, leafIndexParam, true, uint32(0))
 	if err != nil {
 		b.logger.Warnf("invalid L1 info tree index parameter: %v", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		statusCode = http.StatusBadRequest
+		c.JSON(statusCode, gin.H{"error": err.Error()})
 		return
 	}
 
 	depositCount, err := parseUintQuery(c, depositCountParam, true, uint32(0))
 	if err != nil {
 		b.logger.Warnf(errDepositCountParam, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		statusCode = http.StatusBadRequest
+		c.JSON(statusCode, gin.H{"error": err.Error()})
 		return
 	}
 
 	info, err := b.l1InfoTree.GetInfoByIndex(ctx, l1InfoTreeIndex)
 	if err != nil {
-		b.logger.Errorf("failed to get L1 info tree leaf for index %d: %v", l1InfoTreeIndex, err)
-		c.JSON(http.StatusInternalServerError,
-			gin.H{"error": fmt.Sprintf("failed to get l1 info tree leaf for index %d: %s", l1InfoTreeIndex, err)})
+		statusCode = b.respondSyncerError(c, err,
+			fmt.Sprintf("l1infotreesync has not indexed l1 info tree leaf index %d yet, retry later", l1InfoTreeIndex),
+			fmt.Sprintf("failed to get l1 info tree leaf for index %d: %s", l1InfoTreeIndex, err))
 		return
 	}
 
@@ -1059,60 +1064,63 @@ func (b *BridgeService) ClaimProofHandler(c *gin.Context) {
 	switch networkID {
 	case mainnetNetworkID:
 		if b.bridgeL1 == nil {
-			c.JSON(http.StatusServiceUnavailable,
+			statusCode = http.StatusServiceUnavailable
+			c.JSON(statusCode,
 				gin.H{"error": "L1 bridge syncer is not available"})
 			return
 		}
 		proofLocalExitRoot, err = b.bridgeL1.GetProof(ctx, depositCount, info.MainnetExitRoot)
 		if err != nil {
-			b.logger.Errorf("failed to get local exit proof for L1: %v", err)
-			c.JSON(http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("failed to get local exit proof, error: %s", err)})
+			statusCode = b.respondSyncerError(c, err,
+				fmt.Sprintf("bridgesync L1 has not indexed deposit count %d yet, retry later", depositCount),
+				fmt.Sprintf("failed to get local exit proof, error: %s", err))
 			return
 		}
 
 	case b.networkID:
 		localExitRoot, err := b.l1InfoTree.GetLocalExitRoot(ctx, networkID, info.RollupExitRoot)
 		if err != nil {
-			b.logger.Errorf("failed to get local exit root from rollup exit tree: %v", err)
-			c.JSON(http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("failed to get local exit root from rollup exit tree, error: %s", err)})
+			statusCode = b.respondSyncerError(c, err,
+				fmt.Sprintf("l1infotreesync has not indexed the local exit root of network id %d for rollup exit root %s "+
+					"yet, retry later", networkID, info.RollupExitRoot),
+				fmt.Sprintf("failed to get local exit root from rollup exit tree, error: %s", err))
 			return
 		}
 		if b.bridgeL2 == nil {
-			c.JSON(http.StatusServiceUnavailable,
+			statusCode = http.StatusServiceUnavailable
+			c.JSON(statusCode,
 				gin.H{"error": "L2 bridge syncer is not available"})
 			return
 		}
 		proofLocalExitRoot, err = b.bridgeL2.GetProof(ctx, depositCount, localExitRoot)
 		if err != nil {
-			b.logger.Errorf("failed to get local exit proof for L2: %v", err)
-			c.JSON(http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("failed to get local exit proof, error: %s", err)})
+			statusCode = b.respondSyncerError(c, err,
+				fmt.Sprintf("bridgesync L2 has not indexed deposit count %d yet, retry later", depositCount),
+				fmt.Sprintf("failed to get local exit proof, error: %s", err))
 			return
 		}
 
 	default:
 		b.logger.Warnf("unsupported network id for claim proof: %d", networkID)
-		c.JSON(http.StatusBadRequest,
+		statusCode = http.StatusBadRequest
+		c.JSON(statusCode,
 			gin.H{"error": fmt.Sprintf("failed to get claim proof, unsupported network %d", networkID)})
 		return
 	}
 
 	proofRollupExitRoot, err := b.l1InfoTree.GetRollupExitTreeMerkleProof(ctx, networkID, info.RollupExitRoot)
 	if err != nil {
-		b.logger.Errorf("failed to get rollup exit proof (network id=%d, leaf index=%d, deposit count=%d): %v",
-			networkID, l1InfoTreeIndex, depositCount, err)
-		c.JSON(http.StatusInternalServerError,
-			gin.H{
-				"error": fmt.Sprintf("failed to get rollup exit proof (network id=%d, leaf index=%d, deposit count=%d), error: %s",
-					networkID, l1InfoTreeIndex, depositCount, err)})
+		statusCode = b.respondSyncerError(c, err,
+			fmt.Sprintf("l1infotreesync has not indexed the rollup exit tree for network id %d and rollup exit root %s "+
+				"yet, retry later", networkID, info.RollupExitRoot),
+			fmt.Sprintf("failed to get rollup exit proof (network id=%d, leaf index=%d, deposit count=%d), error: %s",
+				networkID, l1InfoTreeIndex, depositCount, err))
 		return
 	}
 
 	infoResponse := NewL1InfoTreeLeafResponse(info)
 
-	c.JSON(http.StatusOK, types.ClaimProof{
+	c.JSON(statusCode, types.ClaimProof{
 		ProofLocalExitRoot:  types.ConvertToProofResponse(proofLocalExitRoot),
 		ProofRollupExitRoot: types.ConvertToProofResponse(proofRollupExitRoot),
 		L1InfoTreeLeaf:      *infoResponse,
@@ -1442,9 +1450,17 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL1Bridge(ctx context.Context, 
 		if err != nil {
 			return 0, fmt.Errorf("failed to get last root for L1: %w", err)
 		}
-		lastInfo, err = b.l1InfoTree.GetInfoByIndex(ctx, root.Index)
+		if root.BlockNum == 0 {
+			return 0, fmt.Errorf("bridgesync L1 has not indexed any block yet: %w", ErrNotOnL1Info)
+		}
+		// root.Index is a position in the L1 bridge exit tree (i.e. a deposit count), not an L1 info
+		// tree index, so it must never be fed into an l1infotreesync leaf lookup. Clamp by the last
+		// L1 block indexed by bridgesync L1 instead, which is the same index space for both syncers.
+		lastInfo, err = b.l1InfoTree.GetLatestL1InfoLeafUntilBlock(ctx, root.BlockNum)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get last info for L1: %w", err)
+			return 0, fmt.Errorf(
+				"l1infotreesync has no L1 info tree leaf at or before L1 block %d "+
+					"(last block indexed by bridgesync L1): %w", root.BlockNum, err)
 		}
 	}
 	if root.Index < depositCount {
@@ -1733,6 +1749,55 @@ func (b *BridgeService) parseGlobalIndexAndSetupRequest(
 func reportMetrics(handlerID string, statusCode int, startTime time.Time) {
 	metrics.IncTotalRequestCounter(handlerID, strconv.Itoa(statusCode))
 	metrics.ObserveRequestLatencyHistogram(handlerID, startTime)
+}
+
+// httpStatusForSyncerError maps an error returned by one of the syncers this service reads from to
+// the HTTP status the API should answer with:
+//
+//	404 - a syncer has not indexed the requested data (yet); callers should retry later
+//	503 - a syncer is halted on an inconsistent state (reorg being resolved); retryable
+//	500 - a genuine fault
+//
+// Both not-found sentinels must be handled: reads routed through l1infotreesync's translateError
+// (e.g. GetLatestL1InfoLeafUntilBlock) surface l1infotreesync.ErrNotFound, while every sibling read
+// surfaces db.ErrNotFound raw.
+func httpStatusForSyncerError(err error) int {
+	switch {
+	case errors.Is(err, aggkitsync.ErrInconsistentState):
+		return http.StatusServiceUnavailable
+	case errors.Is(err, db.ErrNotFound),
+		errors.Is(err, l1infotreesync.ErrNotFound),
+		errors.Is(err, l1infotreesync.ErrBlockNotProcessed),
+		errors.Is(err, l1infotreesync.ErrNoBlock0),
+		errors.Is(err, ErrNotOnL1Info):
+		return http.StatusNotFound
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// respondSyncerError classifies err with httpStatusForSyncerError, logs it at a level matching the
+// resulting status (debug for 404, warn for 503, error for 500) and writes the error response.
+// notFoundMsg is the 404 body, internalMsg the 500 body and the 503 body is fixed. It returns the
+// status code so the caller can propagate it to the request metrics.
+func (b *BridgeService) respondSyncerError(c *gin.Context, err error, notFoundMsg, internalMsg string) int {
+	statusCode := httpStatusForSyncerError(err)
+	msg := internalMsg
+	switch statusCode {
+	case http.StatusNotFound:
+		msg = notFoundMsg
+		b.logger.Debug(msg)
+	case http.StatusServiceUnavailable:
+		// the response body stays generic, but the log keeps the context of the failing call
+		b.logger.Warn(internalMsg)
+		msg = fmt.Sprintf(errSyncerInconsistent, err)
+	default:
+		b.logger.Error(msg)
+	}
+
+	c.JSON(statusCode, gin.H{"error": msg})
+
+	return statusCode
 }
 
 // GetClaimsByGERHandler retrieves all DetailedClaimEvent claims that used the given global exit root.

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -789,7 +789,9 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 	b.logger.Debugf("L1InfoTreeIndexForBridge request received (network id=%s, deposit count=%s)",
 		c.Query(networkIDParam), c.Query(depositCountParam))
 
-	statusCode := http.StatusOK
+	// Pessimistic default: an exit path that forgets to set statusCode reports a fault to
+	// reportMetrics rather than silently reporting success. The success path sets it explicitly.
+	statusCode := http.StatusInternalServerError
 	startTime := time.Now()
 	defer func() {
 		reportMetrics(metrics.GetL1InfoTreeIndexReq, statusCode, startTime)
@@ -836,6 +838,7 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 		return
 	}
 
+	statusCode = http.StatusOK
 	c.JSON(statusCode, l1InfoTreeIndex)
 }
 
@@ -856,7 +859,9 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 	b.logger.Debugf("InjectedInfoAfterIndex request received (network id=%s, leaf index=%s)",
 		c.Query(networkIDParam), c.Query(leafIndexParam))
 
-	statusCode := http.StatusOK
+	// Pessimistic default: an exit path that forgets to set statusCode reports a fault to
+	// reportMetrics rather than silently reporting success. The success path sets it explicitly.
+	statusCode := http.StatusInternalServerError
 	startTime := time.Now()
 	defer func() {
 		reportMetrics(metrics.GetInjectedInfoAfterIndexReq, statusCode, startTime)
@@ -929,6 +934,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 		return
 	}
 
+	statusCode = http.StatusOK
 	c.JSON(statusCode, NewL1InfoTreeLeafResponse(l1InfoLeaf))
 }
 
@@ -1019,7 +1025,10 @@ func (b *BridgeService) ClaimProofHandler(c *gin.Context) {
 	b.logger.Debugf("ClaimProof request received (network id=%s, l1 info tree index=%s, deposit count=%s)",
 		c.Query(networkIDParam), c.Query(leafIndexParam), c.Query(depositCountParam))
 
-	statusCode := http.StatusOK
+	// Pessimistic default: an exit path that forgets to set statusCode reports a fault to
+	// reportMetrics rather than silently reporting success. The success path sets it explicitly.
+	// This handler previously reported 200 for every one of its failure paths.
+	statusCode := http.StatusInternalServerError
 	startTime := time.Now()
 	defer func() {
 		reportMetrics(metrics.GetClaimProofReq, statusCode, startTime)
@@ -1120,6 +1129,7 @@ func (b *BridgeService) ClaimProofHandler(c *gin.Context) {
 
 	infoResponse := NewL1InfoTreeLeafResponse(info)
 
+	statusCode = http.StatusOK
 	c.JSON(statusCode, types.ClaimProof{
 		ProofLocalExitRoot:  types.ConvertToProofResponse(proofLocalExitRoot),
 		ProofRollupExitRoot: types.ConvertToProofResponse(proofRollupExitRoot),

--- a/bridgeservice/bridge_interfaces.go
+++ b/bridgeservice/bridge_interfaces.go
@@ -64,6 +64,7 @@ type L1InfoTreeSyncer interface {
 	GetLastInfo() (*l1infotreesync.L1InfoTreeLeaf, error)
 	GetFirstInfo() (*l1infotreesync.L1InfoTreeLeaf, error)
 	GetFirstInfoAfterBlock(blockNum uint64) (*l1infotreesync.L1InfoTreeLeaf, error)
+	GetLatestL1InfoLeafUntilBlock(ctx context.Context, blockNum uint64) (*l1infotreesync.L1InfoTreeLeaf, error)
 	GetLastVerifiedBatches(rollupID uint32) (*l1infotreesync.VerifyBatches, error)
 	GetFirstVerifiedBatches(rollupID uint32) (*l1infotreesync.VerifyBatches, error)
 	GetFirstVerifiedBatchesAfterBlock(rollupID uint32, blockNum uint64) (*l1infotreesync.VerifyBatches, error)

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -10,9 +10,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	stdsync "sync"
 	"testing"
 	"time"
 
+	"github.com/agglayer/aggkit/bridgeservice/metrics"
 	mocks "github.com/agglayer/aggkit/bridgeservice/mocks"
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync"
@@ -22,10 +24,13 @@ import (
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/l2gersync"
 	"github.com/agglayer/aggkit/log"
+	aggkitprometheus "github.com/agglayer/aggkit/prometheus"
+	aggkitsync "github.com/agglayer/aggkit/sync"
 	tree "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gin-gonic/gin"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -3829,6 +3834,18 @@ func TestPopulateNetworkSyncInfo(t *testing.T) {
 	}
 }
 
+// L1 block numbers used by the GetRootByLER fallback fixtures. tree.Root.Index is a position in the
+// L1 bridge exit tree (a deposit count) while tree.Root.BlockNum is an L1 block number: two
+// different counters that happen to share the same Go type. The fixtures below keep them orders of
+// magnitude apart on purpose, so that a future index/block mix-up cannot silently satisfy a mock
+// expectation the way it did in INC-129.
+const (
+	fallbackBlockNum           = uint64(900_000)
+	fallbackBlockNumLowIndex   = uint64(910_000)
+	fallbackBlockNumHighIndex  = uint64(920_000)
+	fallbackBlockNumClampFails = uint64(930_000)
+)
+
 func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 	ctx := context.Background()
 	networkID := uint32(1)
@@ -3847,7 +3864,9 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 	}
 
 	depositCount := uint32(500)
-	expectedIndex := uint32(500)
+	// deliberately unrelated to depositCount and to any block number used below: the returned value
+	// is an L1 info tree index, a third index space that must not be confused with the other two
+	expectedIndex := uint32(4242)
 
 	t.Run("GetRootByLER fails but GetLastRoot succeeds", func(t *testing.T) {
 		// Setup mocks for the fallback scenario
@@ -3860,23 +3879,26 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 			Return(nil, errors.New("LER not found")).
 			Once()
 
-		// Fallback to GetLastRoot succeeds
+		// Fallback to GetLastRoot succeeds. Index is a position in the L1 bridge exit tree (a
+		// deposit count) while BlockNum is an L1 block number: two different index spaces, so the
+		// fixture keeps them orders of magnitude apart to make any mix-up fail loudly.
 		fallbackRoot := &tree.Root{
 			Index:    depositCount,
-			BlockNum: uint64(depositCount),
+			BlockNum: fallbackBlockNum,
 		}
 		b.bridgeL1.EXPECT().GetLastRoot(ctx).
 			Return(fallbackRoot, nil).
 			Once()
 
-		// After GetLastRoot succeeds, GetInfoByIndex is called with the root's index
-		updatedLastInfo := &l1infotreesync.L1InfoTreeLeaf{
-			BlockNumber:     uint64(depositCount),
-			MainnetExitRoot: common.HexToHash("0x123"),
-			L1InfoTreeIndex: depositCount,
+		// After GetLastRoot succeeds the fallback clamps by the last L1 block bridgesync L1
+		// indexed (root.BlockNum), never by root.Index.
+		clampedLastInfo := &l1infotreesync.L1InfoTreeLeaf{
+			BlockNumber:     fallbackBlockNum - 20_000,
+			MainnetExitRoot: common.HexToHash("0x456"),
+			L1InfoTreeIndex: 3_120,
 		}
-		b.l1InfoTree.EXPECT().GetInfoByIndex(ctx, depositCount).
-			Return(updatedLastInfo, nil).
+		b.l1InfoTree.EXPECT().GetLatestL1InfoLeafUntilBlock(ctx, fallbackBlockNum).
+			Return(clampedLastInfo, nil).
 			Once()
 
 		// Continue with normal flow
@@ -3884,13 +3906,16 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 			Return(firstInfo, nil).
 			Once()
 
-		// Mock the binary search calls
+		// Mock the binary search calls. The probed block proves the binary search upper limit
+		// inherited the clamp from the reassigned lastInfo (it is derived from
+		// clampedLastInfo.BlockNumber, not from the unclamped lastInfo.BlockNumber).
 		targetInfo := &l1infotreesync.L1InfoTreeLeaf{
-			BlockNumber:     uint64(expectedIndex),
+			BlockNumber:     300_000,
 			MainnetExitRoot: common.HexToHash("0x123"),
 			L1InfoTreeIndex: expectedIndex,
 		}
-		b.l1InfoTree.EXPECT().GetFirstInfoAfterBlock(mock.Anything).
+		b.l1InfoTree.EXPECT().
+			GetFirstInfoAfterBlock(midpointBlock(firstInfo.BlockNumber, clampedLastInfo.BlockNumber)).
 			Return(targetInfo, nil).
 			Once()
 
@@ -3951,23 +3976,23 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 			Return(nil, errors.New("LER not found")).
 			Once()
 
-		// Fallback to GetLastRoot succeeds but returns low index
+		// Fallback to GetLastRoot succeeds but returns low index (BlockNum stays orders of
+		// magnitude away from Index, they are different index spaces)
 		fallbackRoot := &tree.Root{
 			Index:    depositCount - 100, // Lower than depositCount
-			BlockNum: uint64(depositCount - 100),
+			BlockNum: fallbackBlockNumLowIndex,
 		}
 		b.bridgeL1.EXPECT().GetLastRoot(ctx).
 			Return(fallbackRoot, nil).
 			Once()
 
-		// After GetLastRoot succeeds, GetInfoByIndex is called with the root's index
-		updatedLastInfo := &l1infotreesync.L1InfoTreeLeaf{
-			BlockNumber:     uint64(depositCount - 100),
-			MainnetExitRoot: common.HexToHash("0x123"),
-			L1InfoTreeIndex: depositCount - 100,
-		}
-		b.l1InfoTree.EXPECT().GetInfoByIndex(ctx, depositCount-100).
-			Return(updatedLastInfo, nil).
+		// The clamp happens before the index check, so it is still exercised here
+		b.l1InfoTree.EXPECT().GetLatestL1InfoLeafUntilBlock(ctx, fallbackBlockNumLowIndex).
+			Return(&l1infotreesync.L1InfoTreeLeaf{
+				BlockNumber:     fallbackBlockNumLowIndex - 5_000,
+				MainnetExitRoot: common.HexToHash("0x456"),
+				L1InfoTreeIndex: 3_150,
+			}, nil).
 			Once()
 
 		// Execute the function
@@ -3977,6 +4002,9 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, uint32(0), actualIndex)
 		require.Equal(t, ErrNotOnL1Info, err)
+		require.ErrorIs(t, err, ErrNotOnL1Info)
+		// and the handler must answer 404 for it, not 500
+		require.Equal(t, http.StatusNotFound, httpStatusForSyncerError(err))
 
 		// Verify all mocks were called as expected
 		b.l1InfoTree.AssertExpectations(t)
@@ -3994,23 +4022,24 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 			Return(nil, errors.New("LER not found")).
 			Once()
 
-		// Fallback to GetLastRoot succeeds with higher index
+		// Fallback to GetLastRoot succeeds with higher index (BlockNum remains orders of magnitude
+		// away from Index, they are different index spaces)
 		fallbackRoot := &tree.Root{
 			Index:    depositCount + 50, // Higher than depositCount
-			BlockNum: uint64(depositCount + 50),
+			BlockNum: fallbackBlockNumHighIndex,
 		}
 		b.bridgeL1.EXPECT().GetLastRoot(ctx).
 			Return(fallbackRoot, nil).
 			Once()
 
-		// After GetLastRoot succeeds, GetInfoByIndex is called with the root's index
-		updatedLastInfo := &l1infotreesync.L1InfoTreeLeaf{
-			BlockNumber:     uint64(depositCount + 50),
-			MainnetExitRoot: common.HexToHash("0x123"),
-			L1InfoTreeIndex: depositCount + 50,
+		// After GetLastRoot succeeds the fallback clamps by root.BlockNum, never by root.Index
+		clampedLastInfo := &l1infotreesync.L1InfoTreeLeaf{
+			BlockNumber:     fallbackBlockNumHighIndex - 2_000,
+			MainnetExitRoot: common.HexToHash("0x456"),
+			L1InfoTreeIndex: 3_180,
 		}
-		b.l1InfoTree.EXPECT().GetInfoByIndex(ctx, depositCount+50).
-			Return(updatedLastInfo, nil).
+		b.l1InfoTree.EXPECT().GetLatestL1InfoLeafUntilBlock(ctx, fallbackBlockNumHighIndex).
+			Return(clampedLastInfo, nil).
 			Once()
 
 		// Continue with normal flow
@@ -4018,13 +4047,14 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 			Return(firstInfo, nil).
 			Once()
 
-		// Mock the binary search calls
+		// Mock the binary search calls; the probed block pins the inherited clamp
 		targetInfo := &l1infotreesync.L1InfoTreeLeaf{
-			BlockNumber:     uint64(expectedIndex),
+			BlockNumber:     310_000,
 			MainnetExitRoot: common.HexToHash("0x123"),
 			L1InfoTreeIndex: expectedIndex,
 		}
-		b.l1InfoTree.EXPECT().GetFirstInfoAfterBlock(mock.Anything).
+		b.l1InfoTree.EXPECT().
+			GetFirstInfoAfterBlock(midpointBlock(firstInfo.BlockNumber, clampedLastInfo.BlockNumber)).
 			Return(targetInfo, nil).
 			Once()
 
@@ -4045,43 +4075,969 @@ func TestGetFirstL1InfoTreeIndexForL1Bridge_GetRootByLERFallback(t *testing.T) {
 		b.bridgeL1.AssertExpectations(t)
 	})
 
-	t.Run("GetRootByLER fails, GetLastRoot succeeds but GetInfoByIndex fails", func(t *testing.T) {
-		// Setup mocks for the fallback scenario where GetInfoByIndex fails
+	// Rewritten from "GetRootByLER fails, GetLastRoot succeeds but GetInfoByIndex fails", which used
+	// to pin the INC-129 bug by asserting the "failed to get last info for L1" wrapper produced by
+	// the (wrong) GetInfoByIndex(root.Index) lookup. The fallback now clamps with
+	// GetLatestL1InfoLeafUntilBlock(root.BlockNum), so this asserts the new wrapper instead and,
+	// crucially, that the not-found sentinel survives it so the handler can answer 404.
+	t.Run("GetRootByLER fails, GetLastRoot succeeds but GetLatestL1InfoLeafUntilBlock fails",
+		func(t *testing.T) {
+			b.l1InfoTree.EXPECT().GetLastInfo().
+				Return(lastInfo, nil).
+				Once()
+
+			// First call to GetRootByLER fails
+			b.bridgeL1.EXPECT().GetRootByLER(ctx, lastInfo.MainnetExitRoot).
+				Return(nil, errors.New("LER not found")).
+				Once()
+
+			// Fallback to GetLastRoot succeeds
+			fallbackRoot := &tree.Root{
+				Index:    depositCount,
+				BlockNum: fallbackBlockNumClampFails,
+			}
+			b.bridgeL1.EXPECT().GetLastRoot(ctx).
+				Return(fallbackRoot, nil).
+				Once()
+
+			// l1infotreesync has nothing at or before that L1 block: the reverse skew
+			b.l1InfoTree.EXPECT().GetLatestL1InfoLeafUntilBlock(ctx, fallbackBlockNumClampFails).
+				Return(nil, l1infotreesync.ErrNotFound).
+				Once()
+
+			actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(ctx, depositCount)
+
+			require.Error(t, err)
+			require.Equal(t, uint32(0), actualIndex)
+			// the sentinel survives the wrap, which is what lets the handler answer 404
+			require.ErrorIs(t, err, l1infotreesync.ErrNotFound)
+			require.Equal(t, http.StatusNotFound, httpStatusForSyncerError(err))
+			require.Contains(t, err.Error(),
+				fmt.Sprintf("l1infotreesync has no L1 info tree leaf at or before L1 block %d",
+					fallbackBlockNumClampFails))
+			// the old, index-space-confused error message must be gone for good
+			require.NotContains(t, err.Error(), "failed to get last info for L1")
+
+			b.l1InfoTree.AssertExpectations(t)
+			b.bridgeL1.AssertExpectations(t)
+		})
+
+	t.Run("GetRootByLER fails and GetLastRoot returns block 0", func(t *testing.T) {
 		b.l1InfoTree.EXPECT().GetLastInfo().
 			Return(lastInfo, nil).
 			Once()
 
-		// First call to GetRootByLER fails
 		b.bridgeL1.EXPECT().GetRootByLER(ctx, lastInfo.MainnetExitRoot).
 			Return(nil, errors.New("LER not found")).
 			Once()
 
-		// Fallback to GetLastRoot succeeds
-		fallbackRoot := &tree.Root{
-			Index:    depositCount,
-			BlockNum: uint64(depositCount),
-		}
+		// bridgesync L1 has not indexed any block yet; the guard must short-circuit before the
+		// clamp so l1infotreesync is never asked for a leaf at or before block 0
 		b.bridgeL1.EXPECT().GetLastRoot(ctx).
-			Return(fallbackRoot, nil).
+			Return(&tree.Root{Index: depositCount, BlockNum: 0}, nil).
 			Once()
 
-		// GetInfoByIndex fails after GetLastRoot succeeds
-		b.l1InfoTree.EXPECT().GetInfoByIndex(ctx, depositCount).
-			Return(nil, errors.New("failed to get info by index")).
-			Once()
-
-		// Execute the function
 		actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(ctx, depositCount)
 
-		// Verify results - should return error from GetInfoByIndex
 		require.Error(t, err)
 		require.Equal(t, uint32(0), actualIndex)
-		require.Contains(t, err.Error(), "failed to get last info for L1")
+		require.ErrorIs(t, err, ErrNotOnL1Info)
+		require.Equal(t, http.StatusNotFound, httpStatusForSyncerError(err))
+		require.Contains(t, err.Error(), "bridgesync L1 has not indexed any block yet")
 
-		// Verify all mocks were called as expected
 		b.l1InfoTree.AssertExpectations(t)
 		b.bridgeL1.AssertExpectations(t)
 	})
+}
+
+// midpointBlock reproduces the binary search probe of getFirstL1InfoTreeIndexForL1Bridge so that a
+// test can assert the exact block the search probes, which pins the search bounds (and therefore
+// that the fallback clamp was inherited by upperLimit).
+func midpointBlock(lowerLimit, upperLimit uint64) uint64 {
+	return lowerLimit + ((upperLimit - lowerLimit) / binarySearchDivider)
+}
+
+// INC-129 regression: the L1 bridge syncer trails the L1 info tree syncer, so GetRootByLER cannot
+// resolve the MER of the newest info tree leaf and the fallback fires. The old fallback fed
+// GetLastRoot's Index -- a position in the L1 bridge exit tree, i.e. a deposit count of ~1.1M --
+// into l1InfoTree.GetInfoByIndex, which expects an L1 info tree index. No such row could exist, so
+// the endpoint answered HTTP 500 "sql: no rows in result set".
+//
+// The fixtures below keep the two index spaces orders of magnitude apart (Index 1_146_035 vs
+// BlockNum 8_412, a factor of ~136) so that a future mix-up cannot accidentally satisfy a mock
+// expectation. On develop this test fails: nothing sets up GetInfoByIndex, so the mock reports an
+// unexpected call.
+func TestGetFirstL1InfoTreeIndexForL1Bridge_KinexysIndexSpaceSkew(t *testing.T) {
+	const (
+		// deposit count the caller asks about, and the deposit count bridgesync L1 has settled
+		depositCount     = uint32(1_146_000)
+		lastRootIndex    = uint32(1_146_035)
+		lastRootBlockNum = uint64(8_412)
+		// the L1 info tree syncer is ahead: its newest leaf sits at a later L1 block
+		tipInfoBlockNum     = uint64(8_501)
+		clampedInfoBlockNum = uint64(8_400)
+		firstInfoBlockNum   = uint64(4_000)
+		expectedIndex       = uint32(74_099)
+	)
+
+	// guard the fixture itself: if the two index spaces ever converge, this test stops proving
+	// anything, because a block number would also be a plausible L1 info tree index
+	require.Greater(t, uint64(lastRootIndex), lastRootBlockNum*100,
+		"the deposit count and the L1 block number must stay orders of magnitude apart")
+
+	tipInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     tipInfoBlockNum,
+		MainnetExitRoot: common.HexToHash("0xdead"),
+		L1InfoTreeIndex: 74_390,
+	}
+	clampedInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     clampedInfoBlockNum,
+		MainnetExitRoot: common.HexToHash("0xcafe"),
+		L1InfoTreeIndex: 74_301,
+	}
+	firstInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     firstInfoBlockNum,
+		MainnetExitRoot: common.HexToHash("0xfeed"),
+		L1InfoTreeIndex: 1,
+	}
+	targetInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     6_250,
+		MainnetExitRoot: common.HexToHash("0xbeef"),
+		L1InfoTreeIndex: expectedIndex,
+	}
+
+	setupSkewedMocks := func(b bridgeWithMocks) {
+		// l1infotreesync is ahead of bridgesync L1
+		b.l1InfoTree.EXPECT().GetLastInfo().Return(tipInfo, nil).Once()
+		// ... so bridgesync L1 has never seen the MER of that leaf
+		b.bridgeL1.EXPECT().GetRootByLER(mock.Anything, tipInfo.MainnetExitRoot).
+			Return(nil, db.ErrNotFound).Once()
+		// the fallback fires: the last root bridgesync L1 knows about carries a deposit count in
+		// Index and an L1 block number in BlockNum
+		b.bridgeL1.EXPECT().GetLastRoot(mock.Anything).
+			Return(&tree.Root{Index: lastRootIndex, BlockNum: lastRootBlockNum}, nil).Once()
+		// the clamp must be by L1 block number, never by the deposit count
+		b.l1InfoTree.EXPECT().GetLatestL1InfoLeafUntilBlock(mock.Anything, lastRootBlockNum).
+			Return(clampedInfo, nil).Once()
+
+		b.l1InfoTree.EXPECT().GetFirstInfo().Return(firstInfo, nil).Once()
+		// the probed block proves upperLimit inherited the clamp (clampedInfo, not tipInfo)
+		b.l1InfoTree.EXPECT().
+			GetFirstInfoAfterBlock(midpointBlock(firstInfoBlockNum, clampedInfoBlockNum)).
+			Return(targetInfo, nil).Once()
+		b.bridgeL1.EXPECT().GetRootByLER(mock.Anything, targetInfo.MainnetExitRoot).
+			Return(&tree.Root{Index: depositCount, BlockNum: 6_260}, nil).Once()
+	}
+
+	t.Run("returns a valid l1 info tree index instead of an error", func(t *testing.T) {
+		b := newBridgeWithMocks(t, l2NetworkID)
+		setupSkewedMocks(b)
+
+		actualIndex, err := b.bridge.getFirstL1InfoTreeIndexForL1Bridge(context.Background(), depositCount)
+
+		require.NoError(t, err)
+		require.Equal(t, expectedIndex, actualIndex)
+
+		b.l1InfoTree.AssertExpectations(t)
+		b.bridgeL1.AssertExpectations(t)
+	})
+
+	t.Run("endpoint answers 200 while the L1 bridge syncer trails", func(t *testing.T) {
+		b := newBridgeWithMocks(t, l2NetworkID)
+		setupSkewedMocks(b)
+
+		queryParams := url.Values{}
+		queryParams.Set(networkIDParam, strconv.Itoa(mainnetNetworkID))
+		queryParams.Set(depositCountParam, fmt.Sprintf("%d", depositCount))
+
+		before := requestMetricCount(t, metrics.GetL1InfoTreeIndexReq, http.StatusOK)
+		w := performRequest(t, b.router,
+			fmt.Sprintf("%s/l1-info-tree-index?%s", BridgeV1Prefix, queryParams.Encode()))
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var response uint32
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.Equal(t, expectedIndex, response)
+		require.Equal(t, before+1, requestMetricCount(t, metrics.GetL1InfoTreeIndexReq, http.StatusOK))
+
+		b.l1InfoTree.AssertExpectations(t)
+		b.bridgeL1.AssertExpectations(t)
+	})
+}
+
+// bridgeRequestsMetric is the name bridgeservice/metrics registers its request counter under. Tests
+// read it back to assert the status code a handler propagated to reportMetrics, which the HTTP
+// response alone cannot prove: ClaimProofHandler used to answer 4xx/5xx while reporting 200.
+const bridgeRequestsMetric = "total_requests"
+
+var registerBridgeMetricsOnce stdsync.Once
+
+// requestMetricCount returns the current value of the bridge request counter for a handler id and
+// status code, registering the collectors on first use.
+func requestMetricCount(t *testing.T, handlerID string, statusCode int) float64 {
+	t.Helper()
+
+	registerBridgeMetricsOnce.Do(func() {
+		aggkitprometheus.Init()
+		metrics.Register()
+	})
+
+	counter, exists := aggkitprometheus.CounterVec(bridgeRequestsMetric)
+	require.True(t, exists, "bridge request counter is not registered")
+
+	return promtestutil.ToFloat64(counter.WithLabelValues(handlerID, strconv.Itoa(statusCode)))
+}
+
+// TestHTTPStatusForSyncerError covers the shared sentinel -> status mapping directly, independently
+// of any HTTP plumbing. Every sentinel is asserted both bare and wrapped, because the handlers only
+// ever see it through a fmt.Errorf("...: %w", err) chain.
+func TestHTTPStatusForSyncerError(t *testing.T) {
+	testCases := []struct {
+		description    string
+		err            error
+		expectedStatus int
+	}{
+		{
+			description:    "sync.ErrInconsistentState is a halted syncer, retryable",
+			err:            aggkitsync.ErrInconsistentState,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			description:    "sync.ErrInconsistentState survives wrapping",
+			err:            fmt.Errorf("clamp by block 8412 failed: %w", aggkitsync.ErrInconsistentState),
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			description:    "db.ErrNotFound, the sentinel every sibling l1infotreesync read returns",
+			err:            db.ErrNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "db.ErrNotFound survives wrapping",
+			err:            fmt.Errorf("failed to get last info for L1: %w", db.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "l1infotreesync.ErrNotFound, the sentinel the new fallback clamp returns",
+			err:            l1infotreesync.ErrNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description: "l1infotreesync.ErrNotFound survives wrapping",
+			err: fmt.Errorf("l1infotreesync has no L1 info tree leaf at or before L1 block 8412: %w",
+				l1infotreesync.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "l1infotreesync.ErrBlockNotProcessed is the reverse skew",
+			err:            l1infotreesync.ErrBlockNotProcessed,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "l1infotreesync.ErrBlockNotProcessed survives wrapping",
+			err:            fmt.Errorf("clamp by block 8412 failed: %w", l1infotreesync.ErrBlockNotProcessed),
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "l1infotreesync.ErrNoBlock0 means nothing is indexed yet",
+			err:            l1infotreesync.ErrNoBlock0,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "l1infotreesync.ErrNoBlock0 survives wrapping",
+			err:            fmt.Errorf("clamp by block 0 failed: %w", l1infotreesync.ErrNoBlock0),
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "ErrNotOnL1Info means no l1 info tree leaf covers the deposit yet",
+			err:            ErrNotOnL1Info,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "ErrNotOnL1Info survives wrapping",
+			err:            fmt.Errorf("bridgesync L1 has not indexed any block yet: %w", ErrNotOnL1Info),
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description:    "a sentinel-free error is a genuine fault",
+			err:            errors.New(fooErrMsg),
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			description:    "a wrapped sentinel-free error is still a genuine fault",
+			err:            fmt.Errorf("failed to get l1 info tree index: %w", errors.New(barErrMsg)),
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			require.Equal(t, tc.expectedStatus, httpStatusForSyncerError(tc.err))
+		})
+	}
+}
+
+// TestRespondSyncerError covers the status respondSyncerError *returns* (which the handlers assign
+// to statusCode and therefore report to reportMetrics), alongside the body it writes.
+func TestRespondSyncerError(t *testing.T) {
+	const (
+		notFoundMsg = "l1infotreesync has not indexed l1 info tree leaf index 7 yet, retry later"
+		internalMsg = "failed to get l1 info tree leaf for index 7: boom"
+	)
+
+	testCases := []struct {
+		description    string
+		err            error
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			description:    "404 answers with the not-found message",
+			err:            fmt.Errorf("wrapped: %w", db.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   notFoundMsg,
+		},
+		{
+			description:    "404 for the sentinel the new fallback clamp returns",
+			err:            fmt.Errorf("wrapped: %w", l1infotreesync.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   notFoundMsg,
+		},
+		{
+			description:    "503 answers with the generic inconsistent-state message",
+			err:            fmt.Errorf("wrapped: %w", aggkitsync.ErrInconsistentState),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description:    "500 answers with the internal message",
+			err:            errors.New(fooErrMsg),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   internalMsg,
+		},
+	}
+
+	b := newBridgeWithMocks(t, l2NetworkID)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			statusCode := b.bridge.respondSyncerError(c, tc.err, notFoundMsg, internalMsg)
+
+			// the returned value is what the handler assigns to statusCode and reports to metrics
+			require.Equal(t, tc.expectedStatus, statusCode)
+			require.Equal(t, tc.expectedStatus, w.Code)
+
+			var response gin.H
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.Contains(t, response["error"], tc.expectedBody)
+		})
+	}
+}
+
+// TestL1InfoTreeIndexForBridgeHandlerSyncerErrorStatuses asserts the HTTP status /l1-info-tree-index
+// answers for each sentinel a syncer can return, and that the same status reaches reportMetrics.
+func TestL1InfoTreeIndexForBridgeHandlerSyncerErrorStatuses(t *testing.T) {
+	const (
+		depositCount     = uint32(1_146_000)
+		lastRootBlockNum = uint64(8_412)
+	)
+
+	tipInfo := &l1infotreesync.L1InfoTreeLeaf{
+		BlockNumber:     8_501,
+		MainnetExitRoot: common.HexToHash("0xdead"),
+		L1InfoTreeIndex: 74_390,
+	}
+
+	// injects the sentinel on the very first syncer read of the L1 path
+	viaGetLastInfo := func(err error) func(bridgeWithMocks) {
+		return func(b bridgeWithMocks) {
+			b.l1InfoTree.EXPECT().GetLastInfo().Return(nil, err).Once()
+		}
+	}
+
+	// injects the sentinel on the new fallback clamp, i.e. the exact INC-129 code path
+	viaFallbackClamp := func(err error) func(bridgeWithMocks) {
+		return func(b bridgeWithMocks) {
+			b.l1InfoTree.EXPECT().GetLastInfo().Return(tipInfo, nil).Once()
+			b.bridgeL1.EXPECT().GetRootByLER(mock.Anything, tipInfo.MainnetExitRoot).
+				Return(nil, db.ErrNotFound).Once()
+			b.bridgeL1.EXPECT().GetLastRoot(mock.Anything).
+				Return(&tree.Root{Index: 1_146_035, BlockNum: lastRootBlockNum}, nil).Once()
+			b.l1InfoTree.EXPECT().GetLatestL1InfoLeafUntilBlock(mock.Anything, lastRootBlockNum).
+				Return(nil, err).Once()
+		}
+	}
+
+	testCases := []struct {
+		description    string
+		setupMocks     func(bridgeWithMocks)
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			description:    "sync.ErrInconsistentState is 503",
+			setupMocks:     viaGetLastInfo(aggkitsync.ErrInconsistentState),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description:    "db.ErrNotFound is 404",
+			setupMocks:     viaGetLastInfo(db.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+		{
+			description:    "l1infotreesync.ErrNotFound is 404",
+			setupMocks:     viaGetLastInfo(l1infotreesync.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+		{
+			description:    "l1infotreesync.ErrBlockNotProcessed is 404",
+			setupMocks:     viaGetLastInfo(l1infotreesync.ErrBlockNotProcessed),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+		{
+			description:    "l1infotreesync.ErrNoBlock0 is 404",
+			setupMocks:     viaGetLastInfo(l1infotreesync.ErrNoBlock0),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+		{
+			description:    "a generic error is still 500",
+			setupMocks:     viaGetLastInfo(errors.New(fooErrMsg)),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get l1 info tree index for network id 0",
+		},
+		{
+			description:    "the fallback clamp returning l1infotreesync.ErrNotFound is 404, not 500",
+			setupMocks:     viaFallbackClamp(l1infotreesync.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+		{
+			description:    "the fallback clamp returning ErrBlockNotProcessed is 404",
+			setupMocks:     viaFallbackClamp(l1infotreesync.ErrBlockNotProcessed),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+		{
+			description:    "the fallback clamp returning ErrInconsistentState is 503",
+			setupMocks:     viaFallbackClamp(aggkitsync.ErrInconsistentState),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description: "ErrNotOnL1Info from the block 0 guard is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetLastInfo().Return(tipInfo, nil).Once()
+				b.bridgeL1.EXPECT().GetRootByLER(mock.Anything, tipInfo.MainnetExitRoot).
+					Return(nil, db.ErrNotFound).Once()
+				b.bridgeL1.EXPECT().GetLastRoot(mock.Anything).
+					Return(&tree.Root{Index: 1_146_035, BlockNum: 0}, nil).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "is not available yet, retry later",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			b := newBridgeWithMocks(t, l2NetworkID)
+			tc.setupMocks(b)
+
+			queryParams := url.Values{}
+			queryParams.Set(networkIDParam, strconv.Itoa(mainnetNetworkID))
+			queryParams.Set(depositCountParam, fmt.Sprintf("%d", depositCount))
+
+			assertHandlerStatus(t, b, metrics.GetL1InfoTreeIndexReq,
+				fmt.Sprintf("%s/l1-info-tree-index?%s", BridgeV1Prefix, queryParams.Encode()),
+				tc.expectedStatus, tc.expectedBody)
+		})
+	}
+}
+
+// TestInjectedL1InfoLeafHandlerSyncerErrorStatuses covers both the L1 lookup and the L2 post-lookup
+// of /injected-l1-info-leaf. The L1 path used to fall through to an unconditional 500.
+func TestInjectedL1InfoLeafHandlerSyncerErrorStatuses(t *testing.T) {
+	const leafIndex = uint32(7)
+
+	viaL1Lookup := func(err error) func(bridgeWithMocks) {
+		return func(b bridgeWithMocks) {
+			b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).Return(nil, err).Once()
+		}
+	}
+
+	// l2gersync already has the GER injected on L2 but l1infotreesync has no leaf at that index:
+	// the cross-syncer skew, with l1infotreesync trailing l2gersync
+	viaL2PostLookup := func(err error) func(bridgeWithMocks) {
+		return func(b bridgeWithMocks) {
+			b.injectedGERs.EXPECT().GetFirstGERAfterL1InfoTreeIndex(mock.Anything, leafIndex).
+				Return(l2gersync.GlobalExitRootInfo{
+					GlobalExitRoot:  common.HexToHash("0xger"),
+					L1InfoTreeIndex: leafIndex,
+				}, nil).Once()
+			b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).Return(nil, err).Once()
+		}
+	}
+
+	testCases := []struct {
+		description    string
+		networkID      uint32
+		setupMocks     func(bridgeWithMocks)
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			description:    "L1 path: db.ErrNotFound is 404, not 500",
+			networkID:      mainnetNetworkID,
+			setupMocks:     viaL1Lookup(db.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 7 yet, retry later",
+		},
+		{
+			description:    "L1 path: l1infotreesync.ErrNotFound is 404",
+			networkID:      mainnetNetworkID,
+			setupMocks:     viaL1Lookup(l1infotreesync.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 7 yet, retry later",
+		},
+		{
+			description:    "L1 path: ErrBlockNotProcessed is 404",
+			networkID:      mainnetNetworkID,
+			setupMocks:     viaL1Lookup(l1infotreesync.ErrBlockNotProcessed),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 7 yet, retry later",
+		},
+		{
+			description:    "L1 path: ErrNoBlock0 is 404",
+			networkID:      mainnetNetworkID,
+			setupMocks:     viaL1Lookup(l1infotreesync.ErrNoBlock0),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 7 yet, retry later",
+		},
+		{
+			description:    "L1 path: sync.ErrInconsistentState is 503",
+			networkID:      mainnetNetworkID,
+			setupMocks:     viaL1Lookup(aggkitsync.ErrInconsistentState),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description:    "L1 path: a generic error is still 500",
+			networkID:      mainnetNetworkID,
+			setupMocks:     viaL1Lookup(errors.New(fooErrMsg)),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get L1 info tree leaf (network id=0, leaf index=7)",
+		},
+		{
+			description:    "L2 post-lookup: db.ErrNotFound is 404 and names both syncers",
+			networkID:      l2NetworkID,
+			setupMocks:     viaL2PostLookup(db.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "already injected on L2 per l2gersync",
+		},
+		{
+			description:    "L2 post-lookup: l1infotreesync.ErrNotFound is 404",
+			networkID:      l2NetworkID,
+			setupMocks:     viaL2PostLookup(l1infotreesync.ErrNotFound),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "already injected on L2 per l2gersync",
+		},
+		{
+			description:    "L2 post-lookup: ErrBlockNotProcessed is 404",
+			networkID:      l2NetworkID,
+			setupMocks:     viaL2PostLookup(l1infotreesync.ErrBlockNotProcessed),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "already injected on L2 per l2gersync",
+		},
+		{
+			description:    "L2 post-lookup: ErrNoBlock0 is 404",
+			networkID:      l2NetworkID,
+			setupMocks:     viaL2PostLookup(l1infotreesync.ErrNoBlock0),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "already injected on L2 per l2gersync",
+		},
+		{
+			description:    "L2 post-lookup: sync.ErrInconsistentState is 503",
+			networkID:      l2NetworkID,
+			setupMocks:     viaL2PostLookup(aggkitsync.ErrInconsistentState),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description:    "L2 post-lookup: a generic error is still 500",
+			networkID:      l2NetworkID,
+			setupMocks:     viaL2PostLookup(errors.New(fooErrMsg)),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get L1 info tree leaf (leaf index=7)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			b := newBridgeWithMocks(t, l2NetworkID)
+			tc.setupMocks(b)
+
+			queryParams := url.Values{}
+			queryParams.Set(networkIDParam, fmt.Sprintf("%d", tc.networkID))
+			queryParams.Set(leafIndexParam, fmt.Sprintf("%d", leafIndex))
+
+			assertHandlerStatus(t, b, metrics.GetInjectedInfoAfterIndexReq,
+				fmt.Sprintf("%s/injected-l1-info-leaf?%s", BridgeV1Prefix, queryParams.Encode()),
+				tc.expectedStatus, tc.expectedBody)
+		})
+	}
+}
+
+// TestClaimProofHandlerStatusPropagation walks every status-bearing exit of ClaimProofHandler and
+// asserts that the status reaching reportMetrics matches the HTTP response. Before this change the
+// handler never reassigned statusCode, so every failure was reported to the metrics as a 200.
+func TestClaimProofHandlerStatusPropagation(t *testing.T) {
+	const (
+		leafIndex    = uint32(1)
+		depositCount = uint32(1)
+	)
+
+	infoLeaf := &l1infotreesync.L1InfoTreeLeaf{
+		MainnetExitRoot: common.HexToHash("0x1"),
+		RollupExitRoot:  common.HexToHash("0x2"),
+	}
+
+	infoOK := func(b bridgeWithMocks) {
+		b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).Return(infoLeaf, nil).Once()
+	}
+
+	testCases := []struct {
+		description    string
+		networkID      string
+		leafIndex      string
+		depositCount   string
+		nilBridgeL1    bool
+		nilBridgeL2    bool
+		setupMocks     func(bridgeWithMocks)
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			description:    "unparseable network_id is 400",
+			networkID:      "not-a-number",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   fmt.Sprintf("invalid %s parameter", networkIDParam),
+		},
+		{
+			description:    "unparseable leaf_index is 400",
+			leafIndex:      "not-a-number",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   fmt.Sprintf("invalid %s parameter", leafIndexParam),
+		},
+		{
+			description:    "unparseable deposit_count is 400",
+			depositCount:   "not-a-number",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   fmt.Sprintf("invalid %s parameter", depositCountParam),
+		},
+		{
+			description: "GetInfoByIndex db.ErrNotFound is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).
+					Return(nil, db.ErrNotFound).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 1 yet, retry later",
+		},
+		{
+			description: "GetInfoByIndex l1infotreesync.ErrNotFound is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).
+					Return(nil, l1infotreesync.ErrNotFound).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 1 yet, retry later",
+		},
+		{
+			description: "GetInfoByIndex l1infotreesync.ErrBlockNotProcessed is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).
+					Return(nil, l1infotreesync.ErrBlockNotProcessed).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 1 yet, retry later",
+		},
+		{
+			description: "GetInfoByIndex l1infotreesync.ErrNoBlock0 is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).
+					Return(nil, l1infotreesync.ErrNoBlock0).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed l1 info tree leaf index 1 yet, retry later",
+		},
+		{
+			description: "GetInfoByIndex sync.ErrInconsistentState is 503",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).
+					Return(nil, aggkitsync.ErrInconsistentState).Once()
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description: "GetInfoByIndex generic error is 500",
+			setupMocks: func(b bridgeWithMocks) {
+				b.l1InfoTree.EXPECT().GetInfoByIndex(mock.Anything, leafIndex).
+					Return(nil, errors.New(fooErrMsg)).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get l1 info tree leaf for index 1",
+		},
+		{
+			description:    "a nil L1 bridge syncer is 503",
+			nilBridgeL1:    true,
+			setupMocks:     infoOK,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "L1 bridge syncer is not available",
+		},
+		{
+			// defensive: tree.Tree.GetProof swallows not-found today, so this is injected through
+			// the mock to prove the branch maps to 404 rather than 500 if that ever changes
+			description: "L1 GetProof db.ErrNotFound is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, db.ErrNotFound).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "bridgesync L1 has not indexed deposit count 1 yet, retry later",
+		},
+		{
+			description: "L1 GetProof sync.ErrInconsistentState is 503",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, aggkitsync.ErrInconsistentState).Once()
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description: "L1 GetProof generic error is 500",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, errors.New(fooErrMsg)).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get local exit proof",
+		},
+		{
+			description: "GetRollupExitTreeMerkleProof l1infotreesync.ErrNotFound is 404",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, nil).Once()
+				b.l1InfoTree.EXPECT().
+					GetRollupExitTreeMerkleProof(mock.Anything, uint32(mainnetNetworkID), infoLeaf.RollupExitRoot).
+					Return(tree.Proof{}, l1infotreesync.ErrNotFound).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed the rollup exit tree for network id 0",
+		},
+		{
+			description: "GetRollupExitTreeMerkleProof sync.ErrInconsistentState is 503",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, nil).Once()
+				b.l1InfoTree.EXPECT().
+					GetRollupExitTreeMerkleProof(mock.Anything, uint32(mainnetNetworkID), infoLeaf.RollupExitRoot).
+					Return(tree.Proof{}, aggkitsync.ErrInconsistentState).Once()
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description: "GetRollupExitTreeMerkleProof generic error is 500",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, nil).Once()
+				b.l1InfoTree.EXPECT().
+					GetRollupExitTreeMerkleProof(mock.Anything, uint32(mainnetNetworkID), infoLeaf.RollupExitRoot).
+					Return(tree.Proof{}, errors.New(fooErrMsg)).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get rollup exit proof",
+		},
+		{
+			description: "L1 success is 200",
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.bridgeL1.EXPECT().GetProof(mock.Anything, depositCount, infoLeaf.MainnetExitRoot).
+					Return(tree.Proof{}, nil).Once()
+				b.l1InfoTree.EXPECT().
+					GetRollupExitTreeMerkleProof(mock.Anything, uint32(mainnetNetworkID), infoLeaf.RollupExitRoot).
+					Return(tree.Proof{}, nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "proof_local_exit_root",
+		},
+		{
+			description: "L2 GetLocalExitRoot db.ErrNotFound is 404",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.Hash{}, db.ErrNotFound).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "l1infotreesync has not indexed the local exit root of network id 10",
+		},
+		{
+			description: "L2 GetLocalExitRoot sync.ErrInconsistentState is 503",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.Hash{}, aggkitsync.ErrInconsistentState).Once()
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description: "L2 GetLocalExitRoot generic error is 500",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.Hash{}, errors.New(fooErrMsg)).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get local exit root from rollup exit tree",
+		},
+		{
+			description: "a nil L2 bridge syncer is 503",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			nilBridgeL2: true,
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.HexToHash("0x3"), nil).Once()
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "L2 bridge syncer is not available",
+		},
+		{
+			// defensive, same reasoning as the L1 GetProof 404 case above
+			description: "L2 GetProof db.ErrNotFound is 404",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.HexToHash("0x3"), nil).Once()
+				b.bridgeL2.EXPECT().GetProof(mock.Anything, depositCount, common.HexToHash("0x3")).
+					Return(tree.Proof{}, db.ErrNotFound).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "bridgesync L2 has not indexed deposit count 1 yet, retry later",
+		},
+		{
+			description: "L2 GetProof sync.ErrInconsistentState is 503",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.HexToHash("0x3"), nil).Once()
+				b.bridgeL2.EXPECT().GetProof(mock.Anything, depositCount, common.HexToHash("0x3")).
+					Return(tree.Proof{}, aggkitsync.ErrInconsistentState).Once()
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "a syncer is temporarily inconsistent (reorg being resolved), retry later",
+		},
+		{
+			description: "L2 GetProof generic error is 500",
+			networkID:   fmt.Sprintf("%d", l2NetworkID),
+			setupMocks: func(b bridgeWithMocks) {
+				infoOK(b)
+				b.l1InfoTree.EXPECT().GetLocalExitRoot(mock.Anything, l2NetworkID, infoLeaf.RollupExitRoot).
+					Return(common.HexToHash("0x3"), nil).Once()
+				b.bridgeL2.EXPECT().GetProof(mock.Anything, depositCount, common.HexToHash("0x3")).
+					Return(tree.Proof{}, errors.New(fooErrMsg)).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "failed to get local exit proof",
+		},
+		{
+			description:    "an unsupported network id is 400",
+			networkID:      "999",
+			setupMocks:     infoOK,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "failed to get claim proof, unsupported network 999",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			b := newBridgeWithMocks(t, l2NetworkID)
+			if tc.nilBridgeL1 {
+				b.bridge.bridgeL1 = nil
+			}
+			if tc.nilBridgeL2 {
+				b.bridge.bridgeL2 = nil
+			}
+			if tc.setupMocks != nil {
+				tc.setupMocks(b)
+			}
+
+			queryParams := url.Values{}
+			queryParams.Set(networkIDParam, valueOrDefault(tc.networkID, strconv.Itoa(mainnetNetworkID)))
+			queryParams.Set(leafIndexParam, valueOrDefault(tc.leafIndex, fmt.Sprintf("%d", leafIndex)))
+			queryParams.Set(depositCountParam, valueOrDefault(tc.depositCount, fmt.Sprintf("%d", depositCount)))
+
+			assertHandlerStatus(t, b, metrics.GetClaimProofReq,
+				fmt.Sprintf("%s/claim-proof?%s", BridgeV1Prefix, queryParams.Encode()),
+				tc.expectedStatus, tc.expectedBody)
+		})
+	}
+}
+
+func valueOrDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+// assertHandlerStatus performs the request and asserts the HTTP status, the response body and -- via
+// the request counter -- the status code the handler propagated to reportMetrics. It also asserts
+// that a failing request did not report a 200, which is the defect this plan fixes.
+func assertHandlerStatus(
+	t *testing.T, b bridgeWithMocks, handlerID, path string, expectedStatus int, expectedBody string,
+) {
+	t.Helper()
+
+	before := requestMetricCount(t, handlerID, expectedStatus)
+	beforeOK := requestMetricCount(t, handlerID, http.StatusOK)
+
+	w := performRequest(t, b.router, path)
+
+	require.Equal(t, expectedStatus, w.Code)
+	require.Contains(t, w.Body.String(), expectedBody)
+	require.Equal(t, before+1, requestMetricCount(t, handlerID, expectedStatus),
+		"the status code reported to reportMetrics must match the HTTP response")
+	if expectedStatus != http.StatusOK {
+		require.Equal(t, beforeOK, requestMetricCount(t, handlerID, http.StatusOK),
+			"a failing request must not be reported to reportMetrics as a 200")
+	}
+
+	b.l1InfoTree.AssertExpectations(t)
+	b.bridgeL1.AssertExpectations(t)
+	b.bridgeL2.AssertExpectations(t)
+	b.injectedGERs.AssertExpectations(t)
 }
 
 func TestGetClaimsByGERHandler(t *testing.T) {

--- a/bridgeservice/client/client.go
+++ b/bridgeservice/client/client.go
@@ -268,13 +268,17 @@ func (c *Client) GetLegacyTokenMigrations(
 }
 
 // GetL1InfoTreeIndex retrieves the L1 Info Tree index for a bridge
+//
+// Uses doRequestAllowNotFound: when the deposit has not yet been indexed by the relevant
+// syncers, the endpoint returns HTTP 404, surfaced here as ErrNotFound so callers can treat it
+// as "retry later" rather than a hard error.
 func (c *Client) GetL1InfoTreeIndex(ctx context.Context, networkID, depositCount int) (uint32, error) {
 	query := url.Values{}
 	query.Set("network_id", strconv.Itoa(networkID))
 	query.Set("deposit_count", strconv.Itoa(depositCount))
 
 	var index uint32
-	if err := c.doRequest(ctx, "/bridge/v1/l1-info-tree-index?"+query.Encode(), &index); err != nil {
+	if err := c.doRequestAllowNotFound(ctx, "/bridge/v1/l1-info-tree-index?"+query.Encode(), &index); err != nil {
 		return 0, err
 	}
 	return index, nil
@@ -318,6 +322,10 @@ func (c *Client) GetL1InfoTreeLeafByGER(ctx context.Context, ger string) (*types
 }
 
 // GetClaimProof retrieves Merkle proofs for claim verification
+//
+// Uses doRequestAllowNotFound: when the underlying syncers have not yet indexed the data needed
+// to build the proof, the endpoint returns HTTP 404, surfaced here as ErrNotFound so callers can
+// treat it as "retry later" rather than a hard error.
 func (c *Client) GetClaimProof(
 	ctx context.Context, networkID, leafIndex, depositCount uint32,
 ) (*types.ClaimProof, error) {
@@ -327,7 +335,7 @@ func (c *Client) GetClaimProof(
 	query.Set("deposit_count", strconv.FormatUint(uint64(depositCount), 10))
 
 	var resp types.ClaimProof
-	if err := c.doRequest(ctx, "/bridge/v1/claim-proof?"+query.Encode(), &resp); err != nil {
+	if err := c.doRequestAllowNotFound(ctx, "/bridge/v1/claim-proof?"+query.Encode(), &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/bridgeservice/client/client_test.go
+++ b/bridgeservice/client/client_test.go
@@ -535,7 +535,7 @@ func TestGetL1InfoTreeIndex(t *testing.T) {
 		require.Equal(t, expectedIndex, index)
 	})
 
-	t.Run("handles error", func(t *testing.T) {
+	t.Run("returns ErrNotFound on 404", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte("not found"))
@@ -546,6 +546,40 @@ func TestGetL1InfoTreeIndex(t *testing.T) {
 		index, err := client.GetL1InfoTreeIndex(context.Background(), 1, 999)
 
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNotFound)
+		require.Equal(t, uint32(0), index)
+	})
+
+	t.Run("handles server error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("error"))
+		}))
+		defer server.Close()
+
+		client := New(Config{BaseURL: server.URL})
+		index, err := client.GetL1InfoTreeIndex(context.Background(), 1, 10)
+
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrNotFound)
+		require.Equal(t, uint32(0), index)
+	})
+
+	// a halted syncer (503) must not be mistaken for "not indexed yet" (404): callers such as
+	// autoclaim retry silently on ErrNotFound, but a 503 signals an operational fault
+	t.Run("surfaces a halted syncer 503 as a plain error, not ErrNotFound", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"a syncer is temporarily inconsistent (reorg being resolved), retry later"}`))
+		}))
+		defer server.Close()
+
+		client := New(Config{BaseURL: server.URL})
+		index, err := client.GetL1InfoTreeIndex(context.Background(), 1, 10)
+
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrNotFound)
+		require.Contains(t, err.Error(), "503")
 		require.Equal(t, uint32(0), index)
 	})
 }
@@ -673,6 +707,53 @@ func TestGetClaimProof(t *testing.T) {
 			types.Hash("0x1234567890123456789012345678901234567890123456789012345678901234"),
 			resp.ProofLocalExitRoot[0])
 		require.Equal(t, uint32(10), resp.L1InfoTreeLeaf.L1InfoTreeIndex)
+	})
+
+	t.Run("returns ErrNotFound on 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(
+				`{"error":"l1infotreesync has not indexed l1 info tree leaf index 10 yet, retry later"}`))
+		}))
+		defer server.Close()
+
+		c := New(Config{BaseURL: server.URL})
+		resp, err := c.GetClaimProof(context.Background(), 1, 10, 5)
+
+		require.ErrorIs(t, err, ErrNotFound)
+		require.Nil(t, resp)
+	})
+
+	t.Run("handles server error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("error"))
+		}))
+		defer server.Close()
+
+		c := New(Config{BaseURL: server.URL})
+		resp, err := c.GetClaimProof(context.Background(), 1, 10, 5)
+
+		require.Error(t, err)
+		require.Nil(t, resp)
+		require.NotErrorIs(t, err, ErrNotFound)
+	})
+
+	// a halted syncer (503) must not be mistaken for "not indexed yet" (404)
+	t.Run("surfaces a halted syncer 503 as a plain error, not ErrNotFound", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"a syncer is temporarily inconsistent (reorg being resolved), retry later"}`))
+		}))
+		defer server.Close()
+
+		c := New(Config{BaseURL: server.URL})
+		resp, err := c.GetClaimProof(context.Background(), 1, 10, 5)
+
+		require.Error(t, err)
+		require.Nil(t, resp)
+		require.NotErrorIs(t, err, ErrNotFound)
+		require.Contains(t, err.Error(), "503")
 	})
 }
 

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -415,8 +415,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found - not indexed by the syncers yet, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - syncer not available or resolving a reorg",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -599,13 +611,19 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Not Found - global exit root not injected yet",
+                        "description": "Not Found - global exit root not injected or leaf not indexed yet",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - a syncer is resolving a reorg, retry later",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -649,6 +667,72 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - not indexed by the syncers yet, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - a syncer is resolving a reorg, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/l1-info-tree-leaf-by-ger": {
+            "get": {
+                "description": "Returns the L1 info tree leaf (index, exit roots, block info) for the given\nGlobal Exit Root. The L1 info tree only exists on L1, so network_id must be 0.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "l1-info-tree-leaf"
+                ],
+                "summary": "Get L1 info tree leaf by Global Exit Root",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Network ID (must be 0, mainnet)",
+                        "name": "network_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Global Exit Root",
+                        "name": "global_exit_root",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.L1InfoTreeLeafResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - GER not part of the L1 info tree (yet)",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -789,6 +873,66 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/root-by-ler": {
+            "get": {
+                "description": "Resolves ler to the position (deposit-count index) it had in network_id's local\nexit tree when it was computed.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bridges"
+                ],
+                "summary": "Get the deposit-count index of a local exit root",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Network ID (0 for L1, L2 network ID otherwise)",
+                        "name": "network_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local exit root (0x-prefixed 32-byte hex)",
+                        "name": "ler",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.RootByLERResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - ler not synced yet",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -1586,6 +1730,27 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/types.RemoveGEREventResponse"
                     }
+                }
+            }
+        },
+        "types.RootByLERResponse": {
+            "description": "The deposit-count position of a local exit root in its network's local exit tree",
+            "type": "object",
+            "properties": {
+                "block_num": {
+                    "description": "BlockNum is the block in which the leaf that produced this root was added",
+                    "type": "integer",
+                    "example": 123456
+                },
+                "block_position": {
+                    "description": "BlockPosition orders same-block roots (multiple deposits in one block)",
+                    "type": "integer",
+                    "example": 0
+                },
+                "index": {
+                    "description": "Index is the deposit count at which this root became the local exit root (0-based)",
+                    "type": "integer",
+                    "example": 42
                 }
             }
         },

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -408,8 +408,20 @@
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found - not indexed by the syncers yet, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - syncer not available or resolving a reorg",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -592,13 +604,19 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found - global exit root not injected yet",
+                        "description": "Not Found - global exit root not injected or leaf not indexed yet",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - a syncer is resolving a reorg, retry later",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -642,6 +660,72 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - not indexed by the syncers yet, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - a syncer is resolving a reorg, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/l1-info-tree-leaf-by-ger": {
+            "get": {
+                "description": "Returns the L1 info tree leaf (index, exit roots, block info) for the given\nGlobal Exit Root. The L1 info tree only exists on L1, so network_id must be 0.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "l1-info-tree-leaf"
+                ],
+                "summary": "Get L1 info tree leaf by Global Exit Root",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Network ID (must be 0, mainnet)",
+                        "name": "network_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Global Exit Root",
+                        "name": "global_exit_root",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.L1InfoTreeLeafResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - GER not part of the L1 info tree (yet)",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -782,6 +866,66 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/root-by-ler": {
+            "get": {
+                "description": "Resolves ler to the position (deposit-count index) it had in network_id's local\nexit tree when it was computed.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bridges"
+                ],
+                "summary": "Get the deposit-count index of a local exit root",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Network ID (0 for L1, L2 network ID otherwise)",
+                        "name": "network_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local exit root (0x-prefixed 32-byte hex)",
+                        "name": "ler",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.RootByLERResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - ler not synced yet",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -1579,6 +1723,27 @@
                     "items": {
                         "$ref": "#/definitions/types.RemoveGEREventResponse"
                     }
+                }
+            }
+        },
+        "types.RootByLERResponse": {
+            "description": "The deposit-count position of a local exit root in its network's local exit tree",
+            "type": "object",
+            "properties": {
+                "block_num": {
+                    "description": "BlockNum is the block in which the leaf that produced this root was added",
+                    "type": "integer",
+                    "example": 123456
+                },
+                "block_position": {
+                    "description": "BlockPosition orders same-block roots (multiple deposits in one block)",
+                    "type": "integer",
+                    "example": 0
+                },
+                "index": {
+                    "description": "Index is the deposit count at which this root became the local exit root (0-based)",
+                    "type": "integer",
+                    "example": 42
                 }
             }
         },

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -440,6 +440,26 @@ definitions:
           $ref: '#/definitions/types.RemoveGEREventResponse'
         type: array
     type: object
+  types.RootByLERResponse:
+    description: The deposit-count position of a local exit root in its network's
+      local exit tree
+    properties:
+      block_num:
+        description: BlockNum is the block in which the leaf that produced this root
+          was added
+        example: 123456
+        type: integer
+      block_position:
+        description: BlockPosition orders same-block roots (multiple deposits in one
+          block)
+        example: 0
+        type: integer
+      index:
+        description: Index is the deposit count at which this root became the local
+          exit root (0-based)
+        example: 42
+        type: integer
+    type: object
   types.SetClaimResponse:
     description: Detailed information about a set claim event
     properties:
@@ -876,8 +896,16 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/types.ErrorResponse'
+        "404":
+          description: Not Found - not indexed by the syncers yet, retry later
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "503":
+          description: Service Unavailable - syncer not available or resolving a reorg
           schema:
             $ref: '#/definitions/types.ErrorResponse'
       summary: Get claim proof
@@ -1004,11 +1032,17 @@ paths:
           schema:
             $ref: '#/definitions/types.ErrorResponse'
         "404":
-          description: Not Found - global exit root not injected yet
+          description: Not Found - global exit root not injected or leaf not indexed
+            yet
           schema:
             $ref: '#/definitions/types.ErrorResponse'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "503":
+          description: Service Unavailable - a syncer is resolving a reorg, retry
+            later
           schema:
             $ref: '#/definitions/types.ErrorResponse'
       summary: Get injected L1 info tree leaf after a given L1 info tree index
@@ -1041,11 +1075,58 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/types.ErrorResponse'
+        "404":
+          description: Not Found - not indexed by the syncers yet, retry later
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/types.ErrorResponse'
+        "503":
+          description: Service Unavailable - a syncer is resolving a reorg, retry
+            later
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
       summary: Get L1 Info Tree index for a bridge
+      tags:
+      - l1-info-tree-leaf
+  /l1-info-tree-leaf-by-ger:
+    get:
+      description: |-
+        Returns the L1 info tree leaf (index, exit roots, block info) for the given
+        Global Exit Root. The L1 info tree only exists on L1, so network_id must be 0.
+      parameters:
+      - description: Network ID (must be 0, mainnet)
+        in: query
+        name: network_id
+        required: true
+        type: integer
+      - description: Global Exit Root
+        in: query
+        name: global_exit_root
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.L1InfoTreeLeafResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "404":
+          description: Not Found - GER not part of the L1 info tree (yet)
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+      summary: Get L1 info tree leaf by Global Exit Root
       tags:
       - l1-info-tree-leaf
   /last-reorg-event:
@@ -1146,6 +1227,48 @@ paths:
       summary: Get remove GER events
       tags:
       - ger-events
+  /root-by-ler:
+    get:
+      description: |-
+        Resolves ler to the position (deposit-count index) it had in network_id's local
+        exit tree when it was computed.
+      parameters:
+      - description: Network ID (0 for L1, L2 network ID otherwise)
+        in: query
+        name: network_id
+        required: true
+        type: integer
+      - description: Local exit root (0x-prefixed 32-byte hex)
+        in: query
+        name: ler
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.RootByLERResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "404":
+          description: Not Found - ler not synced yet
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+      summary: Get the deposit-count index of a local exit root
+      tags:
+      - bridges
   /set-claims:
     get:
       description: Returns set claims for the configured L2 network, paginated.

--- a/bridgeservice/mocks/mock_l1_info_tree_syncer.go
+++ b/bridgeservice/mocks/mock_l1_info_tree_syncer.go
@@ -549,6 +549,65 @@ func (_c *L1InfoTreeSyncer_GetLastVerifiedBatches_Call) RunAndReturn(run func(ui
 	return _c
 }
 
+// GetLatestL1InfoLeafUntilBlock provides a mock function with given fields: ctx, blockNum
+func (_m *L1InfoTreeSyncer) GetLatestL1InfoLeafUntilBlock(ctx context.Context, blockNum uint64) (*l1infotreesync.L1InfoTreeLeaf, error) {
+	ret := _m.Called(ctx, blockNum)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestL1InfoLeafUntilBlock")
+	}
+
+	var r0 *l1infotreesync.L1InfoTreeLeaf
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) (*l1infotreesync.L1InfoTreeLeaf, error)); ok {
+		return rf(ctx, blockNum)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) *l1infotreesync.L1InfoTreeLeaf); ok {
+		r0 = rf(ctx, blockNum)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*l1infotreesync.L1InfoTreeLeaf)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
+		r1 = rf(ctx, blockNum)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestL1InfoLeafUntilBlock'
+type L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call struct {
+	*mock.Call
+}
+
+// GetLatestL1InfoLeafUntilBlock is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blockNum uint64
+func (_e *L1InfoTreeSyncer_Expecter) GetLatestL1InfoLeafUntilBlock(ctx interface{}, blockNum interface{}) *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call {
+	return &L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call{Call: _e.mock.On("GetLatestL1InfoLeafUntilBlock", ctx, blockNum)}
+}
+
+func (_c *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call) Run(run func(ctx context.Context, blockNum uint64)) *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64))
+	})
+	return _c
+}
+
+func (_c *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call) Return(_a0 *l1infotreesync.L1InfoTreeLeaf, _a1 error) *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call) RunAndReturn(run func(context.Context, uint64) (*l1infotreesync.L1InfoTreeLeaf, error)) *L1InfoTreeSyncer_GetLatestL1InfoLeafUntilBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLocalExitRoot provides a mock function with given fields: ctx, networkID, rollupExitRoot
 func (_m *L1InfoTreeSyncer) GetLocalExitRoot(ctx context.Context, networkID uint32, rollupExitRoot common.Hash) (common.Hash, error) {
 	ret := _m.Called(ctx, networkID, rollupExitRoot)

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -408,8 +408,20 @@
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found - not indexed by the syncers yet, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - syncer not available or resolving a reorg",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -592,13 +604,19 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found - global exit root not injected yet",
+                        "description": "Not Found - global exit root not injected or leaf not indexed yet",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - a syncer is resolving a reorg, retry later",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -642,6 +660,72 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - not indexed by the syncers yet, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable - a syncer is resolving a reorg, retry later",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/l1-info-tree-leaf-by-ger": {
+            "get": {
+                "description": "Returns the L1 info tree leaf (index, exit roots, block info) for the given\nGlobal Exit Root. The L1 info tree only exists on L1, so network_id must be 0.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "l1-info-tree-leaf"
+                ],
+                "summary": "Get L1 info tree leaf by Global Exit Root",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Network ID (must be 0, mainnet)",
+                        "name": "network_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Global Exit Root",
+                        "name": "global_exit_root",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.L1InfoTreeLeafResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - GER not part of the L1 info tree (yet)",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -782,6 +866,66 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/root-by-ler": {
+            "get": {
+                "description": "Resolves ler to the position (deposit-count index) it had in network_id's local\nexit tree when it was computed.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bridges"
+                ],
+                "summary": "Get the deposit-count index of a local exit root",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Network ID (0 for L1, L2 network ID otherwise)",
+                        "name": "network_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local exit root (0x-prefixed 32-byte hex)",
+                        "name": "ler",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.RootByLERResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - ler not synced yet",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -1579,6 +1723,27 @@
                     "items": {
                         "$ref": "#/definitions/types.RemoveGEREventResponse"
                     }
+                }
+            }
+        },
+        "types.RootByLERResponse": {
+            "description": "The deposit-count position of a local exit root in its network's local exit tree",
+            "type": "object",
+            "properties": {
+                "block_num": {
+                    "description": "BlockNum is the block in which the leaf that produced this root was added",
+                    "type": "integer",
+                    "example": 123456
+                },
+                "block_position": {
+                    "description": "BlockPosition orders same-block roots (multiple deposits in one block)",
+                    "type": "integer",
+                    "example": 0
+                },
+                "index": {
+                    "description": "Index is the deposit count at which this root became the local exit root (0-based)",
+                    "type": "integer",
+                    "example": 42
                 }
             }
         },

--- a/docs/bridge_service.md
+++ b/docs/bridge_service.md
@@ -93,6 +93,30 @@ sequenceDiagram
    endpoint also backs the Auto Claim destination-readiness gate for L2-destination claimers — see
    [Auto Claim Service](./autoclaim.md#architecture) for how it is used to decide when a bridge is ready to claim.
 
+5. The same `404`-for-not-ready contract from note 4 now also applies to `GET /bridge/v1/l1-info-tree-index`
+   (`bridge_l1InfoTreeIndexForBridge`) and `GET /bridge/v1/claim-proof`: both previously returned `500` whenever
+   the L1 info tree syncer or a bridge syncer had simply not caught up yet to the requested deposit/leaf, and now
+   return `404` for that condition, reserving `500` for genuine faults. The Go client surfaces this as
+   `client.ErrNotFound` on `Client.GetL1InfoTreeIndex` and `Client.GetClaimProof`. In addition, the `404`
+   semantics described in note 4 for `/injected-l1-info-leaf` now cover its **L1** path (`network_id=0`) as well
+   as its L2 path — previously the L1 path fell through to `500` when `l1infotreesync` had not yet indexed the
+   requested leaf; it now answers `404` there too.
+
+6. `/l1-info-tree-index`, `/claim-proof`, and `/injected-l1-info-leaf` can also respond `503 Service Unavailable`
+   when a syncer they read from is halted or in an inconsistent state (e.g. resolving a reorg). `503` is a second
+   retry-later code, but it does **not** mean the same thing as `404`: `404` means the syncer is healthy and
+   simply hasn't indexed the requested data yet, while `503` means a syncer is in an operational fault state.
+   Retrying is appropriate for both, but operators and client authors should not conflate them — persistent `503`s
+   warrant investigating the syncer, whereas persistent `404`s only indicate lag.
+
+7. The fallback inside `getFirstL1InfoTreeIndexForL1Bridge`, which backs `bridge_l1InfoTreeIndexForBridge` in the
+   flow diagrams above, was corrected. When the primary `GetRootByLER` lookup misses because the L1 bridge syncer
+   has not yet caught up to the tip of the L1 info tree, the fallback now clamps to the most recent L1 info tree
+   leaf at or before the last block the L1 bridge syncer has indexed. It previously reused a position from the L1
+   bridge **exit** tree (a deposit count) as if it were an L1 **info** tree index — two different counters in two
+   different trees — which could surface as a `500` `sql: no rows in result set` error for a deposit that was
+   already settled. The flow itself is unchanged; only the correctness of this internal fallback lookup was fixed.
+
 ### Bridge flow L2 -> L1
 
 The diagram below describes the basic L2 -> L1 bridge workflow.

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -261,10 +261,10 @@ func (p *processor) GetInfoByIndex(ctx context.Context, index uint32) (*L1InfoTr
 
 func (p *processor) getInfoByIndexWithTx(tx dbtypes.DBer, index uint32) (*L1InfoTreeLeaf, error) {
 	info := &L1InfoTreeLeaf{}
-	return info, meddler.QueryRow(
+	return info, db.ReturnErrNotFound(meddler.QueryRow(
 		tx, info,
 		`SELECT * FROM l1info_leaf WHERE position = $1;`, index,
-	)
+	))
 }
 
 // GetLastProcessedBlock returns the last processed block.

--- a/l1infotreesync/processor_test.go
+++ b/l1infotreesync/processor_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"math/rand"
 	"path"
 	"strings"
@@ -182,6 +183,76 @@ func TestGetLatestL1InfoLeafUntilBlock(t *testing.T) {
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
+}
+
+// TestGetLatestL1InfoLeafUntilBlockClamp exercises the success path of the clamp against real rows.
+// The sibling table test above only covers the three error sentinels, so nothing pinned the actual
+// "most recent leaf at or before blockNum" semantics that the bridge service's l1-info-tree-index
+// fallback now depends on (INC-129).
+//
+// The L1 block numbers are kept orders of magnitude larger than the L1 info tree indexes on purpose:
+// the bug being guarded against was feeding a value from one index space into the other, and equal
+// or adjacent values let exactly that confusion pass unnoticed.
+func TestGetLatestL1InfoLeafUntilBlockClamp(t *testing.T) {
+	ctx := t.Context()
+	dbPath := path.Join(t.TempDir(), "l1infotreesyncTestGetLatestL1InfoLeafUntilBlockClamp.sqlite")
+	sut, err := newProcessor(dbPath)
+	require.NoError(t, err)
+
+	// One leaf per block, at widely spaced L1 blocks. Leaf N lands on L1 info tree index N.
+	leafBlocks := []uint64{1_000, 5_000, 9_000}
+	for i, blockNum := range leafBlocks {
+		err = sut.ProcessBlock(ctx, aggkitsync.Block{
+			Num: blockNum,
+			Events: []any{
+				Event{UpdateL1InfoTree: &UpdateL1InfoTree{
+					MainnetExitRoot: common.BigToHash(big.NewInt(int64(blockNum))),
+					RollupExitRoot:  common.HexToHash("5ca1e"),
+					ParentHash:      common.BigToHash(big.NewInt(int64(i))),
+					Timestamp:       uint64(i),
+				}},
+			},
+		})
+		require.NoError(t, err)
+	}
+	// Advance the processed height past the newest leaf so queries above 9_000 are not
+	// rejected with ErrBlockNotProcessed.
+	require.NoError(t, sut.ProcessBlock(ctx, aggkitsync.Block{Num: 9_500}))
+
+	tests := []struct {
+		name          string
+		blockNum      uint64
+		expectedIndex uint32
+		expectedBlock uint64
+	}{
+		{name: "exactly on the newest leaf's block", blockNum: 9_000, expectedIndex: 2, expectedBlock: 9_000},
+		{name: "above every leaf clamps to the newest", blockNum: 9_500, expectedIndex: 2, expectedBlock: 9_000},
+		{name: "between leaves clamps back", blockNum: 7_000, expectedIndex: 1, expectedBlock: 5_000},
+		{name: "exactly on a middle leaf's block", blockNum: 5_000, expectedIndex: 1, expectedBlock: 5_000},
+		{name: "one block after a leaf clamps to it", blockNum: 5_001, expectedIndex: 1, expectedBlock: 5_000},
+		{name: "one block before a leaf clamps to the previous", blockNum: 4_999, expectedIndex: 0, expectedBlock: 1_000},
+		{name: "exactly on the oldest leaf's block", blockNum: 1_000, expectedIndex: 0, expectedBlock: 1_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockNum := tt.blockNum
+			leaf, err := sut.GetLatestL1InfoLeafUntilBlock(ctx, &blockNum)
+			require.NoError(t, err)
+			require.NotNil(t, leaf)
+			require.Equal(t, tt.expectedIndex, leaf.L1InfoTreeIndex,
+				"must return the L1 info tree index of the newest leaf at or before the block")
+			require.Equal(t, tt.expectedBlock, leaf.BlockNumber,
+				"the returned leaf must not come from a block after the requested one")
+			require.LessOrEqual(t, leaf.BlockNumber, tt.blockNum, "the clamp must never look ahead")
+		})
+	}
+
+	t.Run("below every leaf is not found", func(t *testing.T) {
+		blockNum := uint64(999)
+		_, err := sut.GetLatestL1InfoLeafUntilBlock(ctx, &blockNum)
+		require.ErrorIs(t, err, db.ErrNotFound)
+	})
 }
 
 func TestProcessor_Reorg(t *testing.T) {


### PR DESCRIPTION
## 🔄 Changes Summary
- **Fixes the INC-129 root cause.** The fallback in `getFirstL1InfoTreeIndexForL1Bridge` took `root.Index` from `bridgeL1.GetLastRoot` — a position in the **L1 bridge exit tree**, i.e. a deposit count (~1,146,035) — and passed it to `l1InfoTree.GetInfoByIndex`, which queries `SELECT * FROM l1info_leaf WHERE position = $1`, an **L1 info tree index**. Two different trees, two different counters, both bare `uint32`. The row could not exist, so `/bridge/v1/l1-info-tree-index` returned HTTP 500 `sql: no rows in result set` whenever the L1 bridge syncer trailed the L1 info tree syncer.
- The fallback now calls `GetLatestL1InfoLeafUntilBlock(ctx, root.BlockNum)`, clamping to the most recent info-tree leaf at or before the last block the bridge syncer indexed — the clamp the original code intended, in the correct index space. `root.BlockNum == 0` is guarded. The tip-anchored binary search, the `GetRootByLER` join, and `ErrNotOnL1Info` are all retained; the search's `upperLimit`/`bestResult` inherit the clamp from the reassigned `lastInfo` without a second assignment.
- **Cross-syncer error taxonomy.** Endpoints that join syncers which can sit at different heights now distinguish "not indexed yet" from a genuine fault, via a single shared `httpStatusForSyncerError` helper: `ErrBlockNotProcessed`, `l1infotreesync.ErrNotFound`, `ErrNoBlock0`, `db.ErrNotFound`, `ErrNotOnL1Info` → **404**; `sync.ErrInconsistentState` → **503**; anything else → **500**.
- **`ClaimProofHandler` metrics fix.** `statusCode` was initialised to `200` and never reassigned, so all 13 exit paths reported `200` to `reportMetrics` — every failure was invisible in metrics. All exits now set it correctly.
- **`GetInfoByIndex` not-found was unwrapped.** `getInfoByIndexWithTx` skipped `db.ReturnErrNotFound`, returning a raw `sql: no rows in result set`. That was the literal 500 body in INC-129, and it meant `errors.Is(err, db.ErrNotFound)` was dead code at three call sites. One-line wrap added.
- **Log levels.** Not-ready conditions now log at `Debug` (404) / `Warn` (503) instead of `Error`, so the INC-129 alert volume does not simply migrate from HTTP 500s into ERROR logs.
- **Same bug fixed in `autoclaim`** (closes #1795). `autoclaim/proof/preparer.go` carried a verbatim copy of the index-space confusion in its own `GetRootByLER` fallback. It now clamps on `root.BlockNum` too. After this, `grep -rn "GetInfoByIndex(ctx, .*\.Index)"` over non-test Go returns **zero** hits — that was the last one.

## ⚠️ Breaking Changes
- 🔌 **API/CLI**: **HTTP 500 → 404 / 503 on three endpoints.** `/bridge/v1/l1-info-tree-index`, `/bridge/v1/claim-proof`, and the **L1** path of `/bridge/v1/injected-l1-info-leaf` now return `404` when a syncer has not indexed the requested data yet (callers should treat it as *not ready yet, retry later*) and `503` when a syncer is halted / in an inconsistent state. Previously all of these were `500`.
  - `/injected-l1-info-leaf`'s L2 path already returned `404`; only its L1 path changes.
  - `bridgeservice/client`: `GetL1InfoTreeIndex` and `GetClaimProof` switch from `doRequest` to `doRequestAllowNotFound`, so they now return the `ErrNotFound` sentinel on `404` instead of a generic error. **Signatures and return types are unchanged**, but callers that treated any error as fatal may now want to retry on `ErrNotFound`. A `503` deliberately stays a plain non-`ErrNotFound` error so a halted syncer is not mistaken for "not indexed yet".
- No success-path response body or schema changed anywhere.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**:
  - `make lint` → `0 issues.`
  - `make test-unit` → exit 0 (whole repo).
  - New regression test `TestGetFirstL1InfoTreeIndexForL1Bridge_KinexysIndexSpaceSkew` reproduces the exact skew: `GetRootByLER` cannot resolve the tip leaf's MER, and `GetLastRoot` returns `Index = 1_146_035` (a deposit count) with `BlockNum = 8_412`. The fixtures keep the two **~136× apart on purpose** — and assert that skew — because every pre-existing fixture set `Index == BlockNum == depositCount`, which is precisely the coincidence that let an index-space confusion hide for so long.
  - **Red/green proof**: reverting only the one fallback line back to `GetInfoByIndex(ctx, root.Index)` makes both subtests fail on the unexpected mock call for `GetLatestL1InfoLeafUntilBlock`; restoring it byte-for-byte returns them to green.
  - The four existing fallback subtests were **rewritten, not deleted**. One of them previously *pinned the bug* by asserting the error contained `"failed to get last info for L1"`; it now asserts `ErrorIs(l1infotreesync.ErrNotFound)`, a 404 mapping, and `NotContains` that old message. A new subtest covers the `root.BlockNum == 0` guard.
  - `TestHTTPStatusForSyncerError` (14 rows — every sentinel bare *and* wrapped) and `TestRespondSyncerError` cover the mapping directly, including `db.ErrNotFound` and `l1infotreesync.ErrNotFound` as separate 404 cases, since the new fallback returns the latter while its siblings return the former.
  - Per-endpoint status tables (10/12/24 rows). `ClaimProofHandler`'s exits are asserted **through the Prometheus counter**, and every failure row also asserts the `200` counter did *not* move — pinning the metrics bug shut.
  - Client tests strengthened: `TestGetL1InfoTreeIndex`'s weak `require.Error` became `require.ErrorIs(err, ErrNotFound)`; `TestGetClaimProof` gained its first `404` subtest; both gained a `503` subtest.
  - **autoclaim (#1795)**: `TestFirstL1InfoTreeIndexForL1BridgeIndexSpaceSkew` reproduces the same skew against the proof preparer (`GetLastRoot().Index = 1_146_035` vs `BlockNum = 8_412`, skew asserted), plus tests for the `BlockNum == 0` guard and the clamp-lookup error wrap. Its probed block (`6_200`, the midpoint of `[4_000, 8_400]`) doubles as proof the clamp actually tightened `upperLimit` — unclamped, the search would probe `6_250` and miss the fixture. Proven red by reverting the one line: the test fails with `l1infotreesync has no L1 info tree leaf at or before L1 block 8412`.
- 🖱️ **Manual**: not reproduced against a live environment. The kinexys condition is reproduced deterministically in the regression test above rather than by hand.

## 🐞 Issues
- Fixes **INC-129** (kinexys `/l1-info-tree-index` HTTP 500, 89 alerts).
- Closes #1795 (the same index-space bug duplicated in `autoclaim/proof/preparer.go`).

## 🔗 Related PRs
- None.

## 📝 Notes

**Scope widening — `l1infotreesync/processor.go`.** The diff intentionally reaches one line outside `bridgeservice/`: `getInfoByIndexWithTx` now wraps its return in `db.ReturnErrNotFound(...)`. Without it, the handlers' `errors.Is(err, db.ErrNotFound)` checks are dead code and the endpoint keeps returning a raw `sql: no rows in result set`. All 9 non-test callers were audited; the decisive evidence that this is the right layer is that three `autoclaim` call sites already work around the asymmetry by checking `errors.Is(db.ErrNotFound) || errors.Is(sql.ErrNoRows)`. `translateError` was deliberately **not** added at the syncer wrapper, so the sentinel stays `db.ErrNotFound`, matching every sibling method.

**Incidental swagger drift (pre-existing, not new).** Regenerating the swagger artefacts also picks up `/l1-info-tree-leaf-by-ger` and `/root-by-ler` entries plus the `types.RootByLERResponse` schema. These were **already annotated in `bridge.go` on `develop`** but had never been regenerated into the committed docs. They are not new functionality introduced here — verified with `git show origin/develop:bridgeservice/bridge.go`.

**The `autoclaim` copy of the bug is now fixed here too (#1795).** `autoclaim/proof/preparer.go` had a verbatim copy — a bridge-exit-tree `root.Index` from `GetLastRoot` fed into `GetInfoByIndex`, with the same `"failed to get last info for L1"` wrapper. It was first flagged with a `TODO`, then fixed in this PR. Two details worth a reviewer's eye:

- The `root.BlockNum == 0` guard reuses the existing `bridgeservice.ErrNotOnL1Info` rather than introducing a sentinel. Its only caller, `selectL1InfoTreeIndex`, already treats that sentinel as *retry next cycle* (`Result{Ready: false}`), which is the correct reading of "bridgesync L1 has indexed nothing yet" — a transient startup state, not a fault. Letting `l1infotreesync.ErrNoBlock0` escape instead would leak an l1infotreesync-internal sentinel into autoclaim's error contract.
- **The `GetLastRoot` fallback in `autoclaim/proof` had zero test coverage** — no pre-existing test ever set `lastRoot` or `rootErrs` on the fake. The copied bug came with a copied coverage gap, which is why it survived. `preparer.go:111` retains a *legitimate* `GetInfoByIndex` call whose argument is already in info-tree space; that one is correct and should not be "fixed".

**Deliberate non-changes.** The deposit-anchored rewrite (`GetBridgeByDepositCount` + a `(block_num, block_pos) >` query) is the better long-term design and is *not* attempted here — this fix is deliberately minimal and in place. `getFirstL1InfoTreeIndexForL2Bridge` is untouched beyond error mapping, and the syncers are not merged. `L1InfoTreeLeafByGERHandler` already matched the taxonomy and was left alone. One pre-existing inconsistency remains: `L1InfoTreeIndexForBridgeHandler`'s nil-syncer path still answers `500` while the same condition answers `503` in `ClaimProofHandler`; fixing it cleanly needs a new sentinel, so it is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvzbGpjp6VeiW6ccThguGC

---

## 🔍 Review follow-up

Applied from the automated review:

- **Pessimistic `statusCode` default** (suggestion 2). `L1InfoTreeIndexForBridgeHandler`, `InjectedL1InfoLeafHandler`, and `ClaimProofHandler` now initialise `statusCode` to `500` and set `200` explicitly on the success path. Worth noting the suggestion as literally written would have introduced a bug: each of these handlers' success responses used `c.JSON(statusCode, ...)` relying on the `http.StatusOK` initialiser, so flipping the default alone would have returned HTTP 500 on success. Setting 200 explicitly is what makes the pessimistic default safe.
- **Autoclaim duplicate bug** (suggestion 3). Filed as #1795, and then **fixed in this PR** rather than deferred — see the Notes section. The `TODO` comment is gone; the audit the issue asked for is clean.

- **DB-level coverage of the clamp** (integration-coverage suggestion). Added `TestGetLatestL1InfoLeafUntilBlockClamp` in `l1infotreesync/processor_test.go`. The pre-existing table test for that method only asserted the three error sentinels (`ErrNoBlock0`, `ErrBlockNotProcessed`, `ErrNotFound`), so the actual **"newest leaf at or before `blockNum`"** semantics the fallback now depends on were never exercised against real rows. This was the one genuinely untested link, and it is the link a mocked syncer *cannot* cover: a mock returns whatever it is told, so it can never catch an index-space error — it only proves the handler passes `root.BlockNum` to the clamp, not that the query answers correctly.

  The new test inserts leaves at L1 blocks `1_000 / 5_000 / 9_000` (indexes `0 / 1 / 2` — kept orders of magnitude apart on purpose, same discipline as the handler fixtures) and asserts index, block, and `leaf.BlockNumber <= requested` across eight cases: exact-boundary, above-all, between-leaves, ±1 around a leaf, and below-all → `ErrNotFound`. Verified non-vacuous by mutation: flipping `ORDER BY … DESC` to `ASC` and `block_num <= $1` to `>= $1` each make it fail (source restored, md5 verified).

Declined, with reasons:

- **Nil-syncer taxonomy unification** (suggestion 1) — the review itself notes this may be intentional, and it is: a nil syncer is a *configuration* fault, not a syncer *state*, and routing it through `respondSyncerError` would require a new sentinel. Left as documented under Deliberate non-changes.
- **`GetLatestL1InfoLeafUntilBlock` pointer parameter** (suggestion 4) — the premise is incorrect. The `*uint64` is the pre-existing **processor** signature, and its `nil` path *is* exercised: `l1infotreesync/l1infotreesync.go:301` passes `nil` for the unbounded "latest leaf" variant, so making it non-pointer would break that caller. The public wrapper this PR consumes already takes a plain `uint64`, which is exactly what the `L1InfoTreeSyncer` interface addition mirrors.
- **Test constant renaming** (suggestion 5) — marked optional by the review, and the proposed names (e.g. `fallbackL1Block_DepositCountBelowBlock`) use underscores in mixedCaps identifiers, which Go style and this repo's linters discourage.
- **A full HTTP → handler → syncer → **database** wired test** (the rest of the integration-coverage suggestion). Two of its three bullets were already satisfied before the suggestion was made: the handler status tests go through a **real gin router** via `performRequest` and assert `w.Code` *and* `w.Body`, and `assertHandlerStatus` reads the **actual Prometheus counter** before and after each request, asserting both that the expected status was reported to `reportMetrics` and that the `200` counter did not move. So "verify the full HTTP response (status + body + metrics)" and "test the `reportMetrics` calls with the correct status codes" are covered. The mocks are also already at the syncer-interface seam — there is no higher seam short of a real database.

  What remained was standing up real `l1infotreesync` + `bridgesync` instances with populated sqlite behind a live `BridgeService`. That is a substantial bespoke harness, and it duplicates what the repo's kurtosis/docker e2e suites already do end-to-end (they are excluded from `make test-unit` by `-short`). The targeted DB-level test above closes the actual coverage hole at a fraction of the cost and maintenance surface. Happy to add the wired harness if reviewers want it, but it did not look like the right trade here.
