### PR TITLE
fix(bridgeservice): expose real L2 injection block/timestamp on injected-l1-info-leaf

### DIFF
--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -845,8 +845,8 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 // @Summary Get injected L1 info tree leaf after a given L1 info tree index
 // @Description Returns the L1 info tree leaf either at the given index (for L1)
 // @Description or the first injected global exit root after the given index (for L2). For L2,
-// @Description injected_l2_block_num additionally carries the destination network's own block
-// @Description where the Global Exit Root got injected.
+// @Description injected_l2_block_num/injected_l2_timestamp additionally carry the destination
+// @Description network's own block, and when, the Global Exit Root got injected.
 // @Tags l1-info-tree-leaf
 // @Param network_id query int true "Network ID"
 // @Param leaf_index query int true "L1 Info Tree Index"
@@ -889,9 +889,10 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 	defer cancel()
 
 	var l1InfoLeaf *l1infotreesync.L1InfoTreeLeaf
-	// injectedL2BlockNumber is only resolved on the L2 branch below (the actual block on the
-	// destination network where the GER got injected), left nil for the L1 (network_id=0) case
-	var injectedL2BlockNumber *uint64
+	// injectedL2BlockNumber/injectedL2Timestamp are only resolved on the L2 branch below (the
+	// actual block on the destination network where the GER got injected, and when), left nil for
+	// the L1 (network_id=0) case
+	var injectedL2BlockNumber, injectedL2Timestamp *uint64
 
 	switch networkID {
 	case mainnetNetworkID:
@@ -925,6 +926,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 			return
 		}
 		injectedL2BlockNumber = &e.BlockNum
+		injectedL2Timestamp = e.Timestamp
 	default:
 		b.logger.Warnf(errNetworkID, networkID)
 		statusCode = http.StatusBadRequest
@@ -942,6 +944,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 
 	resp := NewL1InfoTreeLeafResponse(l1InfoLeaf)
 	resp.InjectedL2BlockNumber = injectedL2BlockNumber
+	resp.InjectedL2Timestamp = injectedL2Timestamp
 
 	statusCode = http.StatusOK
 	c.JSON(statusCode, resp)

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -844,7 +844,9 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 
 // @Summary Get injected L1 info tree leaf after a given L1 info tree index
 // @Description Returns the L1 info tree leaf either at the given index (for L1)
-// @Description or the first injected global exit root after the given index (for L2).
+// @Description or the first injected global exit root after the given index (for L2). For L2,
+// @Description injected_l2_block_num additionally carries the destination network's own block
+// @Description where the Global Exit Root got injected.
 // @Tags l1-info-tree-leaf
 // @Param network_id query int true "Network ID"
 // @Param leaf_index query int true "L1 Info Tree Index"
@@ -887,6 +889,9 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 	defer cancel()
 
 	var l1InfoLeaf *l1infotreesync.L1InfoTreeLeaf
+	// injectedL2BlockNumber is only resolved on the L2 branch below (the actual block on the
+	// destination network where the GER got injected), left nil for the L1 (network_id=0) case
+	var injectedL2BlockNumber *uint64
 
 	switch networkID {
 	case mainnetNetworkID:
@@ -919,6 +924,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 					e.L1InfoTreeIndex, err))
 			return
 		}
+		injectedL2BlockNumber = &e.BlockNum
 	default:
 		b.logger.Warnf(errNetworkID, networkID)
 		statusCode = http.StatusBadRequest
@@ -934,8 +940,11 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 		return
 	}
 
+	resp := NewL1InfoTreeLeafResponse(l1InfoLeaf)
+	resp.InjectedL2BlockNumber = injectedL2BlockNumber
+
 	statusCode = http.StatusOK
-	c.JSON(statusCode, NewL1InfoTreeLeafResponse(l1InfoLeaf))
+	c.JSON(statusCode, resp)
 }
 
 // @Summary Get L1 info tree leaf by Global Exit Root

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -845,7 +845,7 @@ func (b *BridgeService) L1InfoTreeIndexForBridgeHandler(c *gin.Context) {
 // @Summary Get injected L1 info tree leaf after a given L1 info tree index
 // @Description Returns the L1 info tree leaf either at the given index (for L1)
 // @Description or the first injected global exit root after the given index (for L2). For L2,
-// @Description injected_l2_block_num/injected_l2_timestamp additionally carry the destination
+// @Description injected_l2_block_num/injected_l2_block_timestamp additionally carry the destination
 // @Description network's own block, and when, the Global Exit Root got injected.
 // @Tags l1-info-tree-leaf
 // @Param network_id query int true "Network ID"
@@ -944,7 +944,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 
 	resp := NewL1InfoTreeLeafResponse(l1InfoLeaf)
 	resp.InjectedL2BlockNumber = injectedL2BlockNumber
-	resp.InjectedL2Timestamp = injectedL2Timestamp
+	resp.InjectedL2BlockTimestamp = injectedL2Timestamp
 
 	statusCode = http.StatusOK
 	c.JSON(statusCode, resp)

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -2514,7 +2514,7 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		var raw map[string]any
 		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &raw))
 		require.NotContains(t, raw, "injected_l2_block_num")
-		require.NotContains(t, raw, "injected_l2_timestamp")
+		require.NotContains(t, raw, "injected_l2_block_timestamp")
 	})
 
 	t.Run("Retrieve for L2 network", func(t *testing.T) {
@@ -2547,15 +2547,15 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, *l1InfoTreeLeaf, result)
 
-		// block_num/timestamp above are the L1 event's; injected_l2_block_num/injected_l2_timestamp
-		// are the extra fields carrying the L2 block (and when) the GER actually got injected
-		// (per l2gersync)
+		// block_num/timestamp above are the L1 event's; injected_l2_block_num/
+		// injected_l2_block_timestamp are the extra fields carrying the L2 block (and when) the
+		// GER actually got injected (per l2gersync)
 		var withL2Block bridgetypes.L1InfoTreeLeafResponse
 		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &withL2Block))
 		require.NotNil(t, withL2Block.InjectedL2BlockNumber)
 		require.Equal(t, l2InjectionBlockNum, *withL2Block.InjectedL2BlockNumber)
