### PR TITLE
feat: aggkit-proxy: add CORS support for REST and WebSocket endpoints

### DIFF
--- a/bridgetracker/api/api.go
+++ b/bridgetracker/api/api.go
@@ -53,12 +53,14 @@ type API struct {
 // NewAPI returns the tracker HTTP service serving the given supervised registry.
 // registerResolveTimeout is how long GetTxStatus waits, the first time a tx is registered, for
 // the tracking engine's immediate resolution attempt to produce an update before answering (see
-// getTxStatusCommand); <= 0 disables the wait
+// getTxStatusCommand); <= 0 disables the wait. cors governs which origins may open the
+// WebSocket endpoint (see wsHandler)
 func NewAPI(
 	logger aggkitcommon.Logger,
 	configSHA1 string,
 	supervised domain.SupervisedRegistry,
 	registerResolveTimeout time.Duration,
+	cors aggkitcommon.CORSConfig,
 ) *API {
 	return &API{
 		getTxStatusCmd: &getTxStatusCommand{supervised: supervised, resolveTimeout: registerResolveTimeout},
@@ -68,7 +70,7 @@ func NewAPI(
 			instanceID: uuid.NewString(),
 			configSHA1: configSHA1,
 		},
-		wsHandler: &wsHandler{logger: logger, supervised: supervised},
+		wsHandler: newWSHandler(logger, supervised, cors),
 	}
 }
 

--- a/bridgetracker/api/websocket.go
+++ b/bridgetracker/api/websocket.go
@@ -20,17 +20,31 @@ const (
 	wsPingPeriod = (wsPongWait * 9) / 10 //nolint:mnd // conventional 90% of the pong wait
 )
 
-// wsUpgrader upgrades tracker HTTP requests to WebSocket connections. The tracker is a
-// public read-only API served to arbitrary web clients, so cross-origin upgrades are allowed
-var wsUpgrader = websocket.Upgrader{
-	CheckOrigin: func(*http.Request) bool { return true },
-}
-
 // wsHandler serves the WebSocket bridge-status subscription endpoint. Built once at API
 // construction time with the supervised registry and logger it needs.
 type wsHandler struct {
 	logger     aggkitcommon.Logger
 	supervised domain.SupervisedRegistry
+	upgrader   websocket.Upgrader
+}
+
+// newWSHandler builds a wsHandler. Its upgrader enforces cors on the WebSocket handshake:
+// browsers never CORS-preflight or gate the Upgrade request on Access-Control-* headers, so
+// this is the only point at which cross-origin access to this endpoint can be restricted (see
+// aggkitcommon.CORSConfig.OriginAllowed). Disabled CORS (the default) keeps the tracker's
+// original behavior: a public read-only API served to arbitrary web clients.
+func newWSHandler(
+	logger aggkitcommon.Logger, supervised domain.SupervisedRegistry, cors aggkitcommon.CORSConfig,
+) *wsHandler {
+	return &wsHandler{
+		logger:     logger,
+		supervised: supervised,
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return cors.OriginAllowed(r.Header.Get("Origin"))
+			},
+		},
+	}
 }
 
 // TxStatusWSHandler upgrades the request to a WebSocket connection subscribed to the bridge
