### PR TITLE
fix: v0.11.0-rc9 proxy integration: bridgetracker step-error status handling, error-history cap, and bridgeservicefinder ignored-network fix

### DIFF
--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -924,9 +924,7 @@ func (b *BridgeService) InjectedL1InfoLeafHandler(c *gin.Context) {
 			if errors.Is(err, db.ErrNotFound) {
 				b.logger.Debugf("no injected global exit root at or after leaf index=%d yet (not injected)", l1InfoTreeIndex)
 				statusCode = http.StatusNotFound
-				c.JSON(statusCode,
-					gin.H{"error": fmt.Sprintf(
-						"no injected global exit root at or after leaf index %d yet (not injected)", l1InfoTreeIndex)})
+				c.JSON(statusCode, gin.H{"error": b.notInjectedYetError(ctx, l1InfoTreeIndex)})
 				return
 			}
 			b.logger.Errorf("failed to get injected global exit root for leaf index=%d: %v", l1InfoTreeIndex, err)
@@ -1841,6 +1839,30 @@ func (b *BridgeService) respondSyncerError(c *gin.Context, err error, notFoundMs
 	c.JSON(statusCode, gin.H{"error": msg})
 
 	return statusCode
+}
+
+// notInjectedYetError builds the 404 message for InjectedL1InfoLeafHandler when the requested
+// leaf index hasn't been injected on the L2 network yet. It appends how far injection has
+// actually progressed (the last GER that was injected, if any) so callers can tell "not injected
+// yet, but close" from "injection is stuck/far behind" without an extra round trip of their own.
+func (b *BridgeService) notInjectedYetError(ctx context.Context, l1InfoTreeIndex uint32) string {
+	baseMsg := fmt.Sprintf("no injected global exit root at or after leaf index %d yet (not injected)", l1InfoTreeIndex)
+
+	lastGER, err := b.injectedGERs.GetLastGER(ctx)
+	switch {
+	case err == nil:
+		tsSuffix := ""
+		if lastGER.Timestamp != nil {
+			tsSuffix = fmt.Sprintf(", timestamp=%d", *lastGER.Timestamp)
+		}
+		return fmt.Sprintf("%s; last injected leaf index=%d at L2 block %d%s",
+			baseMsg, lastGER.L1InfoTreeIndex, lastGER.BlockNum, tsSuffix)
+	case errors.Is(err, db.ErrNotFound):
+		return fmt.Sprintf("%s; no global exit root has been injected on this network yet", baseMsg)
+	default:
+		b.logger.Warnf("failed to get last injected GER for diagnostic message: %v", err)
+		return baseMsg
+	}
 }
 
 // GetClaimsByGERHandler retrieves all DetailedClaimEvent claims that used the given global exit root.

--- a/bridgeservice/bridge_interfaces.go
+++ b/bridgeservice/bridge_interfaces.go
@@ -54,6 +54,7 @@ type L2GERSyncer interface {
 		ctx context.Context, globalExitRoot *common.Hash, limit uint32,
 	) ([]*l2gersync.RemoveGEREvent, error)
 	GetLastProcessedBlock(ctx context.Context) (uint64, error)
+	GetLastGER(ctx context.Context) (l2gersync.GlobalExitRootInfo, error)
 }
 
 type L1InfoTreeSyncer interface {

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -2613,6 +2613,9 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		bridgeMocks.injectedGERs.EXPECT().
 			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
 			Return(l2gersync.GlobalExitRootInfo{}, db.ErrNotFound)
+		bridgeMocks.injectedGERs.EXPECT().
+			GetLastGER(mock.Anything).
+			Return(l2gersync.GlobalExitRootInfo{}, db.ErrNotFound)
 
 		queryParams := url.Values{}
 		queryParams.Set(networkIDParam, fmt.Sprintf("%d", l2NetworkID))
@@ -2622,6 +2625,56 @@ func TestInjectedL1InfoLeafHandler(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, response.Code)
 		require.Contains(t, response.Body.String(),
 			fmt.Sprintf("no injected global exit root at or after leaf index %d yet (not injected)", l1InfoTreeLeaf.L1InfoTreeIndex))
+		require.Contains(t, response.Body.String(), "no global exit root has been injected on this network yet")
+	})
+
+	t.Run("L2 network - GER not injected yet returns 404, reporting the last injected leaf", func(t *testing.T) {
+		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
+
+		bridgeMocks.injectedGERs.EXPECT().
+			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
+			Return(l2gersync.GlobalExitRootInfo{}, db.ErrNotFound)
+		lastTimestamp := uint64(123456)
+		bridgeMocks.injectedGERs.EXPECT().
+			GetLastGER(mock.Anything).
+			Return(l2gersync.GlobalExitRootInfo{
+				L1InfoTreeIndex: l1InfoTreeLeaf.L1InfoTreeIndex - 1,
+				BlockNum:        42,
+				Timestamp:       &lastTimestamp,
+			}, nil)
+
+		queryParams := url.Values{}
+		queryParams.Set(networkIDParam, fmt.Sprintf("%d", l2NetworkID))
+		queryParams.Set(leafIndexParam, fmt.Sprintf("%d", l1InfoTreeLeaf.L1InfoTreeIndex))
+
+		response := performRequest(t, bridgeMocks.router, fmt.Sprintf("%s/injected-l1-info-leaf?%s", BridgeV1Prefix, queryParams.Encode()))
+		require.Equal(t, http.StatusNotFound, response.Code)
+		require.Contains(t, response.Body.String(),
+			fmt.Sprintf("no injected global exit root at or after leaf index %d yet (not injected)", l1InfoTreeLeaf.L1InfoTreeIndex))
+		require.Contains(t, response.Body.String(),
+			fmt.Sprintf("last injected leaf index=%d at L2 block %d, timestamp=%d",
+				l1InfoTreeLeaf.L1InfoTreeIndex-1, 42, lastTimestamp))
+	})
+
+	t.Run("L2 network - GER not injected yet returns 404, GetLastGER failing falls back to the base message", func(t *testing.T) {
+		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
+
+		bridgeMocks.injectedGERs.EXPECT().
+			GetFirstGERAfterL1InfoTreeIndex(mock.Anything, l1InfoTreeLeaf.L1InfoTreeIndex).
+			Return(l2gersync.GlobalExitRootInfo{}, db.ErrNotFound)
+		bridgeMocks.injectedGERs.EXPECT().
+			GetLastGER(mock.Anything).
+			Return(l2gersync.GlobalExitRootInfo{}, errors.New(barErrMsg))
+
+		queryParams := url.Values{}
+		queryParams.Set(networkIDParam, fmt.Sprintf("%d", l2NetworkID))
+		queryParams.Set(leafIndexParam, fmt.Sprintf("%d", l1InfoTreeLeaf.L1InfoTreeIndex))
+
+		response := performRequest(t, bridgeMocks.router, fmt.Sprintf("%s/injected-l1-info-leaf?%s", BridgeV1Prefix, queryParams.Encode()))
+		require.Equal(t, http.StatusNotFound, response.Code)
+		require.Contains(t, response.Body.String(),
+			fmt.Sprintf("no injected global exit root at or after leaf index %d yet (not injected)", l1InfoTreeLeaf.L1InfoTreeIndex))
+		require.NotContains(t, response.Body.String(), "last injected leaf index")
 	})
 
 	t.Run("L2 network - GetInfoByIndex error", func(t *testing.T) {

--- a/bridgeservice/mocks/mock_l2_ger_syncer.go
+++ b/bridgeservice/mocks/mock_l2_ger_syncer.go
@@ -82,6 +82,62 @@ func (_c *L2GERSyncer_GetFirstGERAfterL1InfoTreeIndex_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetLastGER provides a mock function with given fields: ctx
+func (_m *L2GERSyncer) GetLastGER(ctx context.Context) (l2gersync.GlobalExitRootInfo, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastGER")
+	}
+
+	var r0 l2gersync.GlobalExitRootInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (l2gersync.GlobalExitRootInfo, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) l2gersync.GlobalExitRootInfo); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(l2gersync.GlobalExitRootInfo)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// L2GERSyncer_GetLastGER_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastGER'
+type L2GERSyncer_GetLastGER_Call struct {
+	*mock.Call
+}
+
+// GetLastGER is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *L2GERSyncer_Expecter) GetLastGER(ctx interface{}) *L2GERSyncer_GetLastGER_Call {
+	return &L2GERSyncer_GetLastGER_Call{Call: _e.mock.On("GetLastGER", ctx)}
+}
+
+func (_c *L2GERSyncer_GetLastGER_Call) Run(run func(ctx context.Context)) *L2GERSyncer_GetLastGER_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *L2GERSyncer_GetLastGER_Call) Return(_a0 l2gersync.GlobalExitRootInfo, _a1 error) *L2GERSyncer_GetLastGER_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *L2GERSyncer_GetLastGER_Call) RunAndReturn(run func(context.Context) (l2gersync.GlobalExitRootInfo, error)) *L2GERSyncer_GetLastGER_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLastProcessedBlock provides a mock function with given fields: ctx
 func (_m *L2GERSyncer) GetLastProcessedBlock(ctx context.Context) (uint64, error) {
 	ret := _m.Called(ctx)

--- a/bridgeservicefinder/bridgeservicefinder.go
+++ b/bridgeservicefinder/bridgeservicefinder.go
@@ -226,14 +226,19 @@ func (f *finder) Start(ctx context.Context) error {
 // a cache entry (source-tagged, healthy defaults to false and is set by probeAll). Config-only
 // networks (e.g. network 0 / L1) present in Config.BridgeURLs are also installed, together with
 // their Config.RPCURLs override if any. Networks with no source are skipped. Networks listed in
-// Config.IgnoreNetworkIDs are skipped entirely (no on-chain read at all), though a config override
-// for them, if any, was already installed by the seeding step above.
+// Config.IgnoreNetworkIDs are excluded entirely: no on-chain read is attempted for them and no
+// cache entry is installed even if a config override is present, so GetURL later reports
+// ErrNetworkDisabled for them instead of any information (see GetURL).
 func (f *finder) buildInitialCache(ctx context.Context) error {
 	// Seed config-only entries first (including network 0 / L1) so they are served even if they are
 	// not among the enumerated rollups. Enumeration re-installs an enumerated network's entry with
 	// the same config bridge URL enriched with its JSON-RPC endpoint, so ordering is harmless.
 	for networkID, url := range f.cfg.BridgeURLs {
 		if url == "" {
+			continue
+		}
+
+		if _, ignored := f.ignoreNetworkIDs[networkID]; ignored {
 			continue
 		}
 
@@ -346,12 +351,9 @@ func (f *finder) resolveNetwork(ctx context.Context, rollupID uint32) error {
 }
 
 // probeAll runs a /health probe against every cached entry, updating each entry's healthy flag, and
-// returns the number of entries that were unreachable. A networkID in Config.IgnoreNetworkIDs is
-// skipped even if it has a cache entry (installed by the config-seeding step for a network that is
-// both ignored and config-overridden): probing it would defeat the point of ignoring a known-dead
-// network (the health-check timeout, and a possible ErrServicesUnhealthyOnStart under
-// RequireAllHealthyOnStart, are exactly what IgnoreNetworkIDs is meant to avoid). Its entry is still
-// served by GetURL with healthy defaulting to false (never probed).
+// returns the number of entries that were unreachable. A networkID in Config.IgnoreNetworkIDs never
+// has a cache entry (buildInitialCache excludes it entirely, including from config-seeding), so this
+// ignore check is a defensive no-op kept in case that invariant ever changes.
 func (f *finder) probeAll(ctx context.Context) int {
 	unhealthy := 0
 
@@ -376,10 +378,16 @@ func (f *finder) probeAll(ctx context.Context) int {
 }
 
 // GetURL returns the currently cached URLs (bridge service + JSON-RPC endpoint) for networkID, or
-// ErrURLNotFound if nothing is cached. The JSONRPCURL field may be empty when that source is
-// unavailable (see NetworkURLs). It reads under the cache read lock so it is safe to call
-// concurrently.
+// ErrNetworkDisabled if networkID is listed in Config.IgnoreNetworkIDs, or ErrURLNotFound if
+// nothing is cached. A disabled network is rejected before the cache is even consulted, so no
+// information is ever returned for it — not even a config override (see buildInitialCache). The
+// JSONRPCURL field may be empty when that source is unavailable (see NetworkURLs). It reads under
+// the cache read lock so it is safe to call concurrently.
 func (f *finder) GetURL(networkID uint32) (NetworkURLs, error) {
+	if _, ignored := f.ignoreNetworkIDs[networkID]; ignored {
+		return NetworkURLs{}, fmt.Errorf("%w: network %d", ErrNetworkDisabled, networkID)
+	}
+
 	entry, ok := f.cache.get(networkID)
 	if !ok {
 		return NetworkURLs{}, fmt.Errorf("%w: network %d", ErrURLNotFound, networkID)
@@ -389,9 +397,24 @@ func (f *finder) GetURL(networkID uint32) (NetworkURLs, error) {
 }
 
 // NetworkIDs returns the networkIDs of every network currently resolved (i.e. every network
-// GetURL would presently succeed for).
+// GetURL would presently succeed for). A networkID listed in Config.IgnoreNetworkIDs is filtered
+// out even if it somehow still had a cache entry, since GetURL would reject it anyway.
 func (f *finder) NetworkIDs() []uint32 {
-	return f.cache.networkIDs()
+	ids := f.cache.networkIDs()
+	if len(f.ignoreNetworkIDs) == 0 {
+		return ids
+	}
+
+	filtered := make([]uint32, 0, len(ids))
+	for _, id := range ids {
+		if _, ignored := f.ignoreNetworkIDs[id]; ignored {
+			continue
+		}
+
+		filtered = append(filtered, id)
+	}
+
+	return filtered
 }
 
 // BridgeAddress returns the bridge contract address for networkID, in priority order:

--- a/bridgeservicefinder/config.go
+++ b/bridgeservicefinder/config.go
@@ -86,13 +86,13 @@ type Config struct {
 	// with healthy=false and may be healed by a later on-chain update per the health-gating rule.
 	RequireAllHealthyOnStart bool `mapstructure:"RequireAllHealthyOnStart"`
 
-	// IgnoreNetworkIDs lists networkIDs (rollupIDs) that are entirely excluded from on-chain
-	// resolution: buildInitialCache skips them during enumeration (no RollupIDToRollupData call, no
-	// contract reads, no health probe) and the live listener skips them when a rollup-manager
-	// lifecycle event announces them. This is meant for known "dead" networks (e.g. decommissioned
-	// or unreachable test rollups) whose on-chain reads and health-check timeouts would otherwise
-	// slow down startup and event processing for no benefit. A networkID present in Config.BridgeURLs
-	// is still served from config even if it is also listed here: the ignore only skips on-chain
-	// inspection, never a static override.
+	// IgnoreNetworkIDs lists networkIDs (rollupIDs) that are entirely excluded from resolution:
+	// buildInitialCache skips them during enumeration (no RollupIDToRollupData call, no contract
+	// reads, no health probe) and never installs a cache entry for them even if a Config.BridgeURLs /
+	// Config.RPCURLs override is set, and the live listener skips them when a rollup-manager
+	// lifecycle event announces them. GetURL returns ErrNetworkDisabled for a networkID listed here,
+	// never any cached or config-overridden information. This is meant for known "dead" networks
+	// (e.g. decommissioned or unreachable test rollups) whose on-chain reads and health-check
+	// timeouts would otherwise slow down startup and event processing for no benefit.
 	IgnoreNetworkIDs []uint32 `mapstructure:"IgnoreNetworkIDs"`
 }

--- a/bridgeservicefinder/doc.go
+++ b/bridgeservicefinder/doc.go
@@ -162,22 +162,17 @@
 //
 // # Ignoring known-dead networks (Config.IgnoreNetworkIDs)
 //
-// A networkID listed in Config.IgnoreNetworkIDs is skipped entirely from on-chain resolution: it is
-// excluded from buildInitialCache's enumeration loop (no RollupIDToRollupData call, no contract
-// reader, no health probe) and from the listener's discoverRollup (a CreateNewRollup /
-// CreateNewAggchain / AddExistingRollup event announcing it is a no-op, and its contract address is
-// never added to the watched set). This exists to avoid known-dead networks - decommissioned or
-// permanently unreachable test rollups - from slowing down startup and event processing with RPC
-// calls and health-check timeouts that can never succeed.
-//
-// The ignore list only ever skips on-chain inspection; it never suppresses a static override. A
-// networkID present in both Config.IgnoreNetworkIDs and Config.BridgeURLs is still served from
-// config (the config-seeding step in buildInitialCache runs before, and independently of, the
-// enumeration loop the ignore list affects), but unlike an ordinary config-sourced entry it is also
-// exempted from the Start-time /health probe (see probeAll): probing a known-dead network would
-// defeat the point of ignoring it, incurring the health-check timeout and, under
-// RequireAllHealthyOnStart, possibly failing startup outright. Its cache entry is served with
-// healthy defaulting to false (never probed).
+// A networkID listed in Config.IgnoreNetworkIDs is excluded entirely from resolution: it is skipped
+// by buildInitialCache's config-seeding step (no cache entry is installed even if
+// Config.BridgeURLs / Config.RPCURLs has an override for it) and its enumeration loop (no
+// RollupIDToRollupData call, no contract reader, no health probe), and skipped by the listener's
+// discoverRollup (a CreateNewRollup / CreateNewAggchain / AddExistingRollup event announcing it is a
+// no-op, and its contract address is never added to the watched set). GetURL rejects it up front
+// with ErrNetworkDisabled, before even consulting the cache, and NetworkIDs never lists it. This
+// exists to avoid known-dead networks - decommissioned or permanently unreachable test rollups -
+// from slowing down startup and event processing with RPC calls and health-check timeouts that can
+// never succeed, and to guarantee that disabling a network actually stops it from being served,
+// static override included.
 //
 // # Error handling at Start (fail loudly vs graceful skip)
 //

--- a/bridgeservicefinder/interfaces.go
+++ b/bridgeservicefinder/interfaces.go
@@ -3,6 +3,7 @@ package bridgeservicefinder
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/aggchain-multisig/agglayermanager"
 	aggkittypes "github.com/agglayer/aggkit/types"
@@ -33,6 +34,13 @@ const (
 var (
 	// ErrURLNotFound is returned by GetURL when no bridge service URL is cached for the network.
 	ErrURLNotFound = errors.New("bridge service url not found for network")
+	// ErrNetworkDisabled is returned by GetURL when networkID is listed in Config.IgnoreNetworkIDs.
+	// An ignored network is excluded from resolution entirely: GetURL never returns cached
+	// information for it, even when a config override (BridgeURLs/RPCURLs) is set for that
+	// networkID — the ignore list now takes precedence over a static override, unlike a plain
+	// unresolved network. It wraps ErrURLNotFound so existing callers that classify "not found" as
+	// e.g. an HTTP 404 keep doing so for disabled networks too.
+	ErrNetworkDisabled = fmt.Errorf("%w: network is disabled (listed in IgnoreNetworkIDs)", ErrURLNotFound)
 	// ErrNoSourceAvailable is returned by the resolver when none of the three sources yields a URL.
 	ErrNoSourceAvailable = errors.New("no bridge service url source available for network")
 	// ErrSourceNotAvailable is returned by a RollupContractReader method when the underlying contract
@@ -65,13 +73,15 @@ type Finder interface {
 	// service is unreachable at startup.
 	Start(ctx context.Context) error
 	// GetURL returns the currently cached URLs (bridge service + JSON-RPC) for the given networkID, or
-	// ErrURLNotFound if nothing is cached. networkID follows the mapping documented in doc.go
-	// (networkID == rollupID; network 0 is L1 and is only served if provided via Config.BridgeURLs).
+	// ErrURLNotFound if nothing is cached, or ErrNetworkDisabled if networkID is listed in
+	// Config.IgnoreNetworkIDs (never any cached information for it, even a config override).
+	// networkID follows the mapping documented in doc.go (networkID == rollupID; network 0 is L1 and
+	// is only served if provided via Config.BridgeURLs).
 	GetURL(networkID uint32) (NetworkURLs, error)
 	// NetworkIDs returns the networkIDs of every network currently resolved — i.e. every network
-	// GetURL would presently succeed for. Used by callers that need to enumerate every configured
-	// bridge service rather than query one network at a time (e.g. the bridge tracker's activity
-	// scanner). Order is unspecified.
+	// GetURL would presently succeed for. A networkID listed in Config.IgnoreNetworkIDs is never
+	// included. Used by callers that need to enumerate every configured bridge service rather than
+	// query one network at a time (e.g. the bridge tracker's activity scanner). Order is unspecified.
 	NetworkIDs() []uint32
 	// BridgeAddress returns the bridge contract address for networkID, in priority order:
 	// Config.BridgeAddress[networkID] if set; else Config.BridgeAddress[0] if set (network 0's

--- a/bridgeservicefinder/start_test.go
+++ b/bridgeservicefinder/start_test.go
@@ -471,7 +471,8 @@ func TestStart_AllHealthy_RequireAllHealthyOnStartTrue(t *testing.T) {
 // Config.IgnoreNetworkIDs is skipped entirely during buildInitialCache's enumeration, even though it
 // exposes a perfectly resolvable on-chain source: no cache entry is installed for it, while sibling
 // networks are still resolved normally. It also verifies a config override for the SAME networkID is
-// still served, since the ignore only skips on-chain inspection, never a static override.
+// NOT served: the ignore list takes precedence over a static override, and GetURL rejects it with
+// ErrNetworkDisabled.
 func TestStart_IgnoreNetworkIDs_SkipsEnumeration(t *testing.T) {
 	backend, auth := newTestBackend(t)
 	mgrAddr, rollups := deployRollupManagerWithRollups(t, backend, auth, 3)
@@ -517,12 +518,11 @@ func TestStart_IgnoreNetworkIDs_SkipsEnumeration(t *testing.T) {
 	require.NoError(t, f.Start(ctx))
 
 	_, err = f.GetURL(ignoredNetwork)
-	require.ErrorIs(t, err, ErrURLNotFound, "ignored network must not be resolved despite exposing a valid on-chain source")
+	require.ErrorIs(t, err, ErrNetworkDisabled, "ignored network must not be resolved despite exposing a valid on-chain source")
+	require.ErrorIs(t, err, ErrURLNotFound, "ErrNetworkDisabled must still classify as ErrURLNotFound for existing callers")
 
-	gotConfig, err := f.GetURL(ignoredWithConfig)
-	require.NoError(t, err)
-	require.Equal(t, ignoredConfigURL, gotConfig.BridgeURL, "config override must still be served for an ignored network")
-	require.Empty(t, gotConfig.JSONRPCURL, "on-chain enrichment must not happen for an ignored network")
+	_, err = f.GetURL(ignoredWithConfig)
+	require.ErrorIs(t, err, ErrNetworkDisabled, "a config override must NOT be served for an ignored network")
 
 	gotNormal, err := f.GetURL(normalNetwork)
 	require.NoError(t, err)
@@ -532,6 +532,12 @@ func TestStart_IgnoreNetworkIDs_SkipsEnumeration(t *testing.T) {
 	require.True(t, ok)
 	require.NotContains(t, concrete.addrToNetworkID, rollups[ignoredNetwork-1].addr,
 		"an ignored network's contract must never be registered in the routing table")
+	_, ok = concrete.cache.get(ignoredWithConfig)
+	require.False(t, ok, "an ignored network's config override must never even be seeded into the cache")
+
+	require.NotContains(t, f.NetworkIDs(), ignoredNetwork, "NetworkIDs must never list an ignored network")
+	require.NotContains(t, f.NetworkIDs(), ignoredWithConfig, "NetworkIDs must never list an ignored network")
+	require.Contains(t, f.NetworkIDs(), normalNetwork, "sibling network must still be listed")
 }
 
 // trackingHealthChecker wraps a mapHealthChecker and records every baseURL probed, so a test can
@@ -551,9 +557,9 @@ func (t *trackingHealthChecker) IsHealthy(ctx context.Context, baseURL string) b
 }
 
 // TestStart_IgnoreNetworkIDs_SkipsHealthProbe verifies that a networkID listed in
-// Config.IgnoreNetworkIDs is exempt from probeAll's /health probe even when it has a cache entry
-// installed by a Config.BridgeURLs override (config-seeding runs independently of the enumeration
-// loop the ignore list otherwise affects). It also proves this holds under
+// Config.IgnoreNetworkIDs never even gets a cache entry, despite a Config.BridgeURLs override being
+// set for it (buildInitialCache's config-seeding step excludes ignored networks), and so is
+// naturally exempt from probeAll's /health probe. It also proves this holds under
 // RequireAllHealthyOnStart=true: Start must succeed even though the ignored network's config URL is
 // unreachable, since it is never probed and therefore never counted as unhealthy.
 func TestStart_IgnoreNetworkIDs_SkipsHealthProbe(t *testing.T) {
@@ -591,15 +597,13 @@ func TestStart_IgnoreNetworkIDs_SkipsHealthProbe(t *testing.T) {
 	require.False(t, hc.probed[deadURL], "an ignored network's config-sourced url must never be health-probed")
 	require.True(t, hc.probed[normalURL], "sanity check: a non-ignored config-sourced url is still probed")
 
-	got, err := f.GetURL(ignoredNetwork)
-	require.NoError(t, err)
-	require.Equal(t, deadURL, got.BridgeURL, "the ignored network's config override must still be served")
+	_, err = f.GetURL(ignoredNetwork)
+	require.ErrorIs(t, err, ErrNetworkDisabled, "the ignored network's config override must NOT be served")
 
 	concrete, ok := f.(*finder)
 	require.True(t, ok)
-	entry, ok := concrete.cache.get(ignoredNetwork)
-	require.True(t, ok)
-	require.False(t, entry.healthy, "an unprobed entry must default to healthy=false")
+	_, ok = concrete.cache.get(ignoredNetwork)
+	require.False(t, ok, "an ignored network's config override must never even be seeded into the cache")
 }
 
 // TestStart_NetworkZero covers matrix item #11: network 0 / L1 is never enumerated on-chain; it is

--- a/bridgetracker/activity.go
+++ b/bridgetracker/activity.go
@@ -121,6 +121,17 @@ func (a *ActivityCache) GetActivity(
 	return out, warnings, nil
 }
 
+// FlushActivity implements domain.ActivityQuerier: it discards fromAddress's whole per-address
+// cache, if any — every cached bridge (settled or not) is forgotten, so the next GetActivity
+// call for fromAddress rescans and rechecks everything from scratch, exactly as if it had never
+// been requested before. Safe to call for an address with nothing cached (no-op)
+func (a *ActivityCache) FlushActivity(fromAddress common.Address) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	delete(a.byAddr, fromAddress)
+}
+
 // upsert (re)computes item's entry via refresh and stores it, unless it is already cached and
 // settled — in which case it is left untouched. Safe to call with an item the caller cannot be
 // sure is genuinely new (e.g. a defensive re-check, or a pagination-boundary duplicate): settled

--- a/bridgetracker/activity_test.go
+++ b/bridgetracker/activity_test.go
@@ -290,6 +290,39 @@ func TestActivityCache_ClaimedAndIndexedBridgeIsNeverRechecked(t *testing.T) {
 	require.Equal(t, 2, scanner.calls) // BridgesFrom is still called every time to find new bridges
 }
 
+// TestActivityCache_FlushActivityForcesRecheck verifies that, unlike a plain GetActivity call,
+// FlushActivity discards a settled (claimed + indexed) entry entirely, so the next GetActivity
+// call re-verifies it from scratch instead of reusing it untouched (see settled)
+func TestActivityCache_FlushActivityForcesRecheck(t *testing.T) {
+	claim := &bridgeservicetypes.ClaimResponse{TxHash: "0xclaimtx"}
+	scanner := &fakeActivityScanner{bridges: []*domain.ScannedBridge{testScannedBridge(1)}}
+	// two isClaimed/claimInfo entries: a third consultation would panic on out-of-range, proving
+	// FlushActivity causes exactly one extra recheck, not unbounded rechecks
+	claims := &fakeActivityClaims{
+		isClaimed: []bool{true, true},
+		claimInfo: []*bridgeservicetypes.ClaimResponse{claim, claim},
+	}
+
+	cache := newTestActivityCache(scanner, claims)
+
+	entries, _, err := cache.GetActivity(t.Context(), testFromAddress, false, types.ActivityFilterAll)
+	require.NoError(t, err)
+	require.Equal(t, types.ClaimStatusClaimed, entries[0].ClaimStatus)
+
+	// a plain call would leave the settled entry untouched (see
+	// TestActivityCache_ClaimedAndIndexedBridgeIsNeverRechecked) -- flushing forces a recheck
+	cache.FlushActivity(testFromAddress)
+	entries, _, err = cache.GetActivity(t.Context(), testFromAddress, false, types.ActivityFilterAll)
+	require.NoError(t, err)
+	require.Equal(t, types.ClaimStatusClaimed, entries[0].ClaimStatus)
+	require.Equal(t, claim, entries[0].Claim)
+	require.Equal(t, 2, claims.isClaimedCalls)
+	require.Equal(t, 2, claims.claimInfoCalls)
+
+	// flushing an address with nothing cached is a harmless no-op
+	require.NotPanics(t, func() { cache.FlushActivity(common.HexToAddress("0x02")) })
+}
+
 // TestActivityCache_ClaimedButNotYetIndexedBridgeIsRetried verifies a bridge reported as claimed
 // on-chain, but whose claim record the destination bridge service has not indexed yet (ClaimInfo
 // returns nil), has its claim record retried on the next call — without asking isClaimed() again,

--- a/bridgetracker/api/activity_command.go
+++ b/bridgetracker/api/activity_command.go
@@ -91,10 +91,12 @@ type ActivityResponse struct {
 // snapshot. ?filterBridges=claimed|pending|readyToClaim|error restricts the result to only
 // bridges with that claim state (default "all"); a claimed bridge excluded by
 // "pending"/"readyToClaim"/"error" never has its claim record fetched, so switching back to
-// "all"/"claimed" later fetches it then. A network whose bridge service could not be scanned
-// never fails the request: it is skipped and reported in the "warnings" field instead, so
-// Bridges is still whatever every other network reported. 200 OK unless: invalid
-// from_address/filterBridges (ErrorData/400), or the scan itself failed (ErrorData/500)
+// "all"/"claimed" later fetches it then. ?flush_cache=true discards whatever is already cached
+// for from_address before scanning, forcing every bridge found for it to be freshly rechecked
+// instead of reusing cached state. A network whose bridge service could not be scanned never
+// fails the request: it is skipped and reported in the "warnings" field instead, so Bridges is
+// still whatever every other network reported. 200 OK unless: invalid from_address/filterBridges
+// (ErrorData/400), or the scan itself failed (ErrorData/500)
 //
 // @Summary Get bridge activity by sender address
 // @Description Scans every bridge service the tracker knows about for bridges sent by
@@ -104,14 +106,16 @@ type ActivityResponse struct {
 // @Description includeTracking=true additionally registers every still-unclaimed bridge with
 // @Description the bridge tracker and includes its current tracking snapshot. filterBridges
 // @Description restricts the result to bridges with only that claim state (claimed / still
-// @Description pending / ready to claim / errored while checking). A network whose bridge
-// @Description service could not be scanned is skipped and reported in the "warnings" field
-// @Description instead of failing the whole request.
+// @Description pending / ready to claim / errored while checking). flush_cache=true discards
+// @Description whatever is already cached for from_address first, forcing a fresh recheck. A
+// @Description network whose bridge service could not be scanned is skipped and reported in the
+// @Description "warnings" field instead of failing the whole request.
 // @Tags bridge-tracker
 // @Produce json
 // @Param from_address path string true "Address that sent the bridges to look up"
 // @Param includeTracking query bool false "Register still-unclaimed bridges with the tracker"
 // @Param filterBridges query string false "Claim filter" Enums(all, claimed, pending, readyToClaim, error) default(all)
+// @Param flush_cache query bool false "Discard cached activity for from_address before answering"
 // @Success 200 {object} ActivityResponse
 // @Failure 400 {object} types.ErrorData "Invalid from_address or filterBridges"
 // @Failure 500 {object} types.ErrorData "Scanning the configured bridge services failed"
@@ -122,7 +126,11 @@ func (cmd *activityCommand) Execute(c *gin.Context) (int, any, *types.ErrorData)
 		return 0, nil, &types.ErrorData{Code: http.StatusBadRequest, Message: "invalid from_address parameter"}
 	}
 	fromAddress := common.HexToAddress(addrStr)
-	includeTracking := c.Query(includeTrackingQueryParam) == "true"
+	includeTracking := c.Query(includeTrackingQueryParam) == queryValueTrue
+
+	if c.Query(flushCacheQueryParam) == queryValueTrue {
+		cmd.querier.FlushActivity(fromAddress)
+	}
 
 	filter, err := types.ParseActivityFilter(c.Query(filterBridgesQueryParam))
 	if err != nil {

--- a/bridgetracker/api/api.go
+++ b/bridgetracker/api/api.go
@@ -46,6 +46,18 @@ const (
 	// (default), "claimed", "pending", "readyToClaim" or "error" (see types.ActivityFilter)
 	filterBridgesQueryParam = "filterBridges"
 
+	// flushCacheQueryParam, when set to "true", discards whatever is already cached for this
+	// request's key before answering it — the activity endpoint's per-from_address cache (see
+	// domain.ActivityQuerier.FlushActivity), or the tracker's supervised entry for this
+	// network_id/tx_hash (see domain.SupervisedStore.Forget) — forcing a fresh recheck instead
+	// of reusing cached state. Supported by the tracker's REST endpoint, its WebSocket
+	// endpoint, and the activity endpoint
+	flushCacheQueryParam = "flush_cache"
+
+	// queryValueTrue is the only value that turns on a boolean query flag (includeTracking,
+	// flush_cache): anything else, including its absence, is treated as false
+	queryValueTrue = "true"
+
 	decimalBase   = 10
 	uint32BitSize = 32
 )

--- a/bridgetracker/api/docs/docs.go
+++ b/bridgetracker/api/docs/docs.go
@@ -24,7 +24,7 @@ const docTemplate = `{
     "paths": {
         "/activity/from/{from_address}": {
             "get": {
-                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). A network whose bridge\nservice could not be scanned is skipped and reported in the \"warnings\" field\ninstead of failing the whole request.",
+                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). flush_cache=true discards\nwhatever is already cached for from_address first, forcing a fresh recheck. A\nnetwork whose bridge service could not be scanned is skipped and reported in the\n\"warnings\" field instead of failing the whole request.",
                 "produces": [
                     "application/json"
                 ],
@@ -58,6 +58,12 @@ const docTemplate = `{
                         "default": "all",
                         "description": "Claim filter",
                         "name": "filterBridges",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Discard cached activity for from_address before answering",
+                        "name": "flush_cache",
                         "in": "query"
                     }
                 ],
@@ -177,7 +183,7 @@ const docTemplate = `{
         },
         "/network/{network_id}/tx/{tx_hash}": {
             "get": {
-                "description": "Returns the current step of the bridge and the full path it is expected to\nfollow. Calling this endpoint adds the bridge to the list of supervised\nbridges. The response is always a TrackingData: its bridge_status field is\nnull until the tracker resolves the bridge, so the client keeps polling (or\nsubscribes over the WebSocket) until it is populated",
+                "description": "Returns the current step of the bridge and the full path it is expected to\nfollow. Calling this endpoint adds the bridge to the list of supervised\nbridges. The response is always a TrackingData: its bridge_status field is\nnull until the tracker resolves the bridge, so the client keeps polling (or\nsubscribes over the WebSocket) until it is populated. flush_cache=true discards\nwhatever is already cached for this tx first, forcing it to be re-registered and\nresolved from scratch",
                 "produces": [
                     "application/json"
                 ],
@@ -200,6 +206,12 @@ const docTemplate = `{
                         "name": "tx_hash",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Discard the tracker's cached state for this tx before answering",
+                        "name": "flush_cache",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -226,7 +238,7 @@ const docTemplate = `{
         },
         "/network/{network_id}/tx/{tx_hash}/ws": {
             "get": {
-                "description": "Upgrades the request to a WebSocket connection that receives the bridge\nstatus as it changes, instead of polling the REST endpoint. Connecting adds\nthe bridge to the list of supervised bridges",
+                "description": "Upgrades the request to a WebSocket connection that receives the bridge\nstatus as it changes, instead of polling the REST endpoint. Connecting adds\nthe bridge to the list of supervised bridges. flush_cache=true discards\nwhatever is already cached for this tx first, forcing it to be re-registered and\nresolved from scratch",
                 "tags": [
                     "bridge-tracker"
                 ],
@@ -246,6 +258,12 @@ const docTemplate = `{
                         "name": "tx_hash",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Discard the tracker's cached state for this tx before answering",
+                        "name": "flush_cache",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -562,16 +580,12 @@ const docTemplate = `{
                         1000000000,
                         60000000000,
                         3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
                         1,
                         1000,
                         1000000,
                         1000000000,
                         60000000000,
                         3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
                         1,
                         1000,
                         1000000,
@@ -596,16 +610,12 @@ const docTemplate = `{
                         "Second",
                         "Minute",
                         "Hour",
-                        "minDuration",
-                        "maxDuration",
                         "Nanosecond",
                         "Microsecond",
                         "Millisecond",
                         "Second",
                         "Minute",
                         "Hour",
-                        "minDuration",
-                        "maxDuration",
                         "Nanosecond",
                         "Microsecond",
                         "Millisecond",

--- a/bridgetracker/api/docs/swagger.json
+++ b/bridgetracker/api/docs/swagger.json
@@ -17,7 +17,7 @@
     "paths": {
         "/activity/from/{from_address}": {
             "get": {
-                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). A network whose bridge\nservice could not be scanned is skipped and reported in the \"warnings\" field\ninstead of failing the whole request.",
+                "description": "Scans every bridge service the tracker knows about for bridges sent by\nfrom_address and reports each one's claim state, exactly as the bridge service\nreported it. Results are cached: a bridge already known to be claimed, with its\nclaim record already fetched, is not rechecked on a later call. Passing\nincludeTracking=true additionally registers every still-unclaimed bridge with\nthe bridge tracker and includes its current tracking snapshot. filterBridges\nrestricts the result to bridges with only that claim state (claimed / still\npending / ready to claim / errored while checking). flush_cache=true discards\nwhatever is already cached for from_address first, forcing a fresh recheck. A\nnetwork whose bridge service could not be scanned is skipped and reported in the\n\"warnings\" field instead of failing the whole request.",
                 "produces": [
                     "application/json"
                 ],
@@ -51,6 +51,12 @@
                         "default": "all",
                         "description": "Claim filter",
                         "name": "filterBridges",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Discard cached activity for from_address before answering",
+                        "name": "flush_cache",
                         "in": "query"
                     }
                 ],
@@ -170,7 +176,7 @@
         },
         "/network/{network_id}/tx/{tx_hash}": {
             "get": {
-                "description": "Returns the current step of the bridge and the full path it is expected to\nfollow. Calling this endpoint adds the bridge to the list of supervised\nbridges. The response is always a TrackingData: its bridge_status field is\nnull until the tracker resolves the bridge, so the client keeps polling (or\nsubscribes over the WebSocket) until it is populated",
+                "description": "Returns the current step of the bridge and the full path it is expected to\nfollow. Calling this endpoint adds the bridge to the list of supervised\nbridges. The response is always a TrackingData: its bridge_status field is\nnull until the tracker resolves the bridge, so the client keeps polling (or\nsubscribes over the WebSocket) until it is populated. flush_cache=true discards\nwhatever is already cached for this tx first, forcing it to be re-registered and\nresolved from scratch",
                 "produces": [
                     "application/json"
                 ],
@@ -193,6 +199,12 @@
                         "name": "tx_hash",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Discard the tracker's cached state for this tx before answering",
+                        "name": "flush_cache",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -219,7 +231,7 @@
         },
         "/network/{network_id}/tx/{tx_hash}/ws": {
             "get": {
-                "description": "Upgrades the request to a WebSocket connection that receives the bridge\nstatus as it changes, instead of polling the REST endpoint. Connecting adds\nthe bridge to the list of supervised bridges",
+                "description": "Upgrades the request to a WebSocket connection that receives the bridge\nstatus as it changes, instead of polling the REST endpoint. Connecting adds\nthe bridge to the list of supervised bridges. flush_cache=true discards\nwhatever is already cached for this tx first, forcing it to be re-registered and\nresolved from scratch",
                 "tags": [
                     "bridge-tracker"
                 ],
@@ -239,6 +251,12 @@
                         "name": "tx_hash",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Discard the tracker's cached state for this tx before answering",
+                        "name": "flush_cache",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -555,16 +573,12 @@
                         1000000000,
                         60000000000,
                         3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
                         1,
                         1000,
                         1000000,
                         1000000000,
                         60000000000,
                         3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
                         1,
                         1000,
                         1000000,
@@ -589,16 +603,12 @@
                         "Second",
                         "Minute",
                         "Hour",
-                        "minDuration",
-                        "maxDuration",
                         "Nanosecond",
                         "Microsecond",
                         "Millisecond",
                         "Second",
                         "Minute",
                         "Hour",
-                        "minDuration",
-                        "maxDuration",
                         "Nanosecond",
                         "Microsecond",
                         "Millisecond",

--- a/bridgetracker/api/docs/swagger.yaml
+++ b/bridgetracker/api/docs/swagger.yaml
@@ -281,16 +281,12 @@ definitions:
         - 1000000000
         - 60000000000
         - 3600000000000
-        - -9223372036854775808
-        - 9223372036854775807
         - 1
         - 1000
         - 1000000
         - 1000000000
         - 60000000000
         - 3600000000000
-        - -9223372036854775808
-        - 9223372036854775807
         - 1
         - 1000
         - 1000000
@@ -316,16 +312,12 @@ definitions:
         - Second
         - Minute
         - Hour
-        - minDuration
-        - maxDuration
         - Nanosecond
         - Microsecond
         - Millisecond
         - Second
         - Minute
         - Hour
-        - minDuration
-        - maxDuration
         - Nanosecond
         - Microsecond
         - Millisecond
@@ -603,9 +595,10 @@ paths:
         includeTracking=true additionally registers every still-unclaimed bridge with
         the bridge tracker and includes its current tracking snapshot. filterBridges
         restricts the result to bridges with only that claim state (claimed / still
-        pending / ready to claim / errored while checking). A network whose bridge
-        service could not be scanned is skipped and reported in the "warnings" field
-        instead of failing the whole request.
+        pending / ready to claim / errored while checking). flush_cache=true discards
+        whatever is already cached for from_address first, forcing a fresh recheck. A
+        network whose bridge service could not be scanned is skipped and reported in the
+        "warnings" field instead of failing the whole request.
       parameters:
       - description: Address that sent the bridges to look up
         in: path
@@ -627,6 +620,10 @@ paths:
         in: query
         name: filterBridges
         type: string
+      - description: Discard cached activity for from_address before answering
+        in: query
+        name: flush_cache
+        type: boolean
       produces:
       - application/json
       responses:
@@ -721,7 +718,9 @@ paths:
         follow. Calling this endpoint adds the bridge to the list of supervised
         bridges. The response is always a TrackingData: its bridge_status field is
         null until the tracker resolves the bridge, so the client keeps polling (or
-        subscribes over the WebSocket) until it is populated
+        subscribes over the WebSocket) until it is populated. flush_cache=true discards
+        whatever is already cached for this tx first, forcing it to be re-registered and
+        resolved from scratch
       parameters:
       - description: Network where the bridge transaction was sent (0 -> Mainnet)
         format: int32
@@ -735,6 +734,10 @@ paths:
         name: tx_hash
         required: true
         type: string
+      - description: Discard the tracker's cached state for this tx before answering
+        in: query
+        name: flush_cache
+        type: boolean
       produces:
       - application/json
       responses:
@@ -758,7 +761,9 @@ paths:
       description: |-
         Upgrades the request to a WebSocket connection that receives the bridge
         status as it changes, instead of polling the REST endpoint. Connecting adds
-        the bridge to the list of supervised bridges
+        the bridge to the list of supervised bridges. flush_cache=true discards
+        whatever is already cached for this tx first, forcing it to be re-registered and
+        resolved from scratch
       parameters:
       - description: Network where the bridge transaction was sent (0 -> Mainnet)
         format: int32
@@ -772,6 +777,10 @@ paths:
         name: tx_hash
         required: true
         type: string
+      - description: Discard the tracker's cached state for this tx before answering
+        in: query
+        name: flush_cache
+        type: boolean
       responses:
         "101":
           description: Switching Protocols

--- a/bridgetracker/api/get_tx_status_command.go
+++ b/bridgetracker/api/get_tx_status_command.go
@@ -29,19 +29,24 @@ type getTxStatusCommand struct {
 // first time a tx is registered, it waits up to resolveTimeout for the tracking engine's
 // immediate resolution attempt to land, so this first response has a shot at real progress
 // instead of the bare Registered state; a lookup of an already-registered tx never waits.
-// 200 OK unless: invalid path parameters (ErrorData/400), or the registry is at capacity and
-// this tx is not already registered (ErrorData/503, see domain.ErrRegistryFull)
+// ?flush_cache=true discards whatever the tracker already has for this tx first, so it is
+// registered and resolved from scratch instead of reusing its previous snapshot. 200 OK unless:
+// invalid path parameters (ErrorData/400), or the registry is at capacity and this tx is not
+// already registered (ErrorData/503, see domain.ErrRegistryFull)
 //
 // @Summary Get bridge status by transaction hash
 // @Description Returns the current step of the bridge and the full path it is expected to
 // @Description follow. Calling this endpoint adds the bridge to the list of supervised
 // @Description bridges. The response is always a TrackingData: its bridge_status field is
 // @Description null until the tracker resolves the bridge, so the client keeps polling (or
-// @Description subscribes over the WebSocket) until it is populated
+// @Description subscribes over the WebSocket) until it is populated. flush_cache=true discards
+// @Description whatever is already cached for this tx first, forcing it to be re-registered and
+// @Description resolved from scratch
 // @Tags bridge-tracker
 // @Produce json
 // @Param network_id path uint32 true "Network where the bridge transaction was sent (0 -> Mainnet)"
 // @Param tx_hash path string true "Hash of the transaction that created the bridge (bridgeAsset or bridgeMessage)"
+// @Param flush_cache query bool false "Discard the tracker's cached state for this tx before answering"
 // @Success 200 {object} TrackingData "Bridge registered; bridge_status/error fill in once resolved"
 // @Failure 400 {object} types.ErrorData "Invalid transaction hash or network id"
 // @Failure 503 {object} types.ErrorData "Supervised registry is at capacity"
@@ -53,6 +58,10 @@ func (cmd *getTxStatusCommand) Execute(c *gin.Context) (int, any, *types.ErrorDa
 	}
 
 	id := domain.TrackingID{NetworkID: req.NetworkID, TxHash: req.TxHash}
+	if c.Query(flushCacheQueryParam) == queryValueTrue {
+		cmd.supervised.Forget(id)
+	}
+
 	tracking, err := cmd.supervised.GetAndAwait(id, cmd.resolveTimeout)
 	if err != nil {
 		code := http.StatusInternalServerError

--- a/bridgetracker/api/websocket.go
+++ b/bridgetracker/api/websocket.go
@@ -164,13 +164,13 @@ func (w *wsHandler) wsSendTracking(conn *websocket.Conn, tracking *domain.Tracki
 
 // wsTerminalReason reports whether the given snapshot is a terminal state the connection
 // should close normally after, and the reason to close with: the bridge reached Claimed, or
-// the tracker gave up trying to resolve it at all (domain.TrackingData.Failed — a step-level
-// error on an otherwise-resolved bridge is not terminal, the engine keeps polling it)
+// its tx or a step failed terminally. Transient errors remain open while the engine retries,
+// matching the registry's terminal-state predicate.
 func wsTerminalReason(tracking *domain.TrackingData) (reason string, done bool) {
-	switch {
-	case tracking.TrackingStatus() == types.TrackingStatusFinished:
+	switch tracking.TrackingStatus() {
+	case types.TrackingStatusFinished:
 		return "bridge claimed", true
-	case tracking.Failed():
+	case types.TrackingStatusError:
 		return "tracker gave up resolving the bridge", true
 	default:
 		return "", false

--- a/bridgetracker/api/websocket.go
+++ b/bridgetracker/api/websocket.go
@@ -64,10 +64,13 @@ func newWSHandler(
 // @Summary Subscribe to bridge status updates by transaction hash
 // @Description Upgrades the request to a WebSocket connection that receives the bridge
 // @Description status as it changes, instead of polling the REST endpoint. Connecting adds
-// @Description the bridge to the list of supervised bridges
+// @Description the bridge to the list of supervised bridges. flush_cache=true discards
+// @Description whatever is already cached for this tx first, forcing it to be re-registered and
+// @Description resolved from scratch
 // @Tags bridge-tracker
 // @Param network_id path uint32 true "Network where the bridge transaction was sent (0 -> Mainnet)"
 // @Param tx_hash path string true "Hash of the transaction that created the bridge (bridgeAsset or bridgeMessage)"
+// @Param flush_cache query bool false "Discard the tracker's cached state for this tx before answering"
 // @Success 101 {string} string "Switching Protocols"
 // @Router /network/{network_id}/tx/{tx_hash}/ws [get]
 func (w *wsHandler) TxStatusWSHandler(c *gin.Context) {
@@ -86,6 +89,9 @@ func (w *wsHandler) TxStatusWSHandler(c *gin.Context) {
 	}
 
 	id := domain.TrackingID{NetworkID: req.NetworkID, TxHash: req.TxHash}
+	if c.Query(flushCacheQueryParam) == queryValueTrue {
+		w.supervised.Forget(id)
+	}
 
 	// Subscribe before reading the snapshot so no update published in between is missed;
 	// the latest-value channel semantics collapse any duplicate with the initial message

--- a/bridgetracker/api/websocket_test.go
+++ b/bridgetracker/api/websocket_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/agglayer/aggkit/bridgetracker/domain"
+	"github.com/agglayer/aggkit/bridgetracker/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWSTerminalReason(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		resolved       bool
+		txError        *types.ErrorStep
+		steps          []domain.BridgeStepPath
+		expectedReason string
+		expectedDone   bool
+	}{
+		{name: "registered"},
+		{
+			name:    "transient tx error",
+			txError: &types.ErrorStep{ErrorType: types.StepErrorTransient},
+		},
+		{
+			name:           "permanent tx error",
+			txError:        &types.ErrorStep{ErrorType: types.StepErrorPermanent},
+			expectedReason: "tracker gave up resolving the bridge",
+			expectedDone:   true,
+		},
+		{
+			name:           "exhausted tx error",
+			txError:        &types.ErrorStep{ErrorType: types.StepErrorExhausted},
+			expectedReason: "tracker gave up resolving the bridge",
+			expectedDone:   true,
+		},
+		{
+			name:     "step in progress",
+			resolved: true,
+			steps: []domain.BridgeStepPath{{
+				Step: types.StepWaitingClaim, Status: types.StepStatusInProgress,
+			}},
+		},
+		{
+			name:     "transient step error",
+			resolved: true,
+			steps: []domain.BridgeStepPath{{
+				Step: types.StepWaitL1SettledGER, Status: types.StepStatusError,
+				Error: &types.ErrorStep{ErrorType: types.StepErrorTransient},
+			}},
+		},
+		{
+			name:     "permanent step error",
+			resolved: true,
+			steps: []domain.BridgeStepPath{{
+				Step: types.StepWaitL1SettledGER, Status: types.StepStatusError,
+				Error: &types.ErrorStep{ErrorType: types.StepErrorPermanent},
+			}},
+			expectedReason: "tracker gave up resolving the bridge",
+			expectedDone:   true,
+		},
+		{
+			name:     "exhausted step error",
+			resolved: true,
+			steps: []domain.BridgeStepPath{{
+				Step: types.StepWaitL1SettledGER, Status: types.StepStatusError,
+				Error: &types.ErrorStep{ErrorType: types.StepErrorExhausted},
+			}},
+			expectedReason: "tracker gave up resolving the bridge",
+			expectedDone:   true,
+		},
+		{
+			name:     "step error without details",
+			resolved: true,
+			steps: []domain.BridgeStepPath{{
+				Step: types.StepWaitL1SettledGER, Status: types.StepStatusError,
+			}},
+			expectedReason: "tracker gave up resolving the bridge",
+			expectedDone:   true,
+		},
+		{
+			name:     "claimed",
+			resolved: true,
+			steps: []domain.BridgeStepPath{{
+				Step: types.StepClaimed, Status: types.StepStatusDone,
+			}},
+			expectedReason: "bridge claimed",
+			expectedDone:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			bridgeTx := domain.TrackingBridgeTx{Error: testCase.txError}
+			if testCase.resolved {
+				bridgeTx.Info = &domain.BridgeInfo{NetworkID: 1}
+			}
+			tracking := domain.NewTrackingData(domain.TrackingID{}, bridgeTx, testCase.steps)
+
+			reason, done := wsTerminalReason(tracking)
+			require.Equal(t, testCase.expectedDone, done)
+			require.Equal(t, testCase.expectedReason, reason)
+		})
+	}
+}

--- a/bridgetracker/bridgetracker_test.go
+++ b/bridgetracker/bridgetracker_test.go
@@ -289,6 +289,39 @@ func TestGetTxStatusHandlerTerminalError(t *testing.T) {
 	require.Equal(t, []string{"bridge tx not found"}, tracking.Error.Description)
 }
 
+// TestGetTxStatusHandlerFlushCacheResetsTracking verifies ?flush_cache=true discards the
+// tracker's existing entry for the tx before answering, so a bridge already resolved to
+// "running" reads back as freshly "registered" (bridge_status null) again, exactly as if it had
+// never been requested before; a plain call right after still sees that same fresh entry
+func TestGetTxStatusHandlerFlushCacheResetsTracking(t *testing.T) {
+	tracker, router := newTestTracker(t)
+
+	path := api.TrackerV1Prefix + "/network/1/tx/" + testTxHash
+	resp := performRequest(t, router, http.MethodGet, path)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	tracker.Publish(TrackingID{NetworkID: 1, TxHash: common.HexToHash(testTxHash)}, testBridgeInfo(), testAllSteps(false))
+
+	var tracking struct {
+		TrackingStatus string          `json:"tracking_status"`
+		BridgeStatus   json.RawMessage `json:"bridge_status"`
+	}
+	resp = performRequest(t, router, http.MethodGet, path)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &tracking))
+	require.Equal(t, "running", tracking.TrackingStatus, "resolved before flushing")
+
+	resp = performRequest(t, router, http.MethodGet, path+"?flush_cache=true")
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &tracking))
+	require.Equal(t, "registered", tracking.TrackingStatus, "flushed: starts over as freshly registered")
+	require.Equal(t, "null", string(tracking.BridgeStatus))
+
+	// a plain call right after still sees the freshly re-registered entry, not the old one
+	resp = performRequest(t, router, http.MethodGet, path)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &tracking))
+	require.Equal(t, "registered", tracking.TrackingStatus)
+}
+
 // TestGetTxStatusHandlerUnprefixedTxHash pins the tx-hash validation behaviour inherited from
 // common.IsHexHash: the 0x prefix is optional, so a bare 64-char hex hash is accepted and is
 // registered in the supervised list (200) instead of failing validation
@@ -476,6 +509,48 @@ func TestActivityHandlerIsClaimedFailureReportsErrorStatusAndMessage(t *testing.
 	require.Equal(t, "error", body.Bridges[0].ClaimStatus)
 	require.Nil(t, body.Bridges[0].Claim)
 	require.Equal(t, wantErrMsg, body.Bridges[0].Errors["claim"])
+}
+
+// TestActivityHandlerFlushCacheForcesRecheck verifies ?flush_cache=true discards whatever the
+// activity endpoint already cached for from_address before scanning, so a bridge already
+// settled (claimed + indexed, normally never rechecked) is fetched again instead of being
+// reused untouched
+func TestActivityHandlerFlushCacheForcesRecheck(t *testing.T) {
+	bridge := testBridge(1)
+	claim := &bridgeservicetypes.ClaimResponse{TxHash: "0xclaimtx"}
+
+	gin.SetMode(gin.TestMode)
+	tracker := New(&Config{
+		Logger:     log.WithFields("module", "bridgetracker_test"),
+		ConfigSHA1: testConfigSHA1,
+		ActivityScanner: &fakeActivityScanner{
+			bridges: []*domain.ScannedBridge{scannedBridge(bridge, testScannedNetworkID)},
+		},
+		// two isClaimed/claimInfo entries: a third would panic on out-of-range, proving
+		// flush_cache causes exactly one extra recheck
+		ActivityClaims: &fakeActivityClaims{
+			isClaimed: []bool{true, true},
+			claimInfo: []*bridgeservicetypes.ClaimResponse{claim, claim},
+		},
+	})
+	router := gin.New()
+	tracker.API().RegisterRoutes(router)
+
+	path := api.TrackerV1Prefix + "/activity/from/" + testFromAddress.Hex()
+	resp := performRequest(t, router, http.MethodGet, path)
+	require.Equal(t, http.StatusOK, resp.Code)
+	var body api.ActivityResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, "claimed", body.Bridges[0].ClaimStatus)
+
+	// without flush_cache the settled entry would be reused untouched (see
+	// TestActivityHandlerHappyPath's isClaimed/claimInfo being consulted only once); flushing
+	// forces the second, otherwise-out-of-range consultation configured above
+	resp = performRequest(t, router, http.MethodGet, path+"?flush_cache=true")
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, "claimed", body.Bridges[0].ClaimStatus)
+	require.Equal(t, claim.TxHash, body.Bridges[0].Claim.TxHash)
 }
 
 // TestActivityHandlerInvalidFilterBridges verifies an unrecognized filterBridges value is

--- a/bridgetracker/bridgetracker_test.go
+++ b/bridgetracker/bridgetracker_test.go
@@ -72,11 +72,30 @@ func testAllSteps(claimed bool) []BridgeStepPath {
 	return []BridgeStepPath{{Step: step, Status: stepStatus}}
 }
 
-// testAllStepsWithError returns an expected-path snapshot with its in-progress step failed,
-// for tests exercising a step-level error (as opposed to a terminal resolution failure)
+// testAllStepsWithError returns an expected-path snapshot with its in-progress step still
+// retrying a transient error, for tests exercising a step-level error the tracker keeps
+// retrying (as opposed to a terminal resolution failure — see testAllStepsWithPermanentError)
 func testAllStepsWithError() []BridgeStepPath {
 	return []BridgeStepPath{{
-		Step: types.StepPendingInclusion, Status: types.StepStatusError, Error: testErrorStep(),
+		Step: types.StepPendingInclusion, Status: types.StepStatusError,
+		Error: &types.ErrorStep{
+			ErrorType:   types.StepErrorTransient,
+			RetryCount:  1,
+			Description: []string{"source temporarily unavailable"},
+		},
+	}}
+}
+
+// testAllStepsWithPermanentError returns an expected-path snapshot with its in-progress step
+// failed for a reason retrying cannot fix, for tests exercising a step-level terminal failure
+// (as opposed to testAllStepsWithError's still-retryable transient one)
+func testAllStepsWithPermanentError() []BridgeStepPath {
+	return []BridgeStepPath{{
+		Step: types.StepPendingInclusion, Status: types.StepStatusError,
+		Error: &types.ErrorStep{
+			ErrorType:   types.StepErrorPermanent,
+			Description: []string{"unrecoverable step failure"},
+		},
 	}}
 }
 

--- a/bridgetracker/domain/activity.go
+++ b/bridgetracker/domain/activity.go
@@ -134,4 +134,11 @@ type ActivityQuerier interface {
 	GetActivity(
 		ctx context.Context, fromAddress common.Address, includeTracking bool, filter types.ActivityFilter,
 	) ([]*ActivityEntry, []ActivityWarning, error)
+
+	// FlushActivity discards whatever is cached for fromAddress, forcing every bridge found for
+	// it to be freshly rechecked (claim state re-verified, tracker re-consulted) on the next
+	// GetActivity call, instead of reusing anything cached so far. Safe to call for an address
+	// with nothing cached (no-op). The activity endpoint's ?flush_cache=true parameter uses it
+	// to force a fresh recheck
+	FlushActivity(fromAddress common.Address)
 }

--- a/bridgetracker/domain/ports.go
+++ b/bridgetracker/domain/ports.go
@@ -84,6 +84,14 @@ type SupervisedStore interface {
 	// would otherwise hold onto indefinitely, complementing PruneTerminal's grace period for
 	// bridges that did resolve
 	PruneIdle(olderThan time.Time) (int, error)
+
+	// Forget discards id's cached tracking state, if any, as if it had never been requested. A
+	// later Get/GetAndAwait/Subscribe re-registers it from scratch and tracking starts over.
+	// Safe to call for an id that is not currently registered (no-op). Unlike
+	// PruneTerminal/PruneIdle, this is not a passive time-window sweep: it is an explicit,
+	// immediate reset of one id regardless of its terminal/idle state or active subscribers —
+	// the tracker endpoints' ?flush_cache=true parameter uses it to force a fresh recheck
+	Forget(id TrackingID)
 }
 
 // StatusNotifier is the driven port push consumers (the WebSocket handler) use to follow a

--- a/bridgetracker/domain/resolve_bridge_tx.go
+++ b/bridgetracker/domain/resolve_bridge_tx.go
@@ -49,7 +49,8 @@ type BridgeEventSource interface {
 //     no retries.
 //   - Transient failure (ErrBridgeTxNotFound, or anything else FindBridge returns): the
 //     tx-level Error accumulates a retry, turning Exhausted once Timeout has elapsed since
-//     StartDate (the moment the bridge was first seen unresolved).
+//     StartDate (the moment the bridge was first seen unresolved). Description is capped to its
+//     most recent maxErrorDescriptions entries (see appendErrorDescription), RetryCount is not.
 func ResolveBridgeTx(
 	ctx context.Context, source BridgeEventSource, tracking *TrackingData,
 	unresolvedTimeout time.Duration, now time.Time,
@@ -96,7 +97,7 @@ func ResolveBridgeTx(
 	retryCount, descriptions := 1, []string{description}
 	if tx.Error != nil {
 		retryCount = tx.Error.RetryCount + 1
-		descriptions = append(append([]string{}, tx.Error.Description...), description)
+		descriptions = appendErrorDescription(tx.Error.Description, description)
 	}
 	errorType := types.StepErrorTransient
 	if tx.IsOutdated(now) {

--- a/bridgetracker/domain/resolve_steps.go
+++ b/bridgetracker/domain/resolve_steps.go
@@ -10,6 +10,25 @@ import (
 	aggkitcommon "github.com/agglayer/aggkit/common"
 )
 
+// maxErrorDescriptions caps how many entries an ErrorStep.Description accumulates across
+// retries of the same transient failure — kept low so a step (or the tx-level error in
+// ResolveBridgeTx, which shares this same accumulate-on-retry shape) stuck retrying for a long
+// time does not grow its stored/serialized error without bound. RetryCount itself is unaffected,
+// it keeps counting every retry; only the description history is trimmed, to its most recent
+// entries — the oldest ones are the least useful for diagnosing why it is still failing now
+const maxErrorDescriptions = 10
+
+// appendErrorDescription appends desc to descriptions (copying first, same as the call sites
+// already did, so the previous ErrorStep.Description slice is never mutated), keeping only the
+// most recent maxErrorDescriptions entries
+func appendErrorDescription(descriptions []string, desc string) []string {
+	descriptions = append(append([]string{}, descriptions...), desc)
+	if len(descriptions) > maxErrorDescriptions {
+		descriptions = descriptions[len(descriptions)-maxErrorDescriptions:]
+	}
+	return descriptions
+}
+
 // ErrStepPending is returned by StepResolver.Resolve, or wrapped by a more specific sentinel
 // (see ErrCertificateNotSettled), when the fact check succeeded but the milestone has not
 // happened yet — not a failure, so ResolveSteps neither retries it as one (see UpdateStep's
@@ -94,7 +113,9 @@ func currentStepIndex(steps []BridgeStepPath) int {
 // does (see Permanent/IsPermanent): IsPermanent(stepErr) makes the step StepErrorPermanent with
 // just this failure, no point accumulating a retry history nothing will retry. Any other stepErr
 // is StepErrorTransient, accumulating onto the step's retry count and description instead of
-// discarding the history of a transient source failure. Either way complete is meaningless here
+// discarding the history of a transient source failure — description is capped to its most
+// recent maxErrorDescriptions entries (see appendErrorDescription), retry count is not. Either
+// way complete is meaningless here
 // (a step cannot both fail and complete) and idx+1 is left untouched. With stepErr nil, any
 // previous Error is cleared instead: a successful fact check, even an inconclusive one, clears a
 // previous transient failure, evidence the retry is working, not just that a milestone was met.
@@ -133,7 +154,7 @@ func UpdateStep(
 		retryCount, description := 1, []string{stepErr.Error()}
 		if current.Error != nil {
 			retryCount = current.Error.RetryCount + 1
-			description = append(append([]string{}, current.Error.Description...), stepErr.Error())
+			description = appendErrorDescription(current.Error.Description, stepErr.Error())
 		}
 		current.Error = &types.ErrorStep{
 			ErrorType:   types.StepErrorTransient,

--- a/bridgetracker/domain/resolve_steps.go
+++ b/bridgetracker/domain/resolve_steps.go
@@ -111,11 +111,15 @@ func currentStepIndex(steps []BridgeStepPath) int {
 // StepStatusError — the step-level counterpart of the tx-level error handling in
 // ResolveBridgeTx. A resolver marks stepErr as unrecoverable the same way a BridgeEventSource
 // does (see Permanent/IsPermanent): IsPermanent(stepErr) makes the step StepErrorPermanent with
-// just this failure, no point accumulating a retry history nothing will retry. Any other stepErr
-// is StepErrorTransient, accumulating onto the step's retry count and description instead of
-// discarding the history of a transient source failure — description is capped to its most
-// recent maxErrorDescriptions entries (see appendErrorDescription), retry count is not. Either
-// way complete is meaningless here
+// just this failure, no point accumulating a retry history nothing will retry. Otherwise, if the
+// step was already terminally failed going into this call (isTerminalStepError — nothing stops
+// ResolveSteps from calling a failed step's resolver again, since currentStepIndex only checks
+// Done, not Error), that terminal ErrorType is kept as-is and only its history extended: a plain
+// stepErr from a later poll must never resurrect a terminal failure as merely StepErrorTransient.
+// Any other stepErr is StepErrorTransient, accumulating onto the step's retry count and
+// description instead of discarding the history of a transient source failure — description is
+// capped to its most recent maxErrorDescriptions entries (see appendErrorDescription), retry
+// count is not. Either way complete is meaningless here
 // (a step cannot both fail and complete) and idx+1 is left untouched. With stepErr nil, any
 // previous Error is cleared instead: a successful fact check, even an inconclusive one, clears a
 // previous transient failure, evidence the retry is working, not just that a milestone was met.
@@ -142,24 +146,42 @@ func UpdateStep(
 	current.SetResult(result)
 	switch {
 	case stepErr != nil:
+		// captured before current.Status/Error are touched below: whether this step was
+		// already terminally failed (nothing will resolve it further — see isTerminalStepError)
+		// going into this call
+		wasTerminal := isTerminalStepError(current)
 		current.Status = types.StepStatusError
-		if IsPermanent(stepErr) {
+		switch {
+		case IsPermanent(stepErr):
 			// unrecoverable: no retry history to accumulate, nothing will retry this step
 			current.Error = &types.ErrorStep{
 				ErrorType:   types.StepErrorPermanent,
 				Description: []string{stepErr.Error()},
 			}
-			break
-		}
-		retryCount, description := 1, []string{stepErr.Error()}
-		if current.Error != nil {
-			retryCount = current.Error.RetryCount + 1
-			description = appendErrorDescription(current.Error.Description, stepErr.Error())
-		}
-		current.Error = &types.ErrorStep{
-			ErrorType:   types.StepErrorTransient,
-			RetryCount:  retryCount,
-			Description: description,
+		case wasTerminal:
+			// nothing stops ResolveSteps from calling this step's resolver again once it has
+			// already failed terminally (currentStepIndex only checks Done, not Error) — a
+			// resolver call that then happens to return a plain, non-Permanent-wrapped error
+			// (e.g. a transient hiccup while re-checking an already-doomed fact) must not
+			// resurrect a terminal failure as merely StepErrorTransient: that would misreport
+			// TrackingStatus/ClaimStatus back to Running/Pending for a step that will never
+			// complete. Keep the existing terminal ErrorType, only extend its history
+			current.Error = &types.ErrorStep{
+				ErrorType:   current.Error.ErrorType,
+				RetryCount:  current.Error.RetryCount + 1,
+				Description: appendErrorDescription(current.Error.Description, stepErr.Error()),
+			}
+		default:
+			retryCount, description := 1, []string{stepErr.Error()}
+			if current.Error != nil {
+				retryCount = current.Error.RetryCount + 1
+				description = appendErrorDescription(current.Error.Description, stepErr.Error())
+			}
+			current.Error = &types.ErrorStep{
+				ErrorType:   types.StepErrorTransient,
+				RetryCount:  retryCount,
+				Description: description,
+			}
 		}
 	case complete:
 		current.Error = nil

--- a/bridgetracker/domain/resolve_steps.go
+++ b/bridgetracker/domain/resolve_steps.go
@@ -62,10 +62,11 @@ type StepResolver interface {
 // domain.ResolveBridgeTx/domain.PendingPath) through as much of its expected path as its
 // current facts allow: it resolves the current step (the first not yet Done) via UpdateStep,
 // and if that completed it, whichever step it lands on next, and so on, stopping at the first
-// milestone still unmet (ErrStepPending) or the first real error. On a real error, every step
-// completed earlier this same call stays Done — only the step whose resolver just failed is
-// marked, via UpdateStep's stepErr, incrementing its retry count instead of discarding the
-// in-tick progress
+// milestone still unmet (ErrStepPending), the first real error, or a step that already failed
+// for a reason retrying cannot fix (currentStepIndex returns -1 for that case too, without
+// calling its resolver again — see isTerminalStepError). On a real error, every step completed
+// earlier this same call stays Done — only the step whose resolver just failed is marked, via
+// UpdateStep's stepErr, incrementing its retry count instead of discarding the in-tick progress
 func ResolveSteps(
 	ctx context.Context,
 	logger aggkitcommon.Logger,
@@ -94,10 +95,18 @@ func ResolveSteps(
 }
 
 // currentStepIndex returns the index of the first step not yet Done — the one that needs
-// resolving next — or -1 once the whole path (through StepClaimed) is Done
+// resolving next — or -1 once the whole path (through StepClaimed) is Done, or once that first
+// not-yet-Done step already failed for a reason retrying cannot fix (isTerminalStepError):
+// steps only ever advance strictly in order (see UpdateStep), so a terminally failed one is, by
+// construction, the last one ever reached — nothing stops ResolveSteps from asking its resolver
+// again forever otherwise, which is exactly how a later plain error could downgrade a permanent
+// failure back to transient before UpdateStep started guarding against it
 func currentStepIndex(steps []BridgeStepPath) int {
 	for i, sp := range steps {
 		if sp.Status != types.StepStatusDone {
+			if isTerminalStepError(sp) {
+				return -1
+			}
 			return i
 		}
 	}

--- a/bridgetracker/domain/resolve_steps_test.go
+++ b/bridgetracker/domain/resolve_steps_test.go
@@ -891,6 +891,42 @@ func TestUpdateStep(t *testing.T) {
 		require.Equal(t, 0, sp.Error.RetryCount, "nothing will retry a permanent step, so the count resets")
 		require.Equal(t, []string{errFakeUpdateStep.Error()}, sp.Error.Description)
 	})
+
+	t.Run(
+		"a plain stepErr on an already-permanently-failed step does not downgrade it to transient",
+		func(t *testing.T) {
+			t.Parallel()
+
+			// nothing stops ResolveSteps from calling this step's resolver again once it already
+			// failed permanently (currentStepIndex only checks Done, not Error) — a later poll
+			// returning a plain, non-Permanent-wrapped error (e.g. a transient RPC hiccup while
+			// re-checking an already-doomed fact) must not resurrect the step as merely
+			// StepErrorTransient: TrackingStatus/ClaimStatus would then misreport it as
+			// Running/Pending even though the step will never complete
+			tracking := newTracking(types.BridgeTypeL1ToL2, []BridgeStepPath{
+				{
+					Step: types.StepWaitingGERUpdate, Status: types.StepStatusError, StartDate: &t1,
+					Error: &types.ErrorStep{
+						ErrorType:   types.StepErrorPermanent,
+						Description: []string{"settlement tx receipt does not carry required events"},
+					},
+				},
+				{Step: types.StepWaitingGERInjection, Status: types.StepStatusPending},
+				{Step: types.StepWaitingClaim, Status: types.StepStatusPending},
+				{Step: types.StepClaimed, Status: types.StepStatusPending},
+			}, t1)
+
+			advanced := UpdateStep(tracking, 0, nil, false, errFakeUpdateStep, t2)
+
+			sp := advanced.AllSteps()[0]
+			require.Equal(t, types.StepStatusError, sp.Status)
+			require.Equal(t, types.StepErrorPermanent, sp.Error.ErrorType, "the terminal ErrorType is preserved")
+			require.Equal(t, 1, sp.Error.RetryCount, "the occurrence is still counted")
+			require.Equal(t, []string{
+				"settlement tx receipt does not carry required events", errFakeUpdateStep.Error(),
+			}, sp.Error.Description, "the occurrence is still recorded onto the existing history")
+		},
+	)
 }
 
 // TestCertificateResolverSkipsWaypoints pins that a certificate observed already Settled, with

--- a/bridgetracker/domain/resolve_steps_test.go
+++ b/bridgetracker/domain/resolve_steps_test.go
@@ -522,6 +522,45 @@ func TestResolveStepsClaimedNotIndexedYet(t *testing.T) {
 	require.Equal(t, types.StepClaimed, steps[*idx].Step)
 }
 
+// TestResolveStepsStopsOnTerminalStepError pins that ResolveSteps never calls a step's
+// resolver again once it already failed for a reason retrying cannot fix (StepErrorPermanent):
+// currentStepIndex reports -1 for it, same as a fully Done path, so the loop returns
+// immediately, the snapshot comes back unchanged, and — unlike TestResolveStepsErrors, which
+// pins the same short-circuit for a milestone still unmet (ErrStepPending) — no fact is ever
+// queried at all
+func TestResolveStepsStopsOnTerminalStepError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	permanentlyFailed := BridgeStepPath{
+		Step: types.StepWaitL1SettledGER, Status: types.StepStatusError,
+		Error: &types.ErrorStep{
+			ErrorType:   types.StepErrorPermanent,
+			Description: []string{ErrBadSettlementTx.Error()},
+		},
+	}
+	tracking := newTracking(types.BridgeTypeL2ToL1, []BridgeStepPath{
+		{Step: types.StepWaitingLERUpdate, Status: types.StepStatusDone},
+		{Step: types.StepPendingInclusion, Status: types.StepStatusDone},
+		{Step: types.StepCertificatePending, Status: types.StepStatusDone},
+		permanentlyFailed,
+		{Step: types.StepWaitingL1InfoLeafAvailable, Status: types.StepStatusPending},
+		{Step: types.StepWaitingClaim, Status: types.StepStatusPending},
+		{Step: types.StepClaimed, Status: types.StepStatusPending},
+	}, now)
+	// facts that would let every remaining step succeed if queried, proving they are not
+	facts := fakeFacts{
+		l1InfoTreeIndexForBridge: new(uint32),
+		claimed:                  true,
+		claim:                    &types.ClaimResult{ClaimTx: common.Hash{9}},
+	}
+
+	result, err := ResolveSteps(context.Background(), log.NewLoggerNil(), testResolvers(&facts), tracking, now)
+	require.NoError(t, err)
+	require.Empty(t, facts.queried, "no resolver may be called once the path is stuck on a terminal step error")
+	require.Equal(t, tracking.AllSteps(), result.AllSteps(), "the snapshot is returned unchanged")
+}
+
 func TestResolveStepsErrors(t *testing.T) {
 	t.Parallel()
 

--- a/bridgetracker/domain/resolve_steps_test.go
+++ b/bridgetracker/domain/resolve_steps_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -814,6 +815,37 @@ func TestUpdateStep(t *testing.T) {
 		sp := advanced.AllSteps()[0]
 		require.Equal(t, 2, sp.Error.RetryCount)
 		require.Equal(t, []string{errFakeUpdateStep.Error(), errFakeUpdateStep.Error()}, sp.Error.Description)
+	})
+
+	t.Run("a repeated stepErr caps Description to the most recent maxErrorDescriptions, RetryCount keeps counting", func(t *testing.T) {
+		t.Parallel()
+
+		existing := make([]string, maxErrorDescriptions)
+		for i := range existing {
+			existing[i] = fmt.Sprintf("attempt %d", i)
+		}
+		tracking := newTracking(types.BridgeTypeL1ToL2, []BridgeStepPath{
+			{
+				Step: types.StepWaitingGERUpdate, Status: types.StepStatusError, StartDate: &t1,
+				Error: &types.ErrorStep{
+					ErrorType: types.StepErrorTransient, RetryCount: maxErrorDescriptions,
+					Description: existing,
+				},
+			},
+			{Step: types.StepWaitingGERInjection, Status: types.StepStatusPending},
+			{Step: types.StepWaitingClaim, Status: types.StepStatusPending},
+			{Step: types.StepClaimed, Status: types.StepStatusPending},
+		}, t1)
+
+		advanced := UpdateStep(tracking, 0, nil, false, errFakeUpdateStep, t2)
+
+		sp := advanced.AllSteps()[0]
+		require.Equal(t, maxErrorDescriptions+1, sp.Error.RetryCount, "RetryCount is never trimmed")
+		require.Len(t, sp.Error.Description, maxErrorDescriptions, "Description is trimmed to the most recent entries")
+		require.Equal(t, existing[1:], sp.Error.Description[:maxErrorDescriptions-1],
+			"the oldest entry is dropped, the rest shift down")
+		require.Equal(t, errFakeUpdateStep.Error(), sp.Error.Description[maxErrorDescriptions-1],
+			"the newest entry is kept last")
 	})
 
 	t.Run("a stepErr wrapped as Permanent marks the step StepErrorPermanent with no retry count", func(t *testing.T) {

--- a/bridgetracker/domain/tracking_data.go
+++ b/bridgetracker/domain/tracking_data.go
@@ -79,20 +79,22 @@ func (t *TrackingData) AllSteps() []BridgeStepPath {
 }
 
 // StepIndex returns the index into AllSteps of the step that explains TrackingStatus: the
-// first step in error if any step failed, the step currently in progress if the bridge is
-// still running, or the last step (Claimed, always the tail of every path) once it is
-// finished. nil while AllSteps is nil
+// first step in a terminal error (permanent, or transient turned exhausted) if any step failed
+// that way, the step currently in progress — a step whose error is still transient counts as
+// in progress here too, mirroring TrackingBridgeTx.IsInTerminalError (see
+// isTerminalStepError) — if the bridge is still running, or the last step (Claimed, always the
+// tail of every path) once it is finished. nil while AllSteps is nil
 func (t *TrackingData) StepIndex() *int {
 	if t == nil || t.allSteps == nil {
 		return nil
 	}
 	for i, step := range t.allSteps {
-		if step.Status == types.StepStatusError {
+		if isTerminalStepError(step) {
 			return &i
 		}
 	}
 	for i, step := range t.allSteps {
-		if step.Status == types.StepStatusInProgress {
+		if step.Status == types.StepStatusInProgress || isTransientStepError(step) {
 			return &i
 		}
 	}
@@ -100,18 +102,37 @@ func (t *TrackingData) StepIndex() *int {
 	return &lastIdx
 }
 
+// isTransientStepError reports whether step is StepStatusError with a still-retryable cause
+// (types.StepErrorTransient) — the step-level counterpart of a transient tx-level Error, which
+// TrackingStatus/ClaimStatus already treat as not-yet-failed (see
+// TrackingBridgeTx.IsInTerminalError). A step in error whose Error is nil is not transient: with
+// no ErrorType to read, it cannot be told apart from a permanent one, so it stays an error
+func isTransientStepError(step BridgeStepPath) bool {
+	return step.Status == types.StepStatusError &&
+		step.Error != nil && step.Error.ErrorType == types.StepErrorTransient
+}
+
+// isTerminalStepError reports whether step is in error for a reason retrying will not fix:
+// permanent, or transient retries exhausted. The mirror image of isTransientStepError
+func isTerminalStepError(step BridgeStepPath) bool {
+	return step.Status == types.StepStatusError && !isTransientStepError(step)
+}
+
 // TrackingStatus derives the bridge's lifecycle status from the snapshot, nothing is stored:
 // once AllSteps is resolved it reflects the step that explains it (see StepIndex); until
 // then, the tx-level facts say it all — a terminal Error (the tracker gave up resolving the
 // tx: exhausted or permanent) reads as Error, a resolved tx (IsDone) as Running, and
-// anything else (including a transient failure still being retried) as Registered
+// anything else (including a transient failure still being retried) as Registered. A step in
+// StepStatusError follows the same rule as the tx-level one: only a terminal cause
+// (permanent, or exhausted) reads as Error, a still-retryable transient one reads as Running,
+// same as an in-progress step (see isTransientStepError)
 func (t *TrackingData) TrackingStatus() types.TrackingStatus {
 	if t == nil {
 		return types.TrackingStatusError
 	}
 	stepIndex := t.StepIndex()
 	if stepIndex != nil {
-		return convertStepStatusToTrackingStatus(t.allSteps[*stepIndex].Status)
+		return convertStepStatusToTrackingStatus(t.allSteps[*stepIndex])
 	}
 	if t.trackingBridgeTx.IsInTerminalError() {
 		return types.TrackingStatusError
@@ -177,8 +198,12 @@ func (t *TrackingData) Failed() bool {
 	return t.TrackingStatus() == types.TrackingStatusError && t.Info() == nil
 }
 
-func convertStepStatusToTrackingStatus(stepStatus types.StepStatus) types.TrackingStatus {
-	switch stepStatus {
+// convertStepStatusToTrackingStatus derives TrackingStatus from a single step — the one
+// StepIndex already picked out as current. A transient step error reads as Running, same as
+// an in-progress step (see isTransientStepError); only a terminal one (permanent, or
+// exhausted) reads as Error
+func convertStepStatusToTrackingStatus(step BridgeStepPath) types.TrackingStatus {
+	switch step.Status {
 	case types.StepStatusPending:
 		return types.TrackingStatusRunning
 	case types.StepStatusInProgress:
@@ -186,6 +211,9 @@ func convertStepStatusToTrackingStatus(stepStatus types.StepStatus) types.Tracki
 	case types.StepStatusDone:
 		return types.TrackingStatusFinished
 	case types.StepStatusError:
+		if isTransientStepError(step) {
+			return types.TrackingStatusRunning
+		}
 		return types.TrackingStatusError
 	default:
 		return types.TrackingStatusError

--- a/bridgetracker/domain/tracking_data_test.go
+++ b/bridgetracker/domain/tracking_data_test.go
@@ -76,6 +76,59 @@ func TestTrackingStatusDerivation(t *testing.T) {
 			},
 			expected: types.TrackingStatusError,
 		},
+		{
+			name:     "steps rule once present: step in transient error -> Running (still retrying)",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingClaim,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorTransient},
+				},
+			},
+			expected: types.TrackingStatusRunning,
+		},
+		{
+			name:     "steps rule once present: step in exhausted error -> Error (gave up retrying)",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingClaim,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorExhausted},
+				},
+			},
+			expected: types.TrackingStatusError,
+		},
+		{
+			name:     "steps rule once present: step in permanent error -> Error",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingClaim,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorPermanent},
+				},
+			},
+			expected: types.TrackingStatusError,
+		},
+		{
+			name:     "an earlier step's transient error does not hide a later terminal one -> Error",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingGERUpdate,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorTransient},
+				},
+				{
+					Step:   types.StepWaitingClaim,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorPermanent},
+				},
+			},
+			expected: types.TrackingStatusError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -169,6 +222,42 @@ func TestClaimStatusDerivation(t *testing.T) {
 			bridgeTx: TrackingBridgeTx{Info: info},
 			allSteps: []BridgeStepPath{
 				{Step: types.StepWaitingClaim, Status: types.StepStatusError},
+			},
+			expected: types.TrackerClaimStatusError,
+		},
+		{
+			name:     "transient error on WaitingClaim -> ReadyToClaim (still retrying)",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingClaim,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorTransient},
+				},
+			},
+			expected: types.TrackerClaimStatusReadyToClaim,
+		},
+		{
+			name:     "transient error on an earlier step -> Pending (still retrying)",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingLERUpdate,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorTransient},
+				},
+			},
+			expected: types.TrackerClaimStatusPending,
+		},
+		{
+			name:     "exhausted error on WaitingClaim -> Error (gave up retrying)",
+			bridgeTx: TrackingBridgeTx{Info: info},
+			allSteps: []BridgeStepPath{
+				{
+					Step:   types.StepWaitingClaim,
+					Status: types.StepStatusError,
+					Error:  &types.ErrorStep{ErrorType: types.StepErrorExhausted},
+				},
 			},
 			expected: types.TrackerClaimStatusError,
 		},

--- a/bridgetracker/engine_test.go
+++ b/bridgetracker/engine_test.go
@@ -727,6 +727,53 @@ func TestEngineLifecycleL2ToL1(t *testing.T) {
 	require.Equal(t, types.TrackingStatusFinished, tracking.TrackingStatus())
 }
 
+// TestEngineStepPermanentErrorStopsRetryingAndLeavesActiveList pins the end-to-end fix for a
+// step-level terminal error (domain.ErrBadSettlementTx, Permanent-wrapped): once
+// SettlementGERUpdate reports it, the engine must never call it again for this bridge, and the
+// bridge must leave the active list — same as a bridge the tracker never resolved at all —
+// instead of being retried on every tick forever
+func TestEngineStepPermanentErrorStopsRetryingAndLeavesActiveList(t *testing.T) {
+	f := &fakeSources{bridge: l2ToL1Bridge()}
+	engine, store, _ := newTestEngine(t, f)
+	id := TrackingID{NetworkID: 1, TxHash: testHash}
+
+	mustRegister(t, store, id)
+
+	f.originLER = &types.LERUpdateResult{NetworkID: 1, LER: common.HexToHash("0x0a"), BlockNumber: 10}
+	settledBlockNumber := uint64(1500)
+	settledBlockTimestamp := uint64(1700001500)
+	f.cert = &types.CertificateInclusionData{
+		CertificateData: types.CertificateData{
+			CertificateID: common.HexToHash("0x01"), Status: agglayertypes.Settled,
+			SettlementTxHash: &settlementTxHash,
+			BlockNumber:      &settledBlockNumber, BlockTimestamp: &settledBlockTimestamp,
+		},
+	}
+	f.settlementErr = domain.ErrBadSettlementTx
+
+	engine.tick(t.Context())
+	tracking := mustGet(t, store, id)
+	require.Equal(t, types.TrackingStatusError, tracking.TrackingStatus())
+	require.Equal(t, types.TrackerClaimStatusError, tracking.ClaimStatus())
+	errStep := tracking.AllSteps()[*tracking.StepIndex()]
+	require.Equal(t, types.StepWaitL1SettledGER, errStep.Step)
+	require.Equal(t, types.StepErrorPermanent, errStep.Error.ErrorType)
+	require.Empty(t, mustGetTrackerActives(t, store), "a permanent step error must leave the active list")
+
+	// the settlement source recovers, but nothing may notice: the bridge already left the
+	// active list, so the engine never ticks it again to find out
+	f.settlementErr = nil
+	settlementLeafIndex := uint32(7)
+	f.settlement = &types.L1SettledGERResult{
+		TxHash: settlementTxHash, SettlementBlockNumber: 2000, GER: common.HexToHash("0x0b"),
+		L1InfoTreeIndex: &settlementLeafIndex, HasVerifyBatchesTrustedAggregator: true, HasUpdateL1InfoTree: true,
+	}
+	engine.tick(t.Context())
+	tracking = mustGet(t, store, id)
+	errStep = tracking.AllSteps()[*tracking.StepIndex()]
+	require.Equal(t, types.StepErrorPermanent, errStep.Error.ErrorType, "the terminal error must not be resurrected")
+}
+
 // TestEngineIncrementalResolution pins that resolution is incremental: once the bridge tx and
 // a milestone step are resolved and persisted, later ticks skip their sources entirely — the
 // engine only queries the facts the bridge is still waiting on

--- a/bridgetracker/mocks/mock_activity_querier.go
+++ b/bridgetracker/mocks/mock_activity_querier.go
@@ -27,6 +27,39 @@ func (_m *ActivityQuerier) EXPECT() *ActivityQuerier_Expecter {
 	return &ActivityQuerier_Expecter{mock: &_m.Mock}
 }
 
+// FlushActivity provides a mock function with given fields: fromAddress
+func (_m *ActivityQuerier) FlushActivity(fromAddress common.Address) {
+	_m.Called(fromAddress)
+}
+
+// ActivityQuerier_FlushActivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlushActivity'
+type ActivityQuerier_FlushActivity_Call struct {
+	*mock.Call
+}
+
+// FlushActivity is a helper method to define mock.On call
+//   - fromAddress common.Address
+func (_e *ActivityQuerier_Expecter) FlushActivity(fromAddress interface{}) *ActivityQuerier_FlushActivity_Call {
+	return &ActivityQuerier_FlushActivity_Call{Call: _e.mock.On("FlushActivity", fromAddress)}
+}
+
+func (_c *ActivityQuerier_FlushActivity_Call) Run(run func(fromAddress common.Address)) *ActivityQuerier_FlushActivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(common.Address))
+	})
+	return _c
+}
+
+func (_c *ActivityQuerier_FlushActivity_Call) Return() *ActivityQuerier_FlushActivity_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ActivityQuerier_FlushActivity_Call) RunAndReturn(run func(common.Address)) *ActivityQuerier_FlushActivity_Call {
+	_c.Run(run)
+	return _c
+}
+
 // GetActivity provides a mock function with given fields: ctx, fromAddress, includeTracking, filter
 func (_m *ActivityQuerier) GetActivity(ctx context.Context, fromAddress common.Address, includeTracking bool, filter types.ActivityFilter) ([]*domain.ActivityEntry, []domain.ActivityWarning, error) {
 	ret := _m.Called(ctx, fromAddress, includeTracking, filter)

--- a/bridgetracker/mocks/mock_supervised_registry.go
+++ b/bridgetracker/mocks/mock_supervised_registry.go
@@ -24,6 +24,39 @@ func (_m *SupervisedRegistry) EXPECT() *SupervisedRegistry_Expecter {
 	return &SupervisedRegistry_Expecter{mock: &_m.Mock}
 }
 
+// Forget provides a mock function with given fields: id
+func (_m *SupervisedRegistry) Forget(id domain.TrackingID) {
+	_m.Called(id)
+}
+
+// SupervisedRegistry_Forget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Forget'
+type SupervisedRegistry_Forget_Call struct {
+	*mock.Call
+}
+
+// Forget is a helper method to define mock.On call
+//   - id domain.TrackingID
+func (_e *SupervisedRegistry_Expecter) Forget(id interface{}) *SupervisedRegistry_Forget_Call {
+	return &SupervisedRegistry_Forget_Call{Call: _e.mock.On("Forget", id)}
+}
+
+func (_c *SupervisedRegistry_Forget_Call) Run(run func(id domain.TrackingID)) *SupervisedRegistry_Forget_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(domain.TrackingID))
+	})
+	return _c
+}
+
+func (_c *SupervisedRegistry_Forget_Call) Return() *SupervisedRegistry_Forget_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SupervisedRegistry_Forget_Call) RunAndReturn(run func(domain.TrackingID)) *SupervisedRegistry_Forget_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Get provides a mock function with given fields: id, createIfNotExists
 func (_m *SupervisedRegistry) Get(id domain.TrackingID, createIfNotExists bool) (*domain.TrackingData, error) {
 	ret := _m.Called(id, createIfNotExists)

--- a/bridgetracker/mocks/mock_supervised_store.go
+++ b/bridgetracker/mocks/mock_supervised_store.go
@@ -24,6 +24,39 @@ func (_m *SupervisedStore) EXPECT() *SupervisedStore_Expecter {
 	return &SupervisedStore_Expecter{mock: &_m.Mock}
 }
 
+// Forget provides a mock function with given fields: id
+func (_m *SupervisedStore) Forget(id domain.TrackingID) {
+	_m.Called(id)
+}
+
+// SupervisedStore_Forget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Forget'
+type SupervisedStore_Forget_Call struct {
+	*mock.Call
+}
+
+// Forget is a helper method to define mock.On call
+//   - id domain.TrackingID
+func (_e *SupervisedStore_Expecter) Forget(id interface{}) *SupervisedStore_Forget_Call {
+	return &SupervisedStore_Forget_Call{Call: _e.mock.On("Forget", id)}
+}
+
+func (_c *SupervisedStore_Forget_Call) Run(run func(id domain.TrackingID)) *SupervisedStore_Forget_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(domain.TrackingID))
+	})
+	return _c
+}
+
+func (_c *SupervisedStore_Forget_Call) Return() *SupervisedStore_Forget_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SupervisedStore_Forget_Call) RunAndReturn(run func(domain.TrackingID)) *SupervisedStore_Forget_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Get provides a mock function with given fields: id, createIfNotExists
 func (_m *SupervisedStore) Get(id domain.TrackingID, createIfNotExists bool) (*domain.TrackingData, error) {
 	ret := _m.Called(id, createIfNotExists)

--- a/bridgetracker/registry.go
+++ b/bridgetracker/registry.go
@@ -48,12 +48,21 @@ type memoryRegistry struct {
 	trigger chan TrackingID
 }
 
-// isTerminal reports whether the snapshot will never change again: the bridge finished, or
-// the tracker gave up resolving it. It is exactly the predicate GetTrackerActives excludes
-// by — an entry out of the active list is never updated again, so it is safe to forget once
-// its retention elapses
+// isTerminal reports whether the snapshot will never change again: the bridge finished, the
+// tracker gave up resolving its tx at all (domain.TrackingData.Failed — a strict subset of the
+// TrackingStatusError case below, kept only as the doc anchor for that half of it), or its
+// current step failed for a reason retrying cannot fix. TrackingStatus already folds all of
+// that into TrackingStatusError once AllSteps exists (see domain.TrackingData.TrackingStatus):
+// a step-level error still reads as Running/Pending there while it is merely
+// types.StepErrorTransient — the tracker is still retrying it and it may well recover — so
+// checking TrackingStatus directly, rather than Failed alone, is what correctly also excludes a
+// bridge stuck on a step that will never resolve (see currentStepIndex, which likewise stops
+// asking that step's resolver once it reaches this same state). It is exactly the predicate
+// GetTrackerActives excludes by — an entry out of the active list is never updated again, so it
+// is safe to forget once its retention elapses
 func isTerminal(tracking *domain.TrackingData) bool {
-	return tracking.Failed() || tracking.TrackingStatus() == types.TrackingStatusFinished
+	status := tracking.TrackingStatus()
+	return status == types.TrackingStatusError || status == types.TrackingStatusFinished
 }
 
 // compile-time check: the in-memory adapter fulfils the full port

--- a/bridgetracker/registry.go
+++ b/bridgetracker/registry.go
@@ -305,6 +305,19 @@ func (r *memoryRegistry) PruneIdle(olderThan time.Time) (int, error) {
 	return pruned, nil
 }
 
+// Forget implements SupervisedStore: unlike PruneTerminal/PruneIdle, this is not a passive
+// time-window sweep — it discards id's entry unconditionally and immediately, regardless of its
+// terminal/idle state. Any subscriber currently attached to it is left holding an orphaned
+// channel, exactly as PruneTerminal's doc describes: its unsubscribe still runs harmlessly, it
+// just operates on a record no longer in r.bridges. A later Get/GetAndAwait/Subscribe re-creates
+// id from scratch, same as a bridge that was never requested before
+func (r *memoryRegistry) Forget(id TrackingID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.bridges, id)
+}
+
 // GetNetworks implements SupervisedStore: the networks with at least one supervised bridge,
 // optionally filtered to those with at least one bridge in the given TrackingStatus
 func (r *memoryRegistry) GetNetworks(status *types.TrackingStatus) ([]uint32, error) {

--- a/bridgetracker/registry_test.go
+++ b/bridgetracker/registry_test.go
@@ -185,6 +185,34 @@ func TestRegistryPruneIdle(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRegistryForget pins Forget's semantics: unlike PruneTerminal/PruneIdle, it discards a
+// single id unconditionally and immediately, regardless of tracking status, lastAccess or
+// active subscribers, and is a no-op for an id not currently registered
+func TestRegistryForget(t *testing.T) {
+	r := newMemoryRegistry(0)
+
+	// a live, freshly-touched entry is forgotten just the same
+	live := TrackingID{NetworkID: 1, TxHash: testHash}
+	_, err := r.Get(live, true)
+	require.NoError(t, err)
+	require.NoError(t, publishStatus(r, live, testBridgeInfo(), testAllSteps(false)))
+
+	r.Forget(live)
+	require.Equal(t, 0, r.GetNumTracker())
+	_, err = r.Get(live, false)
+	require.ErrorIs(t, err, domain.ErrTrackingNotFound)
+
+	// a forgotten tx re-registers as new, with no trace of the previous run
+	tracking, err := r.Get(live, true)
+	require.NoError(t, err)
+	require.Equal(t, types.TrackingStatusRegistered, tracking.TrackingStatus())
+	require.Nil(t, tracking.Info())
+
+	// forgetting an id that was never registered is a harmless no-op
+	unknown := TrackingID{NetworkID: 1, TxHash: common.HexToHash("0x09")}
+	require.NotPanics(t, func() { r.Forget(unknown) })
+}
+
 // TestRegistryPruneIdleSkipsRecentlyAccessedEntry pins that a plain Get (no subscription) counts
 // as access and extends the idle window: a bridge a client keeps polling is never idle-evicted
 // out from under it

--- a/bridgetracker/registry_test.go
+++ b/bridgetracker/registry_test.go
@@ -375,9 +375,10 @@ func TestRegistryGetTrackerActivesFiltersByNetwork(t *testing.T) {
 }
 
 // TestRegistryGetTrackerActivesKeepsStepLevelErrors pins that a bridge resolved with a
-// step-level error (e.g. a certificate stuck InError) stays active: the engine must keep
-// polling it in case the error clears, unlike a bridge the tracker never managed to resolve
-// at all
+// still-retryable (transient) step-level error stays active: the engine must keep polling it
+// in case the error clears, unlike a bridge the tracker never managed to resolve at all, or one
+// whose step failed for a reason retrying cannot fix (see
+// TestRegistryGetTrackerActivesExcludesPermanentStepErrors)
 func TestRegistryGetTrackerActivesKeepsStepLevelErrors(t *testing.T) {
 	r := newMemoryRegistry(0)
 	erroring := TrackingID{NetworkID: 1, TxHash: common.HexToHash("0x04")}
@@ -390,6 +391,24 @@ func TestRegistryGetTrackerActivesKeepsStepLevelErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, active, 1)
 	require.Equal(t, erroring, active[0].ID())
+}
+
+// TestRegistryGetTrackerActivesExcludesPermanentStepErrors pins that a bridge whose current
+// step failed for a reason retrying cannot fix (types.StepErrorPermanent) leaves the active
+// list, same as a bridge the tracker never managed to resolve at all: nothing further will ever
+// happen to it (see domain's currentStepIndex, which likewise stops asking that step's resolver
+// once it reaches this same state), so polling it forever would be pure waste
+func TestRegistryGetTrackerActivesExcludesPermanentStepErrors(t *testing.T) {
+	r := newMemoryRegistry(0)
+	failed := TrackingID{NetworkID: 1, TxHash: common.HexToHash("0x05")}
+
+	_, err := r.Get(failed, true)
+	require.NoError(t, err)
+	require.NoError(t, publishStatus(r, failed, testBridgeInfo(), testAllStepsWithPermanentError()))
+
+	active, err := r.GetTrackerActives(nil)
+	require.NoError(t, err)
+	require.Empty(t, active)
 }
 
 func TestRegistryUnsubscribeStopsUpdates(t *testing.T) {

--- a/bridgetracker/websocket_test.go
+++ b/bridgetracker/websocket_test.go
@@ -158,6 +158,41 @@ func TestWSInitialStatusWhenKnown(t *testing.T) {
 	require.Equal(t, types.WSTypeStatus, msg.Type)
 }
 
+// TestWSFlushCacheResetsTracking verifies ?flush_cache=true on the WebSocket endpoint discards
+// the tracker's existing entry for the tx before subscribing, so a bridge already resolved to
+// "running" is pushed as freshly "registered" (bridge_status null) again on connect, exactly as
+// if it had never been requested before
+func TestWSFlushCacheResetsTracking(t *testing.T) {
+	tracker, router := newTestTracker(t)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	// register + resolve before connecting
+	resp := performRequest(t, router, http.MethodGet, api.TrackerV1Prefix+"/network/1/tx/"+testTxHash)
+	require.Equal(t, http.StatusOK, resp.Code)
+	tracker.Publish(TrackingID{NetworkID: 1, TxHash: common.HexToHash(testTxHash)}, testBridgeInfo(), testAllSteps(false))
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
+		api.TrackerV1Prefix + "/network/1/tx/" + testTxHash + "/ws?flush_cache=true"
+	conn, dialResp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	if dialResp != nil && dialResp.Body != nil {
+		dialResp.Body.Close()
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	msg := readEnvelope(t, conn)
+	require.Equal(t, types.WSTypeStatus, msg.Type)
+
+	var tracking struct {
+		TrackingStatus string          `json:"tracking_status"`
+		BridgeStatus   json.RawMessage `json:"bridge_status"`
+	}
+	require.NoError(t, json.Unmarshal(msg.Data, &tracking))
+	require.Equal(t, "registered", tracking.TrackingStatus, "flushed: starts over as freshly registered")
+	require.Equal(t, "null", string(tracking.BridgeStatus))
+}
+
 // TestWSTerminalError pins that giving up trying to resolve a bridge is pushed as a normal
 // "status" message (tracking_status: error, TrackingData.Error set) followed by a normal
 // closure — not a distinct "error" message, which is reserved for invalid request parameters

--- a/l2gersync/l2_ger_syncer.go
+++ b/l2gersync/l2_ger_syncer.go
@@ -205,6 +205,16 @@ func (s *L2GERSync) GetFirstGERAfterL1InfoTreeIndex(
 	return info, nil
 }
 
+// GetLastGER returns the most recently injected global exit root (the one with the highest L1
+// info tree index), or db.ErrNotFound if none has been injected yet. This is diagnostic-only —
+// e.g. bridgeservice.InjectedL1InfoLeafHandler uses it to report how far injection has actually
+// progressed when the requested leaf index hasn't been reached yet — so, unlike
+// GetFirstGERAfterL1InfoTreeIndex, it does not backfill a missing timestamp from the L2 RPC: an
+// extra RPC round trip isn't worth paying on an error path just to fill in an optional field.
+func (s *L2GERSync) GetLastGER(ctx context.Context) (GlobalExitRootInfo, error) {
+	return s.processor.GetLastGER(ctx)
+}
+
 // GetInjectedGERsForRange retrieves all injected global exit roots within a specified block range.
 // It returns a map where the keys are the global exit root hashes and the values are the
 // corresponding GlobalExitRootInfo containing the L1 info tree index, global exit root and block number.

--- a/l2gersync/processor.go
+++ b/l2gersync/processor.go
@@ -252,6 +252,25 @@ func (p *processor) GetFirstGERAfterL1InfoTreeIndex(
 	return e, nil
 }
 
+// GetLastGER retrieves the most recently injected global exit root, i.e. the row with the
+// highest L1 info tree index. Returns db.ErrNotFound if no GER has been injected yet.
+func (p *processor) GetLastGER(ctx context.Context) (GlobalExitRootInfo, error) {
+	e := GlobalExitRootInfo{}
+	err := meddler.QueryRow(p.database, &e, `
+		SELECT l1_info_tree_index, block_num, global_exit_root, block_pos, block_timestamp
+		FROM imported_global_exit_root_v2
+		ORDER BY l1_info_tree_index DESC LIMIT 1;
+	`)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return e, db.ErrNotFound
+		}
+		return e, fmt.Errorf("failed to get last injected GER: %w", err)
+	}
+
+	return e, nil
+}
+
 // UpdateTimestamp backfills the timestamp column of an already-inserted injected GER row,
 // identified by its (block_num, block_pos) primary key. Used when a row predates timestamp
 // persistence (nullable column, see l2gersync0006.sql) — see


### PR DESCRIPTION
## 🔄 Changes Summary

### aggkit-proxy
- **bridgeservicefinder**: `GetURL` now rejects any `networkID` in `Config.IgnoreNetworkIDs` up front (new `ErrNetworkDisabled`, wrapping `ErrURLNotFound`), and `buildInitialCache` no longer seeds a cache entry for an ignored network even when a `BridgeURLs`/`RPCURLs` override is configured for it — previously such an override could still be served for a network meant to be fully disabled.
- **bridgetracker**: a step in `StepStatusError` is now classified the same way the tracker already classifies a tx-level error — only a **terminal** cause (permanent, or transient-turned-exhausted) reads as `TrackingStatusError`/`TrackerClaimStatusError`; a step still retrying a **transient** error (e.g. a bridge-service instance temporarily inconsistent during a reorg) is grouped with in-progress steps, so `tracking_status`/`claim_status` correctly report `running`/`pending`/`readyToClaim` instead of `error` while the tracker keeps retrying it.
- **bridgetracker**: `ErrorStep.Description` (accumulated on every retry of a transient error, at both the step level and the tx level) is now capped to the 10 most recent entries via a shared `appendErrorDescription` helper, instead of growing without bound across hundreds of retries. `RetryCount` is unaffected and keeps counting every retry.
- **bridgetracker**: the tracker's REST/WebSocket tx endpoints and the activity endpoint now accept `?flush_cache=true`, discarding whatever is already cached for that request's key (the tracker's supervised entry for a `network_id`/`tx_hash`, or the activity endpoint's per-`from_address` cache) before answering, forcing a fresh recheck instead of reusing cached state — useful when a bridge/claim's on-chain or bridge-service state changed but the cache hasn't caught up yet.

### bridge service
- **bridgeservice**: `GET /injected-l1-info-leaf`'s 404 (leaf not yet injected on L2) now reports how far injection has actually progressed instead of just "not injected" — the last injected leaf index, L2 block, and timestamp (when available), via a new `l2gersync.GetLastGER` (most recently injected GER, by highest L1 info tree index), or a note that nothing has been injected yet on that network.

## ⚠️ Breaking Changes
- 🛠️ **Config**: none
- 🔌 **API/CLI**: `GET /tracker/v1/network/{network_id}/tx/{tx_hash}` (and the WebSocket "status" message) can now report `tracking_status`/`claim_status` as running/pending/readyToClaim for a bridge whose current step is retrying a transient error, where it previously reported `error`. `all_steps[].error.description` may now contain at most 10 entries instead of the full retry history. The new `flush_cache` query parameter is additive/opt-in on all three endpoints and does not change default behavior. `GET /injected-l1-info-leaf`'s 404 error message gains extra diagnostic text appended after the original message (existing clients matching the error string with `Contains` are unaffected; an exact-match comparison would break).
- 🗑️ **Deprecated Features**: none

## 📋 Config Updates
- None

## ✅ Testing
- 🤖 **Automatic**: extended `bridgetracker/domain` unit tests — `TestTrackingStatusDerivation`/`TestClaimStatusDerivation` (transient/permanent/exhausted step-error cases) and a new case in the `UpdateStep` table covering the `Description` cap and unbounded `RetryCount`. Added `TestRegistryForget`, `TestActivityCache_FlushActivityForcesRecheck`, and handler-level tests (`TestGetTxStatusHandlerFlushCacheResetsTracking`, `TestActivityHandlerFlushCacheForcesRecheck`, `TestWSFlushCacheResetsTracking`) covering the new `flush_cache` parameter. Added `bridgeservice` cases for the enriched 404 (last GER reported, nothing injected yet, and `GetLastGER` itself failing). Ran `make test-unit` and `make lint` (0 issues) on the affected packages.
- 🖱️ **Manual**: none required beyond the above.

## 🐞 Issues
- None tracked; fixes reported directly by the user during pairing.

## 🔗 Related PRs
- None

## 📝 Notes
- The bridgeservicefinder fix, the two bridgetracker step-error fixes, the `flush_cache` parameter, and the bridgeservice 404 diagnostic fix were made as separate commits on this branch across multiple sessions; grouped into a single PR per user request.
- Swagger docs (`bridgetracker/api/docs/`) regenerated via `swag init` to reflect the new `flush_cache` parameter.