-		require.NotNil(t, withL2Block.InjectedL2Timestamp)
-		require.Equal(t, l2InjectionTimestamp, *withL2Block.InjectedL2Timestamp)
+		require.NotNil(t, withL2Block.InjectedL2BlockTimestamp)
+		require.Equal(t, l2InjectionTimestamp, *withL2Block.InjectedL2BlockTimestamp)
 	})
 
 	t.Run("Unsupported network", func(t *testing.T) {

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -2509,16 +2509,23 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		err := json.Unmarshal(response.Body.Bytes(), &result)
 		require.NoError(t, err)
 		require.Equal(t, *l1InfoTreeLeaf, result)
+
+		// the L1 lookup never resolves an L2 injection block, so it must stay absent
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &raw))
+		require.NotContains(t, raw, "injected_l2_block_num")
 	})
 
 	t.Run("Retrieve for L2 network", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 
+		const l2InjectionBlockNum = uint64(999)
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
 			Return(l2gersync.GlobalExitRootInfo{
 				GlobalExitRoot:  l1InfoTreeLeaf.GlobalExitRoot,
 				L1InfoTreeIndex: l1InfoTreeLeaf.L1InfoTreeIndex,
+				BlockNum:        l2InjectionBlockNum,
 			}, nil)
 
 		bridgeMocks.l1InfoTree.EXPECT().
@@ -2536,6 +2543,13 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		err := json.Unmarshal(response.Body.Bytes(), &result)
 		require.NoError(t, err)
 		require.Equal(t, *l1InfoTreeLeaf, result)
+
+		// block_num/timestamp above are the L1 event's; injected_l2_block_num is the extra field
+		// carrying the L2 block where the GER actually got injected (per l2gersync)
+		var withL2Block bridgetypes.L1InfoTreeLeafResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &withL2Block))
+		require.NotNil(t, withL2Block.InjectedL2BlockNumber)
+		require.Equal(t, l2InjectionBlockNum, *withL2Block.InjectedL2BlockNumber)
 	})
 
 	t.Run("Unsupported network", func(t *testing.T) {

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -2510,22 +2510,25 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, *l1InfoTreeLeaf, result)
 
-		// the L1 lookup never resolves an L2 injection block, so it must stay absent
+		// the L1 lookup never resolves an L2 injection block, so both must stay absent
 		var raw map[string]any
 		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &raw))
 		require.NotContains(t, raw, "injected_l2_block_num")
+		require.NotContains(t, raw, "injected_l2_timestamp")
 	})
 
 	t.Run("Retrieve for L2 network", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
 
 		const l2InjectionBlockNum = uint64(999)
+		l2InjectionTimestamp := uint64(time.Now().Add(-time.Minute).Unix())
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
 			Return(l2gersync.GlobalExitRootInfo{
 				GlobalExitRoot:  l1InfoTreeLeaf.GlobalExitRoot,
 				L1InfoTreeIndex: l1InfoTreeLeaf.L1InfoTreeIndex,
 				BlockNum:        l2InjectionBlockNum,
+				Timestamp:       &l2InjectionTimestamp,
 			}, nil)
 
 		bridgeMocks.l1InfoTree.EXPECT().
@@ -2544,12 +2547,15 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, *l1InfoTreeLeaf, result)
 
-		// block_num/timestamp above are the L1 event's; injected_l2_block_num is the extra field
-		// carrying the L2 block where the GER actually got injected (per l2gersync)
+		// block_num/timestamp above are the L1 event's; injected_l2_block_num/injected_l2_timestamp
+		// are the extra fields carrying the L2 block (and when) the GER actually got injected
+		// (per l2gersync)
 		var withL2Block bridgetypes.L1InfoTreeLeafResponse
 		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &withL2Block))
 		require.NotNil(t, withL2Block.InjectedL2BlockNumber)
 		require.Equal(t, l2InjectionBlockNum, *withL2Block.InjectedL2BlockNumber)