@@ -57,7 +71,7 @@ type wsHandler struct {
 // @Success 101 {string} string "Switching Protocols"
 // @Router /network/{network_id}/tx/{tx_hash}/ws [get]
 func (w *wsHandler) TxStatusWSHandler(c *gin.Context) {
-	conn, err := wsUpgrader.Upgrade(c.Writer, c.Request, nil)
+	conn, err := w.upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		// Upgrade already replied to the client with an HTTP error
 		w.logger.Debugf("websocket upgrade failed: %v", err)

--- a/bridgetracker/bridgetracker.go
+++ b/bridgetracker/bridgetracker.go
@@ -33,7 +33,7 @@ func New(cfg *Config) *BridgeTracker {
 	return &BridgeTracker{
 		logger:     cfg.Logger,
 		supervised: supervised,
-		api:        api.NewAPI(cfg.Logger, cfg.ConfigSHA1, supervised, cfg.RegisterResolveTimeout.Duration),
+		api:        api.NewAPI(cfg.Logger, cfg.ConfigSHA1, supervised, cfg.RegisterResolveTimeout.Duration, cfg.CORS),
 	}
 }
 

--- a/bridgetracker/config.go
+++ b/bridgetracker/config.go
@@ -110,6 +110,12 @@ type Config struct {
 	// adapter (single instance); inject a shared-store implementation so several tracker
 	// instances behind a proxy answer for any registered tx
 	Registry SupervisedRegistry `mapstructure:"-"`
+
+	// CORS mirrors the proxy's REST.CORS: it governs which origins may open a WebSocket
+	// connection to this tracker's endpoints (see aggkitcommon.CORSConfig.OriginAllowed for
+	// why WebSocket needs its own check instead of reusing the REST CORS headers). Wired
+	// programmatically from REST.CORS by the binary, not read directly from [Tracker].
+	CORS aggkitcommon.CORSConfig `mapstructure:"-"`
 }
 
 // Validate checks if the configuration is valid

--- a/bridgetracker/websocket_test.go
+++ b/bridgetracker/websocket_test.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/agglayer/aggkit/bridgetracker/api"
 	"github.com/agglayer/aggkit/bridgetracker/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
+	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +25,22 @@ const wsTestTimeout = 5 * time.Second
 type wsEnvelope struct {
 	Type string          `json:"type"`
 	Data json.RawMessage `json:"data"`
+}
+
+// newTestTrackerWithCORS is like newTestTracker but with a custom CORS policy, for tests that
+// exercise the WebSocket endpoint's origin check.
+func newTestTrackerWithCORS(t *testing.T, cors aggkitcommon.CORSConfig) (*BridgeTracker, *gin.Engine) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	tracker := New(&Config{
+		Logger:     log.WithFields("module", "bridgetracker_test"),
+		ConfigSHA1: testConfigSHA1,
+		CORS:       cors,
+	})
+	router := gin.New()
+	tracker.API().RegisterRoutes(router)
+	return tracker, router
 }
 
 // dialWS spins up the tracker on a test server and opens a WebSocket connection to the
@@ -184,4 +203,63 @@ func TestWSInvalidParams(t *testing.T) {
 	require.Contains(t, errData.Message, "tx_hash")
 
 	require.Equal(t, websocket.ClosePolicyViolation, expectClose(t, conn))
+}
+
+// TestWSCORSOriginCheck pins that the WebSocket handshake enforces the tracker's CORS policy
+// instead of Access-Control-* response headers (browsers never CORS-preflight or gate the
+// Upgrade request on those): disabled CORS (the default) accepts any origin, matching the
+// tracker's pre-CORS-config behavior; enabled with a restricted AllowedOrigins rejects the
+// handshake outright (403) for an origin not on the list, and accepts one that is.
+func TestWSCORSOriginCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		cors       aggkitcommon.CORSConfig
+		origin     string
+		wantForbid bool
+	}{
+		{
+			name:   "CORS disabled allows any origin",
+			cors:   aggkitcommon.CORSConfig{Enabled: false},
+			origin: "https://not-in-the-list.com",
+		},
+		{
+			name:   "CORS enabled allows a listed origin",
+			cors:   aggkitcommon.CORSConfig{Enabled: true, AllowedOrigins: []string{"https://allowed.com"}},
+			origin: "https://allowed.com",
+		},
+		{
+			name:       "CORS enabled rejects an origin not on the list",
+			cors:       aggkitcommon.CORSConfig{Enabled: true, AllowedOrigins: []string{"https://allowed.com"}},
+			origin:     "https://not-allowed.com",
+			wantForbid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, router := newTestTrackerWithCORS(t, tt.cors)
+			server := httptest.NewServer(router)
+			t.Cleanup(server.Close)
+
+			wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
+				api.TrackerV1Prefix + "/network/1/tx/" + testTxHash + "/ws"
+			header := http.Header{"Origin": []string{tt.origin}}
+			conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+			if resp != nil && resp.Body != nil {
+				defer resp.Body.Close()
+			}
+
+			if tt.wantForbid {
+				require.Error(t, err)
+				require.NotNil(t, resp)
+				require.Equal(t, http.StatusForbidden, resp.StatusCode)
+				return
+			}
+
+			require.NoError(t, err)
+			t.Cleanup(func() { conn.Close() })
+			msg := readEnvelope(t, conn)
+			require.Equal(t, types.WSTypeStatus, msg.Type)
+		})
+	}
 }

--- a/common/config.go
+++ b/common/config.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/agglayer/aggkit/config/types"
 )
