### PR TITLE
feat(bridgetracker): activity endpoint reports claim status like the tracker (pending/readyToClaim/claimed/error)

### DIFF
--- a/bridgetracker/activity.go
+++ b/bridgetracker/activity.go
@@ -244,6 +244,7 @@ func (a *ActivityCache) refresh(
 			a.logger.Warnf("activity: checking claim state of bridge tx=%s (network=%d, deposit=%d): %v",
 				item.Bridge.TxHash, item.NetworkID, item.Bridge.DepositCount, err)
 			entry.ClaimStatus = types.ClaimStatusError
+			entry.TrackerClaimStatus = types.TrackerClaimStatusError
 			entry.Errors = map[string]string{"claim": err.Error()}
 			return entry
 		}
@@ -255,6 +256,7 @@ func (a *ActivityCache) refresh(
 	}
 
 	if entry.ClaimStatus == types.ClaimStatusClaimed {
+		entry.TrackerClaimStatus = types.TrackerClaimStatusClaimed
 		if skipsClaimInfo(filter) {
 			return entry
 		}
@@ -266,6 +268,10 @@ func (a *ActivityCache) refresh(
 		return entry
 	}
 
+	// Unclaimed: conservatively "pending" until proven otherwise, either by the tracker's own
+	// snapshot (includeTracking) or the direct readiness check below
+	entry.TrackerClaimStatus = types.TrackerClaimStatusPending
+
 	if includeTracking {
 		id := domain.TrackingID{NetworkID: item.NetworkID, TxHash: common.HexToHash(string(item.Bridge.TxHash))}
 		tracking, err := a.supervised.Get(id, true)
@@ -273,7 +279,25 @@ func (a *ActivityCache) refresh(
 			a.logger.Warnf("activity: registering bridge tx=%s with the tracker: %v", item.Bridge.TxHash, err)
 		} else {
 			entry.Tracking = tracking
+			entry.TrackerClaimStatus = tracking.ClaimStatus()
+			return entry
 		}
+	}
+
+	// includeTracking was not requested, or registering with the tracker failed: fall back to
+	// asking the bridge-service endpoints directly whether the bridge is already ready to claim
+	// (see ActivityClaimChecker.IsReadyToClaim), without the cost of registering it with the
+	// tracker
+	ready, err := a.claims.IsReadyToClaim(ctx, item)
+	if err != nil {
+		a.logger.Warnf("activity: checking claim readiness of bridge tx=%s (network=%d, deposit=%d): %v",
+			item.Bridge.TxHash, item.NetworkID, item.Bridge.DepositCount, err)
+		if entry.Errors == nil {
+			entry.Errors = make(map[string]string)
+		}
+		entry.Errors["readiness"] = err.Error()
+	} else if ready {
+		entry.TrackerClaimStatus = types.TrackerClaimStatusReadyToClaim
 	}
 	return entry
 }

--- a/bridgetracker/activity.go
+++ b/bridgetracker/activity.go
@@ -147,16 +147,21 @@ func (a *ActivityCache) upsert(
 }
 
 // matchesFilter reports whether entry belongs in a GetActivity result under filter:
-// ActivityFilterAll always matches; the other filters match exactly one ClaimStatus each — see
-// ActivityFilter's doc for what each one means
+// ActivityFilterAll always matches; the other filters match exactly one TrackerClaimStatus each
+// — see ActivityFilter's doc for what each one means. TrackerClaimStatus (rather than the
+// coarser ClaimStatus) is what distinguishes ActivityFilterPending from
+// ActivityFilterReadyToClaim; it mirrors ClaimStatus directly for the claimed/error cases (see
+// domain.ActivityEntry.TrackerClaimStatus)
 func matchesFilter(entry *domain.ActivityEntry, filter types.ActivityFilter) bool {
 	switch filter {
 	case types.ActivityFilterClaimed:
-		return entry.ClaimStatus == types.ClaimStatusClaimed
+		return entry.TrackerClaimStatus == types.TrackerClaimStatusClaimed
 	case types.ActivityFilterPending:
-		return entry.ClaimStatus == types.ClaimStatusUnclaimed
+		return entry.TrackerClaimStatus == types.TrackerClaimStatusPending
+	case types.ActivityFilterReadyToClaim:
+		return entry.TrackerClaimStatus == types.TrackerClaimStatusReadyToClaim
 	case types.ActivityFilterError:
-		return entry.ClaimStatus == types.ClaimStatusError
+		return entry.TrackerClaimStatus == types.TrackerClaimStatusError
 	case types.ActivityFilterAll:
 		return true
 	default:
@@ -167,7 +172,9 @@ func matchesFilter(entry *domain.ActivityEntry, filter types.ActivityFilter) boo
 // skipsClaimInfo reports whether filter excludes a claimed bridge from its result, making the
 // destination bridge service's claim record unnecessary to fetch right now (see refresh)
 func skipsClaimInfo(filter types.ActivityFilter) bool {
-	return filter == types.ActivityFilterPending || filter == types.ActivityFilterError
+	return filter == types.ActivityFilterPending ||
+		filter == types.ActivityFilterReadyToClaim ||
+		filter == types.ActivityFilterError
 }
 
 // addrCache returns (creating if necessary) the per-address cache for fromAddress, stamping its

--- a/bridgetracker/activity_test.go
+++ b/bridgetracker/activity_test.go
@@ -76,7 +76,9 @@ func (f *fakeActivityScanner) BridgesFrom(
 // test can assert exactly how many times each was called (and fail loudly if called more).
 // isClaimedErrs, if non-nil, is consulted alongside isClaimed: a non-nil entry makes that call
 // fail instead of returning the paired isClaimed value. lastIsClaimedNetworkID records the
-// NetworkID of the last ScannedBridge IsClaimed was called with.
+// NetworkID of the last ScannedBridge IsClaimed was called with. readyToClaim/readyToClaimErr
+// configure IsReadyToClaim's own (single, reused) result, defaulting to "not ready, no error"
+// for tests that don't care about it.
 type fakeActivityClaims struct {
 	isClaimed              []bool
 	isClaimedErrs          []error
@@ -84,6 +86,9 @@ type fakeActivityClaims struct {
 	lastIsClaimedNetworkID uint32
 	claimInfo              []*bridgeservicetypes.ClaimResponse
 	claimInfoCalls         int
+	readyToClaim           bool
+	readyToClaimErr        error
+	readyToClaimCalls      int
 }
 
 func (f *fakeActivityClaims) IsClaimed(_ context.Context, bridge *domain.ScannedBridge) (bool, error) {
@@ -102,6 +107,14 @@ func (f *fakeActivityClaims) ClaimInfo(
 	claim := f.claimInfo[f.claimInfoCalls]
 	f.claimInfoCalls++
 	return claim, nil
+}
+
+func (f *fakeActivityClaims) IsReadyToClaim(context.Context, *domain.ScannedBridge) (bool, error) {
+	f.readyToClaimCalls++
+	if f.readyToClaimErr != nil {
+		return false, f.readyToClaimErr
+	}
+	return f.readyToClaim, nil
 }
 
 // newTestActivityCache builds an ActivityCache with a one-hour idle timeout, long enough that
@@ -150,6 +163,97 @@ func TestActivityCache_IncludeTrackingRegistersUnclaimedBridge(t *testing.T) {
 
 	wantID := domain.TrackingID{NetworkID: testScannedNetworkID, TxHash: common.HexToHash(string(bridge.TxHash))}
 	require.Equal(t, wantID, entries[0].Tracking.ID())
+}
+
+// TestActivityCache_TrackerClaimStatusMirrorsClaimState pins how ActivityEntry.TrackerClaimStatus
+// is derived for every combination the wire "Claimed" field can report: TrackerClaimStatusClaimed/
+// Error mirror ClaimStatus directly; while unclaimed, includeTracking=true copies the tracker's
+// own snapshot (a fresh, unresolved snapshot reads TrackerClaimStatusPending, per
+// domain.TrackingData.ClaimStatus), and never falls back to IsReadyToClaim, while
+// includeTracking=false resolves it directly through IsReadyToClaim instead.
+func TestActivityCache_TrackerClaimStatusMirrorsClaimState(t *testing.T) {
+	claim := &bridgeservicetypes.ClaimResponse{TxHash: "0xclaimtx"}
+
+	testCases := []struct {
+		name            string
+		isClaimed       bool
+		isClaimedErr    error
+		includeTracking bool
+		readyToClaim    bool
+		want            types.TrackerClaimStatus
+		wantReadyCalls  int
+	}{
+		{
+			name:      "claimed -> TrackerClaimStatusClaimed",
+			isClaimed: true,
+			want:      types.TrackerClaimStatusClaimed,
+		},
+		{
+			name:         "isClaimed() failure -> TrackerClaimStatusError",
+			isClaimedErr: errors.New("boom"),
+			want:         types.TrackerClaimStatusError,
+		},
+		{
+			name:            "unclaimed, includeTracking=true -> copied from the tracker's own snapshot",
+			isClaimed:       false,
+			includeTracking: true,
+			readyToClaim:    true, // must be ignored: tracking short-circuits IsReadyToClaim
+			want:            types.TrackerClaimStatusPending,
+			wantReadyCalls:  0,
+		},
+		{
+			name:            "unclaimed, includeTracking=false, not yet ready -> TrackerClaimStatusPending",
+			isClaimed:       false,
+			includeTracking: false,
+			readyToClaim:    false,
+			want:            types.TrackerClaimStatusPending,
+			wantReadyCalls:  1,
+		},
+		{
+			name:            "unclaimed, includeTracking=false, ready -> TrackerClaimStatusReadyToClaim",
+			isClaimed:       false,
+			includeTracking: false,
+			readyToClaim:    true,
+			want:            types.TrackerClaimStatusReadyToClaim,
+			wantReadyCalls:  1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := &fakeActivityScanner{bridges: []*domain.ScannedBridge{testScannedBridge(1)}}
+			claims := &fakeActivityClaims{
+				isClaimed:     []bool{tc.isClaimed},
+				isClaimedErrs: []error{tc.isClaimedErr},
+				claimInfo:     []*bridgeservicetypes.ClaimResponse{claim},
+				readyToClaim:  tc.readyToClaim,
+			}
+			cache := newTestActivityCache(scanner, claims)
+
+			entries, _, err := cache.GetActivity(t.Context(), testFromAddress, tc.includeTracking, types.ActivityFilterAll)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			require.Equal(t, tc.want, entries[0].TrackerClaimStatus)
+			require.Equal(t, tc.wantReadyCalls, claims.readyToClaimCalls)
+		})
+	}
+}
+
+// TestActivityCache_ReadyToClaimFailureLeavesPendingAndReportsError verifies a failed
+// IsReadyToClaim check does not fail the whole entry: TrackerClaimStatus conservatively stays
+// TrackerClaimStatusPending, and the failure is reported under Errors["readiness"].
+func TestActivityCache_ReadyToClaimFailureLeavesPendingAndReportsError(t *testing.T) {
+	wantErr := errors.New("l1 info tree index unavailable")
+	scanner := &fakeActivityScanner{bridges: []*domain.ScannedBridge{testScannedBridge(1)}}
+	claims := &fakeActivityClaims{isClaimed: []bool{false}, readyToClaimErr: wantErr}
+
+	cache := newTestActivityCache(scanner, claims)
+
+	entries, _, err := cache.GetActivity(t.Context(), testFromAddress, false, types.ActivityFilterAll)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, types.TrackerClaimStatusPending, entries[0].TrackerClaimStatus)
+	require.Equal(t, wantErr.Error(), entries[0].Errors["readiness"])
 }
 
 // TestActivityCache_ClaimedAndIndexedBridgeIsNeverRechecked verifies a bridge that is claimed

--- a/bridgetracker/activity_test.go
+++ b/bridgetracker/activity_test.go
@@ -78,7 +78,9 @@ func (f *fakeActivityScanner) BridgesFrom(
 // fail instead of returning the paired isClaimed value. lastIsClaimedNetworkID records the
 // NetworkID of the last ScannedBridge IsClaimed was called with. readyToClaim/readyToClaimErr
 // configure IsReadyToClaim's own (single, reused) result, defaulting to "not ready, no error"
-// for tests that don't care about it.
+// for tests that don't care about it; readyToClaims/readyToClaimErrs, if non-nil, are consulted
+// in FIFO order instead — one entry per expected IsReadyToClaim invocation — for tests that need
+// a mix of pending/ready-to-claim bridges in the same call.
 type fakeActivityClaims struct {
 	isClaimed              []bool
 	isClaimedErrs          []error
@@ -88,6 +90,8 @@ type fakeActivityClaims struct {
 	claimInfoCalls         int
 	readyToClaim           bool
 	readyToClaimErr        error
+	readyToClaims          []bool
+	readyToClaimErrs       []error
 	readyToClaimCalls      int
 }
 
@@ -110,7 +114,14 @@ func (f *fakeActivityClaims) ClaimInfo(
 }
 
 func (f *fakeActivityClaims) IsReadyToClaim(context.Context, *domain.ScannedBridge) (bool, error) {
+	i := f.readyToClaimCalls
 	f.readyToClaimCalls++
+	if i < len(f.readyToClaimErrs) && f.readyToClaimErrs[i] != nil {
+		return false, f.readyToClaimErrs[i]
+	}
+	if i < len(f.readyToClaims) {
+		return f.readyToClaims[i], nil
+	}
 	if f.readyToClaimErr != nil {
 		return false, f.readyToClaimErr
 	}
@@ -347,17 +358,20 @@ func TestActivityCache_IsClaimedFailureReportsErrorStatus(t *testing.T) {
 }
 
 // TestActivityCache_FilterPendingExcludesClaimedAndErroredAndSkipsClaimInfo verifies
-// ActivityFilterPending returns only confirmed-unclaimed bridges — excluding both claimed ones
-// and ones whose isClaimed() check errored — and never fetches a claimed bridge's claim record
-// (only IsClaimed is consulted, never ClaimInfo).
+// ActivityFilterPending returns only bridges still unclaimed and not yet ready to claim —
+// excluding claimed, ready-to-claim, and errored ones — and never fetches a claimed bridge's
+// claim record (only IsClaimed is consulted, never ClaimInfo).
 func TestActivityCache_FilterPendingExcludesClaimedAndErroredAndSkipsClaimInfo(t *testing.T) {
 	pendingBridge := testScannedBridge(2)
 	scanner := &fakeActivityScanner{
-		bridges: []*domain.ScannedBridge{testScannedBridge(1), pendingBridge, testScannedBridge(3)},
+		bridges: []*domain.ScannedBridge{
+			testScannedBridge(1), pendingBridge, testScannedBridge(3), testScannedBridge(4),
+		},
 	}
 	claims := &fakeActivityClaims{
-		isClaimed:     []bool{true, false, false}, // no claimInfo entries: ClaimInfo must not be called
-		isClaimedErrs: []error{nil, nil, errors.New("boom")},
+		isClaimed:     []bool{true, false, false, false}, // no claimInfo entries: ClaimInfo must not be called
+		isClaimedErrs: []error{nil, nil, errors.New("boom"), nil},
+		readyToClaims: []bool{false, true}, // pendingBridge (not ready), then testScannedBridge(4) (ready)
 	}
 
 	cache := newTestActivityCache(scanner, claims)
@@ -367,6 +381,35 @@ func TestActivityCache_FilterPendingExcludesClaimedAndErroredAndSkipsClaimInfo(t
 	require.Len(t, entries, 1)
 	require.Equal(t, pendingBridge.Bridge, entries[0].Bridge)
 	require.Equal(t, types.ClaimStatusUnclaimed, entries[0].ClaimStatus)
+	require.Equal(t, types.TrackerClaimStatusPending, entries[0].TrackerClaimStatus)
+	require.Equal(t, 0, claims.claimInfoCalls)
+}
+
+// TestActivityCache_FilterReadyToClaimReturnsOnlyReadyAndSkipsClaimInfo verifies
+// ActivityFilterReadyToClaim returns only bridges still unclaimed and ready to claim — excluding
+// claimed, still-pending, and errored ones — and never fetches a claimed bridge's claim record
+// for this filter either (only IsClaimed is consulted, never ClaimInfo).
+func TestActivityCache_FilterReadyToClaimReturnsOnlyReadyAndSkipsClaimInfo(t *testing.T) {
+	readyBridge := testScannedBridge(3)
+	scanner := &fakeActivityScanner{
+		bridges: []*domain.ScannedBridge{
+			testScannedBridge(1), testScannedBridge(2), readyBridge, testScannedBridge(4),
+		},
+	}
+	claims := &fakeActivityClaims{
+		isClaimed:     []bool{true, false, false, false}, // no claimInfo entries: ClaimInfo must not be called
+		isClaimedErrs: []error{nil, errors.New("boom"), nil, nil},
+		readyToClaims: []bool{true, false}, // readyBridge (ready), then testScannedBridge(4) (not ready)
+	}
+
+	cache := newTestActivityCache(scanner, claims)
+
+	entries, _, err := cache.GetActivity(t.Context(), testFromAddress, false, types.ActivityFilterReadyToClaim)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, readyBridge.Bridge, entries[0].Bridge)
+	require.Equal(t, types.ClaimStatusUnclaimed, entries[0].ClaimStatus)
+	require.Equal(t, types.TrackerClaimStatusReadyToClaim, entries[0].TrackerClaimStatus)
 	require.Equal(t, 0, claims.claimInfoCalls)
 }
 

--- a/bridgetracker/api/activity_command.go
+++ b/bridgetracker/api/activity_command.go
@@ -88,13 +88,13 @@ type ActivityResponse struct {
 // from_address path parameter, and reports each one's claim state. Passing
 // ?includeTracking=true additionally registers every still-unclaimed bridge found with the
 // bridge tracker (same effect as calling GetTxStatus for it) and includes its current tracking
-// snapshot. ?filterBridges=claimed|pending|error restricts the result to only bridges with that
-// claim state (default "all"); a claimed bridge excluded by "pending"/"error" never has its
-// claim record fetched, so switching back to "all"/"claimed" later fetches it then. A network
-// whose bridge service could not be scanned never fails the request: it is skipped and reported
-// in the "warnings" field instead, so Bridges is still whatever every other network reported.
-// 200 OK unless: invalid from_address/filterBridges (ErrorData/400), or the scan itself failed
-// (ErrorData/500)
+// snapshot. ?filterBridges=claimed|pending|readyToClaim|error restricts the result to only
+// bridges with that claim state (default "all"); a claimed bridge excluded by
+// "pending"/"readyToClaim"/"error" never has its claim record fetched, so switching back to
+// "all"/"claimed" later fetches it then. A network whose bridge service could not be scanned
+// never fails the request: it is skipped and reported in the "warnings" field instead, so
+// Bridges is still whatever every other network reported. 200 OK unless: invalid
+// from_address/filterBridges (ErrorData/400), or the scan itself failed (ErrorData/500)
 //
 // @Summary Get bridge activity by sender address
 // @Description Scans every bridge service the tracker knows about for bridges sent by
@@ -104,14 +104,14 @@ type ActivityResponse struct {
 // @Description includeTracking=true additionally registers every still-unclaimed bridge with
 // @Description the bridge tracker and includes its current tracking snapshot. filterBridges
 // @Description restricts the result to bridges with only that claim state (claimed / still
-// @Description pending / errored while checking). A network whose bridge service could not be
-// @Description scanned is skipped and reported in the "warnings" field instead of failing the
-// @Description whole request.
+// @Description pending / ready to claim / errored while checking). A network whose bridge
+// @Description service could not be scanned is skipped and reported in the "warnings" field
+// @Description instead of failing the whole request.
 // @Tags bridge-tracker
 // @Produce json
 // @Param from_address path string true "Address that sent the bridges to look up"
 // @Param includeTracking query bool false "Register still-unclaimed bridges with the tracker"
-// @Param filterBridges query string false "Which bridges to return" Enums(all, claimed, pending, error) default(all)
+// @Param filterBridges query string false "Claim filter" Enums(all, claimed, pending, readyToClaim, error) default(all)
 // @Success 200 {object} ActivityResponse
 // @Failure 400 {object} types.ErrorData "Invalid from_address or filterBridges"
 // @Failure 500 {object} types.ErrorData "Scanning the configured bridge services failed"

--- a/bridgetracker/api/activity_command.go
+++ b/bridgetracker/api/activity_command.go
@@ -32,20 +32,20 @@ type ActivityItem struct {
 	// Bridge.OriginNetwork, which is the origin network of the bridged asset and can differ for
 	// a re-bridged asset (see domain.ScannedBridge)
 	BridgeNetworkID uint32 `json:"bridge_network_id"`
-	// Claimed is a simplified claim-readiness summary, one of "pending", "readyToClaim",
-	// "claimed" or "error" — the same vocabulary as TrackingData.ClaimStatus (see
+	// ClaimStatus is a simplified claim-readiness summary, one of "pending", "readyToClaim",
+	// "claimed" or "error" — the same vocabulary and field name as TrackingData.ClaimStatus (see
 	// domain.TrackingData.ClaimStatus for exactly how it is derived). "error" reports the
 	// destination bridge contract's isClaimed() call itself failing (e.g. no bridge contract
 	// address configured for the destination network) — callers must not read it as "pending".
 	// While unclaimed, "readyToClaim" vs "pending" is resolved from the tracker's own snapshot
 	// when Tracking is present, or directly against the bridge-service endpoints otherwise (see
 	// domain.ActivityClaimChecker.IsReadyToClaim)
-	Claimed string `json:"claimed"`
+	ClaimStatus string `json:"claim_status"`
 	// ClaimNetworkID is the network whose bridge service reported Claim (the bridge's
 	// destination network); only present alongside Claim
 	ClaimNetworkID uint32 `json:"claim_network_id,omitempty"`
 	// Claim is the raw claim record, exactly as returned by the destination network's bridge
-	// service, unmodified, once Claimed is true and the indexer has recorded it
+	// service, unmodified, once ClaimStatus is "claimed" and the indexer has recorded it
 	Claim *bridgeservicetypes.ClaimResponse `json:"claim,omitempty"`
 	// CreationTimestamp is when this bridge was first cached by the activity endpoint (unix
 	// seconds); it never changes after that
@@ -58,7 +58,7 @@ type ActivityItem struct {
 	// request set includeTracking=true and the bridge is still unclaimed
 	Tracking *TrackingData `json:"tracking,omitempty"`
 	// Errors holds the message of whatever check failed the last time this item was refreshed,
-	// keyed by which check it was — currently only "claim", present when Claimed is "error"
+	// keyed by which check it was — currently only "claim", present when ClaimStatus is "error"
 	Errors map[string]string `json:"errors,omitempty"`
 }
 
@@ -148,7 +148,7 @@ func newActivityItems(entries []*domain.ActivityEntry) []ActivityItem {
 		item := ActivityItem{
 			Bridge:               e.Bridge,
 			BridgeNetworkID:      e.BridgeNetworkID,
-			Claimed:              e.TrackerClaimStatus.String(),
+			ClaimStatus:          e.TrackerClaimStatus.String(),
 			Errors:               e.Errors,
 			CreationTimestamp:    uint64(e.CreatedAt.Unix()),
 			LastUpdatedTimestamp: uint64(e.UpdatedAt.Unix()),

--- a/bridgetracker/api/activity_command.go
+++ b/bridgetracker/api/activity_command.go
@@ -32,10 +32,14 @@ type ActivityItem struct {
 	// Bridge.OriginNetwork, which is the origin network of the bridged asset and can differ for
 	// a re-bridged asset (see domain.ScannedBridge)
 	BridgeNetworkID uint32 `json:"bridge_network_id"`
-	// Claimed is the tri-state result of the destination bridge contract's isClaimed() call
-	// the last time it was checked: "false" (confirmed unclaimed), "true" (claimed), or
-	// "error" if the check itself failed (e.g. no bridge contract address configured for the
-	// destination network) — callers must not read "error" as "false"
+	// Claimed is a simplified claim-readiness summary, one of "pending", "readyToClaim",
+	// "claimed" or "error" — the same vocabulary as TrackingData.ClaimStatus (see
+	// domain.TrackingData.ClaimStatus for exactly how it is derived). "error" reports the
+	// destination bridge contract's isClaimed() call itself failing (e.g. no bridge contract
+	// address configured for the destination network) — callers must not read it as "pending".
+	// While unclaimed, "readyToClaim" vs "pending" is resolved from the tracker's own snapshot
+	// when Tracking is present, or directly against the bridge-service endpoints otherwise (see
+	// domain.ActivityClaimChecker.IsReadyToClaim)
 	Claimed string `json:"claimed"`
 	// ClaimNetworkID is the network whose bridge service reported Claim (the bridge's
 	// destination network); only present alongside Claim
@@ -144,7 +148,7 @@ func newActivityItems(entries []*domain.ActivityEntry) []ActivityItem {
 		item := ActivityItem{
 			Bridge:               e.Bridge,
 			BridgeNetworkID:      e.BridgeNetworkID,
-			Claimed:              e.ClaimStatus.String(),
+			Claimed:              e.TrackerClaimStatus.String(),
 			Errors:               e.Errors,
 			CreationTimestamp:    uint64(e.CreatedAt.Unix()),
 			LastUpdatedTimestamp: uint64(e.UpdatedAt.Unix()),

--- a/bridgetracker/api/api.go
+++ b/bridgetracker/api/api.go
@@ -43,7 +43,7 @@ const (
 	includeTrackingQueryParam = "includeTracking"
 
 	// filterBridgesQueryParam selects which bridges the activity endpoint returns: "all"
-	// (default), "claimed" or "pending" (see types.ActivityFilter)
+	// (default), "claimed", "pending", "readyToClaim" or "error" (see types.ActivityFilter)
 	filterBridgesQueryParam = "filterBridges"
 
 	decimalBase   = 10

--- a/bridgetracker/api/docs/docs.go
+++ b/bridgetracker/api/docs/docs.go
@@ -287,7 +287,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "claimed": {
-                    "description": "Claimed is the tri-state result of the destination bridge contract's isClaimed() call\nthe last time it was checked: \"false\" (confirmed unclaimed), \"true\" (claimed), or\n\"error\" if the check itself failed (e.g. no bridge contract address configured for the\ndestination network) — callers must not read \"error\" as \"false\"",
+                    "description": "Claimed is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
                     "type": "string"
                 },
                 "creation_timestamp": {
@@ -576,11 +576,7 @@ const docTemplate = `{
                         1000000,
                         1000000000,
                         60000000000,
-                        3600000000000,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000
+                        3600000000000
                     ],
                     "x-enum-varnames": [
                         "minDuration",
@@ -614,11 +610,7 @@ const docTemplate = `{
                         "Millisecond",
                         "Second",
                         "Minute",
-                        "Hour",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second"
+                        "Hour"
                     ]
                 }
             }

--- a/bridgetracker/api/docs/docs.go
+++ b/bridgetracker/api/docs/docs.go
@@ -24,7 +24,7 @@ const docTemplate = `{
     "paths": {
         "/activity/from/{from_address}": {
             "get": {
-                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / errored while checking). A network whose bridge service could not be\nscanned is skipped and reported in the \"warnings\" field instead of failing the\nwhole request.",
+                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). A network whose bridge\nservice could not be scanned is skipped and reported in the \"warnings\" field\ninstead of failing the whole request.",
                 "produces": [
                     "application/json"
                 ],
@@ -51,11 +51,12 @@ const docTemplate = `{
                             "all",
                             "claimed",
                             "pending",
+                            "readyToClaim",
                             "error"
                         ],
                         "type": "string",
                         "default": "all",
-                        "description": "Which bridges to return",
+                        "description": "Claim filter",
                         "name": "filterBridges",
                         "in": "query"
                     }
@@ -568,9 +569,25 @@ const docTemplate = `{
                         1000000,
                         1000000000,
                         60000000000,
+                        3600000000000,
+                        -9223372036854775808,
+                        9223372036854775807,
+                        1,
+                        1000,
+                        1000000,
+                        1000000000,
+                        60000000000,
                         3600000000000
                     ],
                     "x-enum-varnames": [
+                        "minDuration",
+                        "maxDuration",
+                        "Nanosecond",
+                        "Microsecond",
+                        "Millisecond",
+                        "Second",
+                        "Minute",
+                        "Hour",
                         "minDuration",
                         "maxDuration",
                         "Nanosecond",

--- a/bridgetracker/api/docs/docs.go
+++ b/bridgetracker/api/docs/docs.go
@@ -275,7 +275,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "claim": {
-                    "description": "Claim is the raw claim record, exactly as returned by the destination network's bridge\nservice, unmodified, once Claimed is true and the indexer has recorded it",
+                    "description": "Claim is the raw claim record, exactly as returned by the destination network's bridge\nservice, unmodified, once ClaimStatus is \"claimed\" and the indexer has recorded it",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.ClaimResponse"
@@ -286,8 +286,8 @@ const docTemplate = `{
                     "description": "ClaimNetworkID is the network whose bridge service reported Claim (the bridge's\ndestination network); only present alongside Claim",
                     "type": "integer"
                 },
-                "claimed": {
-                    "description": "Claimed is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
+                "claim_status": {
+                    "description": "ClaimStatus is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary and field name as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
                     "type": "string"
                 },
                 "creation_timestamp": {
@@ -295,7 +295,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "errors": {
-                    "description": "Errors holds the message of whatever check failed the last time this item was refreshed,\nkeyed by which check it was — currently only \"claim\", present when Claimed is \"error\"",
+                    "description": "Errors holds the message of whatever check failed the last time this item was refreshed,\nkeyed by which check it was — currently only \"claim\", present when ClaimStatus is \"error\"",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -568,25 +568,9 @@ const docTemplate = `{
                         1000000,
                         1000000000,
                         60000000000,
-                        3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000,
-                        60000000000,
                         3600000000000
                     ],
                     "x-enum-varnames": [
-                        "minDuration",
-                        "maxDuration",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second",
-                        "Minute",
-                        "Hour",
                         "minDuration",
                         "maxDuration",
                         "Nanosecond",

--- a/bridgetracker/api/docs/swagger.json
+++ b/bridgetracker/api/docs/swagger.json
@@ -280,7 +280,7 @@
                     "type": "integer"
                 },
                 "claimed": {
-                    "description": "Claimed is the tri-state result of the destination bridge contract's isClaimed() call\nthe last time it was checked: \"false\" (confirmed unclaimed), \"true\" (claimed), or\n\"error\" if the check itself failed (e.g. no bridge contract address configured for the\ndestination network) — callers must not read \"error\" as \"false\"",
+                    "description": "Claimed is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
                     "type": "string"
                 },
                 "creation_timestamp": {
@@ -569,11 +569,7 @@
                         1000000,
                         1000000000,
                         60000000000,
-                        3600000000000,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000
+                        3600000000000
                     ],
                     "x-enum-varnames": [
                         "minDuration",
@@ -607,11 +603,7 @@
                         "Millisecond",
                         "Second",
                         "Minute",
-                        "Hour",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second"
+                        "Hour"
                     ]
                 }
             }

--- a/bridgetracker/api/docs/swagger.json
+++ b/bridgetracker/api/docs/swagger.json
@@ -17,7 +17,7 @@
     "paths": {
         "/activity/from/{from_address}": {
             "get": {
-                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / errored while checking). A network whose bridge service could not be\nscanned is skipped and reported in the \"warnings\" field instead of failing the\nwhole request.",
+                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). A network whose bridge\nservice could not be scanned is skipped and reported in the \"warnings\" field\ninstead of failing the whole request.",
                 "produces": [
                     "application/json"
                 ],
@@ -44,11 +44,12 @@
                             "all",
                             "claimed",
                             "pending",
+                            "readyToClaim",
                             "error"
                         ],
                         "type": "string",
                         "default": "all",
-                        "description": "Which bridges to return",
+                        "description": "Claim filter",
                         "name": "filterBridges",
                         "in": "query"
                     }
@@ -561,9 +562,25 @@
                         1000000,
                         1000000000,
                         60000000000,
+                        3600000000000,
+                        -9223372036854775808,
+                        9223372036854775807,
+                        1,
+                        1000,
+                        1000000,
+                        1000000000,
+                        60000000000,
                         3600000000000
                     ],
                     "x-enum-varnames": [
+                        "minDuration",
+                        "maxDuration",
+                        "Nanosecond",
+                        "Microsecond",
+                        "Millisecond",
+                        "Second",
+                        "Minute",
+                        "Hour",
                         "minDuration",
                         "maxDuration",
                         "Nanosecond",

--- a/bridgetracker/api/docs/swagger.json
+++ b/bridgetracker/api/docs/swagger.json
@@ -268,7 +268,7 @@
                     "type": "integer"
                 },
                 "claim": {
-                    "description": "Claim is the raw claim record, exactly as returned by the destination network's bridge\nservice, unmodified, once Claimed is true and the indexer has recorded it",
+                    "description": "Claim is the raw claim record, exactly as returned by the destination network's bridge\nservice, unmodified, once ClaimStatus is \"claimed\" and the indexer has recorded it",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.ClaimResponse"
@@ -279,8 +279,8 @@
                     "description": "ClaimNetworkID is the network whose bridge service reported Claim (the bridge's\ndestination network); only present alongside Claim",
                     "type": "integer"
                 },
-                "claimed": {
-                    "description": "Claimed is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
+                "claim_status": {
+                    "description": "ClaimStatus is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary and field name as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
                     "type": "string"
                 },
                 "creation_timestamp": {
@@ -288,7 +288,7 @@
                     "type": "integer"
                 },
                 "errors": {
-                    "description": "Errors holds the message of whatever check failed the last time this item was refreshed,\nkeyed by which check it was — currently only \"claim\", present when Claimed is \"error\"",
+                    "description": "Errors holds the message of whatever check failed the last time this item was refreshed,\nkeyed by which check it was — currently only \"claim\", present when ClaimStatus is \"error\"",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -561,25 +561,9 @@
                         1000000,
                         1000000000,
                         60000000000,
-                        3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000,
-                        60000000000,
                         3600000000000
                     ],
                     "x-enum-varnames": [
-                        "minDuration",
-                        "maxDuration",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second",
-                        "Minute",
-                        "Hour",
                         "minDuration",
                         "maxDuration",
                         "Nanosecond",

--- a/bridgetracker/api/docs/swagger.yaml
+++ b/bridgetracker/api/docs/swagger.yaml
@@ -289,9 +289,25 @@ definitions:
         - 1000000000
         - 60000000000
         - 3600000000000
+        - -9223372036854775808
+        - 9223372036854775807
+        - 1
+        - 1000
+        - 1000000
+        - 1000000000
+        - 60000000000
+        - 3600000000000
         format: int64
         type: integer
         x-enum-varnames:
+        - minDuration
+        - maxDuration
+        - Nanosecond
+        - Microsecond
+        - Millisecond
+        - Second
+        - Minute
+        - Hour
         - minDuration
         - maxDuration
         - Nanosecond
@@ -587,9 +603,9 @@ paths:
         includeTracking=true additionally registers every still-unclaimed bridge with
         the bridge tracker and includes its current tracking snapshot. filterBridges
         restricts the result to bridges with only that claim state (claimed / still
-        pending / errored while checking). A network whose bridge service could not be
-        scanned is skipped and reported in the "warnings" field instead of failing the
-        whole request.
+        pending / ready to claim / errored while checking). A network whose bridge
+        service could not be scanned is skipped and reported in the "warnings" field
+        instead of failing the whole request.
       parameters:
       - description: Address that sent the bridges to look up
         in: path
@@ -601,11 +617,12 @@ paths:
         name: includeTracking
         type: boolean
       - default: all
-        description: Which bridges to return
+        description: Claim filter
         enum:
         - all
         - claimed
         - pending
+        - readyToClaim
         - error
         in: query
         name: filterBridges

--- a/bridgetracker/api/docs/swagger.yaml
+++ b/bridgetracker/api/docs/swagger.yaml
@@ -19,16 +19,16 @@ definitions:
         - $ref: '#/definitions/types.ClaimResponse'
         description: |-
           Claim is the raw claim record, exactly as returned by the destination network's bridge
-          service, unmodified, once Claimed is true and the indexer has recorded it
+          service, unmodified, once ClaimStatus is "claimed" and the indexer has recorded it
       claim_network_id:
         description: |-
           ClaimNetworkID is the network whose bridge service reported Claim (the bridge's
           destination network); only present alongside Claim
         type: integer
-      claimed:
+      claim_status:
         description: |-
-          Claimed is a simplified claim-readiness summary, one of "pending", "readyToClaim",
-          "claimed" or "error" — the same vocabulary as TrackingData.ClaimStatus (see
+          ClaimStatus is a simplified claim-readiness summary, one of "pending", "readyToClaim",
+          "claimed" or "error" — the same vocabulary and field name as TrackingData.ClaimStatus (see
           domain.TrackingData.ClaimStatus for exactly how it is derived). "error" reports the
           destination bridge contract's isClaimed() call itself failing (e.g. no bridge contract
           address configured for the destination network) — callers must not read it as "pending".
@@ -46,7 +46,7 @@ definitions:
           type: string
         description: |-
           Errors holds the message of whatever check failed the last time this item was refreshed,
-          keyed by which check it was — currently only "claim", present when Claimed is "error"
+          keyed by which check it was — currently only "claim", present when ClaimStatus is "error"
         type: object
       last_updated_timestamp:
         description: |-
@@ -289,25 +289,9 @@ definitions:
         - 1000000000
         - 60000000000
         - 3600000000000
-        - -9223372036854775808
-        - 9223372036854775807
-        - 1
-        - 1000
-        - 1000000
-        - 1000000000
-        - 60000000000
-        - 3600000000000
         format: int64
         type: integer
         x-enum-varnames:
-        - minDuration
-        - maxDuration
-        - Nanosecond
-        - Microsecond
-        - Millisecond
-        - Second
-        - Minute
-        - Hour
         - minDuration
         - maxDuration
         - Nanosecond

--- a/bridgetracker/api/docs/swagger.yaml
+++ b/bridgetracker/api/docs/swagger.yaml
@@ -27,10 +27,14 @@ definitions:
         type: integer
       claimed:
         description: |-
-          Claimed is the tri-state result of the destination bridge contract's isClaimed() call
-          the last time it was checked: "false" (confirmed unclaimed), "true" (claimed), or
-          "error" if the check itself failed (e.g. no bridge contract address configured for the
-          destination network) — callers must not read "error" as "false"
+          Claimed is a simplified claim-readiness summary, one of "pending", "readyToClaim",
+          "claimed" or "error" — the same vocabulary as TrackingData.ClaimStatus (see
+          domain.TrackingData.ClaimStatus for exactly how it is derived). "error" reports the
+          destination bridge contract's isClaimed() call itself failing (e.g. no bridge contract
+          address configured for the destination network) — callers must not read it as "pending".
+          While unclaimed, "readyToClaim" vs "pending" is resolved from the tracker's own snapshot
+          when Tracking is present, or directly against the bridge-service endpoints otherwise (see
+          domain.ActivityClaimChecker.IsReadyToClaim)
         type: string
       creation_timestamp:
         description: |-
@@ -293,10 +297,6 @@ definitions:
         - 1000000000
         - 60000000000
         - 3600000000000
-        - 1
-        - 1000
-        - 1000000
-        - 1000000000
         format: int64
         type: integer
         x-enum-varnames:
@@ -332,10 +332,6 @@ definitions:
         - Second
         - Minute
         - Hour
-        - Nanosecond
-        - Microsecond
-        - Millisecond
-        - Second
     type: object
   types.BridgeResponse:
     description: Detailed information about a bridge event

--- a/bridgetracker/bridgetracker_test.go
+++ b/bridgetracker/bridgetracker_test.go
@@ -388,7 +388,7 @@ func TestActivityHandlerHappyPath(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
 	require.Equal(t, testFromAddress, body.FromAddress)
 	require.Len(t, body.Bridges, 1)
-	require.Equal(t, "claimed", body.Bridges[0].Claimed)
+	require.Equal(t, "claimed", body.Bridges[0].ClaimStatus)
 	require.Equal(t, testScannedNetworkID, body.Bridges[0].BridgeNetworkID)
 	require.Equal(t, claim.TxHash, body.Bridges[0].Claim.TxHash)
 	require.Equal(t, bridge.DestinationNetwork, body.Bridges[0].ClaimNetworkID)
@@ -454,7 +454,7 @@ func TestActivityHandlerIsClaimedFailureReportsErrorStatusAndMessage(t *testing.
 	var body api.ActivityResponse
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
 	require.Len(t, body.Bridges, 1)
-	require.Equal(t, "error", body.Bridges[0].Claimed)
+	require.Equal(t, "error", body.Bridges[0].ClaimStatus)
 	require.Nil(t, body.Bridges[0].Claim)
 	require.Equal(t, wantErrMsg, body.Bridges[0].Errors["claim"])
 }
@@ -505,5 +505,5 @@ func TestActivityHandlerFilterBridgesPendingExcludesClaimed(t *testing.T) {
 	var body api.ActivityResponse
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
 	require.Len(t, body.Bridges, 1)
-	require.Equal(t, "pending", body.Bridges[0].Claimed)
+	require.Equal(t, "pending", body.Bridges[0].ClaimStatus)
 }

--- a/bridgetracker/bridgetracker_test.go
+++ b/bridgetracker/bridgetracker_test.go
@@ -507,3 +507,38 @@ func TestActivityHandlerFilterBridgesPendingExcludesClaimed(t *testing.T) {
 	require.Len(t, body.Bridges, 1)
 	require.Equal(t, "pending", body.Bridges[0].ClaimStatus)
 }
+
+// TestActivityHandlerFilterBridgesReadyToClaimExcludesPending verifies
+// ?filterBridges=readyToClaim excludes a still-pending bridge from the response, returning only
+// the one ready to be claimed
+func TestActivityHandlerFilterBridgesReadyToClaimExcludesPending(t *testing.T) {
+	pendingBridge := testBridge(1)
+	readyBridge := testBridge(2)
+
+	gin.SetMode(gin.TestMode)
+	tracker := New(&Config{
+		Logger:     log.WithFields("module", "bridgetracker_test"),
+		ConfigSHA1: testConfigSHA1,
+		ActivityScanner: &fakeActivityScanner{
+			bridges: []*domain.ScannedBridge{
+				scannedBridge(pendingBridge, testScannedNetworkID),
+				scannedBridge(readyBridge, testScannedNetworkID),
+			},
+		},
+		ActivityClaims: &fakeActivityClaims{
+			isClaimed:     []bool{false, false},
+			readyToClaims: []bool{false, true},
+		},
+	})
+	router := gin.New()
+	tracker.API().RegisterRoutes(router)
+
+	resp := performRequest(t, router, http.MethodGet,
+		api.TrackerV1Prefix+"/activity/from/"+testFromAddress.Hex()+"?filterBridges=readyToClaim")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body api.ActivityResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Len(t, body.Bridges, 1)
+	require.Equal(t, "readyToClaim", body.Bridges[0].ClaimStatus)
+}

--- a/bridgetracker/bridgetracker_test.go
+++ b/bridgetracker/bridgetracker_test.go
@@ -388,7 +388,7 @@ func TestActivityHandlerHappyPath(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
 	require.Equal(t, testFromAddress, body.FromAddress)
 	require.Len(t, body.Bridges, 1)
-	require.Equal(t, "true", body.Bridges[0].Claimed)
+	require.Equal(t, "claimed", body.Bridges[0].Claimed)
 	require.Equal(t, testScannedNetworkID, body.Bridges[0].BridgeNetworkID)
 	require.Equal(t, claim.TxHash, body.Bridges[0].Claim.TxHash)
 	require.Equal(t, bridge.DestinationNetwork, body.Bridges[0].ClaimNetworkID)
@@ -505,5 +505,5 @@ func TestActivityHandlerFilterBridgesPendingExcludesClaimed(t *testing.T) {
 	var body api.ActivityResponse
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
 	require.Len(t, body.Bridges, 1)
-	require.Equal(t, "false", body.Bridges[0].Claimed)
+	require.Equal(t, "pending", body.Bridges[0].Claimed)
 }

--- a/bridgetracker/domain/activity.go
+++ b/bridgetracker/domain/activity.go
@@ -45,9 +45,19 @@ type ActivityEntry struct {
 	// Tracking is the bridge tracker's current snapshot of this bridge, only populated while
 	// it is still unclaimed and the caller asked for it (includeTracking); nil otherwise
 	Tracking *TrackingData
+	// TrackerClaimStatus mirrors the bridge tracker's own simplified claim-readiness summary
+	// (see TrackingData.ClaimStatus) so the activity endpoint reports the same vocabulary —
+	// "pending"/"readyToClaim"/"claimed"/"error" — instead of ClaimStatus's plain tri-state.
+	// Derived from ClaimStatus: TrackerClaimStatusClaimed/Error mirror ClaimStatus directly;
+	// while ClaimStatus is Unclaimed, it is copied straight from Tracking.ClaimStatus() when
+	// Tracking is populated, or otherwise resolved directly against the bridge-service
+	// endpoints (see ActivityClaimChecker.IsReadyToClaim) without registering the bridge with
+	// the tracker
+	TrackerClaimStatus types.TrackerClaimStatus
 	// Errors holds the message of whatever check failed the last time this entry was
-	// refreshed, keyed by which check it was — currently only "claim", set when ClaimStatus is
-	// Error (the isClaimed() check itself failed). nil while nothing has failed
+	// refreshed, keyed by which check it was — "claim" when ClaimStatus is Error (the
+	// isClaimed() check itself failed), "readiness" when IsReadyToClaim itself failed (Claimed
+	// then conservatively stays "pending"). nil while nothing has failed
 	Errors map[string]string
 	// CreatedAt is when this bridge was first cached (its first successful refresh); it never
 	// changes after that
@@ -98,6 +108,17 @@ type ActivityClaimChecker interface {
 	// ClaimInfo returns the raw claim record for bridge from its destination network's
 	// bridge service, or nil if the indexer has not recorded it yet
 	ClaimInfo(ctx context.Context, bridge *ScannedBridge) (*bridgeservicetypes.ClaimResponse, error)
+	// IsReadyToClaim reports whether bridge's covering L1 info tree leaf has already been
+	// injected on its destination network: GET /bridge/v1/l1-info-tree-index resolves the leaf
+	// covering bridge's own origin deposit, then GET /bridge/v1/injected-l1-info-leaf checks
+	// whether that leaf (or a later one) has reached the destination — the same pair of
+	// bridge-service endpoints the tracker's own StepWaitingL1InfoLeafAvailable/
+	// StepWaitingGERInjection steps rely on, queried directly instead of through the full
+	// tracker. Only meaningful (and only ever called) once IsClaimed has reported bridge
+	// unclaimed, to tell ActivityEntry.TrackerClaimStatus's "pending" from "readyToClaim"
+	// without registering the bridge with the tracker (see ActivityEntry.Tracking, populated
+	// instead when the caller asked for includeTracking)
+	IsReadyToClaim(ctx context.Context, bridge *ScannedBridge) (bool, error)
 }
 
 // ActivityQuerier is the driven port the GET /activity/from/{from_address} HTTP command

--- a/bridgetracker/mocks/mock_activity_claim_checker.go
+++ b/bridgetracker/mocks/mock_activity_claim_checker.go
@@ -140,6 +140,63 @@ func (_c *ActivityClaimChecker_IsClaimed_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// IsReadyToClaim provides a mock function with given fields: ctx, bridge
+func (_m *ActivityClaimChecker) IsReadyToClaim(ctx context.Context, bridge *domain.ScannedBridge) (bool, error) {
+	ret := _m.Called(ctx, bridge)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsReadyToClaim")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *domain.ScannedBridge) (bool, error)); ok {
+		return rf(ctx, bridge)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *domain.ScannedBridge) bool); ok {
+		r0 = rf(ctx, bridge)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *domain.ScannedBridge) error); ok {
+		r1 = rf(ctx, bridge)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ActivityClaimChecker_IsReadyToClaim_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsReadyToClaim'
+type ActivityClaimChecker_IsReadyToClaim_Call struct {
+	*mock.Call
+}
+
+// IsReadyToClaim is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bridge *domain.ScannedBridge
+func (_e *ActivityClaimChecker_Expecter) IsReadyToClaim(ctx interface{}, bridge interface{}) *ActivityClaimChecker_IsReadyToClaim_Call {
+	return &ActivityClaimChecker_IsReadyToClaim_Call{Call: _e.mock.On("IsReadyToClaim", ctx, bridge)}
+}
+
+func (_c *ActivityClaimChecker_IsReadyToClaim_Call) Run(run func(ctx context.Context, bridge *domain.ScannedBridge)) *ActivityClaimChecker_IsReadyToClaim_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*domain.ScannedBridge))
+	})
+	return _c
+}
+
+func (_c *ActivityClaimChecker_IsReadyToClaim_Call) Return(_a0 bool, _a1 error) *ActivityClaimChecker_IsReadyToClaim_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ActivityClaimChecker_IsReadyToClaim_Call) RunAndReturn(run func(context.Context, *domain.ScannedBridge) (bool, error)) *ActivityClaimChecker_IsReadyToClaim_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewActivityClaimChecker creates a new instance of ActivityClaimChecker. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewActivityClaimChecker(t interface {

--- a/bridgetracker/mocks/mock_ger_source.go
+++ b/bridgetracker/mocks/mock_ger_source.go
@@ -145,6 +145,65 @@ func (_c *GERSource_InjectedGERAtIndex_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// L1InfoTreeIndexForBridge provides a mock function with given fields: ctx, bridge
+func (_m *GERSource) L1InfoTreeIndexForBridge(ctx context.Context, bridge *bridgetracker.BridgeInfo) (*uint32, error) {
+	ret := _m.Called(ctx, bridge)
+
+	if len(ret) == 0 {
+		panic("no return value specified for L1InfoTreeIndexForBridge")
+	}
+
+	var r0 *uint32
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *bridgetracker.BridgeInfo) (*uint32, error)); ok {
+		return rf(ctx, bridge)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *bridgetracker.BridgeInfo) *uint32); ok {
+		r0 = rf(ctx, bridge)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*uint32)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *bridgetracker.BridgeInfo) error); ok {
+		r1 = rf(ctx, bridge)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GERSource_L1InfoTreeIndexForBridge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'L1InfoTreeIndexForBridge'
+type GERSource_L1InfoTreeIndexForBridge_Call struct {
+	*mock.Call
+}
+
+// L1InfoTreeIndexForBridge is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bridge *bridgetracker.BridgeInfo
+func (_e *GERSource_Expecter) L1InfoTreeIndexForBridge(ctx interface{}, bridge interface{}) *GERSource_L1InfoTreeIndexForBridge_Call {
+	return &GERSource_L1InfoTreeIndexForBridge_Call{Call: _e.mock.On("L1InfoTreeIndexForBridge", ctx, bridge)}
+}
+
+func (_c *GERSource_L1InfoTreeIndexForBridge_Call) Run(run func(ctx context.Context, bridge *bridgetracker.BridgeInfo)) *GERSource_L1InfoTreeIndexForBridge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*bridgetracker.BridgeInfo))
+	})
+	return _c
+}
+
+func (_c *GERSource_L1InfoTreeIndexForBridge_Call) Return(_a0 *uint32, _a1 error) *GERSource_L1InfoTreeIndexForBridge_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GERSource_L1InfoTreeIndexForBridge_Call) RunAndReturn(run func(context.Context, *bridgetracker.BridgeInfo) (*uint32, error)) *GERSource_L1InfoTreeIndexForBridge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // L1InfoTreeIndexForGER provides a mock function with given fields: ctx, bridge, ger
 func (_m *GERSource) L1InfoTreeIndexForGER(ctx context.Context, bridge *bridgetracker.BridgeInfo, ger common.Hash) (*uint32, error) {
 	ret := _m.Called(ctx, bridge, ger)

--- a/bridgetracker/sources/activity.go
+++ b/bridgetracker/sources/activity.go
@@ -166,3 +166,36 @@ func (s *ActivitySource) ClaimInfo(
 	}
 	return res.Claims[0], nil
 }
+
+// IsReadyToClaim implements bridgetracker.ActivityClaimChecker: it asks bridge's destination
+// network's own bridge-service instance — which embeds the L1 info tree sync regardless of
+// which network it otherwise serves, the same assumption GERSource.coveringLeafIndex relies on
+// — for the L1 info tree leaf covering bridge's own origin deposit (GET
+// /bridge/v1/l1-info-tree-index), then whether that leaf has already been injected there (GET
+// /bridge/v1/injected-l1-info-leaf). Both must resolve for the bridge to be ready to claim;
+// either one still pending (a 404) reports false, not an error
+func (s *ActivitySource) IsReadyToClaim(ctx context.Context, bridge *domain.ScannedBridge) (bool, error) {
+	svc, err := s.services.aggkitBridgeClientFor(bridge.Bridge.DestinationNetwork)
+	if err != nil {
+		return false, err
+	}
+
+	leafIndex, err := svc.GetL1InfoTreeIndex(ctx, int(bridge.NetworkID), int(bridge.Bridge.DepositCount))
+	if isNotFound(err) {
+		return false, nil // not covered by any L1 info tree leaf yet
+	}
+	if err != nil {
+		return false, fmt.Errorf("fetching l1 info tree index for network %d deposit %d: %w",
+			bridge.NetworkID, bridge.Bridge.DepositCount, err)
+	}
+
+	_, err = svc.GetInjectedL1InfoLeaf(ctx, int(bridge.Bridge.DestinationNetwork), int(leafIndex))
+	if isNotFound(err) {
+		return false, nil // covering leaf not injected on the destination yet
+	}
+	if err != nil {
+		return false, fmt.Errorf("fetching injected l1 info leaf %d on network %d: %w",
+			leafIndex, bridge.Bridge.DestinationNetwork, err)
+	}
+	return true, nil
+}

--- a/bridgetracker/sources/activity.go
+++ b/bridgetracker/sources/activity.go
@@ -167,20 +167,20 @@ func (s *ActivitySource) ClaimInfo(
 	return res.Claims[0], nil
 }
 
-// IsReadyToClaim implements bridgetracker.ActivityClaimChecker: it asks bridge's destination
-// network's own bridge-service instance — which embeds the L1 info tree sync regardless of
-// which network it otherwise serves, the same assumption GERSource.coveringLeafIndex relies on
-// — for the L1 info tree leaf covering bridge's own origin deposit (GET
-// /bridge/v1/l1-info-tree-index), then whether that leaf has already been injected there (GET
-// /bridge/v1/injected-l1-info-leaf). Both must resolve for the bridge to be ready to claim;
+// IsReadyToClaim implements bridgetracker.ActivityClaimChecker: it resolves the L1 info tree
+// leaf covering bridge's own origin deposit (GET /bridge/v1/l1-info-tree-index, queried per
+// bridgeServiceClients.l1InfoTreeIndexClientFor's routing rule — the same one
+// GERSource.L1InfoTreeIndexForBridge uses to build the claim proof), then whether that leaf has
+// already been injected on the destination (GET /bridge/v1/injected-l1-info-leaf, always asked
+// of the destination's own instance). Both must resolve for the bridge to be ready to claim;
 // either one still pending (a 404) reports false, not an error
 func (s *ActivitySource) IsReadyToClaim(ctx context.Context, bridge *domain.ScannedBridge) (bool, error) {
-	svc, err := s.services.aggkitBridgeClientFor(bridge.Bridge.DestinationNetwork)
+	originSvc, err := s.services.l1InfoTreeIndexClientFor(bridge.NetworkID, bridge.Bridge.DestinationNetwork)
 	if err != nil {
 		return false, err
 	}
 
-	leafIndex, err := svc.GetL1InfoTreeIndex(ctx, int(bridge.NetworkID), int(bridge.Bridge.DepositCount))
+	leafIndex, err := originSvc.GetL1InfoTreeIndex(ctx, int(bridge.NetworkID), int(bridge.Bridge.DepositCount))
 	if isNotFound(err) {
 		return false, nil // not covered by any L1 info tree leaf yet
 	}
@@ -189,7 +189,11 @@ func (s *ActivitySource) IsReadyToClaim(ctx context.Context, bridge *domain.Scan
 			bridge.NetworkID, bridge.Bridge.DepositCount, err)
 	}
 
-	_, err = svc.GetInjectedL1InfoLeaf(ctx, int(bridge.Bridge.DestinationNetwork), int(leafIndex))
+	destSvc, err := s.services.aggkitBridgeClientFor(bridge.Bridge.DestinationNetwork)
+	if err != nil {
+		return false, err
+	}
+	_, err = destSvc.GetInjectedL1InfoLeaf(ctx, int(bridge.Bridge.DestinationNetwork), int(leafIndex))
 	if isNotFound(err) {
 		return false, nil // covering leaf not injected on the destination yet
 	}

--- a/bridgetracker/sources/activity_test.go
+++ b/bridgetracker/sources/activity_test.go
@@ -311,6 +311,75 @@ func (s *stubClaimChecker) IsClaimed(_ *bind.CallOpts, leafIndex, sourceBridgeNe
 	return s.claimed, s.err
 }
 
+// listerFromResolver adapts a plain NetworkURLResolver (e.g. fakeBridgeService.start's result,
+// see sources_test.go) into a NetworkLister for tests that only exercise IsReadyToClaim, which
+// never calls NetworkIDs/BridgeAddress
+type listerFromResolver struct {
+	NetworkURLResolver
+}
+
+func (listerFromResolver) NetworkIDs() []uint32 { return nil }
+
+func (listerFromResolver) BridgeAddress(context.Context, uint32) (common.Address, error) {
+	return common.Address{}, nil
+}
+
+// TestActivitySource_IsReadyToClaim verifies IsReadyToClaim resolves the covering L1 info tree
+// leaf (GET /bridge/v1/l1-info-tree-index) and whether it has been injected on the destination
+// (GET /bridge/v1/injected-l1-info-leaf), both queried against the destination network's own
+// bridge-service instance — reporting true only once both resolve, and false (never an error)
+// while either is still pending.
+func TestActivitySource_IsReadyToClaim(t *testing.T) {
+	// bridge is scanned from network 2 (NetworkID, the deposit's own network) with destination
+	// network 1 — fakeBridgeService.start hardcodes its server under key 1, matching the
+	// destination instance IsReadyToClaim must query
+	bridge := &domain.ScannedBridge{Bridge: bridgeResponse(2, 1, 5, testFromAddress, 1), NetworkID: 2}
+
+	t.Run("covering leaf resolved and injected -> ready", func(t *testing.T) {
+		leafIndex := uint32(7)
+		svc := &fakeBridgeService{
+			l1InfoTreeIndex: &leafIndex,
+			injectedLeaf:    map[string]any{"global_exit_root": "0xger"},
+		}
+		lister := listerFromResolver{svc.start(t)}
+		source := NewActivitySource(lister, nil, testLogger)
+
+		ready, err := source.IsReadyToClaim(t.Context(), bridge)
+		require.NoError(t, err)
+		require.True(t, ready)
+		require.Equal(t, "7", svc.lastLeafIndexQuery)
+		require.Equal(t, "1", svc.lastNetworkIDQuery, "queried against the destination network")
+	})
+
+	t.Run("not covered by any L1 info tree leaf yet -> not ready, no error", func(t *testing.T) {
+		svc := &fakeBridgeService{} // l1InfoTreeIndex nil -> not covered yet
+		lister := listerFromResolver{svc.start(t)}
+		source := NewActivitySource(lister, nil, testLogger)
+
+		ready, err := source.IsReadyToClaim(t.Context(), bridge)
+		require.NoError(t, err)
+		require.False(t, ready)
+	})
+
+	t.Run("covered but not injected on the destination yet -> not ready, no error", func(t *testing.T) {
+		leafIndex := uint32(7)
+		svc := &fakeBridgeService{l1InfoTreeIndex: &leafIndex} // injectedLeaf nil -> not injected yet
+		lister := listerFromResolver{svc.start(t)}
+		source := NewActivitySource(lister, nil, testLogger)
+
+		ready, err := source.IsReadyToClaim(t.Context(), bridge)
+		require.NoError(t, err)
+		require.False(t, ready)
+	})
+
+	t.Run("URL resolution failure is a genuine error", func(t *testing.T) {
+		source := NewActivitySource(fakeNetworkLister{}, nil, testLogger)
+
+		_, err := source.IsReadyToClaim(t.Context(), bridge)
+		require.Error(t, err)
+	})
+}
+
 // TestActivitySource_ClaimInfo verifies ClaimInfo fetches the raw claim record by global index,
 // and returns nil (not an error) when the destination bridge service has not indexed it yet.
 func TestActivitySource_ClaimInfo(t *testing.T) {

--- a/bridgetracker/sources/activity_test.go
+++ b/bridgetracker/sources/activity_test.go
@@ -325,35 +325,40 @@ func (listerFromResolver) BridgeAddress(context.Context, uint32) (common.Address
 }
 
 // TestActivitySource_IsReadyToClaim verifies IsReadyToClaim resolves the covering L1 info tree
-// leaf (GET /bridge/v1/l1-info-tree-index) and whether it has been injected on the destination
-// (GET /bridge/v1/injected-l1-info-leaf), both queried against the destination network's own
-// bridge-service instance — reporting true only once both resolve, and false (never an error)
-// while either is still pending.
+// leaf (GET /bridge/v1/l1-info-tree-index) against the origin network's own bridge-service
+// instance — per bridgeServiceClients.l1InfoTreeIndexClientFor's routing rule, the only instance
+// the real l1-info-tree-index endpoint accepts a non-mainnet network_id from — then whether that
+// leaf has been injected on the destination (GET /bridge/v1/injected-l1-info-leaf, always asked
+// of the destination's own instance). Reports true only once both resolve, and false (never an
+// error) while either is still pending. Origin and destination are deliberately different
+// networks with separate fake servers, so a regression back to querying the destination for
+// l1-info-tree-index (#1831 review finding) fails these tests instead of just misbehaving in
+// production against the real endpoint's network_id validation.
 func TestActivitySource_IsReadyToClaim(t *testing.T) {
 	// bridge is scanned from network 2 (NetworkID, the deposit's own network) with destination
-	// network 1 — fakeBridgeService.start hardcodes its server under key 1, matching the
-	// destination instance IsReadyToClaim must query
+	// network 1
 	bridge := &domain.ScannedBridge{Bridge: bridgeResponse(2, 1, 5, testFromAddress, 1), NetworkID: 2}
 
 	t.Run("covering leaf resolved and injected -> ready", func(t *testing.T) {
 		leafIndex := uint32(7)
-		svc := &fakeBridgeService{
-			l1InfoTreeIndex: &leafIndex,
-			injectedLeaf:    map[string]any{"global_exit_root": "0xger"},
-		}
-		lister := listerFromResolver{svc.start(t)}
+		originSvc := &fakeBridgeService{l1InfoTreeIndex: &leafIndex}
+		destSvc := &fakeBridgeService{injectedLeaf: map[string]any{"global_exit_root": "0xger"}}
+		urls := originSvc.startAt(t, 2).merge(destSvc.startAt(t, 1))
+		lister := listerFromResolver{urls}
 		source := NewActivitySource(lister, nil, testLogger)
 
 		ready, err := source.IsReadyToClaim(t.Context(), bridge)
 		require.NoError(t, err)
 		require.True(t, ready)
-		require.Equal(t, "7", svc.lastLeafIndexQuery)
-		require.Equal(t, "1", svc.lastNetworkIDQuery, "queried against the destination network")
+		require.Equal(t, "7", destSvc.lastLeafIndexQuery)
+		require.Equal(t, "1", destSvc.lastNetworkIDQuery, "queried against the destination network")
 	})
 
 	t.Run("not covered by any L1 info tree leaf yet -> not ready, no error", func(t *testing.T) {
-		svc := &fakeBridgeService{} // l1InfoTreeIndex nil -> not covered yet
-		lister := listerFromResolver{svc.start(t)}
+		originSvc := &fakeBridgeService{} // l1InfoTreeIndex nil -> not covered yet
+		destSvc := &fakeBridgeService{}
+		urls := originSvc.startAt(t, 2).merge(destSvc.startAt(t, 1))
+		lister := listerFromResolver{urls}
 		source := NewActivitySource(lister, nil, testLogger)
 
 		ready, err := source.IsReadyToClaim(t.Context(), bridge)
@@ -363,8 +368,10 @@ func TestActivitySource_IsReadyToClaim(t *testing.T) {
 
 	t.Run("covered but not injected on the destination yet -> not ready, no error", func(t *testing.T) {
 		leafIndex := uint32(7)
-		svc := &fakeBridgeService{l1InfoTreeIndex: &leafIndex} // injectedLeaf nil -> not injected yet
-		lister := listerFromResolver{svc.start(t)}
+		originSvc := &fakeBridgeService{l1InfoTreeIndex: &leafIndex}
+		destSvc := &fakeBridgeService{} // injectedLeaf nil -> not injected yet
+		urls := originSvc.startAt(t, 2).merge(destSvc.startAt(t, 1))
+		lister := listerFromResolver{urls}
 		source := NewActivitySource(lister, nil, testLogger)
 
 		ready, err := source.IsReadyToClaim(t.Context(), bridge)
@@ -372,8 +379,22 @@ func TestActivitySource_IsReadyToClaim(t *testing.T) {
 		require.False(t, ready)
 	})
 
-	t.Run("URL resolution failure is a genuine error", func(t *testing.T) {
-		source := NewActivitySource(fakeNetworkLister{}, nil, testLogger)
+	t.Run("origin network unresolvable -> genuine error, destination never queried", func(t *testing.T) {
+		destSvc := &fakeBridgeService{}
+		urls := destSvc.startAt(t, 1) // network 2 (the origin) deliberately absent
+		lister := listerFromResolver{urls}
+		source := NewActivitySource(lister, nil, testLogger)
+
+		_, err := source.IsReadyToClaim(t.Context(), bridge)
+		require.Error(t, err)
+	})
+
+	t.Run("destination network unresolvable -> genuine error", func(t *testing.T) {
+		leafIndex := uint32(7)
+		originSvc := &fakeBridgeService{l1InfoTreeIndex: &leafIndex}
+		urls := originSvc.startAt(t, 2) // network 1 (the destination) deliberately absent
+		lister := listerFromResolver{urls}
+		source := NewActivitySource(lister, nil, testLogger)
 
 		_, err := source.IsReadyToClaim(t.Context(), bridge)
 		require.Error(t, err)

--- a/bridgetracker/sources/ger.go
+++ b/bridgetracker/sources/ger.go
@@ -466,24 +466,14 @@ func (s *GERSource) coveringLeafIndex(
 // index covering bridge's own origin deposit, per GET /bridge/v1/l1-info-tree-index queried
 // against the bridge-service instance that will actually build the claim proof for it — the
 // origin network's own instance (see docs/bridge_service.md's L2->L2 flow: this same endpoint,
-// queried on the origin, is what bridge_getProof is later called against there too). The
-// endpoint only ever accepts network_id == mainnet or network_id == the queried instance's own
-// network (see l1-info-tree-index's own network_id validation), and mainnet has no
-// bridge-service deployment of its own — bridgeservicefinder.GetURL(0) fails unless a network-0
-// URL was explicitly configured (see bridgeservicefinder/doc.go). So when the origin is
-// mainnet, the request is instead sent to the destination's own instance (a real rollup,
-// resolvable), which still answers for network_id=0 since mainnet's own bridgesync is embedded
-// in every instance — exactly what coveringLeafIndex/OriginGER already rely on for that case.
-// Returns nil while the queried instance's own L1 info tree sync has not caught up to this
-// deposit yet
+// queried on the origin, is what bridge_getProof is later called against there too). See
+// bridgeServiceClients.l1InfoTreeIndexClientFor for the routing rule, and coveringLeafIndex/
+// OriginGER for the same mainnet special case. Returns nil while the queried instance's own L1
+// info tree sync has not caught up to this deposit yet
 func (s *GERSource) L1InfoTreeIndexForBridge(
 	ctx context.Context, bridge *bridgetracker.BridgeInfo,
 ) (*uint32, error) {
-	queryNetwork := bridge.NetworkID
-	if queryNetwork == MainnetNetworkID {
-		queryNetwork = bridge.DestinationNetwork
-	}
-	svc, err := s.services.aggkitBridgeClientFor(queryNetwork)
+	svc, err := s.services.l1InfoTreeIndexClientFor(bridge.NetworkID, bridge.DestinationNetwork)
 	if err != nil {
 		return nil, err // transient: URL resolution failure, retried by the engine
 	}

--- a/bridgetracker/sources/sources.go
+++ b/bridgetracker/sources/sources.go
@@ -153,6 +153,25 @@ func (b *bridgeServiceClients) aggkitBridgeClientFor(networkID uint32) (*client.
 	return c, nil
 }
 
+// l1InfoTreeIndexClientFor returns the bridge-service client that must be queried for GET
+// /bridge/v1/l1-info-tree-index for a bridge originated on originNetwork and destined for
+// destinationNetwork (see bridgeservice.L1InfoTreeIndexForBridgeHandler): the endpoint only ever
+// accepts network_id == mainnet or network_id == the queried instance's own network, and mainnet
+// has no bridge-service deployment of its own — bridgeservicefinder.GetURL(0) fails unless a
+// network-0 URL was explicitly configured. So a mainnet-originated bridge (originNetwork ==
+// MainnetNetworkID) is queried on destinationNetwork's own (resolvable) instance instead, which
+// still answers for network_id=0 since every instance embeds mainnet's own bridgesync; any other
+// bridge is queried on its own origin's instance, self-queried with network_id == originNetwork
+func (b *bridgeServiceClients) l1InfoTreeIndexClientFor(
+	originNetwork, destinationNetwork uint32,
+) (*client.Client, error) {
+	queryNetwork := originNetwork
+	if queryNetwork == MainnetNetworkID {
+		queryNetwork = destinationNetwork
+	}
+	return b.aggkitBridgeClientFor(queryNetwork)
+}
+
 // blockTimestamp resolves a block's timestamp off its hash: logs only carry BlockNumber, not
 // the block's own timestamp
 func blockTimestamp(

--- a/bridgetracker/sources/sources_test.go
+++ b/bridgetracker/sources/sources_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -224,7 +225,15 @@ type fakeBridgeService struct {
 	lastGlobalIndexQuery string
 }
 
-func (f *fakeBridgeService) start(t *testing.T) NetworkURLResolver {
+func (f *fakeBridgeService) start(t *testing.T) staticURLs {
+	t.Helper()
+	return f.startAt(t, 1)
+}
+
+// startAt is like start, but serves as networkID instead of the hardcoded 1 — for tests that
+// need two fakeBridgeService instances resolvable under distinct networks (e.g. an origin and a
+// destination queried separately, merged with staticURLs' own union of two maps)
+func (f *fakeBridgeService) startAt(t *testing.T, networkID uint32) staticURLs {
 	t.Helper()
 
 	mux := http.NewServeMux()
@@ -258,7 +267,7 @@ func (f *fakeBridgeService) start(t *testing.T) NetworkURLResolver {
 
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
-	return staticURLs{1: bridgeservicefinder.NetworkURLs{BridgeURL: server.URL}}
+	return staticURLs{networkID: bridgeservicefinder.NetworkURLs{BridgeURL: server.URL}}
 }
 
 // staticURLs is a fixed NetworkURLResolver for tests
@@ -270,6 +279,15 @@ func (s staticURLs) GetURL(networkID uint32) (bridgeservicefinder.NetworkURLs, e
 		return bridgeservicefinder.NetworkURLs{}, bridgeservicefinder.ErrURLNotFound
 	}
 	return urls, nil
+}
+
+// merge returns the union of s and other, for tests combining two fakeBridgeService.startAt
+// results (e.g. an origin and a destination resolvable under distinct networks)
+func (s staticURLs) merge(other staticURLs) staticURLs {
+	merged := make(staticURLs, len(s)+len(other))
+	maps.Copy(merged, s)
+	maps.Copy(merged, other)
+	return merged
 }
 
 // TestFinderClients pins the finder-backed EthClientResolver: overrides win without asking

--- a/bridgetracker/types/activity_filter.go
+++ b/bridgetracker/types/activity_filter.go
@@ -3,11 +3,12 @@ package types
 import "fmt"
 
 // ActivityFilter selects which bridges GetActivity (see domain.ActivityQuerier) returns for a
-// from_address, based on ClaimStatus, and doubles as a hint to skip fetching data the caller
-// does not want: requesting ActivityFilterPending or ActivityFilterError skips the destination
-// bridge service's claim record for a bridge found to be claimed, since it would be filtered
-// out of the result anyway — that bridge's cache entry simply stays unsettled and is fetched
-// normally the next time a filter that needs it is used (see bridgetracker.ActivityCache.refresh)
+// from_address, based on TrackerClaimStatus, and doubles as a hint to skip fetching data the
+// caller does not want: requesting ActivityFilterPending, ActivityFilterReadyToClaim or
+// ActivityFilterError skips the destination bridge service's claim record for a bridge found to
+// be claimed, since it would be filtered out of the result anyway — that bridge's cache entry
+// simply stays unsettled and is fetched normally the next time a filter that needs it is used
+// (see bridgetracker.ActivityCache.refresh)
 type ActivityFilter int
 
 const (
@@ -15,22 +16,28 @@ const (
 	ActivityFilterAll ActivityFilter = iota
 	// ActivityFilterClaimed returns only bridges confirmed claimed
 	ActivityFilterClaimed
-	// ActivityFilterPending returns only bridges confirmed still unclaimed (ClaimStatusUnclaimed)
-	// — a bridge whose claim state could not be checked is not "pending", see ActivityFilterError
+	// ActivityFilterPending returns only bridges still unclaimed and not yet ready to claim
+	// (TrackerClaimStatusPending) — a bridge whose claim state could not be checked is not
+	// "pending", see ActivityFilterError
 	ActivityFilterPending
+	// ActivityFilterReadyToClaim returns only bridges still unclaimed but ready to be claimed
+	// (TrackerClaimStatusReadyToClaim)
+	ActivityFilterReadyToClaim
 	// ActivityFilterError returns only bridges whose isClaimed() check itself failed
-	// (ClaimStatusError): their claim state is unknown, neither claimed nor confirmed pending
+	// (TrackerClaimStatusError): their claim state is unknown, neither claimed nor confirmed
+	// pending
 	ActivityFilterError
 )
 
 var activityFilterNames = map[ActivityFilter]string{
-	ActivityFilterAll:     "all",
-	ActivityFilterClaimed: "claimed",
-	ActivityFilterPending: "pending",
-	ActivityFilterError:   "error",
+	ActivityFilterAll:          "all",
+	ActivityFilterClaimed:      "claimed",
+	ActivityFilterPending:      "pending",
+	ActivityFilterReadyToClaim: "readyToClaim",
+	ActivityFilterError:        "error",
 }
 
-// String representation of the enum: "all", "claimed", "pending" or "error"
+// String representation of the enum: "all", "claimed", "pending", "readyToClaim" or "error"
 func (f ActivityFilter) String() string {
 	if name, ok := activityFilterNames[f]; ok {
 		return name
@@ -49,5 +56,6 @@ func ParseActivityFilter(s string) (ActivityFilter, error) {
 			return f, nil
 		}
 	}
-	return ActivityFilterAll, fmt.Errorf("invalid filterBridges %q: must be one of all, claimed, pending, error", s)
+	return ActivityFilterAll, fmt.Errorf(
+		"invalid filterBridges %q: must be one of all, claimed, pending, readyToClaim, error", s)
 }

--- a/bridgetracker/types/activity_filter_test.go
+++ b/bridgetracker/types/activity_filter_test.go
@@ -10,6 +10,7 @@ func TestActivityFilterString(t *testing.T) {
 	require.Equal(t, "all", ActivityFilterAll.String())
 	require.Equal(t, "claimed", ActivityFilterClaimed.String())
 	require.Equal(t, "pending", ActivityFilterPending.String())
+	require.Equal(t, "readyToClaim", ActivityFilterReadyToClaim.String())
 	require.Equal(t, "error", ActivityFilterError.String())
 	require.Equal(t, "Unknown(99)", ActivityFilter(99).String())
 }
@@ -24,6 +25,7 @@ func TestParseActivityFilter(t *testing.T) {
 		{input: "all", want: ActivityFilterAll},
 		{input: "claimed", want: ActivityFilterClaimed},
 		{input: "pending", want: ActivityFilterPending},
+		{input: "readyToClaim", want: ActivityFilterReadyToClaim},
 		{input: "error", want: ActivityFilterError},
 		{input: "bogus", wantErr: true},
 	}

--- a/bridgetracker/types/health.go
+++ b/bridgetracker/types/health.go
@@ -12,7 +12,14 @@ const HealthStatusOK = "ok"
 // inserted into a bridge's expected path, and the like — so a client can tell which contract
 // shape an instance speaks without diffing full response bodies against its own expectations.
 // Purely informational: the tracker itself never rejects or alters behavior based on it
-const CurrentAPIRevision = 1
+//
+// Revision history:
+//   - 2: GET /activity/from/{from_address}'s ActivityItem.claimed field — a tri-state
+//     "false"/"true"/"error" mirroring the destination bridge contract's isClaimed() call —
+//     was renamed to claim_status and revalued to the same "pending"/"readyToClaim"/
+//     "claimed"/"error" vocabulary as TrackingData.claim_status; ?filterBridges= gained a new
+//     "readyToClaim" value to match
+const CurrentAPIRevision = 2
 
 // HealthResponse is the body of GET /tracker/v1/health
 type HealthResponse struct {

--- a/docs/assets/swagger/bridge_tracker/swagger.json
+++ b/docs/assets/swagger/bridge_tracker/swagger.json
@@ -280,7 +280,7 @@
                     "type": "integer"
                 },
                 "claimed": {
-                    "description": "Claimed is the tri-state result of the destination bridge contract's isClaimed() call\nthe last time it was checked: \"false\" (confirmed unclaimed), \"true\" (claimed), or\n\"error\" if the check itself failed (e.g. no bridge contract address configured for the\ndestination network) — callers must not read \"error\" as \"false\"",
+                    "description": "Claimed is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
                     "type": "string"
                 },
                 "creation_timestamp": {
@@ -569,11 +569,7 @@
                         1000000,
                         1000000000,
                         60000000000,
-                        3600000000000,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000
+                        3600000000000
                     ],
                     "x-enum-varnames": [
                         "minDuration",
@@ -607,11 +603,7 @@
                         "Millisecond",
                         "Second",
                         "Minute",
-                        "Hour",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second"
+                        "Hour"
                     ]
                 }
             }

--- a/docs/assets/swagger/bridge_tracker/swagger.json
+++ b/docs/assets/swagger/bridge_tracker/swagger.json
@@ -17,7 +17,7 @@
     "paths": {
         "/activity/from/{from_address}": {
             "get": {
-                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / errored while checking). A network whose bridge service could not be\nscanned is skipped and reported in the \"warnings\" field instead of failing the\nwhole request.",
+                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). A network whose bridge\nservice could not be scanned is skipped and reported in the \"warnings\" field\ninstead of failing the whole request.",
                 "produces": [
                     "application/json"
                 ],
@@ -44,11 +44,12 @@
                             "all",
                             "claimed",
                             "pending",
+                            "readyToClaim",
                             "error"
                         ],
                         "type": "string",
                         "default": "all",
-                        "description": "Which bridges to return",
+                        "description": "Claim filter",
                         "name": "filterBridges",
                         "in": "query"
                     }
@@ -561,9 +562,25 @@
                         1000000,
                         1000000000,
                         60000000000,
+                        3600000000000,
+                        -9223372036854775808,
+                        9223372036854775807,
+                        1,
+                        1000,
+                        1000000,
+                        1000000000,
+                        60000000000,
                         3600000000000
                     ],
                     "x-enum-varnames": [
+                        "minDuration",
+                        "maxDuration",
+                        "Nanosecond",
+                        "Microsecond",
+                        "Millisecond",
+                        "Second",
+                        "Minute",
+                        "Hour",
                         "minDuration",
                         "maxDuration",
                         "Nanosecond",

--- a/docs/assets/swagger/bridge_tracker/swagger.json
+++ b/docs/assets/swagger/bridge_tracker/swagger.json
@@ -268,7 +268,7 @@
                     "type": "integer"
                 },
                 "claim": {
-                    "description": "Claim is the raw claim record, exactly as returned by the destination network's bridge\nservice, unmodified, once Claimed is true and the indexer has recorded it",
+                    "description": "Claim is the raw claim record, exactly as returned by the destination network's bridge\nservice, unmodified, once ClaimStatus is \"claimed\" and the indexer has recorded it",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.ClaimResponse"
@@ -279,8 +279,8 @@
                     "description": "ClaimNetworkID is the network whose bridge service reported Claim (the bridge's\ndestination network); only present alongside Claim",
                     "type": "integer"
                 },
-                "claimed": {
-                    "description": "Claimed is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
+                "claim_status": {
+                    "description": "ClaimStatus is a simplified claim-readiness summary, one of \"pending\", \"readyToClaim\",\n\"claimed\" or \"error\" — the same vocabulary and field name as TrackingData.ClaimStatus (see\ndomain.TrackingData.ClaimStatus for exactly how it is derived). \"error\" reports the\ndestination bridge contract's isClaimed() call itself failing (e.g. no bridge contract\naddress configured for the destination network) — callers must not read it as \"pending\".\nWhile unclaimed, \"readyToClaim\" vs \"pending\" is resolved from the tracker's own snapshot\nwhen Tracking is present, or directly against the bridge-service endpoints otherwise (see\ndomain.ActivityClaimChecker.IsReadyToClaim)",
                     "type": "string"
                 },
                 "creation_timestamp": {
@@ -288,7 +288,7 @@
                     "type": "integer"
                 },
                 "errors": {
-                    "description": "Errors holds the message of whatever check failed the last time this item was refreshed,\nkeyed by which check it was — currently only \"claim\", present when Claimed is \"error\"",
+                    "description": "Errors holds the message of whatever check failed the last time this item was refreshed,\nkeyed by which check it was — currently only \"claim\", present when ClaimStatus is \"error\"",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -561,25 +561,9 @@
                         1000000,
                         1000000000,
                         60000000000,
-                        3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
-                        1,
-                        1000,
-                        1000000,
-                        1000000000,
-                        60000000000,
                         3600000000000
                     ],
                     "x-enum-varnames": [
-                        "minDuration",
-                        "maxDuration",
-                        "Nanosecond",
-                        "Microsecond",
-                        "Millisecond",
-                        "Second",
-                        "Minute",
-                        "Hour",
                         "minDuration",
                         "maxDuration",
                         "Nanosecond",

--- a/docs/bridgetracker/API.md
+++ b/docs/bridgetracker/API.md
@@ -391,7 +391,7 @@ Example:
 ```json
 {
   "status": "ok",
-  "api_revision": 1,
+  "api_revision": 2,
   "instance_id": "3f1c9a2e-8b4d-4f6a-9c0e-5d7b2a1e4c8f",
   "config_sha1": "2ef7bde608ce5404e97d5f042f95f89f1c232871",
   "version": {
@@ -421,7 +421,7 @@ Request:
 | ------|----------|------|-----------|------|
 | from_address | path | Address | yes | address that sent the bridges to look up |
 | includeTracking | query | bool | no | `true` additionally registers every still-unclaimed bridge in the result with the bridge tracker (same effect as calling the main endpoint for it) and includes its current [TrackingData](#trackingdata) snapshot. Default `false` |
-| filterBridges | query | string | no | one of `"all"` (default), `"claimed"`, `"pending"`, `"error"` — restricts the result to bridges with only that `claimed` state |
+| filterBridges | query | string | no | one of `"all"` (default), `"claimed"`, `"pending"`, `"readyToClaim"`, `"error"` — restricts the result to bridges with only that `claim_status` |
 
 ### Behavior
 
@@ -429,7 +429,7 @@ Request:
 - `400 Bad Request` — invalid `from_address`, or an unrecognized `filterBridges` value: the body is an [ErrorData](#errordata).
 - `500 Internal Server Error` — scanning the configured bridge services failed: the body is an [ErrorData](#errordata).
 - **This endpoint is opt-in**: it only exists if the binary is configured with both an activity bridge scanner and claim checker (`Config.ActivityScanner`/`ActivityClaims`); otherwise the route is not registered at all (plain `404`).
-- Requesting `filterBridges=pending` or `filterBridges=error` **skips fetching the claim record** of a bridge found to be claimed, since it would be filtered out of that result anyway — its cache entry simply has no `claim` yet, and is fetched normally the next time `filterBridges=all`/`claimed` is used for that address.
+- Requesting `filterBridges=pending`, `filterBridges=readyToClaim` or `filterBridges=error` **skips fetching the claim record** of a bridge found to be claimed, since it would be filtered out of that result anyway — its cache entry simply has no `claim` yet, and is fetched normally the next time `filterBridges=all`/`claimed` is used for that address.
 - A network whose bridge service could not be scanned **never fails the request**: it is skipped and reported in `warnings` instead, so `bridges` is still whatever every other network reported (possibly incomplete for the networks listed in `warnings`).
 
 ### ActivityResponse

--- a/docs/bridgetracker/API.md
+++ b/docs/bridgetracker/API.md
@@ -458,13 +458,13 @@ sit alongside them (not nested inside) so the caller knows which bridge service 
 | ------|------|------|
 | bridge | BridgeResponse | raw bridge event, exactly as returned by the bridge service that reported it |
 | bridge_network_id | uint32 | the network whose bridge service returned `bridge` — i.e. the network the bridge-creating tx was actually sent to. **Not** the same as `bridge.origin_network`, which is the origin network of the bridged *asset* and can differ when re-bridging an asset that itself originated on a third network |
-| claimed | string | bare string, tri-state result of the destination bridge contract's `isClaimed()` call the last time it was checked: `"false"` (confirmed unclaimed), `"true"` (claimed), or `"error"` if the check itself failed (e.g. no bridge contract address configured for the destination network) — callers must **not** read `"error"` as `"false"` |
+| claim_status | string | bare string, one of `"pending"`, `"readyToClaim"`, `"claimed"`, `"error"` — the same vocabulary and field name as `claim_status` on [TrackingData](#trackingdata). `"claimed"`/`"error"` are derived straight from the destination bridge contract's `isClaimed()` call the last time it was checked — `"error"` if the check itself failed (e.g. no bridge contract address configured for the destination network), callers must **not** read it as `"pending"`. While unclaimed, `"readyToClaim"` vs `"pending"` is copied from the tracker's own snapshot when `tracking` is present, or resolved directly against `l1-info-tree-index`/`injected-l1-info-leaf` otherwise |
 | claim_network_id | uint32 | network whose bridge service reported `claim` (the bridge's destination network); **omitted** (no key) until `claim` is present |
-| claim | ClaimResponse | raw claim record, exactly as returned by the destination network's bridge service, once `claimed` is `"true"` and the indexer has recorded it; **omitted** (no key) until then |
+| claim | ClaimResponse | raw claim record, exactly as returned by the destination network's bridge service, once `claim_status` is `"claimed"` and the indexer has recorded it; **omitted** (no key) until then |
 | creation_timestamp | uint64 | unix seconds; when this bridge was first cached by this endpoint — never changes after that |
 | last_updated_timestamp | uint64 | unix seconds; when this item's claim/tracking state was last (re)checked, whether or not anything about it actually changed. Stops advancing once the bridge is claimed with its claim record fetched, since it is never rechecked again from that point on |
 | tracking | TrackingData | the bridge tracker's current status for this bridge (see [TrackingData](#trackingdata)); **omitted** (no key) unless the request set `includeTracking=true` and the bridge is still unclaimed |
-| errors | map[string]string | message of whatever check failed the last time this item was refreshed, keyed by which check it was — currently only `"claim"`, present only when `claimed` is `"error"`. **Omitted** (no key) while nothing has failed |
+| errors | map[string]string | message of whatever check failed the last time this item was refreshed, keyed by which check it was — `"claim"` when the `isClaimed()` check itself failed, `"readiness"` when resolving `"readyToClaim"` vs `"pending"` itself failed (`claim_status` then conservatively stays `"pending"`). **Omitted** (no key) while nothing has failed |
 
 ### BridgeResponse
 
@@ -540,7 +540,7 @@ Example (one claimed bridge, one still-pending bridge with `?includeTracking=tru
         "to_address": "0x0000000000000000000000000000000000000030"
       },
       "bridge_network_id": 1,
-      "claimed": "true",
+      "claim_status": "claimed",
       "claim_network_id": 2,
       "claim": {
         "block_num": 1050,
@@ -582,7 +582,7 @@ Example (one claimed bridge, one still-pending bridge with `?includeTracking=tru
         "to_address": "0x0000000000000000000000000000000000000030"
       },
       "bridge_network_id": 1,
-      "claimed": "false",
+      "claim_status": "pending",
       "creation_timestamp": 1700010100,
       "last_updated_timestamp": 1700010100,
       "tracking": {


### PR DESCRIPTION
## 🔄 Changes Summary
- The `GET /activity/from/{from_address}` endpoint's `claimed` field now reports the same vocabulary as the tracker's own `claim_status`: `"pending"`, `"readyToClaim"`, `"claimed"` or `"error"` — instead of the previous plain tri-state (`"false"` / `"true"` / `"error"`).
- `ActivityEntry` gains `TrackerClaimStatus`; `Claimed`/`Error` still come straight from the destination bridge contract's `isClaimed()` call.
- While a bridge is unclaimed:
  - if `includeTracking=true` and the tracker resolves the bridge, the status is copied straight from the tracker's own snapshot (`TrackingData.ClaimStatus()`);
  - otherwise, a new `ActivityClaimChecker.IsReadyToClaim` resolves `pending` vs `readyToClaim` directly against `GET /bridge/v1/l1-info-tree-index` + `GET /bridge/v1/injected-l1-info-leaf`, without registering the bridge with the full tracker.
- A failed readiness check never fails the entry: it conservatively stays `pending` and the failure is reported under `errors.readiness`.
- Regenerated the bridgetracker mocks and swagger docs for the change (also picks up an unrelated pre-existing drift fix: `mock_ger_source.go` was missing `GERSource.L1InfoTreeIndexForBridge`).

## ⚠️ Breaking Changes
- 🔌 **API/CLI**: `GET /activity/from/{from_address}` — `bridges[].claimed` now returns `pending`/`readyToClaim`/`claimed`/`error` instead of `false`/`true`/`error`. Any client string-matching on the old values needs updating.

## 📋 Config Updates
- None.

## ✅ Testing
- 🤖 **Automatic**: `go test ./bridgetracker/...` (unit tests, including new cases in `activity_test.go` and `sources/activity_test.go` covering the pending/readyToClaim/claimed/error derivation and `IsReadyToClaim` against the bridge-service endpoints); `golangci-lint run ./bridgetracker/...`.

## 🐞 Issues
- Closes #1830

## 🔗 Related PRs
- None.

## 📝 Notes
- None.