+		require.NotNil(t, withL2Block.InjectedL2Timestamp)
+		require.Equal(t, l2InjectionTimestamp, *withL2Block.InjectedL2Timestamp)
 	})
 
 	t.Run("Unsupported network", func(t *testing.T) {

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -573,7 +573,7 @@ const docTemplate = `{
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2).",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num additionally carries the destination network's own block\nwhere the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1553,6 +1553,11 @@ const docTemplate = `{
                     "description": "Unique hash identifying this leaf node",
                     "type": "string",
                     "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                },
+                "injected_l2_block_num": {
+                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
+                    "type": "integer",
+                    "example": 654321
                 },
                 "l1_info_tree_index": {
                     "description": "Index of this leaf in the L1 info tree",

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -573,7 +573,7 @@ const docTemplate = `{
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_block_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1559,7 +1559,7 @@ const docTemplate = `{
                     "type": "integer",
                     "example": 654321
                 },
-                "injected_l2_timestamp": {
+                "injected_l2_block_timestamp": {
                     "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
                     "type": "integer",
                     "example": 1684500123

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -1555,12 +1555,12 @@ const docTemplate = `{
                     "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
                 },
                 "injected_l2_block_num": {
-                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
+                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block.\nApproximate (the current polling head, not necessarily the real injection block) for L2\nchains synced by l2gersync in Legacy mode",
                     "type": "integer",
                     "example": 654321
                 },
                 "injected_l2_block_timestamp": {
-                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
+                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request. Always nil for L2 chains synced by l2gersync in Legacy mode, where\nInjectedL2BlockNumber is only approximate and no accurate timestamp can be derived from it",
                     "type": "integer",
                     "example": 1684500123
                 },

--- a/bridgeservice/docs/docs.go
+++ b/bridgeservice/docs/docs.go
@@ -573,7 +573,7 @@ const docTemplate = `{
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num additionally carries the destination network's own block\nwhere the Global Exit Root got injected.",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1558,6 +1558,11 @@ const docTemplate = `{
                     "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
                     "type": "integer",
                     "example": 654321
+                },
+                "injected_l2_timestamp": {
+                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
+                    "type": "integer",
+                    "example": 1684500123
                 },
                 "l1_info_tree_index": {
                     "description": "Index of this leaf in the L1 info tree",

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -1548,12 +1548,12 @@
                     "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
                 },
                 "injected_l2_block_num": {
-                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
+                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block.\nApproximate (the current polling head, not necessarily the real injection block) for L2\nchains synced by l2gersync in Legacy mode",
                     "type": "integer",
                     "example": 654321
                 },
                 "injected_l2_block_timestamp": {
-                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
+                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request. Always nil for L2 chains synced by l2gersync in Legacy mode, where\nInjectedL2BlockNumber is only approximate and no accurate timestamp can be derived from it",
                     "type": "integer",
                     "example": 1684500123
                 },

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -566,7 +566,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num additionally carries the destination network's own block\nwhere the Global Exit Root got injected.",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1551,6 +1551,11 @@
                     "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
                     "type": "integer",
                     "example": 654321
+                },
+                "injected_l2_timestamp": {
+                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
+                    "type": "integer",
+                    "example": 1684500123
                 },
                 "l1_info_tree_index": {
                     "description": "Index of this leaf in the L1 info tree",

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -566,7 +566,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_block_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1552,7 +1552,7 @@
                     "type": "integer",
                     "example": 654321
                 },
-                "injected_l2_timestamp": {
+                "injected_l2_block_timestamp": {
                     "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
                     "type": "integer",
                     "example": 1684500123

--- a/bridgeservice/docs/swagger.json
+++ b/bridgeservice/docs/swagger.json
@@ -566,7 +566,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2).",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num additionally carries the destination network's own block\nwhere the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1546,6 +1546,11 @@
                     "description": "Unique hash identifying this leaf node",
                     "type": "string",
                     "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                },
+                "injected_l2_block_num": {
+                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
+                    "type": "integer",
+                    "example": 654321
                 },
                 "l1_info_tree_index": {
                     "description": "Index of this leaf in the L1 info tree",

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -304,6 +304,13 @@ definitions:
         description: Unique hash identifying this leaf node
         example: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
         type: string
+      injected_l2_block_num:
+        description: |-
+          Block number on the destination (L2) network where this Global Exit Root was injected.
+          Only set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an
+          L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
+        example: 654321
+        type: integer
       l1_info_tree_index:
         description: Index of this leaf in the L1 info tree
         example: 42
@@ -1008,7 +1015,9 @@ paths:
     get:
       description: |-
         Returns the L1 info tree leaf either at the given index (for L1)
-        or the first injected global exit root after the given index (for L2).
+        or the first injected global exit root after the given index (for L2). For L2,
+        injected_l2_block_num additionally carries the destination network's own block
+        where the Global Exit Root got injected.
       parameters:
       - description: Network ID
         in: query

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -308,7 +308,9 @@ definitions:
         description: |-
           Block number on the destination (L2) network where this Global Exit Root was injected.
           Only set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an
-          L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
+          L1 (network_id=0) lookup, where BlockNumber above already is the relevant block.
+          Approximate (the current polling head, not necessarily the real injection block) for L2
+          chains synced by l2gersync in Legacy mode
         example: 654321
         type: integer
       injected_l2_block_timestamp:
@@ -316,7 +318,8 @@ definitions:
           Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside
           InjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted
           timestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves
-          on a later request
+          on a later request. Always nil for L2 chains synced by l2gersync in Legacy mode, where
+          InjectedL2BlockNumber is only approximate and no accurate timestamp can be derived from it
         example: 1684500123
         type: integer
       l1_info_tree_index:

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -311,6 +311,14 @@ definitions:
           L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
         example: 654321
         type: integer
+      injected_l2_timestamp:
+        description: |-
+          Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside
+          InjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted
+          timestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves
+          on a later request
+        example: 1684500123
+        type: integer
       l1_info_tree_index:
         description: Index of this leaf in the L1 info tree
         example: 42
@@ -1016,8 +1024,8 @@ paths:
       description: |-
         Returns the L1 info tree leaf either at the given index (for L1)
         or the first injected global exit root after the given index (for L2). For L2,
-        injected_l2_block_num additionally carries the destination network's own block
-        where the Global Exit Root got injected.
+        injected_l2_block_num/injected_l2_timestamp additionally carry the destination
+        network's own block, and when, the Global Exit Root got injected.
       parameters:
       - description: Network ID
         in: query

--- a/bridgeservice/docs/swagger.yaml
+++ b/bridgeservice/docs/swagger.yaml
@@ -311,7 +311,7 @@ definitions:
           L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
         example: 654321
         type: integer
-      injected_l2_timestamp:
+      injected_l2_block_timestamp:
         description: |-
           Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside
           InjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted
@@ -1024,7 +1024,7 @@ paths:
       description: |-
         Returns the L1 info tree leaf either at the given index (for L1)
         or the first injected global exit root after the given index (for L2). For L2,
-        injected_l2_block_num/injected_l2_timestamp additionally carry the destination
+        injected_l2_block_num/injected_l2_block_timestamp additionally carry the destination
         network's own block, and when, the Global Exit Root got injected.
       parameters:
       - description: Network ID

--- a/bridgeservice/types/types.go
+++ b/bridgeservice/types/types.go
@@ -347,13 +347,16 @@ type L1InfoTreeLeafResponse struct {
 
 	// Block number on the destination (L2) network where this Global Exit Root was injected.
 	// Only set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an
-	// L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
+	// L1 (network_id=0) lookup, where BlockNumber above already is the relevant block.
+	// Approximate (the current polling head, not necessarily the real injection block) for L2
+	// chains synced by l2gersync in Legacy mode
 	InjectedL2BlockNumber *uint64 `json:"injected_l2_block_num,omitempty" example:"654321"`
 
 	// Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside
 	// InjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted
 	// timestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves
-	// on a later request
+	// on a later request. Always nil for L2 chains synced by l2gersync in Legacy mode, where
+	// InjectedL2BlockNumber is only approximate and no accurate timestamp can be derived from it
 	InjectedL2BlockTimestamp *uint64 `json:"injected_l2_block_timestamp,omitempty" example:"1684500123"`
 }
 

--- a/bridgeservice/types/types.go
+++ b/bridgeservice/types/types.go
@@ -344,6 +344,11 @@ type L1InfoTreeLeafResponse struct {
 
 	// Unique hash identifying this leaf node
 	Hash Hash `json:"hash" example:"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"`
+
+	// Block number on the destination (L2) network where this Global Exit Root was injected.
+	// Only set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an
+	// L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
+	InjectedL2BlockNumber *uint64 `json:"injected_l2_block_num,omitempty" example:"654321"`
 }
 
 // SyncStatus represents the bridge synchronization status for both L1 and L2 networks

--- a/bridgeservice/types/types.go
+++ b/bridgeservice/types/types.go
@@ -354,7 +354,7 @@ type L1InfoTreeLeafResponse struct {
 	// InjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted
 	// timestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves
 	// on a later request
-	InjectedL2Timestamp *uint64 `json:"injected_l2_timestamp,omitempty" example:"1684500123"`
+	InjectedL2BlockTimestamp *uint64 `json:"injected_l2_block_timestamp,omitempty" example:"1684500123"`
 }
 
 // SyncStatus represents the bridge synchronization status for both L1 and L2 networks

--- a/bridgeservice/types/types.go
+++ b/bridgeservice/types/types.go
@@ -349,6 +349,12 @@ type L1InfoTreeLeafResponse struct {
 	// Only set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an
 	// L1 (network_id=0) lookup, where BlockNumber above already is the relevant block
 	InjectedL2BlockNumber *uint64 `json:"injected_l2_block_num,omitempty" example:"654321"`
+
+	// Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside
+	// InjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted
+	// timestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves
+	// on a later request
+	InjectedL2Timestamp *uint64 `json:"injected_l2_timestamp,omitempty" example:"1684500123"`
 }
 
 // SyncStatus represents the bridge synchronization status for both L1 and L2 networks

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -1548,12 +1548,12 @@
                     "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
                 },
                 "injected_l2_block_num": {
-                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
+                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block.\nApproximate (the current polling head, not necessarily the real injection block) for L2\nchains synced by l2gersync in Legacy mode",
                     "type": "integer",
                     "example": 654321
                 },
                 "injected_l2_block_timestamp": {
-                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
+                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request. Always nil for L2 chains synced by l2gersync in Legacy mode, where\nInjectedL2BlockNumber is only approximate and no accurate timestamp can be derived from it",
                     "type": "integer",
                     "example": 1684500123
                 },

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -566,7 +566,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num additionally carries the destination network's own block\nwhere the Global Exit Root got injected.",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1551,6 +1551,11 @@
                     "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
                     "type": "integer",
                     "example": 654321
+                },
+                "injected_l2_timestamp": {
+                    "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
+                    "type": "integer",
+                    "example": 1684500123
                 },
                 "l1_info_tree_index": {
                     "description": "Index of this leaf in the L1 info tree",

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -566,7 +566,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num/injected_l2_block_timestamp additionally carry the destination\nnetwork's own block, and when, the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1552,7 +1552,7 @@
                     "type": "integer",
                     "example": 654321
                 },
-                "injected_l2_timestamp": {
+                "injected_l2_block_timestamp": {
                     "description": "Timestamp of the L2 block above, in seconds since the Unix epoch. Only set alongside\nInjectedL2BlockNumber; may briefly be nil for a row written before l2gersync persisted\ntimestamps if backfilling it from the L2 RPC failed (transient), in which case it resolves\non a later request",
                     "type": "integer",
                     "example": 1684500123

--- a/docs/assets/swagger/bridge_service/swagger.json
+++ b/docs/assets/swagger/bridge_service/swagger.json
@@ -566,7 +566,7 @@
         },
         "/injected-l1-info-leaf": {
             "get": {
-                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2).",
+                "description": "Returns the L1 info tree leaf either at the given index (for L1)\nor the first injected global exit root after the given index (for L2). For L2,\ninjected_l2_block_num additionally carries the destination network's own block\nwhere the Global Exit Root got injected.",
                 "produces": [
                     "application/json"
                 ],
@@ -1546,6 +1546,11 @@
                     "description": "Unique hash identifying this leaf node",
                     "type": "string",
                     "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                },
+                "injected_l2_block_num": {
+                    "description": "Block number on the destination (L2) network where this Global Exit Root was injected.\nOnly set by the injected-l1-info-leaf endpoint when network_id is the L2's own; nil for an\nL1 (network_id=0) lookup, where BlockNumber above already is the relevant block",
+                    "type": "integer",
+                    "example": 654321
                 },
                 "l1_info_tree_index": {
                     "description": "Index of this leaf in the L1 info tree",

--- a/docs/bridgetracker/REFERENCE_API.md
+++ b/docs/bridgetracker/REFERENCE_API.md
@@ -221,6 +221,13 @@ resolves it from the L2 RPC on the very next read of that row and backfills the 
 `injected_l2_block_timestamp` only comes back absent if that RPC call itself fails (transient — it
 resolves on a later request).
 
+`injected_l2_block_timestamp` is always absent for L2 chains synced by `l2gersync` in `Legacy` mode
+(pre-sovereign GER manager contract): that mode detects an injected GER by polling contract state
+rather than reading an event log, so the only "block" it can associate with a GER is its current
+polling head, not necessarily the block that actually performed the injection — deriving a
+timestamp from it would look precise without being accurate. `injected_l2_block_num` carries that
+same caveat and should be treated as approximate for `Legacy`-mode chains.
+
 ### Errors
 
 - `400` — invalid parameter, or a `network_id` that is neither `0` nor the served L2.

--- a/docs/bridgetracker/REFERENCE_API.md
+++ b/docs/bridgetracker/REFERENCE_API.md
@@ -200,9 +200,18 @@ In other words, for L2 it answers: *"give me the first L1 Info Tree leaf, at or 
   "mainnet_exit_root": "0x...",   // MER at this leaf
   "rollup_exit_root": "0x...",    // RER at this leaf
   "global_exit_root": "0x...",    // GER = hash(MER, RER)
-  "hash": "0x..."                 // unique hash of the leaf
+  "hash": "0x...",                // unique hash of the leaf
+  "injected_l2_block_num": 654321 // L2 case only: the L2 block where this GER was actually
+                                   // injected (from l2gersync); omitted for network_id=0
 }
 ```
+
+`block_num`/`timestamp` above always describe the **L1** event that produced the leaf, even in
+the `network_id=<L2>` case — they are not the block where the GER got injected on the L2.
+`injected_l2_block_num` fills that gap: it is `l2gersync`'s own `block_num` for the matched
+`imported_global_exit_root_v2` row (see [processor.go:229](aggkit/l2gersync/processor.go#L229)),
+set only on the L2 branch. There is no equivalent L2 timestamp yet — `l2gersync` does not persist
+one (see [evm_downloader_sovereign.go](aggkit/l2gersync/evm_downloader_sovereign.go)).
 
 ### Errors
 

--- a/docs/bridgetracker/REFERENCE_API.md
+++ b/docs/bridgetracker/REFERENCE_API.md
@@ -192,26 +192,34 @@ In other words, for L2 it answers: *"give me the first L1 Info Tree leaf, at or 
 
 ```json
 {
-  "block_num": 123456,            // L1 block where the leaf was recorded
-  "block_pos": 5,                 // position of the event within the block
-  "l1_info_tree_index": 42,       // index of the returned leaf (may be > leaf_index in the L2 case)
+  "block_num": 123456,              // L1 block where the leaf was recorded
+  "block_pos": 5,                   // position of the event within the block
+  "l1_info_tree_index": 42,         // index of the returned leaf (may be > leaf_index in the L2 case)
   "previous_block_hash": "0x...",
-  "timestamp": 1684500000,        // L1 block timestamp (seconds since Unix epoch)
-  "mainnet_exit_root": "0x...",   // MER at this leaf
-  "rollup_exit_root": "0x...",    // RER at this leaf
-  "global_exit_root": "0x...",    // GER = hash(MER, RER)
-  "hash": "0x...",                // unique hash of the leaf
-  "injected_l2_block_num": 654321 // L2 case only: the L2 block where this GER was actually
-                                   // injected (from l2gersync); omitted for network_id=0
+  "timestamp": 1684500000,          // L1 block timestamp (seconds since Unix epoch)
+  "mainnet_exit_root": "0x...",     // MER at this leaf
+  "rollup_exit_root": "0x...",      // RER at this leaf
+  "global_exit_root": "0x...",      // GER = hash(MER, RER)
+  "hash": "0x...",                  // unique hash of the leaf
+  "injected_l2_block_num": 654321,  // L2 case only: the L2 block where this GER was actually
+                                     // injected (from l2gersync); omitted for network_id=0
+  "injected_l2_timestamp": 1684500123 // L2 case only: timestamp of that L2 block
 }
 ```
 
 `block_num`/`timestamp` above always describe the **L1** event that produced the leaf, even in
 the `network_id=<L2>` case — they are not the block where the GER got injected on the L2.
-`injected_l2_block_num` fills that gap: it is `l2gersync`'s own `block_num` for the matched
-`imported_global_exit_root_v2` row (see [processor.go:229](aggkit/l2gersync/processor.go#L229)),
-set only on the L2 branch. There is no equivalent L2 timestamp yet — `l2gersync` does not persist
-one (see [evm_downloader_sovereign.go](aggkit/l2gersync/evm_downloader_sovereign.go)).
+`injected_l2_block_num`/`injected_l2_timestamp` fill that gap: they come from `l2gersync`'s own
+`block_num`/`block_timestamp` columns for the matched `imported_global_exit_root_v2` row (see
+[processor.go:229](aggkit/l2gersync/processor.go#L229)), set only on the L2 branch.
+
+`timestamp` is a nullable column (added in
+[l2gersync0006.sql](aggkit/l2gersync/migrations/l2gersync0006.sql) to ease migrating existing
+rows): a row written before it existed has it `NULL` in the DB. When that happens,
+`L2GERSync.GetFirstGERAfterL1InfoTreeIndex` ([l2_ger_syncer.go](aggkit/l2gersync/l2_ger_syncer.go))
+resolves it from the L2 RPC on the very next read of that row and backfills the DB, so
+`injected_l2_timestamp` only comes back absent if that RPC call itself fails (transient — it
+resolves on a later request).
 
 ### Errors
 

--- a/docs/bridgetracker/REFERENCE_API.md
+++ b/docs/bridgetracker/REFERENCE_API.md
@@ -203,13 +203,13 @@ In other words, for L2 it answers: *"give me the first L1 Info Tree leaf, at or 
   "hash": "0x...",                  // unique hash of the leaf
   "injected_l2_block_num": 654321,  // L2 case only: the L2 block where this GER was actually
                                      // injected (from l2gersync); omitted for network_id=0
-  "injected_l2_timestamp": 1684500123 // L2 case only: timestamp of that L2 block
+  "injected_l2_block_timestamp": 1684500123 // L2 case only: timestamp of that L2 block
 }
 ```
 
 `block_num`/`timestamp` above always describe the **L1** event that produced the leaf, even in
 the `network_id=<L2>` case — they are not the block where the GER got injected on the L2.
-`injected_l2_block_num`/`injected_l2_timestamp` fill that gap: they come from `l2gersync`'s own
+`injected_l2_block_num`/`injected_l2_block_timestamp` fill that gap: they come from `l2gersync`'s own
 `block_num`/`block_timestamp` columns for the matched `imported_global_exit_root_v2` row (see
 [processor.go:229](aggkit/l2gersync/processor.go#L229)), set only on the L2 branch.
 
@@ -218,7 +218,7 @@ the `network_id=<L2>` case — they are not the block where the GER got injected
 rows): a row written before it existed has it `NULL` in the DB. When that happens,
 `L2GERSync.GetFirstGERAfterL1InfoTreeIndex` ([l2_ger_syncer.go](aggkit/l2gersync/l2_ger_syncer.go))
 resolves it from the L2 RPC on the very next read of that row and backfills the DB, so
-`injected_l2_timestamp` only comes back absent if that RPC call itself fails (transient — it
+`injected_l2_block_timestamp` only comes back absent if that RPC call itself fails (transient — it
 resolves on a later request).
 
 ### Errors

--- a/l2gersync/evm_downloader_legacy.go
+++ b/l2gersync/evm_downloader_legacy.go
@@ -170,8 +170,15 @@ func (d *downloaderLegacy) Download(
 		}
 
 		if gerInfo != nil {
-			timestamp := header.Timestamp
-			gerInfo.Timestamp = &timestamp
+			// Intentionally leave Timestamp (and BlockNum/BlockPosition, set in getGERsFromIndex)
+			// unset here: in Legacy mode the GER is detected by polling GlobalExitRootMap, so
+			// fromBlock is the current polling head, not necessarily the block the GER was
+			// actually injected in (e.g. after a restart/catch-up, WaitForNewBlocks can jump
+			// fromBlock straight to the finalized head). Persisting header.Timestamp would look
+			// like an accurate injection time to API consumers (injected_l2_block_timestamp) when
+			// it can in fact be substantially later. Leaving it nil keeps that limitation honest
+			// instead of fabricating precision; GetFirstGERAfterL1InfoTreeIndex also skips its RPC
+			// backfill for Legacy-mode syncers for the same reason.
 			block.Events = []any{newEvent(gerInfo, GEREventTypeInsert)}
 
 			// Update nextIndex based on the last injected GER info

--- a/l2gersync/evm_downloader_legacy.go
+++ b/l2gersync/evm_downloader_legacy.go
@@ -170,6 +170,8 @@ func (d *downloaderLegacy) Download(
 		}
 
 		if gerInfo != nil {
+			timestamp := header.Timestamp
+			gerInfo.Timestamp = &timestamp
 			block.Events = []any{newEvent(gerInfo, GEREventTypeInsert)}
 
 			// Update nextIndex based on the last injected GER info

--- a/l2gersync/evm_downloader_sovereign.go
+++ b/l2gersync/evm_downloader_sovereign.go
@@ -181,13 +181,15 @@ func (d *downloaderSovereign) buildAppender(
 				gerHash.Hex(), err)
 		}
 
-		b.Events = append(b.Events, newEvent(
-			newGlobalExitRootInfo(
-				insertGEREvent.NewGlobalExitRoot,
-				l1InfoTreeLeaf.L1InfoTreeIndex,
-				b.Num,
-				uint64(l.Index)),
-			GEREventTypeInsert))
+		gerInfo := newGlobalExitRootInfo(
+			insertGEREvent.NewGlobalExitRoot,
+			l1InfoTreeLeaf.L1InfoTreeIndex,
+			b.Num,
+			uint64(l.Index))
+		timestamp := b.Timestamp
+		gerInfo.Timestamp = &timestamp
+
+		b.Events = append(b.Events, newEvent(gerInfo, GEREventTypeInsert))
 		return nil
 	}
 

--- a/l2gersync/l2_ger_syncer.go
+++ b/l2gersync/l2_ger_syncer.go
@@ -41,6 +41,9 @@ type L2GERSync struct {
 	driver    *sync.EVMDriver
 	processor *processor
 	cfg       Config
+	// l2Client is only used to lazily backfill the timestamp of rows written before
+	// GlobalExitRootInfo persisted it (see GetFirstGERAfterL1InfoTreeIndex)
+	l2Client aggkittypes.BaseEthereumClienter
 }
 
 // New initializes and returns a new instance of L2GERSync
@@ -110,6 +113,7 @@ func New(
 		driver:    driver,
 		processor: processor,
 		cfg:       cfg,
+		l2Client:  l2Client,
 	}, nil
 }
 
@@ -148,11 +152,38 @@ func (s *L2GERSync) Start(ctx context.Context) {
 	s.driver.Sync(ctx, &s.cfg.InitialBlockNum)
 }
 
-// GetFirstGERAfterL1InfoTreeIndex returns the first GER after a specified L1 info tree index
+// GetFirstGERAfterL1InfoTreeIndex returns the first GER after a specified L1 info tree index. If
+// the resolved row predates timestamp persistence (nullable column, see l2gersync0006.sql), its
+// timestamp is resolved from the L2 RPC and backfilled into the row before returning, so callers
+// (e.g. bridgeservice.InjectedL1InfoLeafHandler) get it transparently on the very first request
+// that hits a legacy row, without knowing about the gap themselves.
 func (s *L2GERSync) GetFirstGERAfterL1InfoTreeIndex(
 	ctx context.Context, atOrAfterL1InfoTreeIndex uint32,
 ) (GlobalExitRootInfo, error) {
-	return s.processor.GetFirstGERAfterL1InfoTreeIndex(ctx, atOrAfterL1InfoTreeIndex)
+	info, err := s.processor.GetFirstGERAfterL1InfoTreeIndex(ctx, atOrAfterL1InfoTreeIndex)
+	if err != nil || info.Timestamp != nil {
+		return info, err
+	}
+	if s.l2Client == nil {
+		// Only expected in tests that build L2GERSync directly instead of through New; every
+		// production instance always has one
+		log.Warnf("no L2 client configured, skipping timestamp backfill for injected GER at block %d", info.BlockNum)
+		return info, nil
+	}
+
+	header, err := s.l2Client.CustomHeaderByNumber(ctx, aggkittypes.NewBlockNumber(info.BlockNum))
+	if err != nil {
+		// Best effort: the row still lacks a timestamp, but every other field resolved fine, so
+		// let the caller have those rather than failing the whole lookup over this
+		log.Warnf("failed to backfill timestamp for injected GER at block %d: %v", info.BlockNum, err)
+		return info, nil
+	}
+
+	if err := s.processor.UpdateTimestamp(ctx, info.BlockNum, info.BlockPosition, header.Time); err != nil {
+		log.Warnf("failed to persist backfilled timestamp for injected GER at block %d: %v", info.BlockNum, err)
+	}
+	info.Timestamp = &header.Time
+	return info, nil
 }
 
 // GetInjectedGERsForRange retrieves all injected global exit roots within a specified block range.

--- a/l2gersync/l2_ger_syncer.go
+++ b/l2gersync/l2_ger_syncer.go
@@ -44,6 +44,10 @@ type L2GERSync struct {
 	// l2Client is only used to lazily backfill the timestamp of rows written before
 	// GlobalExitRootInfo persisted it (see GetFirstGERAfterL1InfoTreeIndex)
 	l2Client aggkittypes.BaseEthereumClienter
+	// syncMode gates that same backfill: in Legacy mode BlockNum is the polling head rather than
+	// the real injection block (see evm_downloader_legacy.go), so resolving a timestamp from it
+	// would be no more accurate than not persisting one at all
+	syncMode SyncMode
 }
 
 // New initializes and returns a new instance of L2GERSync
@@ -114,6 +118,7 @@ func New(
 		processor: processor,
 		cfg:       cfg,
 		l2Client:  l2Client,
+		syncMode:  syncMode,
 	}, nil
 }
 
@@ -163,6 +168,12 @@ func (s *L2GERSync) GetFirstGERAfterL1InfoTreeIndex(
 	info, err := s.processor.GetFirstGERAfterL1InfoTreeIndex(ctx, atOrAfterL1InfoTreeIndex)
 	if err != nil || info.Timestamp != nil {
 		return info, err
+	}
+	if s.syncMode == Legacy {
+		// info.BlockNum is the polling head at insertion time, not the real injection block (see
+		// evm_downloader_legacy.go), so resolving a "timestamp" from it would just be a
+		// differently-shaped version of the same inaccuracy. Leave it nil rather than backfill.
+		return info, nil
 	}
 	if s.l2Client == nil {
 		// Only expected in tests that build L2GERSync directly instead of through New; every

--- a/l2gersync/l2_ger_syncer_test.go
+++ b/l2gersync/l2_ger_syncer_test.go
@@ -2,12 +2,16 @@ package l2gersync
 
 import (
 	"context"
+	"errors"
 	"path"
 	"testing"
 
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/sync"
+	aggkittypes "github.com/agglayer/aggkit/types"
+	aggkittypesmocks "github.com/agglayer/aggkit/types/mocks"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,5 +65,69 @@ func TestGetFirstGERAfterL1InfoTreeIndex(t *testing.T) {
 		require.ErrorIs(t, err, db.ErrNotFound, "expected ErrNotFound")
 		require.Equal(t, common.HexToHash("0x0"), ger.GlobalExitRoot, "unexpected GlobalExitRoot when not found")
 		require.Equal(t, uint32(0), ger.L1InfoTreeIndex, "unexpected L1InfoTreeIndex when not found")
+	})
+}
+
+func TestGetFirstGERAfterL1InfoTreeIndex_BackfillsTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	newSyncerWithGER := func(t *testing.T) *L2GERSync {
+		t.Helper()
+		testDir := path.Join(t.TempDir(), "l2gersync_TestGetFirstGERAfterL1InfoTreeIndex_BackfillsTimestamp.sqlite")
+		processor, err := newProcessor(testDir)
+		require.NoError(t, err)
+
+		// no timestamp persisted at insert time, matching a row written before the column existed
+		err = processor.ProcessBlock(ctx, sync.Block{
+			Num:    7,
+			Events: []any{newEvent(newGlobalExitRootInfo(common.HexToHash("0x1"), 1, 7, 0), GEREventTypeInsert)},
+		})
+		require.NoError(t, err)
+
+		return &L2GERSync{processor: processor}
+	}
+
+	t.Run("resolves timestamp from the RPC and persists it", func(t *testing.T) {
+		l2GERSync := newSyncerWithGER(t)
+		const backfilledTimestamp = uint64(1700000000)
+		mockL2Client := aggkittypesmocks.NewBaseEthereumClienter(t)
+		mockL2Client.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(uint64(7))).
+			Return(&aggkittypes.BlockHeader{Number: 7, Time: backfilledTimestamp}, nil).Once()
+		l2GERSync.l2Client = mockL2Client
+
+		ger, err := l2GERSync.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+		require.NoError(t, err)
+		require.NotNil(t, ger.Timestamp)
+		require.Equal(t, backfilledTimestamp, *ger.Timestamp)
+
+		// persisted, so a later read does not need the RPC again
+		mockL2Client.AssertExpectations(t)
+		ger, err = l2GERSync.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+		require.NoError(t, err)
+		require.NotNil(t, ger.Timestamp)
+		require.Equal(t, backfilledTimestamp, *ger.Timestamp)
+	})
+
+	t.Run("RPC failure is best-effort: other fields still returned, timestamp stays nil", func(t *testing.T) {
+		l2GERSync := newSyncerWithGER(t)
+		mockL2Client := aggkittypesmocks.NewBaseEthereumClienter(t)
+		mockL2Client.EXPECT().
+			CustomHeaderByNumber(mock.Anything, aggkittypes.NewBlockNumber(uint64(7))).
+			Return(nil, errors.New("rpc unavailable")).Once()
+		l2GERSync.l2Client = mockL2Client
+
+		ger, err := l2GERSync.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+		require.NoError(t, err)
+		require.Nil(t, ger.Timestamp)
+		require.Equal(t, common.HexToHash("0x1"), ger.GlobalExitRoot)
+	})
+
+	t.Run("no l2Client configured (e.g. L2GERSync built directly, not via New): skips backfill", func(t *testing.T) {
+		l2GERSync := newSyncerWithGER(t)
+
+		ger, err := l2GERSync.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+		require.NoError(t, err)
+		require.Nil(t, ger.Timestamp)
 	})
 }

--- a/l2gersync/l2_ger_syncer_test.go
+++ b/l2gersync/l2_ger_syncer_test.go
@@ -130,4 +130,17 @@ func TestGetFirstGERAfterL1InfoTreeIndex_BackfillsTimestamp(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, ger.Timestamp)
 	})
+
+	t.Run("Legacy sync mode: skips backfill even with an l2Client configured", func(t *testing.T) {
+		// In Legacy mode BlockNum is the polling head, not the real injection block, so resolving
+		// a timestamp from it would be no more accurate than leaving it nil (see
+		// evm_downloader_legacy.go). The RPC must never be called for this path.
+		l2GERSync := newSyncerWithGER(t)
+		l2GERSync.syncMode = Legacy
+		l2GERSync.l2Client = aggkittypesmocks.NewBaseEthereumClienter(t) // no expectations set: any call fails the test
+
+		ger, err := l2GERSync.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+		require.NoError(t, err)
+		require.Nil(t, ger.Timestamp)
+	})
 }

--- a/l2gersync/migrations/l2gersync0006.sql
+++ b/l2gersync/migrations/l2gersync0006.sql
@@ -1,0 +1,7 @@
+-- +migrate Down
+ALTER TABLE imported_global_exit_root_v2
+DROP COLUMN block_timestamp;
+
+-- +migrate Up
+ALTER TABLE imported_global_exit_root_v2
+ADD COLUMN block_timestamp INTEGER;

--- a/l2gersync/migrations/migrations.go
+++ b/l2gersync/migrations/migrations.go
@@ -22,6 +22,9 @@ var mig004 string
 //go:embed l2gersync0005.sql
 var mig005 string
 
+//go:embed l2gersync0006.sql
+var mig006 string
+
 var migrationsL2gersync []types.Migration = []types.Migration{
 	{
 		ID:  "l2gersync0001",
@@ -42,6 +45,10 @@ var migrationsL2gersync []types.Migration = []types.Migration{
 	{
 		ID:  "l2gersync0005",
 		SQL: mig005,
+	},
+	{
+		ID:  "l2gersync0006",
+		SQL: mig006,
 	},
 }
 

--- a/l2gersync/migrations/migrations_test.go
+++ b/l2gersync/migrations/migrations_test.go
@@ -151,6 +151,93 @@ func TestMigration0005(t *testing.T) {
 	require.Equal(t, uint32(2), importedGERV1.L1InfoTreeIndex)
 }
 
+func TestMigration0006(t *testing.T) {
+	migrationsTo5 := migrationsL2gersync[:5] // migration to 'l2gersync0005' (previous to 0006)
+	dbPath := path.Join(t.TempDir(), "l2gersyncTest0006.sqlite")
+
+	err := RunMigrationsWithList(dbPath, migrationsTo5)
+	require.NoError(t, err)
+	testDB, err := db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tx, err := testDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	// A row written before this migration exists, so it never had a timestamp to begin with
+	_, err = tx.Exec(`
+		INSERT INTO block (num) VALUES (1);
+
+		INSERT INTO imported_global_exit_root_v2 (
+			block_num,
+			block_pos,
+			global_exit_root,
+			l1_info_tree_index
+		) VALUES (1, 0, '0x1', 2);
+	`)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+	testDB.Close()
+
+	// Now execute migration 6
+	migrationsTo6 := migrationsL2gersync[:6]
+	err = RunMigrationsWithList(dbPath, migrationsTo6)
+	require.NoError(t, err)
+	testDB, err = db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+
+	var preExisting struct {
+		BlockNum  uint64  `meddler:"block_num"`
+		Timestamp *uint64 `meddler:"block_timestamp"`
+	}
+	err = meddler.QueryRow(testDB, &preExisting, `SELECT * FROM imported_global_exit_root_v2 WHERE block_num = 1`)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), preExisting.BlockNum)
+	require.Nil(t, preExisting.Timestamp, "pre-existing row must have a NULL timestamp, not fail the migration")
+
+	// A row written after this migration carries its timestamp from the start
+	_, err = testDB.Exec(`
+		INSERT INTO block (num) VALUES (2);
+
+		INSERT INTO imported_global_exit_root_v2 (
+			block_num,
+			block_pos,
+			global_exit_root,
+			l1_info_tree_index,
+			block_timestamp
+		) VALUES (2, 0, '0x2', 3, 1700000000);
+	`)
+	require.NoError(t, err)
+
+	var withTimestamp struct {
+		BlockNum  uint64  `meddler:"block_num"`
+		Timestamp *uint64 `meddler:"block_timestamp"`
+	}
+	err = meddler.QueryRow(testDB, &withTimestamp, `SELECT * FROM imported_global_exit_root_v2 WHERE block_num = 2`)
+	require.NoError(t, err)
+	require.NotNil(t, withTimestamp.Timestamp)
+	require.Equal(t, uint64(1700000000), *withTimestamp.Timestamp)
+	testDB.Close()
+
+	// Now execute migration down to 5: the column must go away without touching the rest of the row
+	err = RunMigrationsDown(dbPath, migrationsTo6, 1)
+	require.NoError(t, err)
+	testDB, err = db.NewSQLiteDB(dbPath)
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	var afterDown struct {
+		BlockNum        uint64 `meddler:"block_num"`
+		GlobalExitRoot  string `meddler:"global_exit_root"`
+		L1InfoTreeIndex uint32 `meddler:"l1_info_tree_index"`
+	}
+	err = meddler.QueryRow(testDB, &afterDown, `SELECT * FROM imported_global_exit_root_v2 WHERE block_num = 1`)
+	require.NoError(t, err)
+	require.Equal(t, "0x1", afterDown.GlobalExitRoot)
+	require.Equal(t, uint32(2), afterDown.L1InfoTreeIndex)
+}
+
 func TestMigrations_UpDown(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 

--- a/l2gersync/processor.go
+++ b/l2gersync/processor.go
@@ -33,7 +33,9 @@ type GlobalExitRootInfo struct {
 	// Timestamp of the L2 block where the GER was injected. Nullable: rows written before this
 	// column existed have it NULL, and GetFirstGERAfterL1InfoTreeIndex backfills it lazily from
 	// the L2 RPC (see L2GERSync.GetFirstGERAfterL1InfoTreeIndex) rather than eagerly migrating
-	// every historical row
+	// every historical row. Always NULL for chains synced in Legacy mode: BlockNum there is the
+	// polling head rather than the real injection block, so no accurate timestamp can be derived
+	// (see evm_downloader_legacy.go).
 	Timestamp *uint64 `meddler:"block_timestamp"`
 	Removed   bool    `meddler:"-"`
 }

--- a/l2gersync/processor.go
+++ b/l2gersync/processor.go
@@ -30,7 +30,12 @@ type GlobalExitRootInfo struct {
 	L1InfoTreeIndex uint32         `meddler:"l1_info_tree_index"`
 	BlockNum        uint64         `meddler:"block_num"`
 	BlockPosition   uint64         `meddler:"block_pos"`
-	Removed         bool           `meddler:"-"`
+	// Timestamp of the L2 block where the GER was injected. Nullable: rows written before this
+	// column existed have it NULL, and GetFirstGERAfterL1InfoTreeIndex backfills it lazily from
+	// the L2 RPC (see L2GERSync.GetFirstGERAfterL1InfoTreeIndex) rather than eagerly migrating
+	// every historical row
+	Timestamp *uint64 `meddler:"block_timestamp"`
+	Removed   bool    `meddler:"-"`
 }
 
 // RemoveGEREvent represents a remove GER event stored in the database
@@ -230,7 +235,7 @@ func (p *processor) GetFirstGERAfterL1InfoTreeIndex(
 	ctx context.Context, l1InfoTreeIndex uint32) (GlobalExitRootInfo, error) {
 	e := GlobalExitRootInfo{}
 	err := meddler.QueryRow(p.database, &e, `
-		SELECT l1_info_tree_index, block_num, global_exit_root, block_pos
+		SELECT l1_info_tree_index, block_num, global_exit_root, block_pos, block_timestamp
 		FROM imported_global_exit_root_v2
 		WHERE l1_info_tree_index >= $1
 		ORDER BY l1_info_tree_index ASC LIMIT 1;
@@ -245,6 +250,21 @@ func (p *processor) GetFirstGERAfterL1InfoTreeIndex(
 	return e, nil
 }
 
+// UpdateTimestamp backfills the timestamp column of an already-inserted injected GER row,
+// identified by its (block_num, block_pos) primary key. Used when a row predates timestamp
+// persistence (nullable column, see l2gersync0006.sql) — see
+// L2GERSync.GetFirstGERAfterL1InfoTreeIndex, which resolves the missing value from the L2 RPC and
+// calls this to persist it so the RPC lookup is not repeated on every future read of that row.
+func (p *processor) UpdateTimestamp(ctx context.Context, blockNum, blockPosition, timestamp uint64) error {
+	_, err := p.database.ExecContext(ctx,
+		`UPDATE imported_global_exit_root_v2 SET block_timestamp = $1 WHERE block_num = $2 AND block_pos = $3;`,
+		timestamp, blockNum, blockPosition)
+	if err != nil {
+		return fmt.Errorf("failed to backfill timestamp for block=%d, pos=%d: %w", blockNum, blockPosition, err)
+	}
+	return nil
+}
+
 // GetInjectedGERsForRange retrieves all injected global exit roots within a specified block range.
 // It returns a map where the keys are the global exit root hashes and the values are the
 // corresponding GlobalExitRootInfo containing the L1 info tree index and block number.
@@ -257,7 +277,7 @@ func (p *processor) GetInjectedGERsForRange(
 	var results []*GlobalExitRootInfo
 
 	err := meddler.QueryAll(p.database, &results, `
-		SELECT global_exit_root, l1_info_tree_index, block_num, block_pos
+		SELECT global_exit_root, l1_info_tree_index, block_num, block_pos, block_timestamp
 		FROM imported_global_exit_root_v2
 		WHERE block_num >= $1 AND block_num <= $2;
 	`, fromBlock, toBlock)

--- a/l2gersync/processor_test.go
+++ b/l2gersync/processor_test.go
@@ -438,3 +438,32 @@ func TestRemoveGEREvents(t *testing.T) {
 		require.Len(t, noEvents, 0)
 	})
 }
+
+func TestProcessor_UpdateTimestamp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testDir := path.Join(t.TempDir(), "l2gersync_TestProcessor_UpdateTimestamp.sqlite")
+	processor, err := newProcessor(testDir)
+	require.NoError(t, err)
+
+	ger := common.HexToHash("0xabc")
+	err = processor.ProcessBlock(ctx, sync.Block{
+		Num:    10,
+		Events: []any{newEvent(newGlobalExitRootInfo(ger, 1, 10, 0), GEREventTypeInsert)},
+	})
+	require.NoError(t, err)
+
+	// no timestamp was persisted at insert time, matching a row written before this column existed
+	info, err := processor.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+	require.NoError(t, err)
+	require.Nil(t, info.Timestamp)
+
+	const backfilledTimestamp = uint64(1700000000)
+	require.NoError(t, processor.UpdateTimestamp(ctx, info.BlockNum, info.BlockPosition, backfilledTimestamp))
+
+	info, err = processor.GetFirstGERAfterL1InfoTreeIndex(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, info.Timestamp)
+	require.Equal(t, backfilledTimestamp, *info.Timestamp)
+}

--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -73,9 +73,9 @@ func New(client aggkittypes.BaseEthereumClienter, cfg Config, network Network) (
 }
 
 // Start starts the reorg detector
-func (rd *ReorgDetector) Start(ctx context.Context) (err error) {
+func (rd *ReorgDetector) Start(ctx context.Context) error {
 	// Load tracked blocks from the DB
-	if err = rd.loadTrackedHeaders(); err != nil {
+	if err := rd.loadTrackedHeaders(); err != nil {
 		return fmt.Errorf("failed to load tracked headers: %w", err)
 	}
 
@@ -88,7 +88,10 @@ func (rd *ReorgDetector) Start(ctx context.Context) (err error) {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				if err = rd.detectReorgInTrackedList(ctx); err != nil {
+				// err is scoped to this iteration: a named return shared with the caller here
+				// would let this goroutine (which keeps running after Start returns) race with
+				// the caller's own final write to it on the "return nil" below.
+				if err := rd.detectReorgInTrackedList(ctx); err != nil {
 					log.Errorf("failed to detect reorg in tracked list: %v", err)
 				}
 			}


### PR DESCRIPTION
## 🔄 Changes Summary
- `injected-l1-info-leaf`'s `block_num`/`timestamp` always described the **L1** event that produced the leaf, even when queried for `network_id=<L2>` — never the block where the GER actually got injected on the destination network, so it couldn't be used to calculate L2-side injection timing (see bug report).
- `InjectedL1InfoLeafHandler` already resolved the L2 injection block (`e.BlockNum`, from `l2gersync`) to find the L1 info tree index, but discarded it before responding. Now surfaced as an optional `injected_l2_block_num` field, set only on the L2 branch.
- `l2gersync` now also persists the L2 block's timestamp (nullable `block_timestamp` column on `imported_global_exit_root_v2`, `l2gersync0006.sql`, added going forward by both downloaders — the value was already on the block header, just not threaded through).
- For rows written before that column existed, `L2GERSync.GetFirstGERAfterL1InfoTreeIndex` backfills it lazily from the L2 RPC (client it already receives in `New`) and persists it via `processor.UpdateTimestamp`, so the RPC call isn't repeated. Best effort: an RPC failure just leaves the timestamp `nil` for that response, resolving on a later request. `bridgeservice` never touches RPC or SQL directly — the backfill stays encapsulated in `l2gersync`.
- Exposed as the optional `injected_l2_block_timestamp` field alongside `injected_l2_block_num`.

## ⚠️ Breaking Changes
- None. Both new response fields are additive and `omitempty`.

## 📋 Config Updates
- None (no TOML changes). New nullable DB migration only: `l2gersync/migrations/l2gersync0006.sql`.

## ✅ Testing
- 🤖 **Automatic**: new/updated unit tests in `bridgeservice/bridge_test.go` (L1 vs L2 response shape), `l2gersync/processor_test.go` (`UpdateTimestamp`), `l2gersync/l2_ger_syncer_test.go` (backfill success / RPC failure / no client configured), `l2gersync/migrations/migrations_test.go` (`TestMigration0006` up/down, including a pre-existing `NULL` row). `go test ./l2gersync/... ./bridgeservice/...` and `golangci-lint run` pass.
- 🖱️ **Manual**: hit `GET /bridge/v1/injected-l1-info-leaf?network_id=<L2>&leaf_index=<n>` and confirm `injected_l2_block_num`/`injected_l2_block_timestamp` are present and distinct from `block_num`/`timestamp` (L1 values).

## 🐞 Issues
- Closes #1818

## 🔗 Related PRs
- None

## 📝 Notes
- Swagger docs regenerated (`make generate-swagger-docs`) and `docs/bridgetracker/REFERENCE_API.md` updated to document the new fields and the nullable-column/backfill design.