@@ -60,12 +61,45 @@ type CORSConfig struct {
 
 	// AllowCredentials allows cross-origin requests to include cookies / HTTP
 	// auth. Per the CORS spec this cannot be combined with AllowedOrigins
-	// containing "*": the reflected origin is sent back instead of "*"
-	// whenever this is true.
+	// containing "*": when both are set, the caller's origin is reflected
+	// back instead of "*" so browsers still accept the credentialed response.
 	AllowCredentials bool `mapstructure:"AllowCredentials"`
 
 	// MaxAge is how long browsers may cache a preflight (OPTIONS) response.
 	// 0 (the default) omits the Access-Control-Max-Age header, so browsers
 	// fall back to their own default (5s per spec).
 	MaxAge types.Duration `mapstructure:"MaxAge"`
+}
+
+// OriginAllowed reports whether origin may access an endpoint under this CORS policy, for
+// callers that can't rely on the Access-Control-* response headers rs/cors sets (e.g. a
+// WebSocket upgrade: browsers never CORS-preflight or gate the Upgrade request on those
+// headers, so restricting origins there means rejecting the handshake outright instead).
+//
+// When CORS is disabled this returns true unconditionally, preserving the pre-CORS-config
+// behavior of unrestricted cross-origin access. Once enabled, matching mirrors rs/cors:
+// case-insensitive, "*" allows any origin, and an AllowedOrigins entry may contain a single
+// "*" wildcard segment (e.g. "https://*.example.com").
+func (c CORSConfig) OriginAllowed(origin string) bool {
+	if !c.Enabled {
+		return true
+	}
+
+	origin = strings.ToLower(origin)
+	for _, allowed := range c.AllowedOrigins {
+		allowed = strings.ToLower(allowed)
+		if allowed == "*" {
+			return true
+		}
+		if prefix, suffix, found := strings.Cut(allowed, "*"); found {
+			if strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
+				return true
+			}
+			continue
+		}
+		if allowed == origin {
+			return true
+		}
+	}
+	return false
 }

--- a/common/config.go
+++ b/common/config.go
@@ -27,9 +27,45 @@ type RESTConfig struct {
 	// does not enforce request rate limiting in-process. Apply rate limiting
 	// at the fronting reverse proxy / API gateway / ingress if needed.
 	MaxRequestsPerIPAndSecond float64 `mapstructure:"MaxRequestsPerIPAndSecond"`
+
+	// CORS configures Cross-Origin Resource Sharing for this REST service.
+	// Disabled by default, which keeps the current behavior (no CORS headers,
+	// so cross-origin browser requests are rejected by the browser).
+	CORS CORSConfig `mapstructure:"CORS"`
 }
 
 // Address constructs and returns the address as a string in the format "host:port".
 func (c *RESTConfig) Address() string {
 	return fmt.Sprintf("%s:%d", c.Host, c.Port)
+}
+
+// CORSConfig configures Cross-Origin Resource Sharing (CORS) headers for a
+// RESTConfig-backed HTTP server, so it can be called from browser-based
+// clients hosted on a different origin.
+type CORSConfig struct {
+	// Enabled turns on CORS header handling. Disabled by default: a REST
+	// service is only reachable cross-origin from a browser once this is set.
+	Enabled bool `mapstructure:"Enabled"`
+
+	// AllowedOrigins lists the origins allowed to make cross-origin requests.
+	// "*" allows any origin. Ignored (and CORS effectively grants nothing)
+	// when empty.
+	AllowedOrigins []string `mapstructure:"AllowedOrigins"`
+
+	// AllowedMethods lists the HTTP methods allowed for cross-origin requests.
+	AllowedMethods []string `mapstructure:"AllowedMethods"`
+
+	// AllowedHeaders lists the request headers allowed for cross-origin requests.
+	AllowedHeaders []string `mapstructure:"AllowedHeaders"`
+
+	// AllowCredentials allows cross-origin requests to include cookies / HTTP
+	// auth. Per the CORS spec this cannot be combined with AllowedOrigins
+	// containing "*": the reflected origin is sent back instead of "*"
+	// whenever this is true.
+	AllowCredentials bool `mapstructure:"AllowCredentials"`
+
+	// MaxAge is how long browsers may cache a preflight (OPTIONS) response.
+	// 0 (the default) omits the Access-Control-Max-Age header, so browsers
+	// fall back to their own default (5s per spec).
+	MaxAge types.Duration `mapstructure:"MaxAge"`
 }

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORSConfigOriginAllowed(t *testing.T) {
+	tests := []struct {
+		name   string
+		cors   CORSConfig
+		origin string
+		want   bool
+	}{
+		{
+			name:   "disabled allows any origin, matching the pre-CORS-config default",
+			cors:   CORSConfig{Enabled: false, AllowedOrigins: []string{"https://allowed.com"}},
+			origin: "https://not-in-the-list.com",
+			want:   true,
+		},
+		{
+			name:   "disabled allows an empty origin too",
+			cors:   CORSConfig{Enabled: false},
+			origin: "",
+			want:   true,
+		},
+		{
+			name:   "enabled with empty AllowedOrigins grants nothing",
+			cors:   CORSConfig{Enabled: true},
+			origin: "https://example.com",
+			want:   false,
+		},
+		{
+			name:   "enabled with wildcard allows any origin",
+			cors:   CORSConfig{Enabled: true, AllowedOrigins: []string{"*"}},
+			origin: "https://example.com",
+			want:   true,
+		},
+		{
+			name:   "enabled with exact match allows it",
+			cors:   CORSConfig{Enabled: true, AllowedOrigins: []string{"https://example.com"}},
+			origin: "https://example.com",
+			want:   true,
+		},
+		{
+			name:   "enabled matching is case-insensitive",
+			cors:   CORSConfig{Enabled: true, AllowedOrigins: []string{"HTTPS://EXAMPLE.COM"}},
+			origin: "https://example.com",
+			want:   true,
+		},
+		{
+			name:   "enabled rejects an origin not in the list",
+			cors:   CORSConfig{Enabled: true, AllowedOrigins: []string{"https://example.com"}},
+			origin: "https://not-allowed.com",
+			want:   false,
+		},
+		{
+			name:   "enabled with a single embedded wildcard matches a subdomain",
+			cors:   CORSConfig{Enabled: true, AllowedOrigins: []string{"https://*.example.com"}},
+			origin: "https://app.example.com",
+			want:   true,
+		},
+		{
+			name:   "enabled with a single embedded wildcard rejects a non-matching origin",
+			cors:   CORSConfig{Enabled: true, AllowedOrigins: []string{"https://*.example.com"}},
+			origin: "https://example.org",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.cors.OriginAllowed(tt.origin))
+		})
+	}
+}

--- a/common/httpserver.go
+++ b/common/httpserver.go
@@ -101,13 +101,23 @@ func corsHandler(cfg CORSConfig) *cors.Cors {
 		MaxAge:           int(cfg.MaxAge.Seconds()),
 	}
 
-	// rs/cors always answers with the literal "*" when AllowedOrigins contains
-	// "*", even with AllowCredentials set. Per the Fetch spec, browsers refuse
-	// to expose a credentialed response when Access-Control-Allow-Origin is
-	// "*", so that combination would silently break every credentialed
-	// cross-origin request. Route through AllowOriginFunc instead, which
-	// rs/cors always answers by reflecting the caller's Origin, never "*".
-	if cfg.AllowCredentials && slices.Contains(cfg.AllowedOrigins, "*") {
+	switch {
+	case len(cfg.AllowedOrigins) == 0:
+		// rs/cors treats an empty AllowedOrigins as "allow every origin" — its
+		// own zero-value default — the opposite of what CORSConfig documents
+		// and of OriginAllowed's fail-closed behavior for the WebSocket
+		// handshake. Force deny-all instead, so an operator who enables CORS
+		// without filling in AllowedOrigins doesn't accidentally open it to
+		// every origin.
+		opts.AllowOriginFunc = func(_ string) bool { return false }
+	case cfg.AllowCredentials && slices.Contains(cfg.AllowedOrigins, "*"):
+		// rs/cors always answers with the literal "*" when AllowedOrigins
+		// contains "*", even with AllowCredentials set. Per the Fetch spec,
+		// browsers refuse to expose a credentialed response when
+		// Access-Control-Allow-Origin is "*", so that combination would
+		// silently break every credentialed cross-origin request. Route
+		// through AllowOriginFunc instead, which rs/cors always answers by
+		// reflecting the caller's Origin, never "*".
 		opts.AllowOriginFunc = func(_ string) bool { return true }
 	}
 

--- a/common/httpserver.go
+++ b/common/httpserver.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -90,17 +91,27 @@ func (s *HTTPServer) Start(ctx context.Context) error {
 	return nil
 }
 
-// corsHandler builds a CORS handler from cfg. AllowCredentials with a
-// wildcard origin is invalid per the CORS spec, so rs/cors reflects the
-// request's Origin back instead of sending "*" whenever it's set.
+// corsHandler builds a CORS handler from cfg.
 func corsHandler(cfg CORSConfig) *cors.Cors {
-	return cors.New(cors.Options{
+	opts := cors.Options{
 		AllowedOrigins:   cfg.AllowedOrigins,
 		AllowedMethods:   cfg.AllowedMethods,
 		AllowedHeaders:   cfg.AllowedHeaders,
 		AllowCredentials: cfg.AllowCredentials,
-		MaxAge:           int(cfg.MaxAge.Duration.Seconds()),
-	})
+		MaxAge:           int(cfg.MaxAge.Seconds()),
+	}
+
+	// rs/cors always answers with the literal "*" when AllowedOrigins contains
+	// "*", even with AllowCredentials set. Per the Fetch spec, browsers refuse
+	// to expose a credentialed response when Access-Control-Allow-Origin is
+	// "*", so that combination would silently break every credentialed
+	// cross-origin request. Route through AllowOriginFunc instead, which
+	// rs/cors always answers by reflecting the caller's Origin, never "*".
+	if cfg.AllowCredentials && slices.Contains(cfg.AllowedOrigins, "*") {
+		opts.AllowOriginFunc = func(_ string) bool { return true }
+	}
+
+	return cors.New(opts)
 }
 
 // HTTPLoggerHandler returns a Gin middleware that logs HTTP requests using logger at DEBUG level.

--- a/common/httpserver.go
+++ b/common/httpserver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/cors"
 )
 
 const httpServerShutdownTimeout = 5 * time.Second
@@ -60,8 +61,13 @@ func (s *HTTPServer) Start(ctx context.Context) error {
 		return fmt.Errorf("httpserver: failed to listen on %s: %w", s.cfg.Address(), err)
 	}
 
+	var handler http.Handler = s.engine
+	if s.cfg.CORS.Enabled {
+		handler = corsHandler(s.cfg.CORS).Handler(handler)
+	}
+
 	srv := &http.Server{
-		Handler:      s.engine,
+		Handler:      handler,
 		ReadTimeout:  s.cfg.ReadTimeout.Duration,
 		WriteTimeout: s.cfg.WriteTimeout.Duration,
 	}
@@ -82,6 +88,19 @@ func (s *HTTPServer) Start(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+// corsHandler builds a CORS handler from cfg. AllowCredentials with a
+// wildcard origin is invalid per the CORS spec, so rs/cors reflects the
+// request's Origin back instead of sending "*" whenever it's set.
+func corsHandler(cfg CORSConfig) *cors.Cors {
+	return cors.New(cors.Options{
+		AllowedOrigins:   cfg.AllowedOrigins,
+		AllowedMethods:   cfg.AllowedMethods,
+		AllowedHeaders:   cfg.AllowedHeaders,
+		AllowCredentials: cfg.AllowCredentials,
+		MaxAge:           int(cfg.MaxAge.Duration.Seconds()),
+	})
 }
 
 // HTTPLoggerHandler returns a Gin middleware that logs HTTP requests using logger at DEBUG level.

--- a/common/httpserver_test.go
+++ b/common/httpserver_test.go
@@ -258,6 +258,36 @@ func TestHTTPServerStartCORSAllowCredentialsReflectsOriginInsteadOfWildcard(t *t
 	require.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
 }
 
+func TestHTTPServerStartCORSEnabledWithEmptyAllowedOriginsDeniesAll(t *testing.T) {
+	t.Setenv("GIN_MODE", gin.TestMode)
+	cfg := testRESTConfig(t)
+	cfg.CORS = CORSConfig{
+		Enabled:        true,
+		AllowedOrigins: []string{},
+		AllowedMethods: []string{http.MethodGet},
+	}
+	srv := NewHTTPServer(cfg, nil)
+	srv.Engine().GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, srv.Start(ctx))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+cfg.Address()+"/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// rs/cors treats an empty AllowedOrigins as its own "allow every origin"
+	// default; corsHandler must override that so an operator who enables CORS
+	// without filling in AllowedOrigins doesn't accidentally open it to every
+	// origin (matching CORSConfig.OriginAllowed's fail-closed behavior).
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
 func TestCorsHandlerMapsConfig(t *testing.T) {
 	cfg := CORSConfig{
 		AllowedOrigins:   []string{"https://example.com"},

--- a/common/httpserver_test.go
+++ b/common/httpserver_test.go
@@ -146,6 +146,145 @@ func TestHTTPLoggerHandlerWithQueryString(t *testing.T) {
 	require.Contains(t, log.debugfCalls[0], "foo=bar")
 }
 
+func TestHTTPServerStartCORSDisabledByDefault(t *testing.T) {
+	t.Setenv("GIN_MODE", gin.TestMode)
+	cfg := testRESTConfig(t)
+	srv := NewHTTPServer(cfg, nil)
+	srv.Engine().GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, srv.Start(ctx))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+cfg.Address()+"/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestHTTPServerStartCORSEnabled(t *testing.T) {
+	t.Setenv("GIN_MODE", gin.TestMode)
+	cfg := testRESTConfig(t)
+	cfg.CORS = CORSConfig{
+		Enabled:        true,
+		AllowedOrigins: []string{"https://example.com"},
+		AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodOptions},
+		AllowedHeaders: []string{"Content-Type"},
+		MaxAge:         configtypes.Duration{Duration: 12 * time.Hour},
+	}
+	srv := NewHTTPServer(cfg, nil)
+	srv.Engine().GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, srv.Start(ctx))
+
+	// Simple (non-preflight) request from an allowed origin gets the origin echoed back.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+cfg.Address()+"/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+	// A request from a non-allowed origin does not get CORS headers, so the
+	// browser blocks the response from being read cross-origin.
+	req2, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+cfg.Address()+"/health", nil)
+	require.NoError(t, err)
+	req2.Header.Set("Origin", "https://not-allowed.com")
+
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	require.Empty(t, resp2.Header.Get("Access-Control-Allow-Origin"))
+
+	// Preflight request advertises the configured methods/headers/max-age.
+	preflight, err := http.NewRequestWithContext(ctx, http.MethodOptions, "http://"+cfg.Address()+"/health", nil)
+	require.NoError(t, err)
+	preflight.Header.Set("Origin", "https://example.com")
+	preflight.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	// Per the Fetch spec, browsers send this lowercased; mimic that here since
+	// rs/cors compares it case-sensitively against the allow-list.
+	preflight.Header.Set("Access-Control-Request-Headers", "content-type")
+
+	preflightResp, err := http.DefaultClient.Do(preflight)
+	require.NoError(t, err)
+	defer preflightResp.Body.Close()
+
+	require.Equal(t, "https://example.com", preflightResp.Header.Get("Access-Control-Allow-Origin"))
+	require.Contains(t, preflightResp.Header.Get("Access-Control-Allow-Methods"), http.MethodGet)
+	require.Equal(t, "content-type", preflightResp.Header.Get("Access-Control-Allow-Headers"))
+	require.Equal(t, fmt.Sprintf("%d", int((12*time.Hour).Seconds())), preflightResp.Header.Get("Access-Control-Max-Age"))
+}
+
+func TestHTTPServerStartCORSAllowCredentialsReflectsOriginInsteadOfWildcard(t *testing.T) {
+	t.Setenv("GIN_MODE", gin.TestMode)
+	cfg := testRESTConfig(t)
+	cfg.CORS = CORSConfig{
+		Enabled:          true,
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{http.MethodGet},
+		AllowCredentials: true,
+	}
+	srv := NewHTTPServer(cfg, nil)
+	srv.Engine().GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, srv.Start(ctx))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+cfg.Address()+"/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Per the CORS spec, credentials cannot be combined with a wildcard origin,
+	// so the caller's origin must be reflected back instead of "*".
+	require.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+}
+
+func TestCorsHandlerMapsConfig(t *testing.T) {
+	cfg := CORSConfig{
+		AllowedOrigins:   []string{"https://example.com"},
+		AllowedMethods:   []string{http.MethodGet},
+		AllowedHeaders:   []string{"Content-Type"},
+		AllowCredentials: true,
+		MaxAge:           configtypes.Duration{Duration: 30 * time.Minute},
+	}
+
+	handler := corsHandler(cfg)
+	require.NotNil(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	base := gin.New()
+	base.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	preflight := httptest.NewRequest(http.MethodOptions, "/ping", nil)
+	preflight.Header.Set("Origin", "https://example.com")
+	preflight.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	w := httptest.NewRecorder()
+	handler.Handler(base).ServeHTTP(w, preflight)
+
+	require.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"))
+	require.Equal(t, fmt.Sprintf("%d", int((30*time.Minute).Seconds())), w.Header().Get("Access-Control-Max-Age"))
+}
+
 func TestHTTPLoggerHandlerWithoutQueryString(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	log := &mockHTTPLogger{}

--- a/docs/bridgetracker/API.md
+++ b/docs/bridgetracker/API.md
@@ -361,6 +361,14 @@ An `error` message ([ErrorData](#errordata)) is sent, followed by the closure of
 
 The server sends WebSocket `ping` frames periodically; the client must answer with `pong` (handled automatically by most WebSocket libraries). Connections that miss pongs are closed by the server.
 
+### Cross-origin access
+
+Browsers don't apply CORS to the WebSocket `Upgrade` request (no preflight, no `Access-Control-*`
+headers), so the REST server's `[REST.CORS]` config (see `docs/common_config.md`) can't restrict this
+endpoint the same way it restricts REST responses. Instead, the handshake itself is rejected (`403`)
+for a disallowed origin, based on the same `[REST.CORS].AllowedOrigins` list. With CORS disabled (the
+default), any origin can connect, same as before `[REST.CORS]` existed.
+
 
 
 ## Notes

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -146,11 +146,38 @@ When rate limiting is enabled, if the number of requests exceeds `NumRequests` w
 | ReadTimeout | types.Duration | HTTP server read timeout |
 | WriteTimeout | types.Duration | HTTP server write timeout |
 | MaxRequestsPerIPAndSecond | float64 | Unused; kept for config compatibility. See below |
+| CORS | CORSConfig | Cross-Origin Resource Sharing settings for this REST service. See below |
 
 `MaxRequestsPerIPAndSecond` is not enforced: aggkit does not rate-limit requests in-process. Its default is `0`
 (unlimited). If you need per-IP request throttling, apply it at the fronting reverse proxy / API gateway / ingress —
 that is also where it is most effective, since a service sitting behind a proxy typically sees every client as the
 proxy's single IP, making in-process per-IP limiting ineffective anyway.
+
+### CORSConfig
+
+`CORSConfig` configures Cross-Origin Resource Sharing headers, so the REST service can be called from a
+browser-based client hosted on a different origin. Disabled by default, which preserves the current behavior (no
+CORS headers, so browsers block cross-origin requests).
+
+| Field Name | Type | Description |
+| --- | --- | --- |
+| Enabled | bool | Turns on CORS header handling |
+| AllowedOrigins | []string | Origins allowed to make cross-origin requests. `"*"` allows any origin |
+| AllowedMethods | []string | HTTP methods allowed for cross-origin requests |
+| AllowedHeaders | []string | Request headers allowed for cross-origin requests |
+| AllowCredentials | bool | Allows cookies / HTTP auth on cross-origin requests. When true, the request's `Origin` is reflected back instead of `*`, since the CORS spec forbids combining credentials with a wildcard origin |
+| MaxAge | types.Duration | How long browsers may cache a preflight (`OPTIONS`) response. `0` (default) omits the header |
+
+Example, enabling CORS for the proxy's `[REST]` section for a frontend hosted at `https://example.com`:
+```
+[REST.CORS]
+Enabled = true
+AllowedOrigins = ["https://example.com"]
+AllowedMethods = ["GET", "POST", "OPTIONS"]
+AllowedHeaders = ["Content-Type", "Authorization"]
+AllowCredentials = false
+MaxAge = "12h"
+```
 
 Note that the `[RPC]` section is **not** a `RESTConfig`: it is the JSON-RPC server config from
 `github.com/0xPolygon/cdk-rpc`, whose `MaxRequestsPerIPAndSecond` **is** enforced (via tollbooth). There, `0` does

--- a/docs/common_config.md
+++ b/docs/common_config.md
@@ -162,7 +162,7 @@ CORS headers, so browsers block cross-origin requests).
 | Field Name | Type | Description |
 | --- | --- | --- |
 | Enabled | bool | Turns on CORS header handling |
-| AllowedOrigins | []string | Origins allowed to make cross-origin requests. `"*"` allows any origin |
+| AllowedOrigins | []string | Origins allowed to make cross-origin requests. `"*"` allows any origin; empty denies every origin once `Enabled` is true |
 | AllowedMethods | []string | HTTP methods allowed for cross-origin requests |
 | AllowedHeaders | []string | Request headers allowed for cross-origin requests |
 | AllowCredentials | bool | Allows cookies / HTTP auth on cross-origin requests. When true, the request's `Origin` is reflected back instead of `*`, since the CORS spec forbids combining credentials with a wildcard origin |

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/prometheus/client_golang v1.24.0
 	github.com/prometheus/client_model v0.6.2
+	github.com/rs/cors v1.11.0
 	github.com/rubenv/sql-migrate v1.8.1
 	github.com/russross/meddler v1.0.1
 	github.com/spf13/viper v1.21.0
@@ -176,7 +177,6 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/rs/cors v1.11.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect

--- a/proxy/cmd/run.go
+++ b/proxy/cmd/run.go
@@ -162,6 +162,10 @@ func runTracker(
 	trackerCfg.Logger = log.WithFields("module", "bridgetracker")
 	trackerCfg.ConfigSHA1 = configSHA1
 	trackerCfg.Registry = registry
+	// The tracker's WebSocket endpoint enforces the same origin policy as the REST server it's
+	// served alongside (see aggkitcommon.CORSConfig.OriginAllowed for why it can't just reuse
+	// the REST CORS headers).
+	trackerCfg.CORS = cfg.REST.CORS
 	tracker := bridgetracker.New(&trackerCfg)
 
 	if err := trackerCfg.AgglayerClient.Validate(); err != nil {

--- a/proxy/config/default.go
+++ b/proxy/config/default.go
@@ -33,9 +33,10 @@ MaxRequestsPerIPAndSecond = 0
 # Disabled by default: enable it if a browser-based frontend on a different
 # origin needs to call this REST server directly.
 Enabled = false
+# Empty denies every origin once Enabled is true; use ["*"] to allow any origin.
 AllowedOrigins = []
-AllowedMethods = ["GET", "POST", "OPTIONS"]
-AllowedHeaders = ["Content-Type", "Authorization"]
+AllowedMethods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+AllowedHeaders = ["*"]
 AllowCredentials = false
 MaxAge = "12h"
 

--- a/proxy/config/default.go
+++ b/proxy/config/default.go
@@ -29,6 +29,16 @@ ReadTimeout = "5m"
 WriteTimeout = "5m"
 MaxRequestsPerIPAndSecond = 0
 
+[REST.CORS]
+# Disabled by default: enable it if a browser-based frontend on a different
+# origin needs to call this REST server directly.
+Enabled = false
+AllowedOrigins = []
+AllowedMethods = ["GET", "POST", "OPTIONS"]
+AllowedHeaders = ["Content-Type", "Authorization"]
+AllowCredentials = false
+MaxAge = "12h"
+
 [Tracker]
 # RetentionPeriod: how long a terminal bridge (finished, or failed to ever resolve) stays
 # queryable before the tracker forgets it; a later request for the same tx re-registers it and


### PR DESCRIPTION
## 🔄 Changes Summary
- New `REST.CORS` config on the shared `RESTConfig`/`HTTPServer` (`common/config.go`, `common/httpserver.go`): `Enabled`, `AllowedOrigins`, `AllowedMethods`, `AllowedHeaders`, `AllowCredentials`, `MaxAge`. Wraps the gin engine with `rs/cors` when enabled. Disabled by default — no behavior change for existing deployments.
- `[REST.CORS]` section added to the proxy's default config (`proxy/config/default.go`), disabled, with `AllowedMethods`/`AllowedHeaders` covering the common REST verbs and any header, ready to flip on.
- The bridgetracker's WebSocket endpoint now enforces the same origin policy: browsers never CORS-preflight the `Upgrade` request, so `Access-Control-*` headers can't restrict it — instead the handshake itself is rejected (403) for a disallowed origin, via a new `CORSConfig.OriginAllowed` check wired from `REST.CORS` down into `bridgetracker.Config` → `wsHandler`'s `websocket.Upgrader.CheckOrigin`. With CORS disabled (default), the WS endpoint stays fully public, same as before.
- Fixed two bugs uncovered while adding tests, both in how `corsHandler` maps `AllowedOrigins` onto `rs/cors`:
  - `rs/cors` always answers `Access-Control-Allow-Origin: *` when `AllowedOrigins` contains `"*"`, even with `AllowCredentials` set — browsers reject that combination outright. Now routed through `AllowOriginFunc` so the origin is actually reflected, matching the documented intent.
  - `rs/cors` treats an **empty** `AllowedOrigins` as its own default of "allow every origin" — the opposite of what `CORSConfig.AllowedOrigins` documents and of `OriginAllowed`'s fail-closed behavior for the WebSocket handshake. Enabling CORS without filling in `AllowedOrigins` used to silently open the REST server to every origin while denying the WS endpoint under the same config. Now forced to deny-all via `AllowOriginFunc`, consistent with the docs and with WS.
- `docs/common_config.md` and `docs/bridgetracker/API.md` updated accordingly.

## ⚠️ Breaking Changes
- 🛠️ **Config**: New optional `[REST.CORS]` section on every `RESTConfig`-backed service (proxy, aggsender-rpc, bridgeservice, autoclaim-api, …), not just the proxy. Fully backward-compatible: `Enabled` defaults to `false`.

## 📋 Config Updates
```toml
[REST.CORS]
Enabled = false
# Empty denies every origin once Enabled is true; use ["*"] to allow any origin.
AllowedOrigins = []
AllowedMethods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
AllowedHeaders = ["*"]
AllowCredentials = false
MaxAge = "12h"
```

## ✅ Testing
- 🤖 **Automatic**: `common/httpserver_test.go` (CORS disabled/enabled, preflight, `AllowCredentials`+wildcard reflection, empty-`AllowedOrigins` deny-all, `corsHandler` mapping), `common/config_test.go` (`CORSConfig.OriginAllowed` table), `bridgetracker/websocket_test.go` (`TestWSCORSOriginCheck`: handshake allowed/rejected per origin policy). `make test-unit`, `make lint` both pass.

## 🐞 Issues
- Closes #1806

## 📝 Notes
- CORS is added at the shared `RESTConfig`/`HTTPServer` level rather than proxy-specific, so any service built on it gets the capability for free.
- WebSocket origin enforcement is a genuine server-side access check (unlike CORS headers, which are a browser-side courtesy) — see the new "Cross-origin access" section in `docs/bridgetracker/API.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)